### PR TITLE
(#11379) Manage Listen directives

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,7 +28,7 @@ class apache {
   # May want to purge all none realize modules using the resources resource type.
   #
   A2mod { require => Package['httpd'], notify => Service['httpd']}
-  case $operatingsystem {
+  case $::operatingsystem {
     'debian','ubuntu': {
       @a2mod {
        'rewrite' : ensure => present;
@@ -39,11 +39,26 @@ class apache {
     default: { }
   }
   
-  
   file { $apache::params::vdir:
     ensure => directory,
     recurse => true,
     purge => true,
     notify => Service['httpd'],
   } 
+
+  file {
+    $apache::params::apache_temp_dir:
+      ensure => directory;
+    "${apache::params::apache_temp_dir}/ports.d":
+      ensure  => directory,
+      purge   => true,
+      recurse => true,
+  }
+
+  exec { 'rebuild-apache-ports':
+    command     => "sort -u ${apache::params::apache_temp_dir}/ports.d/*-ports.conf > ${apache::params::ports_conf}",
+    path        => ['/usr/bin', '/bin'],
+    refreshonly => true,
+    subscribe   => File["${apache::params::apache_temp_dir}/ports.d"],
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,14 +29,16 @@ class apache::params {
   $redirect_ssl  = false
   $options       = 'Indexes FollowSymLinks MultiViews'
   $vhost_name    = '*'
+  $apache_temp_dir = '/tmp'
 
-  case $operatingsystem {
+  case $::operatingsystem {
     'centos', 'redhat', 'fedora', 'scientific': {
        $apache_name = 'httpd'
        $php_package = 'php'
        $ssl_package = 'mod_ssl'
        $apache_dev  = 'httpd-devel'
        $vdir = '/etc/httpd/conf.d/'
+       $ports_conf = '/etc/httpd/conf.d/ports.conf'
     }
     'ubuntu', 'debian': {
        $apache_name = 'apache2'
@@ -44,6 +46,7 @@ class apache::params {
        $ssl_package = 'apache-ssl'
        $apache_dev  = [ 'libaprutil1-dev', 'libapr1-dev', 'apache2-prefork-dev' ]
        $vdir = '/etc/apache2/sites-enabled/'
+       $ports_conf = '/etc/apache2/ports.conf'
     }
     default: {
        $apache_name = 'apache2'
@@ -51,6 +54,7 @@ class apache::params {
        $ssl_package = 'apache-ssl'
        $apache_dev  = 'apache-dev'
        $vdir = '/etc/apache2/sites-enabled/'
+       $ports_conf = '/etc/apache2/ports.conf'
     }
   }
 }

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -80,5 +80,12 @@ define apache::vhost(
         proto => 'tcp'
     }
   }
+
+  file {
+    "${apache::params::apache_temp_dir}/ports.d/${name}-ports.conf":
+      content => template('apache/ports.conf.erb'),
+      notify => Exec['rebuild-apache-ports'],
+      before => Service['httpd']
+  }
 }
 

--- a/templates/ports.conf.erb
+++ b/templates/ports.conf.erb
@@ -1,0 +1,1 @@
+Listen <%= port %>


### PR DESCRIPTION
Manage the Listen apache directives based on the ports being used by
apache::vhost resources.  One Listen directive is created for each
unique port being used.
