### PR TITLE
(#11706) puppetlabs-apache depends on puppetlabs-firewall

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,2 +1,3 @@
 name 'puppetlabs-apache'
 version '0.0.3'
+dependency 'puppetlabs-firewall', '>= 0.0.1'


### PR DESCRIPTION
Without this patch puppetlabs-apache does not depend on
puppetlabs-firewall.

This patch solves this problem by updating the Modulefile to specify
the dependency on puppetlabs-firewall.
