### PR TITLE
(#12581) Add explicit ordering for vdir directory

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,9 +41,10 @@ class apache {
   
   
   file { $apache::params::vdir:
-    ensure => directory,
+    ensure  => directory,
     recurse => true,
-    purge => true,
-    notify => Service['httpd'],
-  } 
+    purge   => true,
+    notify  => Service['httpd'],
+    require => Package['httpd'],
+  }
 }


### PR DESCRIPTION
The apache::params::vdir directory depends on the existence of the
httpd package, and trying to include the module may cause an ordering
failure. Added the necessary explicit ordering.
