### PR TITLE
Make management of firewalls configurable for vhosts

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -6,6 +6,8 @@
 # - The $port to configure the host on
 # - The $docroot provides the DocumentationRoot variable
 # - The $ssl option is set true or false to enable SSL for this Virtual Host
+# - The $configure_firewall option is set to true or false to specify if
+#   a firewall should be configured.
 # - The $template option specifies whether to use the default template or override
 # - The $priority of the site
 # - The $serveraliases of the site
@@ -28,16 +30,17 @@
 define apache::vhost(
     $port,
     $docroot,
-    $ssl           = $apache::params::ssl,
-    $template      = $apache::params::template,
-    $priority      = $apache::params::priority,
-    $servername    = $apache::params::servername,
-    $serveraliases = $apache::params::serveraliases,
-    $auth          = $apache::params::auth,
-    $redirect_ssl  = $apache::params::redirect_ssl,
-    $options       = $apache::params::options,
-    $apache_name   = $apache::params::apache_name,
-    $vhost_name    = $apache::params::vhost_name
+    $configure_firewall = true,
+    $ssl                = $apache::params::ssl,
+    $template           = $apache::params::template,
+    $priority           = $apache::params::priority,
+    $servername         = $apache::params::servername,
+    $serveraliases      = $apache::params::serveraliases,
+    $auth               = $apache::params::auth,
+    $redirect_ssl       = $apache::params::redirect_ssl,
+    $options            = $apache::params::options,
+    $apache_name        = $apache::params::apache_name,
+    $vhost_name         = $apache::params::vhost_name
   ) {
 
   include apache
@@ -72,12 +75,14 @@ define apache::vhost(
       notify  => Service['httpd'],
   }
 
-  if ! defined(Firewall["0100-INPUT ACCEPT $port"]) {
-    @firewall {
-      "0100-INPUT ACCEPT $port":
-        action => 'accept',
-        dport => "$port",
-        proto => 'tcp'
+  if $configure_firewall {
+    if ! defined(Firewall["0100-INPUT ACCEPT $port"]) {
+      @firewall {
+        "0100-INPUT ACCEPT $port":
+          action => 'accept',
+          dport => "$port",
+          proto => 'tcp'
+      }
     }
   }
 }


### PR DESCRIPTION
Previously, it was necessary to configure a firewall
entry for every port associated with a vhost.

This commit makes the confuration of firewalls for vhosts
configurable. This configuration option has been added to spare
users from having to configure firewalls if they do not wish
to.
