### PR TITLE
(#12902) Re-enable local php class

### DIFF
--- a/manifests/php.pp
+++ b/manifests/php.pp
@@ -13,10 +13,9 @@
 # Sample Usage:
 #
 class apache::php {
-	include php
-#  include apache::params
+  include apache::params
 
-#  package { $apache::params::php_package:
-#    ensure => present,
-#  }
+  package { $apache::params::php_package:
+    ensure => present,
+  }
 }


### PR DESCRIPTION
Previously, commit 8a56ee91 removed local control of the apache::php_package management in favor of "include php". However, no dependency was added to the Modulefile and to date the php module referenced in apache::php has not been released.

This commit implements one of the possible solutions, reinstating local class management of apache-related php packages to the apache::php class.
