### PR TITLE
(#13072) Move mod python and wsgi package names to params

### DIFF
--- a/manifests/mod/python.pp
+++ b/manifests/mod/python.pp
@@ -1,11 +1,8 @@
 class apache::mod::python {
   include apache
 
-  package { "python":
-    name => $operatingsystem ? {
-      'centos', 'fedora', 'redhat', 'scientific' => "mod_python",
-      default => "libapache2-mod-python",
-    },
+  package { "mod_python_package":
+    name    => $apache::params::mod_python_package,
     ensure  => installed,
     require => Package["httpd"];
   }

--- a/manifests/mod/wsgi.pp
+++ b/manifests/mod/wsgi.pp
@@ -1,11 +1,8 @@
 class apache::mod::wsgi {
   include apache
 
-  package { "wsgi":
-    name => $operatingsystem ? {
-      'centos', 'fedora', 'redhat', 'scientific' => "mod_wsgi",
-      default => "libapache2-mod-wsgi",
-    },
+  package { "mod_wsgi_package":
+    name    => $apache::params::mod_wsgi_package,
     ensure  => installed,
     require => Package["httpd"];
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,6 +34,8 @@ class apache::params {
     'centos', 'redhat', 'fedora', 'scientific': {
        $apache_name = 'httpd'
        $php_package = 'php'
+       $mod_python_package = 'mod_python'
+       $mod_wsgi_package = 'mod_wsgi'
        $ssl_package = 'mod_ssl'
        $apache_dev  = 'httpd-devel'
        $vdir = '/etc/httpd/conf.d/'
@@ -41,6 +43,8 @@ class apache::params {
     'ubuntu', 'debian': {
        $apache_name = 'apache2'
        $php_package = 'libapache2-mod-php5'
+       $mod_python_package = 'libapache2-mod-python'
+       $mod_wsgi_package = 'libapache2-mod-wsgi'
        $ssl_package = 'apache-ssl'
        $apache_dev  = [ 'libaprutil1-dev', 'libapr1-dev', 'apache2-prefork-dev' ]
        $vdir = '/etc/apache2/sites-enabled/'
@@ -48,6 +52,8 @@ class apache::params {
     default: {
        $apache_name = 'apache2'
        $php_package = 'libapache2-mod-php5'
+       $mod_python_package = 'libapache2-mod-python'
+       $mod_wsgi_package = 'libapache2-mod-wsgi'
        $ssl_package = 'apache-ssl'
        $apache_dev  = 'apache-dev'
        $vdir = '/etc/apache2/sites-enabled/'


### PR DESCRIPTION
Previously apache::mod::python and apache::mod::wsgi used
a case statement to determine which package to install. This
commit moves the package names to the params class and fixes
the syntax errors introduced in commit 2b79e8b when the
selectors were changed to include Scientific Linux.
