### PR TITLE
(#6899) Remove virtual a2mod definition

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,21 +25,6 @@ class apache {
     subscribe => Package['httpd'],
   }
 
-  # May want to purge all none realize modules using the resources resource type.
-  #
-  A2mod { require => Package['httpd'], notify => Service['httpd']}
-  case $operatingsystem {
-    'debian','ubuntu': {
-      @a2mod {
-       'rewrite' : ensure => present;
-       'headers' : ensure => present;
-       'expires' : ensure => present;
-      }
-    }
-    default: { }
-  }
-  
-  
   file { $apache::params::vdir:
     ensure  => directory,
     recurse => true,


### PR DESCRIPTION
Previously users were required to realize rewrite,
headers, and expires on debian systems. This commit
removes the virtual a2mod definition which makes the
three a2mod resources consistent with other operating
systems and other a2mod resources.
