### PR TITLE
Syntax error in a2mod.rb

### DIFF
--- a/lib/puppet/type/a2mod.rb
+++ b/lib/puppet/type/a2mod.rb
@@ -1,14 +1,14 @@
 Puppet::Type.newtype(:a2mod) do
-    @doc = "Manage Apache 2 modules on Debian and Ubuntu"
+  @doc = "Manage Apache 2 modules on Debian and Ubuntu"
 
-    ensurable
+  ensurable
 
-    newparam(:name) do
-       desc "The name of the module to be managed"
+  newparam(:name) do
+     desc "The name of the module to be managed"
 
-       isnamevar
+     isnamevar
 
-    end
-
-    autorequire(:package) { catalog.resource(:package, 'httpd') }
   end
+
+  autorequire(:package) { catalog.resource(:package, 'httpd') }
+end


### PR DESCRIPTION
I'm quite new to Puppet, so I may be missing something here, but I was getting this error:

```
Could not autoload a2mod: /tmp/vagrant-puppet/modules-0/apache/lib/puppet/type/a2mod.rb:16: syntax error, unexpected kEND, expecting $end at /tmp/vagrant-puppet/modules-0/hdo/manifests/init.pp:171 on node lucid32.wr
```

This change gets rid of an extra "end" in the file that fixes the problem for me. I was unable to run the tests as they seem to expect me to have code under `~/.puppet` that I don't know what should be.
