### PR TITLE
Fix broken tests for ssl, vhost, vhost::*

### DIFF
--- a/spec/classes/ssl_spec.rb
+++ b/spec/classes/ssl_spec.rb
@@ -2,28 +2,34 @@ require 'spec_helper'
 
 describe 'apache::ssl', :type => :class do
 
-  it { should include_class("apache") }
-  it { should include_class("apache::params") }
+  describe 'when running on an unsupported OS' do
+    let(:facts) { {:operatingsystem => 'MagicUnicorn'} }
+    it {
+      expect {
+        should raise_error(Puppet::Error, /not defined in apache::ssl/ )
+      }
+    }
+  end
 
-  describe "it should install the ssl package in redhat" do
-    let :facts do
-      { :operatingsystem => 'redhat' }
-    end
+  describe 'when running on a supported OS' do
+    let(:facts) { {:operatingsystem => 'redhat'} }
+    it { should include_class('apache') }
+    it { should include_class('apache::params') }
+  end
 
-    it { should contain_package("apache_ssl_package").with(
+  describe 'when running on redhat' do
+    let(:facts) { {:operatingsystem => 'redhat'} }
+    it {
+      should contain_package('apache_ssl_package').with(
         'ensure'  => 'installed'
       )
     }
   end
 
-  describe "it should contain a2mod ssl in debian" do
-    let :facts do
-      { :operatingsystem => 'debian' }
-    end
-
-    it { should contain_a2mod("ssl").with(
-        'ensure'  => 'present'
-      )
+  describe 'when running on debian' do
+    let(:facts) { {:operatingsystem => 'debian'} }
+    it {
+      should contain_a2mod('ssl').with('ensure'  => 'present')
     }
   end
 

--- a/spec/defines/vhost/proxy_spec.rb
+++ b/spec/defines/vhost/proxy_spec.rb
@@ -6,6 +6,9 @@ describe 'apache::vhost::proxy', :type => :define do
     'my_proxy_vhost'
   end
 
+  let :facts do
+    { :operatingsystem => 'redhat' }
+  end
 
   let :default_params do
     {
@@ -51,7 +54,7 @@ describe 'apache::vhost::proxy', :type => :define do
       it { should contain_file("#{param_hash[:priority]}-#{title}").with({
           'owner'     => 'root',
           'group'     => 'root',
-          'mode'      => '755',
+          'mode'      => '0755',
           'require'   => 'Package[httpd]',
           'notify'    => 'Service[httpd]'
         })

--- a/spec/defines/vhost/redirect_spec.rb
+++ b/spec/defines/vhost/redirect_spec.rb
@@ -38,7 +38,7 @@ describe 'apache::vhost::redirect', :type => :define do
       it { should contain_file("#{param_hash[:priority]}-#{title}").with({
           'owner'     => 'root',
           'group'     => 'root',
-          'mode'      => '755',
+          'mode'      => '0755',
           'require'   => 'Package[httpd]',
           'notify'    => 'Service[httpd]'
         })

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -57,7 +57,7 @@ describe 'apache::vhost', :type => :define do
       it { should contain_file("#{param_hash[:priority]}-#{title}.conf").with({
           'owner'     => 'root',
           'group'     => 'root',
-          'mode'      => '755',
+          'mode'      => '0755',
           'require'   => 'Package[httpd]',
           'notify'    => 'Service[httpd]'
         })


### PR DESCRIPTION
A number of tests were broken by the last few style commits when '755' became '0755' and the tests didn't get updated. This commit fixes the tests so that they work again.

The tests for apache::ssl were broken because the 'operatingsystem' fact was not being set in the tests. Don't know how long that's been busted, but in any case this commit fixes that problem as well by adding appropriate let(:facts).
