### PR TITLE
(#15008) enable AllowOverride setting in vhost

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,6 +29,7 @@ class apache::params {
   $auth          = false
   $redirect_ssl  = false
   $options       = 'Indexes FollowSymLinks MultiViews'
+  $override      = 'None'
   $vhost_name    = '*'
 
   case $::operatingsystem {

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -15,6 +15,7 @@
 # - The $servername is the primary name of the virtual host
 # - The $serveraliases of the site
 # - The $options for the given vhost
+# - The $override for the given vhost (array of AllowOverride arguments)
 # - The $vhost_name for name based virtualhosting, defaulting to *
 # - The $logroot specifies the location of the virtual hosts logfiles, default to /var/log/<apache log location>/
 #
@@ -44,6 +45,7 @@ define apache::vhost(
     $auth               = $apache::params::auth,
     $redirect_ssl       = $apache::params::redirect_ssl,
     $options            = $apache::params::options,
+    $override           = $apache::params::override,
     $apache_name        = $apache::params::apache_name,
     $vhost_name         = $apache::params::vhost_name,
     $logroot            = "/var/log/$apache::params::apache_name"

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -12,6 +12,7 @@ describe 'apache::vhost', :type => :define do
     :auth          => false,
     :docroot       => 'path/to/docroot',
     :options       => 'Indexes FollowSymLinks MultiViews',
+    :override      => 'None',
     :port          => '80',
     :priority      => '25',
     :redirect_ssl  => false,
@@ -26,6 +27,7 @@ describe 'apache::vhost', :type => :define do
   [{
       :apache_name   => 'httpd',
       :docroot       => 'path/to/docroot',
+      :override      => ['Options', 'FileInfo'],
       :port          => '80',
       :priority      => '25',
       :serveradmin   => 'serveradmin@puppet',

--- a/templates/test.vhost.erb
+++ b/templates/test.vhost.erb
@@ -5,9 +5,9 @@ NameVirtualHost *:80
 <VirtualHost *:80>
   ServerName testvhost
   DocumentRoot <%= docroot %>
-  <Directory <%= docroot %>> 
-    Options Indexes FollowSymLinks MultiViews
-    AllowOverride None
+  <Directory <%= docroot %>>
+    Options <%= options %>
+    AllowOverride <%= Array(override).join(' ') %>
     Order allow,deny
     allow from all
   </Directory>

--- a/templates/vhost-default.conf.erb
+++ b/templates/vhost-default.conf.erb
@@ -17,7 +17,7 @@ NameVirtualHost <%= vhost_name %>:<%= port %>
   DocumentRoot <%= docroot %>
   <Directory <%= docroot %>>
     Options <%= options %>
-    AllowOverride None
+    AllowOverride <%= Array(override).join(' ') %>
     Order allow,deny
     allow from all
   </Directory>

--- a/tests/vhost.pp
+++ b/tests/vhost.pp
@@ -1,6 +1,12 @@
 include apache
-apache::vhost { 'test.vhost':
-  port     => 80,
-  docroot  => '/tmp/testvhost',
-  template => 'apache/test.vhost.erb'
+apache::vhost {
+  'test.vhost':
+    port     => 80,
+    docroot  => '/tmp/testvhost',
+    template => 'apache/test.vhost.erb';
+  'test.vhost-override':
+    port     => 80,
+    docroot  => '/tmp/testvhost',
+    override => ['Options', 'FileInfo'],
+    template => 'apache/test.vhost.erb';
 }


### PR DESCRIPTION
Permit passing an `override` parameter to `apache::vhost`; its value will be
plugged into the `AllowOverride` directive inside the docroot
configuration. The default value is ‘None’, so default behavior of the
module should not change.

This pull request is associated with [issue #15009](https://projects.puppetlabs.com/issues/15008).
