### PR TITLE
virtualhost serveradmin configuration

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -31,6 +31,7 @@
 define apache::vhost(
     $port,
     $docroot,
+    $serveradmin,
     $configure_firewall = true,
     $ssl                = $apache::params::ssl,
     $template           = $apache::params::template,

--- a/templates/vhost-default.conf.erb
+++ b/templates/vhost-default.conf.erb
@@ -6,6 +6,9 @@
 NameVirtualHost <%= vhost_name %>:<%= port %>
 <VirtualHost <%= vhost_name %>:<%= port %>>
   ServerName <%= srvname %>
+<% if serveradmin %>
+  ServerAdmin <%= serveradmin %>
+<% end %>
 <% if serveraliases.is_a? Array -%>
 <% serveraliases.each do |name| -%><%= "  ServerAlias #{name}\n" %><% end -%>
 <% elsif serveraliases != '' -%>


### PR DESCRIPTION
Add ServerAdmin, if provided, to the virtual host.

I am in the process of migrating some existing system setups and adding this in allows for the generated template to match closer what is already in production.

This should not cause existing systems to have any changes if they do not wish to use the serveradmin variable.
