### PR TITLE
Some doc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Contributors
 Copyright and License
 ---------------------
 
-Copyright (C) 2012 Puppet Labs Inc
+Copyright (C) 2012 [Puppet Labs](https://www.puppetlabs.com/) Inc
 
 Puppet Labs can be contacted at: info@puppetlabs.com
 
@@ -61,7 +61,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
- update the English
- correct documentation to vhost_name rather than ipaddr (which was what my private version was using)
- make some of the links clickable when render on github
