### PR TITLE
Fix broken tests introduced in commit 98d91be

### DIFF
--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -28,6 +28,7 @@ describe 'apache::vhost', :type => :define do
       :docroot       => 'path/to/docroot',
       :port          => '80',
       :priority      => '25',
+      :serveradmin   => 'serveradmin@puppet',
       :ssl           => false,
       :template      => 'apache/vhost-default.conf.erb',
    },
@@ -58,7 +59,6 @@ describe 'apache::vhost', :type => :define do
           'owner'     => 'root',
           'group'     => 'root',
           'mode'      => '0755',
-          'require'   => 'Package[httpd]',
           'notify'    => 'Service[httpd]'
         })
       }


### PR DESCRIPTION
This commit adds the serveradmin param to the spec
tests and removes the test for require on the vhost
file resource since puppet-rspec can't handle arrays
