### PR TITLE
Update the documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Puppetlabs module for Apache
 ============================
 
 Apache is widely-used web server and this module will allow to configure
-various modules and setup virtual hosts with minimal effort
+various modules and setup virtual hosts with minimal effort.
 
 Basic usage
 -----------
@@ -23,16 +23,16 @@ example is:
 
     apache::vhost { 'www.example.com':
         priority        => '10',
-        ipaddr          => '192.0.2.1',
+        vhost_name      => '192.0.2.1',
         port            => '80',
     }
 
-A slightly more complicated example, which move the docroot and
-logfile to alternate location, might be:
+A slightly more complicated example, which moves the docroot and
+logfile to an alternate location, might be:
 
     apache::vhost { 'www.example.com':
         priority        => '10',
-        ipaddr          => '192.0.2.1',
+        vhost_name      => '192.0.2.1',
         port            => '80',
         docroot         => '/home/www.example.com/docroot/',
         logroot         => '/srv/www.example.com/logroot/',
@@ -53,7 +53,7 @@ Contributors
 Copyright and License
 ---------------------
 
-Copyright (C) 2012 Puppet Labs Inc
+Copyright (C) 2012 [Puppet Labs](https://www.puppetlabs.com/) Inc
 
 Puppet Labs can be contacted at: info@puppetlabs.com
 
@@ -61,7 +61,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+  http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Correct various bits and pieces so that the English is correct.

Replace instances of 'ipaddr' with 'vhost_name'.

 My earlier fork used ipaddr whereas the puppetlabs version uses
 vhost_name. Update the documentation to match the puppetlabs version.

Make some of the links in the README clickable

This is merely a re-spin on pull request #36
