### PR TITLE
Add Listen statement to vhost template

### DIFF
--- a/templates/vhost-default.conf.erb
+++ b/templates/vhost-default.conf.erb
@@ -3,6 +3,7 @@
 # Managed by Puppet
 # ************************************
 
+Listen <%= vhost_name %>:<%= port %>
 NameVirtualHost <%= vhost_name %>:<%= port %>
 <VirtualHost <%= vhost_name %>:<%= port %>>
   ServerName <%= srvname %>


### PR DESCRIPTION
Previously, the vhost-default.conf.erb template didn't include a
Listen statement that told Apache to listen on the required port.  This
commit provides that line.
