### PR TITLE
Remove single quoted variable declaration

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -100,7 +100,7 @@ define apache::vhost(
       @firewall {
         "0100-INPUT ACCEPT $port":
           action => 'accept',
-          dport  => '$port',
+          dport  => $port,
           proto  => 'tcp'
       }
     }


### PR DESCRIPTION
Previously, the vhost defined resource type included a Firewall
declaration that contained a single-quoted variable being dereferenced.
Because single-quotes are string-literal in Puppet, they had to be
removed (to allow for dereferencing the variable).
