### PR TITLE
Ensure proxy mods are loaded by vhost::proxy

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -49,6 +49,7 @@ class apache::params {
       $ssl_package = 'apache-ssl'
       $apache_dev  = ['libaprutil1-dev', 'libapr1-dev', 'apache2-prefork-dev']
       $vdir = '/etc/apache2/sites-enabled/'
+      $proxy_modules  = ['proxy', 'proxy_http']
     }
     default: {
       $apache_name = 'apache2'
@@ -58,6 +59,7 @@ class apache::params {
       $ssl_package = 'apache-ssl'
       $apache_dev  = 'apache-dev'
       $vdir = '/etc/apache2/sites-enabled/'
+      $proxy_modules  = ['proxy', 'proxy_http']
     }
   }
 }

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -1,0 +1,21 @@
+# Class: apache::proxy
+#
+# This class enabled the proxy module for Apache
+#
+# Actions:
+#   - Enables Apache Proxy module
+#
+# Requires:
+#
+# Sample Usage:
+#
+class apache::proxy {
+  include apache::params
+  include apache
+
+  a2mod { $apache::params::proxy_modules:
+    ensure => present,
+    before => Service[httpd]
+  }
+
+}

--- a/manifests/vhost/proxy.pp
+++ b/manifests/vhost/proxy.pp
@@ -30,6 +30,7 @@ define apache::vhost::proxy (
   ) {
 
   include apache
+  include apache::proxy
 
   $apache_name = $apache::params::apache_name
   $ssl_path = $apache::params::ssl_path


### PR DESCRIPTION
At the moment, defining an apache::vhost::proxy resource will lead to
Apache failing to start by default. This is because nothing ensures the
relevant proxy modules are loaded into Apache. This patch fixes that on
Debian and Ubuntu. Hopefully, someone can fill in the blanks on the
RedHat family of operating systems.
