### PR TITLE
Add no_proxy_uris param to apache::vhost::proxy

### DIFF
--- a/manifests/vhost/proxy.pp
+++ b/manifests/vhost/proxy.pp
@@ -26,7 +26,8 @@ define apache::vhost::proxy (
     $servername    = '',
     $serveraliases = '',
     $ssl           = false,
-    $vhost_name    = '*'
+    $vhost_name    = '*',
+    $no_proxy_uris = []
   ) {
 
   include apache

--- a/templates/vhost-proxy.conf.erb
+++ b/templates/vhost-proxy.conf.erb
@@ -16,6 +16,10 @@ NameVirtualHost <%= vhost_name %>:<%= port %>
      Order deny,allow
      Allow from all
    </Proxy>
+
+<% for uri in no_proxy_uris %>
+   ProxyPass        <%= uri %> !
+<% end %>
    ProxyPass        / <%= dest %>/
    ProxyPassReverse / <%= dest %>/
    ProxyPreserveHost On 


### PR DESCRIPTION
Add a mechanism to prevent certain URI's from being proxied.

This is particularly useful if you want to specify a proxy vhost pointed
at a webapp that installs itself under /SOME_URI in Apache's global
configuration. This is common on Debian and derivatives. Adding a vhost
for these is now as simple as:

   apache::vhost::proxy { 'manage.example.com':
     port          => 80,
     dest          => 'http://localhost/openstack-dashboard',
     no_proxy_uris => '/openstack-dashboard'
   }

Without this, you can easily get caught in an infinite, internal
redirect loop.
