### PR TITLE
Modified vhost type to use ensure_resource

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -9,4 +9,3 @@ project_page 'https://github.com/puppetlabs/puppetlabs-apache'
 
 ## Add dependencies, if any:
 dependency 'puppetlabs/firewall', '>= 0.0.4'
-dependency 'bodepd/puppet-ensure_resource', '>= 0'

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -73,10 +73,18 @@ define apache::vhost(
 
   # This ensures that the docroot exists
   # But enables it to be specified across multiple vhost resources
-  ensure_resource('file', $docroot, {'ensure' => 'directory'})
+  if ! defined(File[$docroot]) {
+    file { $docroot:
+      ensure => directory,
+    }
+  }
 
-  # This does the same thing, but for the logroot dir
-  ensure_resource('file', $logroot, {'ensure' => 'directory'})
+  # Same as above, but for logroot
+  if ! defined(File[$logroot]) {
+    file { $logroot:
+      ensure => directory,
+    }
+  }
 
   file { "${priority}-${name}.conf":
       path    => "${apache::params::vdir}/${priority}-${name}.conf",


### PR DESCRIPTION
Hello,

As discussed [here](https://groups.google.com/forum/?fromgroups#!topic/puppet-users/kogpkDOXKgc) and [here](https://github.com/puppetlabs/puppetlabs-apache/commit/c2c75a62b7dafced8a6120a14bacfc8be7539282#commitcomment-1654941), these changes allow multiple vhosts to be defined that share the same docroot and/or logroot.

Thanks,
Joe
