### PR TITLE
Make the serveradmin vhost parameter optional

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -34,7 +34,7 @@
 define apache::vhost(
     $port,
     $docroot,
-    $serveradmin,
+    $serveradmin        = false,
     $configure_firewall = true,
     $ssl                = $apache::params::ssl,
     $template           = $apache::params::template,


### PR DESCRIPTION
The original committer I think intended for this to be optional, but without a
default the serveradmin parameter is required.
