### PR TITLE
Update whitespace for puppet lint

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,34 +34,34 @@ class apache::params {
 
   case $::operatingsystem {
     'centos', 'redhat', 'fedora', 'scientific', 'amazon': {
-      $apache_name = 'httpd'
-      $php_package = 'php'
-      $mod_python_package = 'mod_python'
-      $mod_wsgi_package = 'mod_wsgi'
+      $apache_name           = 'httpd'
+      $php_package           = 'php'
+      $mod_python_package    = 'mod_python'
+      $mod_wsgi_package      = 'mod_wsgi'
       $mod_auth_kerb_package = 'mod_auth_kerb'
-      $ssl_package = 'mod_ssl'
-      $apache_dev  = 'httpd-devel'
-      $vdir = '/etc/httpd/conf.d/'
+      $ssl_package           = 'mod_ssl'
+      $apache_dev            = 'httpd-devel'
+      $vdir                  = '/etc/httpd/conf.d/'
     }
     'ubuntu', 'debian': {
-      $apache_name = 'apache2'
-      $php_package = 'libapache2-mod-php5'
-      $mod_python_package = 'libapache2-mod-python'
-      $mod_wsgi_package = 'libapache2-mod-wsgi'
+      $apache_name           = 'apache2'
+      $php_package           = 'libapache2-mod-php5'
+      $mod_python_package    = 'libapache2-mod-python'
+      $mod_wsgi_package      = 'libapache2-mod-wsgi'
       $mod_auth_kerb_package = 'libapache2-mod-auth-kerb'
-      $ssl_package = 'apache-ssl'
-      $apache_dev  = ['libaprutil1-dev', 'libapr1-dev', 'apache2-prefork-dev']
-      $vdir = '/etc/apache2/sites-enabled/'
+      $ssl_package           = 'apache-ssl'
+      $apache_dev            = ['libaprutil1-dev', 'libapr1-dev', 'apache2-prefork-dev']
+      $vdir                  = '/etc/apache2/sites-enabled/'
     }
     default: {
-      $apache_name = 'apache2'
-      $php_package = 'libapache2-mod-php5'
-      $mod_python_package = 'libapache2-mod-python'
-      $mod_wsgi_package = 'libapache2-mod-wsgi'
+      $apache_name           = 'apache2'
+      $php_package           = 'libapache2-mod-php5'
+      $mod_python_package    = 'libapache2-mod-python'
+      $mod_wsgi_package      = 'libapache2-mod-wsgi'
       $mod_auth_kerb_package = 'libapache2-mod-auth-kerb'
-      $ssl_package = 'apache-ssl'
-      $apache_dev  = 'apache-dev'
-      $vdir = '/etc/apache2/sites-enabled/'
+      $ssl_package           = 'apache-ssl'
+      $apache_dev            = 'apache-dev'
+      $vdir                  = '/etc/apache2/sites-enabled/'
     }
   }
 }

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -5,7 +5,8 @@
 # Parameters:
 # - The $port to configure the host on
 # - The $docroot provides the DocumentationRoot variable
-# - The $serveradmin will specify an email address for Apache that it will display when it renders one of it's error pages
+# - The $serveradmin will specify an email address for Apache that it will
+#   display when it renders one of it's error pages
 # - The $configure_firewall option is set to true or false to specify if
 #   a firewall should be configured.
 # - The $ssl option is set true or false to enable SSL for this Virtual Host
@@ -17,7 +18,8 @@
 # - The $options for the given vhost
 # - The $override for the given vhost (array of AllowOverride arguments)
 # - The $vhost_name for name based virtualhosting, defaulting to *
-# - The $logroot specifies the location of the virtual hosts logfiles, default to /var/log/<apache log location>/
+# - The $logroot specifies the location of the virtual hosts logfiles, default
+#   to /var/log/<apache log location>/
 # - The $ensure specifies if vhost file is present or absent.
 #
 # Actions:
@@ -56,7 +58,7 @@ define apache::vhost(
   validate_re($ensure, [ '^present$', '^absent$' ],
   "${ensure} is not supported for ensure.
   Allowed values are 'present' and 'absent'.")
-  
+
   include apache
 
   if $servername == '' {
@@ -108,7 +110,7 @@ define apache::vhost(
     ],
     notify  => Service['httpd'],
   }
-  
+
   if $configure_firewall {
     if ! defined(Firewall["0100-INPUT ACCEPT $port"]) {
       @firewall {

--- a/templates/vhost-proxy.conf.erb
+++ b/templates/vhost-proxy.conf.erb
@@ -11,22 +11,21 @@ NameVirtualHost <%= vhost_name %>:<%= port %>
 <% elsif serveraliases != '' %>
 <%= "  ServerAlias #{serveraliases}" %>
 <% end %>
-   ProxyRequests Off
-   <Proxy *>
-     Order deny,allow
-     Allow from all
-   </Proxy>
+  ProxyRequests Off
+  <Proxy *>
+    Order deny,allow
+    Allow from all
+  </Proxy>
 
 <% for uri in no_proxy_uris %>
-   ProxyPass        <%= uri %> !
+  ProxyPass        <%= uri %> !
 <% end %>
-   ProxyPass        / <%= dest %>/
-   ProxyPassReverse / <%= dest %>/
-   ProxyPreserveHost On 
+  ProxyPass        / <%= dest %>/
+  ProxyPassReverse / <%= dest %>/
+  ProxyPreserveHost On 
 
-   ErrorLog /var/log/<%= scope.lookupvar("apache::params::apache_name") %>/<%= name %>_error.log
-   LogLevel warn
-   CustomLog /var/log/<%= scope.lookupvar("apache::params::apache_name") %>/<%= name %>_access.log combined
-
+  ErrorLog /var/log/<%= scope.lookupvar("apache::params::apache_name") %>/<%= name %>_error.log
+  LogLevel warn
+  CustomLog /var/log/<%= scope.lookupvar("apache::params::apache_name") %>/<%= name %>_access.log combined
 </VirtualHost>
 


### PR DESCRIPTION
- Align = signs in apache::param for readibility
- Keep comment lines from passing 80 characters
- Correct indentation in vhost proxy template
