### PR TITLE
Use $osfamily instead of $operatingsystem

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,36 +32,32 @@ class apache::params {
   $override      = 'None'
   $vhost_name    = '*'
 
-  case $::operatingsystem {
-    'centos', 'redhat', 'fedora', 'scientific', 'amazon': {
-      $apache_name           = 'httpd'
-      $php_package           = 'php'
-      $mod_python_package    = 'mod_python'
-      $mod_wsgi_package      = 'mod_wsgi'
-      $mod_auth_kerb_package = 'mod_auth_kerb'
-      $ssl_package           = 'mod_ssl'
-      $apache_dev            = 'httpd-devel'
-      $vdir                  = '/etc/httpd/conf.d/'
-    }
-    'ubuntu', 'debian': {
-      $apache_name           = 'apache2'
-      $php_package           = 'libapache2-mod-php5'
-      $mod_python_package    = 'libapache2-mod-python'
-      $mod_wsgi_package      = 'libapache2-mod-wsgi'
-      $mod_auth_kerb_package = 'libapache2-mod-auth-kerb'
-      $ssl_package           = 'apache-ssl'
-      $apache_dev            = ['libaprutil1-dev', 'libapr1-dev', 'apache2-prefork-dev']
-      $vdir                  = '/etc/apache2/sites-enabled/'
-    }
-    default: {
-      $apache_name           = 'apache2'
-      $php_package           = 'libapache2-mod-php5'
-      $mod_python_package    = 'libapache2-mod-python'
-      $mod_wsgi_package      = 'libapache2-mod-wsgi'
-      $mod_auth_kerb_package = 'libapache2-mod-auth-kerb'
-      $ssl_package           = 'apache-ssl'
-      $apache_dev            = 'apache-dev'
-      $vdir                  = '/etc/apache2/sites-enabled/'
-    }
+  if $::osfamily == 'redhat' or $::operatingsystem == 'amazon' {
+    $apache_name           = 'httpd'
+    $php_package           = 'php'
+    $mod_python_package    = 'mod_python'
+    $mod_wsgi_package      = 'mod_wsgi'
+    $mod_auth_kerb_package = 'mod_auth_kerb'
+    $ssl_package           = 'mod_ssl'
+    $apache_dev            = 'httpd-devel'
+    $vdir                  = '/etc/httpd/conf.d/'
+  } elsif $::osfamily == 'debian' {
+    $apache_name           = 'apache2'
+    $php_package           = 'libapache2-mod-php5'
+    $mod_python_package    = 'libapache2-mod-python'
+    $mod_wsgi_package      = 'libapache2-mod-wsgi'
+    $mod_auth_kerb_package = 'libapache2-mod-auth-kerb'
+    $ssl_package           = 'apache-ssl'
+    $apache_dev            = ['libaprutil1-dev', 'libapr1-dev', 'apache2-prefork-dev']
+    $vdir                  = '/etc/apache2/sites-enabled/'
+  } else {
+    $apache_name           = 'apache2'
+    $php_package           = 'libapache2-mod-php5'
+    $mod_python_package    = 'libapache2-mod-python'
+    $mod_wsgi_package      = 'libapache2-mod-wsgi'
+    $mod_auth_kerb_package = 'libapache2-mod-auth-kerb'
+    $ssl_package           = 'apache-ssl'
+    $apache_dev            = 'apache-dev'
+    $vdir                  = '/etc/apache2/sites-enabled/'
   }
 }

--- a/manifests/ssl.pp
+++ b/manifests/ssl.pp
@@ -16,19 +16,15 @@ class apache::ssl {
 
   include apache
 
-  case $::operatingsystem {
-    'centos', 'fedora', 'redhat', 'scientific', 'amazon': {
-      package { 'apache_ssl_package':
-        ensure  => installed,
-        name    => $apache::params::ssl_package,
-        require => Package['httpd'],
-      }
+  if $::osfamily == 'redhat' or $::operatingsystem == 'amazon' {
+    package { 'apache_ssl_package':
+      ensure  => installed,
+      name    => $apache::params::ssl_package,
+      require => Package['httpd'],
     }
-    'ubuntu', 'debian': {
-      a2mod { 'ssl': ensure => present, }
-    }
-    default: {
-      fail( "${::operatingsystem} not defined in apache::ssl.")
-    }
+  } elsif $::osfamily == 'debian' {
+    a2mod { 'ssl': ensure => present, }
+  } else {
+    fail( "${::operatingsystem} not defined in apache::ssl.")
   }
 }

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -73,11 +73,8 @@ define apache::vhost(
 
   # Since the template will use auth, redirect to https requires mod_rewrite
   if $redirect_ssl == true {
-    case $::operatingsystem {
-      'debian','ubuntu': {
-        A2mod <| title == 'rewrite' |>
-      }
-      default: { }
+    if $::osfamily == 'debian' {
+      A2mod <| title == 'rewrite' |>
     }
   }
 

--- a/spec/classes/ssl_spec.rb
+++ b/spec/classes/ssl_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'apache::ssl', :type => :class do
 
   describe 'when running on an unsupported OS' do
-    let(:facts) { {:operatingsystem => 'MagicUnicorn'} }
+    let(:facts) { {:operatingsystem => 'MagicUnicorn', :osfamily => 'Magic'} }
     it {
       expect {
         should raise_error(Puppet::Error, /not defined in apache::ssl/ )
@@ -12,13 +12,13 @@ describe 'apache::ssl', :type => :class do
   end
 
   describe 'when running on a supported OS' do
-    let(:facts) { {:operatingsystem => 'redhat'} }
+    let(:facts) { {:operatingsystem => 'redhat', :osfamily => 'redhat'} }
     it { should include_class('apache') }
     it { should include_class('apache::params') }
   end
 
   describe 'when running on redhat' do
-    let(:facts) { {:operatingsystem => 'redhat'} }
+    let(:facts) { {:operatingsystem => 'redhat', :osfamily => 'redhat'} }
     it {
       should contain_package('apache_ssl_package').with(
         'ensure'  => 'installed'
@@ -27,7 +27,7 @@ describe 'apache::ssl', :type => :class do
   end
 
   describe 'when running on debian' do
-    let(:facts) { {:operatingsystem => 'debian'} }
+    let(:facts) { {:operatingsystem => 'debian', :osfamily => 'debian'} }
     it {
       should contain_a2mod('ssl').with('ensure'  => 'present')
     }

--- a/spec/defines/vhost/proxy_spec.rb
+++ b/spec/defines/vhost/proxy_spec.rb
@@ -7,7 +7,10 @@ describe 'apache::vhost::proxy', :type => :define do
   end
 
   let :facts do
-    { :operatingsystem => 'redhat' }
+    {
+      :operatingsystem => 'redhat',
+      :osfamily        => 'redhat'
+    }
   end
 
   let :default_params do


### PR DESCRIPTION
$osfamily is widely supported and allows for more OS support than
$operatingsystem. Amazon is not yet included in the "redhat" family, but
has http://projects.puppetlabs.com/issues/15792 filed.

Closes #39
