### PR TITLE
Split the userdir module out of the default list and template UserDir

### DIFF
--- a/manifests/mod/default.pp
+++ b/manifests/mod/default.pp
@@ -47,7 +47,6 @@ class apache::mod::default {
   apache::mod { 'speling': }
   apache::mod { 'status': }
   apache::mod { 'suexec': }
-  apache::mod { 'userdir': }
   apache::mod { 'usertrack': }
   apache::mod { 'version': }
   apache::mod { 'vhost_alias': }

--- a/manifests/mod/userdir.pp
+++ b/manifests/mod/userdir.pp
@@ -1,0 +1,11 @@
+class apache::mod::userdir (
+  $dir = 'public_html',
+) {
+  apache::mod { 'userdir': }
+
+  # Template uses $dir
+  file { "${apache::params::vdir}/userdir.conf":
+    ensure  => present,
+    content => template('apache/mod/userdir.conf.erb'),
+  }
+}

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -265,35 +265,6 @@ DocumentRoot "/var/www/html"
 </Directory>
 
 #
-# UserDir: The name of the directory that is appended onto a user's home
-# directory if a ~user request is received.
-#
-# The path to the end user account 'public_html' directory must be
-# accessible to the webserver userid.  This usually means that ~userid
-# must have permissions of 711, ~userid/public_html must have permissions
-# of 755, and documents contained therein must be world-readable.
-# Otherwise, the client will only receive a "403 Forbidden" message.
-#
-# See also: http://httpd.apache.org/docs/misc/FAQ.html#forbidden
-#
-<IfModule mod_userdir.c>
-    #
-    # UserDir is disabled by default since it can confirm the presence
-    # of a username on the system (depending on home directory
-    # permissions).
-    #
-    UserDir disable
-
-    #
-    # To enable requests to /~user/ to serve the user's public_html
-    # directory, remove the "UserDir disable" line above, and uncomment
-    # the following line instead:
-    # 
-    #UserDir public_html
-
-</IfModule>
-
-#
 # Control access to UserDir directories.  The following is an example
 # for a site where these directories are restricted to read-only.
 #

--- a/templates/mod/userdir.conf.erb
+++ b/templates/mod/userdir.conf.erb
@@ -1,0 +1,29 @@
+#
+# UserDir: The name of the directory that is appended onto a user's home
+# directory if a ~user request is received.
+#
+# The path to the end user account 'public_html' directory must be
+# accessible to the webserver userid.  This usually means that ~userid
+# must have permissions of 711, ~userid/public_html must have permissions
+# of 755, and documents contained therein must be world-readable.
+# Otherwise, the client will only receive a "403 Forbidden" message.
+#
+# See also: http://httpd.apache.org/docs/misc/FAQ.html#forbidden
+#
+<IfModule mod_userdir.c>
+    #
+    # UserDir is disabled by default since it can confirm the presence
+    # of a username on the system (depending on home directory
+    # permissions).
+    #
+    #UserDir disable
+
+    #
+    # To enable requests to /~user/ to serve the user's public_html
+    # directory, remove the "UserDir disable" line above, and uncomment
+    # the following line instead:
+    # 
+    #UserDir public_html
+
+    UserDir <%= dir %>
+</IfModule>


### PR DESCRIPTION
This is an example of templating an Apache mod configuration directive paired with a mod load. This class may be included on a per-node basis to enable Apache's `userdir` mod.
