### PR TITLE
Add apache::mod::proxy_html

### DIFF
--- a/manifests/mod/proxy_html.pp
+++ b/manifests/mod/proxy_html.pp
@@ -1,0 +1,10 @@
+class apache::mod::proxy_html {
+  Class[apache::mod::proxy] -> Class[apache::mod::proxy_html]
+  Class[apache::mod::proxy_http] -> Class[apache::mod::proxy_html]
+  apache::mod { 'proxy_html': }
+  # proxy_html uses libxml2 so we need to load this .so
+  file { "${apache::params::mod_dir}/libxml2.load":
+    ensure  => present,
+    content => "LoadFile /usr/lib/libxml2.so.2\n",
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -46,13 +46,14 @@ class apache::params {
     $vdir                  = "${httpd_dir}/conf.d"
     $conf_file             = 'httpd.conf'
     $mod_packages          = {
-      'dev'    => 'httpd-devel',
-      'fcgid'  => 'mod_fcgid',
-      'perl'   => 'mod_perl',
-      'php5'   => 'php',
-      'python' => 'mod_python',
-      'ssl'    => 'mod_ssl',
-      'wsgi'   => 'mod_wsgi',
+      'dev'        => 'httpd-devel',
+      'fcgid'      => 'mod_fcgid',
+      'perl'       => 'mod_perl',
+      'php5'       => 'php',
+      'proxy_html' => 'mod_proxy_html',
+      'python'     => 'mod_python',
+      'ssl'        => 'mod_ssl',
+      'wsgi'       => 'mod_wsgi',
     }
     $mod_libs              = {
       'php5' => 'libphp5.so',


### PR DESCRIPTION
`mod_proxy_html` is a commonly-used third-party module. This code allows this mod to be loaded for use if the correct package is available for installation.
