### PR TITLE
Add server_admin parameter to the apache base class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,8 @@
 # Sample Usage:
 #
 class apache (
-  $default_mods = true
+  $default_mods = true,
+  $server_admin = 'root@localhost'
 ) {
   include apache::params
 
@@ -43,6 +44,7 @@ class apache (
     # - $apache::params::user
     # - $apache::params::group
     # - $apache::params::conf_dir
+    # - $server_admin
     file { "${apache::params::conf_dir}/${apache::params::conf_file}":
       ensure  => present,
       content => template("apache/${apache::params::conf_file}.erb"),

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -178,7 +178,7 @@ Group <%= scope.lookupvar('apache::params::group') %>
 # e-mailed.  This address appears on some server-generated pages, such
 # as error documents.  e.g. admin@your-domain.com
 #
-ServerAdmin root@localhost
+ServerAdmin <%= server_admin %>
 
 #
 # ServerName gives the name and port that the server uses to identify itself.


### PR DESCRIPTION
This adds a parameter to be able to set the global `ServerAdmin` apache directive.
