### PR TITLE
Change `server_admin` parameter to `serveradmin`

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,7 @@
 #
 class apache (
   $default_mods = true,
-  $server_admin = 'root@localhost'
+  $serveradmin = 'root@localhost'
 ) {
   include apache::params
 
@@ -44,7 +44,7 @@ class apache (
     # - $apache::params::user
     # - $apache::params::group
     # - $apache::params::conf_dir
-    # - $server_admin
+    # - $serveradmin
     file { "${apache::params::conf_dir}/${apache::params::conf_file}":
       ensure  => present,
       content => template("apache/${apache::params::conf_file}.erb"),

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -178,7 +178,7 @@ Group <%= scope.lookupvar('apache::params::group') %>
 # e-mailed.  This address appears on some server-generated pages, such
 # as error documents.  e.g. admin@your-domain.com
 #
-ServerAdmin <%= server_admin %>
+ServerAdmin <%= serveradmin %>
 
 #
 # ServerName gives the name and port that the server uses to identify itself.


### PR DESCRIPTION
The parameter for `apache::vhost` is `serveradmin`. This commit changes
the recently-added `server_admin` parameter to match this to avoid being
backwards incompatible upon release.
