### PR TITLE
mod.pp: we should make sure the package is present before enabling the module

### DIFF
--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -18,13 +18,14 @@ define apache::mod (
     package { $package_REAL:
       ensure  => present,
       require => Package['httpd'],
+      before  => A2mod[$module],
     }
   }
 
   a2mod { $module:
     ensure  => present,
     lib     => $lib,
-    require => [Package['httpd'], Package[$package_REAL]],
+    require => Package['httpd'],
     notify  => Service['httpd']
   }
 }


### PR DESCRIPTION
If a package is defined for a given apache module, then its success or failure to install should also prevent or allow the module to be enabled.

This pull request is backwards compatible.

Closes #73
