### PR TITLE
Remove apache::mod::file_cache from apache::mod::default

### DIFF
--- a/manifests/mod/default.pp
+++ b/manifests/mod/default.pp
@@ -25,7 +25,6 @@ class apache::mod::default {
   apache::mod { 'env': }
   apache::mod { 'expires': }
   apache::mod { 'ext_filter': }
-  apache::mod { 'file_cache': }
   apache::mod { 'headers': }
   apache::mod { 'include': }
   apache::mod { 'info': }


### PR DESCRIPTION
The default apache configuration on CentOS 5 has file_cache enabled, but
no configuration directives for its use. CentOS 6 doesn't even ship with
this module installed by default, and the service will fail to start
when this module is included.

If someone needs to use this module, they can conditionally include it
and template any configuration directives.
