### PR TITLE
Remove apache::mod::mem_cache from apache::mod::default

### DIFF
--- a/manifests/mod/default.pp
+++ b/manifests/mod/default.pp
@@ -31,7 +31,6 @@ class apache::mod::default {
   apache::mod { 'ldap': }
   apache::mod { 'log_config': }
   apache::mod { 'logio': }
-  apache::mod { 'mem_cache': }
   apache::mod { 'mime': }
   apache::mod { 'mime_magic': }
   apache::mod { 'negotiation': }


### PR DESCRIPTION
As per
http://docs.redhat.com/docs/en-US/Red_Hat_Enterprise_Linux/6/html/Migration_Planning_Guide/ch04s04.html
mem_cache is also no longer supported by redhat.
