### PR TITLE
(#16064) Make config files RedHat-compatible

### DIFF
--- a/manifests/vhost/proxy.pp
+++ b/manifests/vhost/proxy.pp
@@ -41,8 +41,8 @@ define apache::vhost::proxy (
     include apache::mod::ssl
   }
 
-  file { "${priority}-${name}":
-    path    => "${apache::params::vdir}/${priority}-${name}",
+  file { "${priority}-${name}.conf":
+    path    => "${apache::params::vdir}/${priority}-${name}.conf",
     content => template($template),
     owner   => 'root',
     group   => 'root',

--- a/manifests/vhost/redirect.pp
+++ b/manifests/vhost/redirect.pp
@@ -30,8 +30,8 @@ define apache::vhost::redirect (
 
   $srvname = $name
 
-  file { "${priority}-${name}":
-    path    => "${apache::params::vdir}/${priority}-${name}",
+  file { "${priority}-${name}.conf":
+    path    => "${apache::params::vdir}/${priority}-${name}.conf",
     content => template($template),
     owner   => 'root',
     group   => 'root',


### PR DESCRIPTION
The `apache::vhost::proxy` and `apache::vhost::redirect` types create
config files of the general form “${priority}–${name}”. Unfortunately,
on RedHat systems these files are not properly sourced by Apache, and so
their configurations are ignored. Line 221 of
`/etc/httpd/conf/httpd.conf` (on RHEL6 systems; there is a similar
directive in other RHEL releases) is as follows:

   Include conf.d/*.conf

This issue does not appear on Debian systems because Debian systems
include the entire directory, rather than filtering by filename
extension.
