### PR TITLE
Fix vhost template

### DIFF
--- a/templates/vhost-default.conf.erb
+++ b/templates/vhost-default.conf.erb
@@ -12,7 +12,7 @@ NameVirtualHost <%= vhost_name %>:<%= port %>
 <% if serveraliases.is_a? Array -%>
 <% serveraliases.each do |name| -%><%= "  ServerAlias #{name}\n" %><% end -%>
 <% elsif serveraliases != '' -%>
-<%= "  ServerAlias #{serveraliases}\n" -%>
+<%= "  ServerAlias #{serveraliases}" %>
 <% end -%>
   DocumentRoot <%= docroot %>
   <Directory <%= docroot %>>


### PR DESCRIPTION
Added a new line character at the end of `$serveraliases` when it is a string and not an array.

Closes #86
