### PR TITLE
Added quotes to package resource title.

### DIFF
--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -15,7 +15,7 @@ define apache::mod (
   }
 
   if $package_REAL {
-    package { "$package_REAL":
+    package { "${package_REAL}":
       ensure  => present,
       require => Package['httpd'],
       before  => A2mod[$module],


### PR DESCRIPTION
If a package title contains hyphens, it needs to be enclosed in double quotes.
