### PR TITLE
(#16134) Quote class names inside relationships

### DIFF
--- a/manifests/mod/dav_fs.pp
+++ b/manifests/mod/dav_fs.pp
@@ -1,4 +1,4 @@
 class apache::mod::dav_fs {
-  Class[apache::mod::dav] -> Class[apache::mod::dav_fs]
+  Class['apache::mod::dav'] -> Class['apache::mod::dav_fs']
   apache::mod { 'dav_fs': }
 }

--- a/manifests/mod/disk_cache.pp
+++ b/manifests/mod/disk_cache.pp
@@ -1,8 +1,8 @@
 class apache::mod::disk_cache (
   $cache_root = '/var/cache/mod_proxy'
 ) {
-  Class[apache::mod::proxy] -> Class[apache::mod::disk_cache]
-  Class[apache::mod::cache] -> Class[apache::mod::disk_cache]
+  Class['apache::mod::proxy'] -> Class['apache::mod::disk_cache']
+  Class['apache::mod::cache'] -> Class['apache::mod::disk_cache']
 
   apache::mod { 'disk_cache': }
   # Template uses $cache_proxy

--- a/manifests/mod/proxy_html.pp
+++ b/manifests/mod/proxy_html.pp
@@ -1,6 +1,6 @@
 class apache::mod::proxy_html {
-  Class[apache::mod::proxy] -> Class[apache::mod::proxy_html]
-  Class[apache::mod::proxy_http] -> Class[apache::mod::proxy_html]
+  Class['apache::mod::proxy'] -> Class['apache::mod::proxy_html']
+  Class['apache::mod::proxy_http'] -> Class['apache::mod::proxy_html']
   apache::mod { 'proxy_html': }
   # proxy_html uses libxml2 so we need to load this .so
   file { "${apache::params::mod_dir}/libxml2.load":

--- a/manifests/mod/proxy_http.pp
+++ b/manifests/mod/proxy_http.pp
@@ -1,4 +1,4 @@
 class apache::mod::proxy_http {
-  Class[apache::mod::proxy] -> Class[apache::mod::proxy_http]
+  Class['apache::mod::proxy'] -> Class['apache::mod::proxy_http']
   apache::mod { 'proxy_http': }
 }


### PR DESCRIPTION
Prior to this commit, the chaining resource relationship syntax
used in several of the apache::mod::\* manifests specified class
relationships without quoting the class names. Apparently, this
broke the parser in Puppet 2.6.x. This commit wraps those class
names inside single quotes, making the 2.6 & 2.7 parser happy.
