### PR TITLE
Added Dependencies to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ logfile to an alternate location, might be:
         serveraliases   => ['example.com',],
     }
 
+Dependencies
+------------
+
+Some functionality is dependent on other modules:
+
+- [stdlib](https://github.com/puppetlabs/puppetlabs-stdlib)
+- [firewall](https://github.com/puppetlabs/puppetlabs-firewall)
+
 Notes
 -----
 


### PR DESCRIPTION
Using the vhost class requires the "stdlib" and "firewall" modules, which is not documented anwhere.
