### PR TITLE
Added rspec tests for apache::mod define

### DIFF
--- a/spec/defines/mod_spec.rb
+++ b/spec/defines/mod_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'apache::mod', :type => :define do
+  context "On a Red Hat OS with shibboleth module and package param passed" do
+    let :facts do
+      { :osfamily => 'redhat' }
+    end
+    # name/title for the apache::mod define
+    let :title do
+      'xsendfile'
+    end
+    # parameters
+    let(:params) { {:package => 'mod_xsendfile'} }
+
+    it { should include_class("apache::params") }
+    it { should contain_package('mod_xsendfile') }
+  end
+
+  context "On a Red Hat OS with shibboleth module" do
+    let :facts do
+      { :osfamily => 'redhat' }
+    end
+    let :title do
+      'shibboleth'
+    end
+    it { should include_class("apache::params") }
+    it { should contain_package('shibboleth') }
+    it do
+      should contain_a2mod(title).with({
+        'ensure'     => 'present',
+        'identifier' => 'mod_shib',
+      })
+    end
+  end
+end


### PR DESCRIPTION
Right now rspec tests cover only classes that use apache::mod define (spec/classes/mod/*). I've added rspec tests for the apache::mod define itself. Any comments or suggestions are welcome.
