### PR TITLE
Allow overriding servername in apache::vhost::redirect

### DIFF
--- a/manifests/vhost/redirect.pp
+++ b/manifests/vhost/redirect.pp
@@ -23,12 +23,17 @@ define apache::vhost::redirect (
     $priority      = '10',
     $serveraliases = '',
     $template      = 'apache/vhost-redirect.conf.erb',
+    $servername    = $apache::params::servername,
     $vhost_name    = '*'
   ) {
 
   include apache
 
-  $srvname = $name
+  if $servername == '' {
+    $srvname = $name
+  } else {
+    $srvname = $servername
+  }
 
   file { "${priority}-${name}.conf":
     path    => "${apache::params::vdir}/${priority}-${name}.conf",


### PR DESCRIPTION
This change adds the parameter servername to apache::vhost::redirect,
allowing the caller to set srvname in the vhost redirect template
(just like apache::vhost does).
