### PR TITLE
Include apache::params in apache::mod::php

### DIFF
--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -1,4 +1,5 @@
 class apache::mod::php {
+  include apache::params
   apache::mod { 'php5': }
   file { "${apache::params::vdir}/php.conf":
     ensure  => present,


### PR DESCRIPTION
The apache::mod::php class makes reference to a params variable but does not explicitely include the apache::params class. Parse order can result in not having the appropriate variable available and a file /php5.conf being created and managed. This commit resolves the problem by adding an explicity `include apache::params` line to apache::mod::php.
