### PR TITLE
Adding basic SSL support for default vhost template

### DIFF
--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -1,3 +1,10 @@
 class apache::mod::ssl {
   apache::mod { 'ssl': }
+  # keep mod_ssl rpm's defaults for redhat systems
+  if $::osfamily == 'redhat' {
+    file { "${apache::params::vdir}/ssl.conf":
+      ensure  => present,
+      content => template('apache/mod/ssl.conf.erb'),
+    }
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -45,6 +45,8 @@ class apache::params {
     $mod_dir               = "${httpd_dir}/mod.d"
     $vdir                  = "${httpd_dir}/conf.d"
     $conf_file             = 'httpd.conf'
+    $ssl_cert_file         = '/etc/pki/tls/certs/localhost.crt'
+    $ssl_cert_key_file     = '/etc/pki/tls/private/localhost.key'
     $mod_packages          = {
       'dev'        => 'httpd-devel',
       'fcgid'      => 'mod_fcgid',
@@ -73,6 +75,8 @@ class apache::params {
     $apache_dev            = ['libaprutil1-dev', 'libapr1-dev', 'apache2-prefork-dev']
     $vdir                  = '/etc/apache2/sites-enabled/'
     $proxy_modules         = ['proxy', 'proxy_http']
+    $ssl_cert_file         = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
+    $ssl_cert_key_file     = '/etc/ssl/private/ssl-cert-snakeoil.key'
     $mod_packages          = {
       'dev'    => ['libaprutil1-dev', 'libapr1-dev', 'apache2-prefork-dev'],
       'fcgid'  => 'libapache2-mod-fcgid',

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -10,6 +10,8 @@
 # - The $configure_firewall option is set to true or false to specify if
 #   a firewall should be configured.
 # - The $ssl option is set true or false to enable SSL for this Virtual Host
+# - The $ssl_cert_file option specifies which cert to use for this virtual host
+# - The $ssl_cert_key_file option specifies which cert key to use for this virtual host
 # - The $template option specifies whether to use the default template or
 #   override
 # - The $priority of the site
@@ -43,6 +45,8 @@ define apache::vhost(
     $serveradmin        = false,
     $configure_firewall = true,
     $ssl                = $apache::params::ssl,
+    $ssl_cert_file      = $apache::params::ssl_cert_file,
+    $ssl_cert_key_file  = $apache::params::ssl_cert_key_file,
     $template           = $apache::params::template,
     $priority           = $apache::params::priority,
     $servername         = $apache::params::servername,

--- a/templates/mod/ssl.conf.erb
+++ b/templates/mod/ssl.conf.erb
@@ -1,0 +1,225 @@
+#
+# This is the Apache server configuration file providing SSL support.
+# It contains the configuration directives to instruct the server how to
+# serve pages over an https connection. For detailing information about these 
+# directives see <URL:http://httpd.apache.org/docs/2.2/mod/mod_ssl.html>
+# 
+# Do NOT simply read the instructions in here without understanding
+# what they do.  They're here only as hints or reminders.  If you are unsure
+# consult the online docs. You have been warned.  
+#
+
+## Loading of the SSL DSO is handled seperately when using the
+## puppetlabs-apache puppet module. This directive can be found in
+## <%= scope.lookupvar('apache::params::mod_dir') %>/ssl.load
+# LoadModule ssl_module modules/mod_ssl.so
+
+#
+# When we also provide SSL we have to listen to the 
+# the HTTPS port in addition.
+#
+Listen 443
+
+##
+##  SSL Global Context
+##
+##  All SSL configuration in this context applies both to
+##  the main server and all SSL-enabled virtual hosts.
+##
+
+#   Pass Phrase Dialog:
+#   Configure the pass phrase gathering process.
+#   The filtering dialog program (`builtin' is a internal
+#   terminal dialog) has to provide the pass phrase on stdout.
+SSLPassPhraseDialog  builtin
+
+#   Inter-Process Session Cache:
+#   Configure the SSL Session Cache: First the mechanism 
+#   to use and second the expiring timeout (in seconds).
+SSLSessionCache         shmcb:/var/cache/mod_ssl/scache(512000)
+SSLSessionCacheTimeout  300
+
+#   Semaphore:
+#   Configure the path to the mutual exclusion semaphore the
+#   SSL engine uses internally for inter-process synchronization. 
+SSLMutex default
+
+#   Pseudo Random Number Generator (PRNG):
+#   Configure one or more sources to seed the PRNG of the 
+#   SSL library. The seed data should be of good random quality.
+#   WARNING! On some platforms /dev/random blocks if not enough entropy
+#   is available. This means you then cannot use the /dev/random device
+#   because it would lead to very long connection times (as long as
+#   it requires to make more entropy available). But usually those
+#   platforms additionally provide a /dev/urandom device which doesn't
+#   block. So, if available, use this one instead. Read the mod_ssl User
+#   Manual for more details.
+SSLRandomSeed startup file:/dev/urandom  256
+SSLRandomSeed connect builtin
+#SSLRandomSeed startup file:/dev/random  512
+#SSLRandomSeed connect file:/dev/random  512
+#SSLRandomSeed connect file:/dev/urandom 512
+
+#
+# Use "SSLCryptoDevice" to enable any supported hardware
+# accelerators. Use "openssl engine -v" to list supported
+# engine names.  NOTE: If you enable an accelerator and the
+# server does not start, consult the error logs and ensure
+# your accelerator is functioning properly. 
+#
+SSLCryptoDevice builtin
+#SSLCryptoDevice ubsec
+
+# ##
+# ## SSL Virtual Host Context
+# ##
+
+# <VirtualHost _default_:443>
+
+# # General setup for the virtual host, inherited from global configuration
+# #DocumentRoot "/var/www/html"
+# #ServerName www.example.com:443
+
+# # Use separate log files for the SSL virtual host; note that LogLevel
+# # is not inherited from httpd.conf.
+# ErrorLog logs/ssl_error_log
+# TransferLog logs/ssl_access_log
+# LogLevel warn
+
+# #   SSL Engine Switch:
+# #   Enable/Disable SSL for this virtual host.
+# SSLEngine on
+
+# #   SSL Protocol support:
+# # List the enable protocol levels with which clients will be able to
+# # connect.  Disable SSLv2 access by default:
+# SSLProtocol all -SSLv2
+
+# #   SSL Cipher Suite:
+# # List the ciphers that the client is permitted to negotiate.
+# # See the mod_ssl documentation for a complete list.
+# SSLCipherSuite ALL:!ADH:!EXPORT:!SSLv2:RC4+RSA:+HIGH:+MEDIUM:+LOW
+
+# #   Server Certificate:
+# # Point SSLCertificateFile at a PEM encoded certificate.  If
+# # the certificate is encrypted, then you will be prompted for a
+# # pass phrase.  Note that a kill -HUP will prompt again.  A new
+# # certificate can be generated using the genkey(1) command.
+# SSLCertificateFile /etc/pki/tls/certs/localhost.crt
+
+# #   Server Private Key:
+# #   If the key is not combined with the certificate, use this
+# #   directive to point at the key file.  Keep in mind that if
+# #   you've both a RSA and a DSA private key you can configure
+# #   both in parallel (to also allow the use of DSA ciphers, etc.)
+# SSLCertificateKeyFile /etc/pki/tls/private/localhost.key
+
+# #   Server Certificate Chain:
+# #   Point SSLCertificateChainFile at a file containing the
+# #   concatenation of PEM encoded CA certificates which form the
+# #   certificate chain for the server certificate. Alternatively
+# #   the referenced file can be the same as SSLCertificateFile
+# #   when the CA certificates are directly appended to the server
+# #   certificate for convinience.
+# #SSLCertificateChainFile /etc/pki/tls/certs/server-chain.crt
+
+# #   Certificate Authority (CA):
+# #   Set the CA certificate verification path where to find CA
+# #   certificates for client authentication or alternatively one
+# #   huge file containing all of them (file must be PEM encoded)
+# #SSLCACertificateFile /etc/pki/tls/certs/ca-bundle.crt
+
+# #   Client Authentication (Type):
+# #   Client certificate verification type and depth.  Types are
+# #   none, optional, require and optional_no_ca.  Depth is a
+# #   number which specifies how deeply to verify the certificate
+# #   issuer chain before deciding the certificate is not valid.
+# #SSLVerifyClient require
+# #SSLVerifyDepth  10
+
+# #   Access Control:
+# #   With SSLRequire you can do per-directory access control based
+# #   on arbitrary complex boolean expressions containing server
+# #   variable checks and other lookup directives.  The syntax is a
+# #   mixture between C and Perl.  See the mod_ssl documentation
+# #   for more details.
+# #<Location />
+# #SSLRequire (    %{SSL_CIPHER} !~ m/^(EXP|NULL)/ \
+# #            and %{SSL_CLIENT_S_DN_O} eq "Snake Oil, Ltd." \
+# #            and %{SSL_CLIENT_S_DN_OU} in {"Staff", "CA", "Dev"} \
+# #            and %{TIME_WDAY} >= 1 and %{TIME_WDAY} <= 5 \
+# #            and %{TIME_HOUR} >= 8 and %{TIME_HOUR} <= 20       ) \
+# #           or %{REMOTE_ADDR} =~ m/^192\.76\.162\.[0-9]+$/
+# #</Location>
+
+# #   SSL Engine Options:
+# #   Set various options for the SSL engine.
+# #   o FakeBasicAuth:
+# #     Translate the client X.509 into a Basic Authorisation.  This means that
+# #     the standard Auth/DBMAuth methods can be used for access control.  The
+# #     user name is the `one line' version of the client's X.509 certificate.
+# #     Note that no password is obtained from the user. Every entry in the user
+# #     file needs this password: `xxj31ZMTZzkVA'.
+# #   o ExportCertData:
+# #     This exports two additional environment variables: SSL_CLIENT_CERT and
+# #     SSL_SERVER_CERT. These contain the PEM-encoded certificates of the
+# #     server (always existing) and the client (only existing when client
+# #     authentication is used). This can be used to import the certificates
+# #     into CGI scripts.
+# #   o StdEnvVars:
+# #     This exports the standard SSL/TLS related `SSL_*' environment variables.
+# #     Per default this exportation is switched off for performance reasons,
+# #     because the extraction step is an expensive operation and is usually
+# #     useless for serving static content. So one usually enables the
+# #     exportation for CGI and SSI requests only.
+# #   o StrictRequire:
+# #     This denies access when "SSLRequireSSL" or "SSLRequire" applied even
+# #     under a "Satisfy any" situation, i.e. when it applies access is denied
+# #     and no other module can change it.
+# #   o OptRenegotiate:
+# #     This enables optimized SSL connection renegotiation handling when SSL
+# #     directives are used in per-directory context. 
+# #SSLOptions +FakeBasicAuth +ExportCertData +StrictRequire
+# <Files ~ "\.(cgi|shtml|phtml|php3?)$">
+#     SSLOptions +StdEnvVars
+# </Files>
+# <Directory "/var/www/cgi-bin">
+#     SSLOptions +StdEnvVars
+# </Directory>
+
+# #   SSL Protocol Adjustments:
+# #   The safe and default but still SSL/TLS standard compliant shutdown
+# #   approach is that mod_ssl sends the close notify alert but doesn't wait for
+# #   the close notify alert from client. When you need a different shutdown
+# #   approach you can use one of the following variables:
+# #   o ssl-unclean-shutdown:
+# #     This forces an unclean shutdown when the connection is closed, i.e. no
+# #     SSL close notify alert is send or allowed to received.  This violates
+# #     the SSL/TLS standard but is needed for some brain-dead browsers. Use
+# #     this when you receive I/O errors because of the standard approach where
+# #     mod_ssl sends the close notify alert.
+# #   o ssl-accurate-shutdown:
+# #     This forces an accurate shutdown when the connection is closed, i.e. a
+# #     SSL close notify alert is send and mod_ssl waits for the close notify
+# #     alert of the client. This is 100% SSL/TLS standard compliant, but in
+# #     practice often causes hanging connections with brain-dead browsers. Use
+# #     this only for browsers where you know that their SSL implementation
+# #     works correctly. 
+# #   Notice: Most problems of broken clients are also related to the HTTP
+# #   keep-alive facility, so you usually additionally want to disable
+# #   keep-alive for those clients, too. Use variable "nokeepalive" for this.
+# #   Similarly, one has to force some clients to use HTTP/1.0 to workaround
+# #   their broken HTTP/1.1 implementation. Use variables "downgrade-1.0" and
+# #   "force-response-1.0" for this.
+# SetEnvIf User-Agent ".*MSIE.*" \
+#          nokeepalive ssl-unclean-shutdown \
+#          downgrade-1.0 force-response-1.0
+
+# #   Per-Server Logging:
+# #   The home of a custom SSL log file. Use this when you want a
+# #   compact non-error SSL logfile on a virtual host basis.
+# CustomLog logs/ssl_request_log \
+#           "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
+
+# </VirtualHost>                                  
+

--- a/templates/vhost-default.conf.erb
+++ b/templates/vhost-default.conf.erb
@@ -15,6 +15,11 @@ NameVirtualHost <%= vhost_name %>:<%= port %>
 <%= "  ServerAlias #{serveraliases}" %>
 <% end -%>
   DocumentRoot <%= docroot %>
+<% if ssl %>
+  SSLEngine on
+  SSLCertificateFile <%= ssl_cert_file %>
+  SSLCertificateKeyFile <%= ssl_cert_key_file %>
+<% end %>
   <Directory <%= docroot %>>
     Options <%= options %>
     AllowOverride <%= Array(override).join(' ') %>


### PR DESCRIPTION
- Adds new SSL cert params that can be passed to apache::vhost that
  will be added to the default vhost template if ssl is set to true.
- Also fixes a bug in redhat-based systems where the
  /etc/httpd/conf.d/ssl.conf file provided by the mod_ssl rpm would get
  removed without duplicating its functionality elsewhere (i.e., Listen
  443)
