### PR TITLE
Ability to enable/disable "EnableSendFile" from base class call.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,8 +14,8 @@
 #
 class apache (
   $default_mods = true,
-  $serveradmin	= 'root@localhost',
-  $sendfile = false,
+  $serveradmin  = 'root@localhost',
+  $sendfile     = false
 ) {
   include apache::params
 

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -178,7 +178,7 @@ Group <%= scope.lookupvar('apache::params::group') %>
 # e-mailed.  This address appears on some server-generated pages, such
 # as error documents.  e.g. admin@your-domain.com
 #
-ServerAdmin <%= serveradmin %>
+ServerAdmin <%= @serveradmin %>
 
 #
 # ServerName gives the name and port that the server uses to identify itself.
@@ -362,7 +362,7 @@ HostnameLookups Off
 # http://httpd.apache.org/docs/2.2/mod/core.html#enablesendfile
 #
 <% if sendfile %>
-EnableSendfile <%= sendfile %>
+EnableSendfile <%= @sendfile %>
 <% end %>
 
 #


### PR DESCRIPTION
In some common environments ( working with Vagrant + Puppet and serving files from shared folder ), there's some problems when EnableSendfile is "on" (by default). It will be really helpful to allow disable this param from base class call.

Could you consider to include in main project?

Best regards!
