### PR TITLE
Add excludes to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,15 @@ branches:
 env:
   - PUPPET_VERSION=2.6.17
   - PUPPET_VERSION=2.7.19
-  - PUPPET_VERSION=3.0.1
+  #- PUPPET_VERSION=3.0.1 # Breaks due to rodjek/rspec-puppet#58
 notifications:
   email: false
 gemfile: .gemfile
+matrix:
+  exclude:
+  - rvm: 1.9.3
+    gemfile: .gemfile
+    env: PUPPET_VERSION=2.6.17
+  - rvm: 1.8.7
+    gemfile: .gemfile
+    env: PUPPET_VERSION=3.0.1


### PR DESCRIPTION
Exclude puppet 2.6 on ruby 1.9 and puppet 3.0 on ruby 1.8
