### PR TITLE
open port for vhost

### DIFF
--- a/templates/vhost-proxy.conf.erb
+++ b/templates/vhost-proxy.conf.erb
@@ -1,3 +1,6 @@
+<% if port.to_s != '80' %>
+Listen <%= vhost_name %>:<%= port %>
+<% end %>
 NameVirtualHost <%= vhost_name %>:<%= port %>
 <VirtualHost <%= vhost_name %>:<%= port %>>
   <% if ssl == true %>


### PR DESCRIPTION
If we are setting up a virtual host on a port other then
port 80, then we need to tell apache to listen on that port
