### PR TITLE
Update Modulefile for 0.5.0-rc1 release

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'puppetlabs-apache'
-version '0.4.0'
+version '0.5.0-rc1'
 source 'git://github.com/puppetlabs/puppetlabs-apache.git'
 author 'puppetlabs'
 license 'Apache 2.0'


### PR DESCRIPTION
A lot of code went in between 0.4.0 and head. You may use this git
command to see the full changelog. `git log 0.4.0...HEAD --no-merges`

The highlights are a number of feature additions, mostly around
apache modules and a number of bug fixes, mostly around Puppet 2.6
compatibility. Also, a number of changes went into the a2mod type
and provider which seem to be backwards compatible feature updates.

Because of some slight uncertainty there and what appears to be some
missing spec tests around the new class parameters, this particular
release will go out labeled as a release candidate to solicit
feedback and test coverage improvement before being considered stable.
