### PR TITLE
Add a2mod instances method on Debian

### DIFF
--- a/lib/puppet/provider/a2mod.rb
+++ b/lib/puppet/provider/a2mod.rb
@@ -1,0 +1,34 @@
+class Puppet::Provider::A2mod < Puppet::Provider
+  def self.prefetch(mods)
+    instances.each do |prov|
+      if mod = mods[prov.name]
+        mod.provider = prov
+      end
+    end
+  end
+
+  def flush
+    @property_hash.clear
+  end
+
+  def properties
+    if @property_hash.empty?
+      @property_hash = query || {:ensure => :absent}
+      @property_hash[:ensure] = :absent if @property_hash.empty?
+    end
+    @property_hash.dup
+  end
+
+  def query
+    self.class.instances.each do |mod|
+      if mod.name == self.name or mod.name.downcase == self.name
+        return mod.properties
+      end
+    end
+    nil
+  end
+
+  def exists?
+    properties[:ensure] != :absent
+  end
+end

--- a/lib/puppet/provider/a2mod/a2mod.rb
+++ b/lib/puppet/provider/a2mod/a2mod.rb
@@ -1,9 +1,11 @@
-Puppet::Type.type(:a2mod).provide(:a2mod) do
+require 'puppet/provider/a2mod'
+
+Puppet::Type.type(:a2mod).provide(:a2mod, :parent => Puppet::Provider::A2mod) do
     desc "Manage Apache 2 modules on Debian and Ubuntu"
 
     optional_commands :encmd => "a2enmod"
     optional_commands :discmd => "a2dismod"
-    optional_commands :apache2ctl => "apache2ctl"
+    commands :apache2ctl => "apache2ctl"
 
     confine :osfamily => :debian
     defaultfor :operatingsystem => [:debian, :ubuntu]
@@ -29,9 +31,5 @@ Puppet::Type.type(:a2mod).provide(:a2mod) do
 
     def destroy
         discmd resource[:name]
-    end
-
-    def exists?
-      @property_hash[:ensure] != :absent
     end
 end

--- a/lib/puppet/provider/a2mod/redhat.rb
+++ b/lib/puppet/provider/a2mod/redhat.rb
@@ -1,5 +1,9 @@
-Puppet::Type.type(:a2mod).provide(:redhat) do
+require 'puppet/provider/a2mod'
+
+Puppet::Type.type(:a2mod).provide(:redhat, :parent => Puppet::Provider::A2mod) do
   desc "Manage Apache 2 modules on RedHat family OSs"
+
+  commands :apachectl => "apachectl"
 
   confine :osfamily => :redhat
   defaultfor :osfamily => :redhat
@@ -30,18 +34,13 @@ Puppet::Type.type(:a2mod).provide(:redhat) do
     File.delete(modfile)
   end
 
-  def exists?
-    File.exists?(modfile) and File.read(modfile).match(libfile)
-  end
-
   def self.instances
-    modules = []
-    Dir.glob("#{modpath}/*.load").each do |file|
-      m = file.match(/(\w+)\.load$/)
-      modules << m[1] if m
-    end
+    modules = apachectl("-M").collect { |line|
+      m = line.match(/(\w+)_module \(shared\)$/)
+      m[1] if m
+    }.compact
 
-    modules.map  do |mod|
+    modules.map do |mod|
       new(
         :name     => mod,
         :ensure   => :present,


### PR DESCRIPTION
The a2mod Debian provider (just called `a2mod.rb` instead of
`debian.rb`) did not have an instances method which did not allow
resource purging or `puppet resource a2mod` to work. This commit adds
this by using the `apache2ctl -M` command which lists loaded modules.
