### PR TITLE
 holds facter's load path, replacing it with

### DIFF
--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -14,7 +14,7 @@ define apache::mod (
   $mod_libs = $apache::params::mod_libs
   $mod_lib = $mod_libs[$mod] # 2.6 compatibility hack
   if "${mod_lib}" {
-    $lib = $mod_lib
+    $lib_dir = $mod_lib
   }
 
   $mod_identifiers = $apache::params::mod_identifiers
@@ -33,7 +33,7 @@ define apache::mod (
 
   a2mod { $mod:
     ensure     => present,
-    lib        => $lib,
+    lib        => $lib_dir,
     identifier => $identifier,
     require    => Package['httpd'],
     notify     => Service['httpd'],


### PR DESCRIPTION
mod fails to create *.load files when FACTERLIB is overriden,  $lib holds FACTERLIB's value (not so sure about this statement though).

https://github.com/stackforge/packstack/blob/master/packstack/plugins/puppet_950.py#L195

causes .load modules like:

LoadModule alias_module /var/tmp/0d00db11-0d8b-4a05-877e-b5093560a5fe/facts

Replace $lib with $lib_dir does fix this weird behavior. 

OS: Red Hat
facter-1.6.6-1.el6.x86_64
puppet-2.6.17-2.el6.noarch
