### PR TITLE
Enable puppet 3.0.1 in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
 env:
   - PUPPET_VERSION=2.6.17
   - PUPPET_VERSION=2.7.19
-  #- PUPPET_VERSION=3.0.1 # Breaks due to rodjek/rspec-puppet#58
+  - PUPPET_VERSION=3.0.1
 notifications:
   email: false
 gemfile: .gemfile
@@ -18,6 +18,3 @@ matrix:
   - rvm: 1.9.3
     gemfile: .gemfile
     env: PUPPET_VERSION=2.6.17
-  - rvm: 1.8.7
-    gemfile: .gemfile
-    env: PUPPET_VERSION=3.0.1


### PR DESCRIPTION
A fix for rodjek/rspec-puppet#58 has been merged which
should allow puppet 3.0.1 to run the spec tests
