### PR TITLE
vhost should Listen to ports if they are not 80!

### DIFF
--- a/templates/vhost-default.conf.erb
+++ b/templates/vhost-default.conf.erb
@@ -3,6 +3,10 @@
 # Managed by Puppet
 # ************************************
 
+<% if port != 80 -%>
+Listen <%= port %>
+<% end -%>
+
 NameVirtualHost <%= vhost_name %>:<%= port %>
 <VirtualHost <%= vhost_name %>:<%= port %>>
   ServerName <%= srvname %>


### PR DESCRIPTION
the vhost template does not create a Listen declaration if the port is not 80

This is required for setting up a puppetmaster virtual host under passenger.
