### PR TITLE
Update apache::vhost::proxy's apache::proxy dependency

### DIFF
--- a/manifests/vhost/proxy.pp
+++ b/manifests/vhost/proxy.pp
@@ -33,7 +33,7 @@ define apache::vhost::proxy (
   ) {
 
   include apache
-  include apache::proxy
+  include apache::mod::proxy
 
   $apache_name = $apache::params::apache_name
   $ssl_path = $apache::params::ssl_path


### PR DESCRIPTION
apache::proxy has been deprecated in favor of apache::mod::proxy.  Update the
include statement in the vhost to the new class.
