### PR TITLE
Minimal example needs docroot or otherwise fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ example is:
         priority        => '10',
         vhost_name      => '192.0.2.1',
         port            => '80',
+        docroot         => '/var/www/html',
     }
 
 A slightly more complicated example, which moves the docroot and


### PR DESCRIPTION
If you don't pass docroot you get an error about it being missing: 

I.e.: Mar  3 00:20:22 pam1 puppet-agent[3525]: Could not retrieve catalog from remote server: Error 400 on SERVER: Must pass docroot to Apache::Vhost[pam1.demo.loc] at /etc/puppet/environme
