### PR TITLE
fix for the apache::mod::python manifest

### DIFF
--- a/manifests/mod/python.pp
+++ b/manifests/mod/python.pp
@@ -1,6 +1,10 @@
 class apache::mod::python {
   #include apache
   apache::mod { 'python': }
+  include apache::params
+  file { "python.conf":
+    path => "${apache::params::vdir}/python.conf",
+  }
 }
 
 


### PR DESCRIPTION
Hi,

The python.conf created by the manifest apache::mod::python was being deleted by the purging of the httpd_vdir directory. 
This fix guarantees the permance of the file python.conf during the execution of the purge of the directory httpd_vdir.
It's similiar to the fix  in the apache::mod::php manifest.

Best regards,
Vitor
