### PR TITLE
Update vhost.pp

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -63,7 +63,7 @@ define apache::vhost(
   "${ensure} is not supported for ensure.
   Allowed values are 'present' and 'absent'.")
 
-  include apache
+  require apache
 
   if $servername == '' {
     $srvname = $name


### PR DESCRIPTION
Requiring instead of including apache, to avoid getting errors such as:

warning: Scope(Apache::Vhost[default]): Could not look up qualified variable 'apache::params::servername'; class apache::params has not been evaluated at /etc/puppet/modules/apache/manifests/vhost.pp:49
