### PR TITLE
Remove spec test warning

### DIFF
--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -235,7 +235,7 @@ describe 'apache::vhost', :type => :define do
         }) end
         it 'should set RewriteCond' do
           should contain_file("25-#{title}.conf").with_content(
-            /^  RewriteCond %{HTTPS} off$/
+            /^  RewriteCond %\{HTTPS\} off$/
           )
         end
       end


### PR DESCRIPTION
Without this patch, running the spec tests encounter a warning
about a regular expresion with a '}' that has not been escaped. This
warning is from line 238 in the vhost_spec.rb file.

This commit eliminates that warning.
