### PR TITLE
Add Validation and rspec tests for $error_log

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -117,6 +117,7 @@ define apache::vhost(
   validate_bool($ip_based)
   validate_bool($configure_firewall)
   validate_bool($access_log)
+  validate_bool($error_log)
   validate_bool($ssl)
   validate_bool($default_vhost)
 

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -165,6 +165,18 @@ describe 'apache::vhost', :type => :define do
           :notmatch => /CustomLog \/var\/log\/.+_access\.log combined$/,
         },
         {
+          :title => 'should contain error logs',
+          :attr  => 'error_log',
+          :value => true,
+          :match => /ErrorLog.+$/,
+        },
+        {
+          :title    => 'should not contain error logs',
+          :attr     => 'error_log',
+          :value    => false,
+          :notmatch => /ErrorLog.+$/,
+        },
+        {
           :title => 'should accept scriptaliases',
           :attr  => 'scriptalias',
           :value => '/usr/scripts',


### PR DESCRIPTION
Without this commit, there is no validation or testing for the
$error_log parameter in the apache::vhost type.

This commit add boolean validation to the apache::vhost type. It also
adds two rspec tests to test the proper function of the parameter.
