### PR TITLE
Fix mod::prefork dependencies

### DIFF
--- a/manifests/mod/prefork.pp
+++ b/manifests/mod/prefork.pp
@@ -30,11 +30,12 @@ class apache::mod::prefork (
   case $::osfamily {
     'redhat': {
       file_line { '/etc/sysconfig/httpd prefork enable':
-        ensure => present,
-        path   => '/etc/sysconfig/httpd',
-        line   => '#HTTPD=/usr/sbin/httpd.prefork',
-        match  => '#?HTTPD=',
-        notify => Service['httpd'],
+        ensure  => present,
+        path    => '/etc/sysconfig/httpd',
+        line    => '#HTTPD=/usr/sbin/httpd.prefork',
+        match   => '#?HTTPD=',
+        require => Package['httpd'],
+        notify  => Service['httpd'],
       }
     }
     'debian': {

--- a/spec/classes/mod/prefork_spec.rb
+++ b/spec/classes/mod/prefork_spec.rb
@@ -27,6 +27,9 @@ describe 'apache::mod::prefork', :type => :class do
     it { should include_class("apache::params") }
     it { should_not contain_apache__mod('prefork') }
     it { should contain_file("/etc/httpd/conf.d/prefork.conf").with_ensure('file') }
-    it { should contain_file_line("/etc/sysconfig/httpd prefork enable") }
+    it { should contain_file_line("/etc/sysconfig/httpd prefork enable").with({
+      'require' => 'Package[httpd]',
+    })
+    }
   end
 end


### PR DESCRIPTION
A dependency on the package resolves the following error:
"Error: /Stage[main]/Apache::Mod::Prefork/File_line[/etc/sysconfig/httpd 
prefork enable]: Could not evaluate: No such file or directory -
/etc/sysconfig/httpd"
