### PR TITLE
use libphp5.so on debian/ubuntu

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -97,7 +97,9 @@ class apache::params {
       'python'     => 'libapache2-mod-python',
       'wsgi'       => 'libapache2-mod-wsgi',
     }
-    $mod_libs         = {}
+    $mod_libs         = {
+      'php5' => 'libphp5.so',
+    }
   } else {
     fail("Class['apache::params']: Unsupported osfamily: ${::osfamily}")
   }


### PR DESCRIPTION
When installing php5 for apache with libapache2-mod-php5_5.4.4-14_amd64.deb puppet should use libphp5.so. Changed manifests/params.pp so that php5 uses libphp5.so on debian based systems.
