### PR TITLE
Move 'ServerLimit' line in worker.erb

### DIFF
--- a/templates/mod/worker.conf.erb
+++ b/templates/mod/worker.conf.erb
@@ -1,9 +1,9 @@
 <IfModule mpm_worker_module>
+  ServerLimit         <%= @serverlimit %>
   StartServers        <%= @startservers %>
   MaxClients          <%= @maxclients %>
   MinSpareThreads     <%= @minsparethreads %>
   MaxSpareThreads     <%= @maxsparethreads %>
   ThreadsPerChild     <%= @threadsperchild %>
   MaxRequestsPerChild <%= @maxrequestsperchild %>
-  ServerLimit         <%= @serverlimit %>
 </IfModule>


### PR DESCRIPTION
It turns out that the order of MPM directives is important in certain
cases. Without this commit, the 'ServerLimit' directive was being
processed too late to be used in calculations for 'ThreadsPerChild'.

This commit moves the 'ServerLimit' directive to the top of the
directives in the ERB. This was based on Apache documentation and an
example config of theirs.
