### PR TITLE
Posibility of setting VirtualDocumentRoot

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -5,6 +5,7 @@
 # Parameters:
 # - The $port to configure the host on
 # - The $docroot provides the DocumentationRoot variable
+# - The $virtual_docroot provides VirtualDocumentationRoot variable
 # - The $serveradmin will specify an email address for Apache that it will
 #   display when it renders one of it's error pages
 # - The $configure_firewall option is set to true or false to specify if
@@ -57,6 +58,7 @@
 #
 define apache::vhost(
     $docroot,
+    $virtual_docroot    = false,
     $port               = undef,
     $ip                 = undef,
     $ip_based           = false,
@@ -292,6 +294,7 @@ define apache::vhost(
   # - $servername_real
   # - $serveradmin
   # - $docroot
+  # - $virtual_docroot
   # - $options
   # - $override
   # - $logroot

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -244,6 +244,14 @@ describe 'apache::vhost', :type => :define do
             '</VirtualHost>',
           ],
         },
+        {
+          :title => 'should contain virtual_docroot',
+          :attr  => 'virtual_docroot',
+          :value => '/not/default',
+          :match => [
+            '  VirtualDocumentRoot /not/default',
+          ],
+        },
       ].each do |param|
         describe "when #{param[:attr]} is #{param[:value]}" do
           let :params do default_params.merge({ param[:attr].to_sym => param[:value] }) end

--- a/templates/vhost.conf.erb
+++ b/templates/vhost.conf.erb
@@ -10,7 +10,11 @@
 <% end -%>
 
   ## Vhost docroot
+<% if virtual_docroot %>
+  VirtualDocumentRoot <%= virtual_docroot %>
+<% else %>
   DocumentRoot <%= @docroot %>
+<% end %>
   <Directory <%= @docroot %>>
     Options <%= Array(@options).join(' ') %>
     AllowOverride <%= Array(@override).join(' ') %>

--- a/tests/vhost.pp
+++ b/tests/vhost.pp
@@ -173,3 +173,13 @@ apache::vhost { 'nineteenth.example.com':
   docroot  => '/var/www/nineteenth',
   setenvif => 'Host "^([^\.]*)\.website\.com$" CLIENT_NAME=$1',
 }
+
+# Vhost with alias for subdomain mapped to same named directory 
+# http://example.com.loc => /var/www/example.com
+apache::vhost { 'subdomain.loc':
+  vhost_name      => '*',
+  port            => '80',
+  virtual_docroot => '/var/www/%-2+',
+  docroot         => '/var/www',
+  serveraliases   => ['*.loc',],
+}


### PR DESCRIPTION
If you want to use one configuration for more subdomain, like *.loc (especialy for local development), you need to set VirtualDocumentRoot instead of standard DocumentRoot.

http://httpd.apache.org/docs/2.2/mod/mod_vhost_alias.html
