### PR TITLE
Remove array key assignment

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -54,16 +54,16 @@ class apache::params {
       'fcgid'      => 'mod_fcgid',
       'passenger'  => 'mod_passenger',
       'perl'       => 'mod_perl',
+      'php5'       => $distrelease ? {
+        '5' => 'php53',
+        '6' => 'php',
+      },
       'proxy_html' => 'mod_proxy_html',
       'python'     => 'mod_python',
       'shibboleth' => 'shibboleth',
       'ssl'        => 'mod_ssl',
       'wsgi'       => 'mod_wsgi',
       'dav_svn'    => 'mod_dav_svn',
-    }
-    $mod_packages['php5'] = $distrelease ? {
-      '5' => 'php53',
-      '6' => 'php',
     }
     $mod_libs             = {
       'php5' => 'libphp5.so',


### PR DESCRIPTION
According to http://docs.puppetlabs.com/puppet/2.7/reference/lang_datatypes.html#significant-bugs-mutability-1 it is incorrect to mutate hashes by assigning directly to keys. This is enforced in the future parser introduced in Puppet 3.2.0 and is reported in #213
