### PR TITLE
Support for mod_xsendfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ There are many `apache::mod::[name]` classes within this module that can be decl
 * `userdir`*
 * `worker`*
 * `wsgi`
+* `xsendfile`
 
 Modules noted with a * indicate that the module has settings and, thus, a template that includes parameters. These parameters control the module's configuration. Most of the time, these parameters will not require any configuration or attention.
 

--- a/manifests/mod/xsendfile.pp
+++ b/manifests/mod/xsendfile.pp
@@ -1,0 +1,4 @@
+class apache::mod::xsendfile {
+  include apache::params
+  apache::mod { 'xsendfile': }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -64,6 +64,7 @@ class apache::params {
       'ssl'        => 'mod_ssl',
       'wsgi'       => 'mod_wsgi',
       'dav_svn'    => 'mod_dav_svn',
+      'xsendfile'  => 'mod_xsendfile',
     }
     $mod_libs             = {
       'php5' => 'libphp5.so',
@@ -100,6 +101,7 @@ class apache::params {
       'python'     => 'libapache2-mod-python',
       'wsgi'       => 'libapache2-mod-wsgi',
       'dav_svn'    => 'libapache2-svn',
+      'xsendfile'  => 'libapache2-mod-xsendfile',
     }
     $mod_libs         = {}
     $conf_template    = 'apache/httpd.conf.erb'


### PR DESCRIPTION
PR adds the ability to install the xsendfile module for Apache on both Ubuntu/Debian and CentOS/Fedora
