### PR TITLE
Add @ to cgisock_path

### DIFF
--- a/templates/mod/cgid.conf.erb
+++ b/templates/mod/cgid.conf.erb
@@ -1,1 +1,1 @@
-ScriptSock <%= cgisock_path %>
+ScriptSock <%= @cgisock_path %>


### PR DESCRIPTION
To stop the warning from being thrown on puppet 3.2.0
