### PR TITLE
Improve documentation on how to redirect non-ssl vhosts to ssl vhosts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,11 +699,11 @@ Set up a mix of SSL and non-SSL vhosts at the same domain
 Configure a vhost to redirect non-SSL connections to SSL
 
     apache::vhost { 'sixteenth.example.com non-ssl':
-      servername   => 'sixteenth.example.com',
-      port         => '80',
-      docroot      => '/var/www/sixteenth',
-      rewrite_cond => '%{HTTPS} off',
-      rewrite_rule => '(.*) https://%{HTTPS_HOST}%{REQUEST_URI}',
+      servername      => 'sixteenth.example.com',
+      port            => '80',
+      docroot         => '/var/www/sixteenth',
+      redirect_status => 'permanent'
+      redirect_dest   => 'https://sixteenth.example.com/' 
     }
     apache::vhost { 'sixteenth.example.com ssl':
       servername => 'sixteenth.example.com',


### PR DESCRIPTION
Hi.

This is the suggested way of redirecting. http://wiki.apache.org/httpd/RedirectSSL

Apache also recommend against using the rewrite method.  http://wiki.apache.org/httpd/RewriteHTTPToHTTPS

Finally, the original rewrite method won't work when using hiera due to http://projects.puppetlabs.com/issues/16235

Kind Regards,
Alex
