### PR TITLE
Add ServerName = @fqdn to httpd.conf

### DIFF
--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -3,6 +3,7 @@ ServerTokens OS
 ServerSignature On
 TraceEnable Off
 
+ServerName "<%= @fqdn %>"
 ServerRoot "<%= @httpd_dir %>"
 PidFile <%= @pidfile %>
 Timeout 120


### PR DESCRIPTION
On some nodes, we were seeing this warning: (thanks @gchaix)

`# service httpd restart
Stopping httpd:                                            [  OK  ]
Starting httpd: httpd: Could not reliably determine the server's fully qualified domain name, using 2001:4801:7817:72:f156:fa90:ff10:3a72 for ServerName [  OK  ]`

We fixed it by adding ServerName = fqdn in the httpd.conf.erb.
