### PR TITLE
Release 0.7.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,13 @@
+2013-07-09 Release 0.7.0
+Changes:
+- Essentially rewrite the module -- too many to list
+- `apache::vhost` has many abilities -- see README.md for details
+- `apache::mod::*` classes provide httpd mod-loading capabilities
+- `apache` base class is much more configurable
+
+Bugfixes:
+- Many. And many more to come
+
 2013-03-2 Release 0.6.0
 - update travis tests (add more supported versions)
 - add access log_parameter

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'puppetlabs-apache'
-version '0.6.0'
+version '0.7.0'
 source 'git://github.com/puppetlabs/puppetlabs-apache.git'
 author 'puppetlabs'
 license 'Apache 2.0'


### PR DESCRIPTION
Changes:
- Essentially rewrite the module -- too many to list
- `apache::vhost` has many abilities -- see README.md for details
- `apache::mod::*` classes provide httpd mod-loading capabilities
- `apache` base class is much more configurable

Bugfixes:
- Many. And many more to come
