### PR TITLE
Issue 230 specifiy that: The apache::mod::* classes that have .conf file

### DIFF
--- a/manifests/mod/alias.pp
+++ b/manifests/mod/alias.pp
@@ -11,5 +11,6 @@ class apache::mod::alias {
     content => template('apache/mod/alias.conf.erb'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
   }
 }

--- a/manifests/mod/autoindex.pp
+++ b/manifests/mod/autoindex.pp
@@ -7,5 +7,6 @@ class apache::mod::autoindex {
     content => template('apache/mod/autoindex.conf.erb'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
   }
 }

--- a/manifests/mod/cgid.pp
+++ b/manifests/mod/cgid.pp
@@ -10,5 +10,6 @@ class apache::mod::cgid {
     content => template('apache/mod/cgid.conf.erb'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
   }
 }

--- a/manifests/mod/dav_fs.pp
+++ b/manifests/mod/dav_fs.pp
@@ -14,5 +14,6 @@ class apache::mod::dav_fs {
     content => template('apache/mod/dav_fs.conf.erb'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
   }
 }

--- a/manifests/mod/deflate.pp
+++ b/manifests/mod/deflate.pp
@@ -7,5 +7,6 @@ class apache::mod::deflate {
     content => template('apache/mod/deflate.conf.erb'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
   }
 }

--- a/manifests/mod/dir.pp
+++ b/manifests/mod/dir.pp
@@ -16,5 +16,6 @@ class apache::mod::dir (
     content => template('apache/mod/dir.conf.erb'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
   }
 }

--- a/manifests/mod/disk_cache.pp
+++ b/manifests/mod/disk_cache.pp
@@ -14,5 +14,6 @@ class apache::mod::disk_cache {
     content => template('apache/mod/disk_cache.conf.erb'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
   }
 }

--- a/manifests/mod/info.pp
+++ b/manifests/mod/info.pp
@@ -9,5 +9,6 @@ class apache::mod::info (
     content => template('apache/mod/info.conf.erb'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
   }
 }

--- a/manifests/mod/ldap.pp
+++ b/manifests/mod/ldap.pp
@@ -7,5 +7,6 @@ class apache::mod::ldap {
     content => template('apache/mod/ldap.conf.erb'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
   }
 }

--- a/manifests/mod/mime.pp
+++ b/manifests/mod/mime.pp
@@ -7,5 +7,6 @@ class apache::mod::mime {
     content => template('apache/mod/mime.conf.erb'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
   }
 }

--- a/manifests/mod/mime_magic.pp
+++ b/manifests/mod/mime_magic.pp
@@ -7,5 +7,6 @@ class apache::mod::mime_magic {
     content => template('apache/mod/mime_magic.conf.erb'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
   }
 }

--- a/manifests/mod/mpm_event.pp
+++ b/manifests/mod/mpm_event.pp
@@ -6,5 +6,6 @@ class apache::mod::mpm_event {
     content => template('apache/mod/mpm_event.conf.erb'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
   }
 }

--- a/manifests/mod/negotiation.pp
+++ b/manifests/mod/negotiation.pp
@@ -7,5 +7,6 @@ class apache::mod::negotiation {
     content => template('apache/mod/negotiation.conf.erb'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
   }
 }

--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -11,5 +11,6 @@ class apache::mod::passenger (
     content => template('apache/mod/passenger.conf.erb'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
   }
 }

--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -12,5 +12,6 @@ class apache::mod::php {
       Exec["mkdir ${apache::mod_dir}"],
     ],
     before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
   }
 }

--- a/manifests/mod/prefork.pp
+++ b/manifests/mod/prefork.pp
@@ -27,6 +27,7 @@ class apache::mod::prefork (
     content => template('apache/mod/prefork.conf.erb'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
   }
 
   case $::osfamily {
@@ -46,6 +47,7 @@ class apache::mod::prefork (
         target  => "${apache::mod_dir}/prefork.conf",
         require => Exec["mkdir ${apache::mod_enable_dir}"],
         before  => File[$apache::mod_enable_dir],
+        notify  => Service['httpd'],
       }
       package { 'apache2-mpm-prefork':
         ensure => present,

--- a/manifests/mod/proxy.pp
+++ b/manifests/mod/proxy.pp
@@ -10,5 +10,6 @@ class apache::mod::proxy (
     content => template('apache/mod/proxy.conf.erb'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
   }
 }

--- a/manifests/mod/proxy_html.pp
+++ b/manifests/mod/proxy_html.pp
@@ -20,5 +20,6 @@ class apache::mod::proxy_html {
     content => template('apache/mod/proxy_html.conf.erb'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
   }
 }

--- a/manifests/mod/reqtimeout.pp
+++ b/manifests/mod/reqtimeout.pp
@@ -7,5 +7,6 @@ class apache::mod::reqtimeout {
     content => template('apache/mod/reqtimeout.conf.erb'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
   }
 }

--- a/manifests/mod/setenvif.pp
+++ b/manifests/mod/setenvif.pp
@@ -7,5 +7,6 @@ class apache::mod::setenvif {
     content => template('apache/mod/setenvif.conf.erb'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
   }
 }

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -18,5 +18,6 @@ class apache::mod::ssl (
     content => template('apache/mod/ssl.conf.erb'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
   }
 }

--- a/manifests/mod/status.pp
+++ b/manifests/mod/status.pp
@@ -7,5 +7,6 @@ class apache::mod::status {
     content => template('apache/mod/status.conf.erb'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
   }
 }

--- a/manifests/mod/userdir.pp
+++ b/manifests/mod/userdir.pp
@@ -12,5 +12,6 @@ class apache::mod::userdir (
     content => template('apache/mod/userdir.conf.erb'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
   }
 }

--- a/manifests/mod/worker.pp
+++ b/manifests/mod/worker.pp
@@ -29,6 +29,7 @@ class apache::mod::worker (
     content => template('apache/mod/worker.conf.erb'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
   }
 
   case $::osfamily {
@@ -47,6 +48,7 @@ class apache::mod::worker (
         target  => "${apache::mod_dir}/worker.conf",
         require => Exec["mkdir ${apache::mod_enable_dir}"],
         before  => File[$apache::mod_enable_dir],
+        notify  => Service['httpd'],
       }
       package { 'apache2-mpm-worker':
         ensure => present,


### PR DESCRIPTION
resources don't refresh the service when the configs are updated, but they
should. (https://github.com/puppetlabs/puppetlabs-apache/issues/230).

This commit fixes the issue by adding:

```
    notify  => Service['httpd'],
```

to all file resources.

Note that the modification has only been tested with a few of the modules.
