### PR TITLE
Use a more specific match for changing to worker

### DIFF
--- a/manifests/mod/prefork.pp
+++ b/manifests/mod/prefork.pp
@@ -35,8 +35,8 @@ class apache::mod::prefork (
       file_line { '/etc/sysconfig/httpd prefork enable':
         ensure  => present,
         path    => '/etc/sysconfig/httpd',
-        line    => '#HTTPD=/usr/sbin/httpd.prefork',
-        match   => '#?HTTPD=',
+        line    => '#HTTPD=/usr/sbin/httpd.worker',
+        match   => '#?HTTPD=/usr/sbin/httpd.worker',
         require => Package['httpd'],
         notify  => Service['httpd'],
       }

--- a/manifests/mod/worker.pp
+++ b/manifests/mod/worker.pp
@@ -38,7 +38,7 @@ class apache::mod::worker (
         ensure => present,
         path   => '/etc/sysconfig/httpd',
         line   => 'HTTPD=/usr/sbin/httpd.worker',
-        match  => '#?HTTPD=',
+        match  => '#?HTTPD=/usr/sbin/httpd.worker',
         notify => Service['httpd'],
       }
     }


### PR DESCRIPTION
httpd from centos.alt.ru has both #HTTPD=/usr/sbin/httpd.worker and #HTTPD=/usr/sbin/httpd.itk
in the default file, so the shorter match gets confused
