### PR TITLE
Release 0.8.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+2013-07-26 Release 0.8.1
+Bugfixes:
+- Update `apache::mpm_module` detection for worker/prefork
+- Update `apache::mod::cgi` and `apache::mod::cgid` detection for
+worker/prefork
+
 2013-07-16 Release 0.8.0
 Features:
 - Add `servername` parameter to `apache` class

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'puppetlabs-apache'
-version '0.8.0'
+version '0.8.1'
 source 'git://github.com/puppetlabs/puppetlabs-apache.git'
 author 'puppetlabs'
 license 'Apache 2.0'


### PR DESCRIPTION
Bugfixes:
- Update `apache::mpm_module` detection for worker/prefork
- Update `apache::mod::cgi` and `apache::mod::cgid` detection for worker/prefork
