### PR TITLE
(#266) Allow apache::mod to specify explicit module identifier and module path

### DIFF
--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -1,6 +1,8 @@
 define apache::mod (
   $package = undef,
-  $lib = undef
+  $lib = undef,
+  $identifier = undef,
+  $path = undef,
 ) {
   if ! defined(Class['apache']) {
     fail('You must include the apache base class before using any apache defined resources')
@@ -20,6 +22,19 @@ define apache::mod (
     $lib_REAL = $mod_lib
   } else {
     $lib_REAL = "mod_${mod}.so"
+  }
+
+  # Determine if declaration specified a path to the module
+  if $path {
+    $path_REAL = $path
+  } else {
+    $path_REAL = "${lib_path}/${lib_REAL}"
+  }
+
+  if $identifier {
+    $id_REAL = $identifier
+  } else {
+    $id_REAL = "${mod}_module"
   }
 
   # Determine if we have a package
@@ -45,7 +60,7 @@ define apache::mod (
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    content => "LoadModule ${mod}_module ${lib_path}/${lib_REAL}\n",
+    content => "LoadModule $id_REAL $path_REAL\n",
     require => [
       Package['httpd'],
       Exec["mkdir ${mod_dir}"],

--- a/tests/mod_load_params.pp
+++ b/tests/mod_load_params.pp
@@ -1,0 +1,11 @@
+# Tests the path and identifier parameters for the apache::mod class
+
+# Base class for clarity:
+class { 'apache': }
+
+
+# Exaple parameter usage:
+apache::mod { 'testmod': 
+  path => '/usr/some/path/mod_testmod.so',
+  identifier => 'testmod_custom_name',
+} 


### PR DESCRIPTION
Using the Shibboleth Apache module as an example, this is the default
way in which the pre-built, RPM-packaged shibboleth install wants to
be called by an Apache config file:

LoadModule mod_shib /opt/shibboleth-sp/lib/shibboleth/mod_shib_22.so

Under the current puppetlabs-apache setup, modules must be called
XXXX_module and the path must be under the standard module directory.

This adds a path parameter and an identifier parameter.  For now, I
use the $varname_REAL convention that was already in use in this class
definition, although this could easily be switched to the $_varname
convention used elsewhere in the puppetlabs-apache module.  In any
case, if either $path or $identifier is supplied, the config directive
looks like this:

LoadModule $identifier $path

If either is omitted, the code constructs them based on the original
logic.

Tests are included, but I have had difficulty getting tests to run.
Test verification by someone with a better setup than me would be
greatly appreciated
