### PR TITLE
(#272) Add parameter sslproxyengine to vhost.pp

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,6 +642,10 @@ Specifies the location of the certificate revocation list.
 
 Specifies the SSL key.
 
+#####`sslproxyengine`
+
+Specifies whether to use `SSLProxyEngine` or not. Defaults to `false`.
+
 #####`vhost_name`
 
 This parameter is for use with name-based virtual hosting. Defaults to '*'.

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -95,6 +95,7 @@ define apache::vhost(
     $scriptalias        = undef,
     $proxy_dest         = undef,
     $proxy_pass         = undef,
+    $sslproxyengine     = false,
     $no_proxy_uris      = [],
     $redirect_source    = '/',
     $redirect_dest      = undef,
@@ -124,6 +125,7 @@ define apache::vhost(
   validate_bool($error_log)
   validate_bool($ssl)
   validate_bool($default_vhost)
+  validate_bool($sslproxyengine)
 
   if $access_log_file and $access_log_pipe {
     fail("Apache::Vhost[${name}]: 'access_log_file' and 'access_log_pipe' cannot be defined at the same time")

--- a/templates/vhost/_ssl.erb
+++ b/templates/vhost/_ssl.erb
@@ -17,6 +17,9 @@
 <% if @ssl_crl -%>
   SSLCARevocationFile     <%= @ssl_crl %>
 <% end -%>
+<% if @sslproxyengine -%>
+  SSLProxyEngine On
+<% end -%>
   <FilesMatch "\.(cgi|shtml|phtml|php)$">
     SSLOptions +StdEnvVars
   </FilesMatch>


### PR DESCRIPTION
In order to use mod_proxy with remote servers using the SSL/TLS protocol it is
needed to activate the SSL/TLS Protocol Engine for proxy. Setting this
parameter to true adds the directive `SSLProxyEngine on` to the virtual host.
