### PR TITLE
Remove sendfile comment

### DIFF
--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -30,7 +30,7 @@ DefaultType none
 HostnameLookups Off
 ErrorLog <%= @logroot %>/<%= @error_log %>
 LogLevel warn
-<% if @sendfile #XXX Why? %>
+<% if @sendfile %>
 EnableSendfile <%= @sendfile %>
 <% end %>
 


### PR DESCRIPTION
The comment in the conditional block for sendfile directive inclusion caused the plain text directive name to not be included in the resulting conf file.

Example with $sendfile set to `'Off'`:

```
...
LogLevel warn
Off
...
```

Example without comment:

```
...
LogLevel warn

EnableSendfile Off
....
```
