### PR TITLE
(#278) Ports file attempted to be created before Apache installed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -165,10 +165,11 @@ class apache (
   }
 
   concat { $ports_file:
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0644',
-    notify => Service['httpd'],
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    notify  => Service['httpd'],
+    require => Package['httpd'],
   }
   concat::fragment { 'Apache ports header':
     target  => $ports_file,


### PR DESCRIPTION
Ports file creation should depend on Apache being installed.

Closes #278
