### PR TITLE
Add KeepAlive parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,11 @@ Configures which mpm module is loaded and configured for the httpd process by th
 
 Setting this allows you to override the template used for the main apache configuration file.  This is a potentially risky thing to do as this module has been built around the concept of a minimal configuration file with most of the configuration coming in the form of conf.d/ entries.  Defaults to 'apache/httpd.conf.erb'.
 
+#####`keepalive`
+
+Setting this allows you to enable persistent connections.
+ 
+
 ####Class: `apache::default_mods`
 
 Installs default Apache modules based on what OS you are running

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,7 @@ class apache (
   $servername           = $apache::params::servername,
   $user                 = $apache::params::user,
   $group                = $apache::params::group,
+  $keepalive            = $apache::params::keepalive,
 ) inherits apache::params {
 
   package { 'httpd':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -72,6 +72,7 @@ class apache::params {
       'php5' => 'libphp5.so',
     }
     $conf_template        = 'apache/httpd.conf.erb'
+    $keepalive            = 'Off'
   } elsif $::osfamily == 'Debian' {
     $user             = 'www-data'
     $group            = 'www-data'
@@ -110,6 +111,7 @@ class apache::params {
       'php5' => 'libphp5.so',
     }
     $conf_template    = 'apache/httpd.conf.erb'
+    $keepalive        = 'Off'
   } else {
     fail("Class['apache::params']: Unsupported osfamily: ${::osfamily}")
   }

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -7,7 +7,7 @@ ServerName "<%= @servername %>"
 ServerRoot "<%= @httpd_dir %>"
 PidFile <%= @pidfile %>
 Timeout 120
-KeepAlive Off
+KeepAlive <%= @keepalive %>
 MaxKeepAliveRequests 100
 KeepAliveTimeout 15
 


### PR DESCRIPTION
KeepAlive parameter was added to init.pp (by default is equal apache::params::keepalive), params.pp (by default is 'Off') and template httpd.conf.erb
Desription was added to README.md
