### PR TITLE
Allow overriding the passenger package

### DIFF
--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -2,8 +2,12 @@ class apache::mod::passenger (
   $passenger_root          = $apache::params::passenger_root,
   $passenger_ruby          = $apache::params::passenger_ruby,
   $passenger_max_pool_size = undef,
+  $package                 = undef,
 ) {
-  apache::mod { 'passenger': }
+  apache::mod { 'passenger':
+    package => $package,
+  }
+
   # Template uses: $passenger_root, $passenger_ruby, $passenger_max_pool_size
   file { 'passenger.conf':
     ensure  => file,

--- a/spec/classes/mod/passenger_spec.rb
+++ b/spec/classes/mod/passenger_spec.rb
@@ -26,4 +26,19 @@ describe 'apache::mod::passenger', :type => :class do
     it { should contain_apache__mod('passenger') }
     it { should contain_package("mod_passenger") }
   end
+  context "with overridden package" do
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
+      }
+    end
+    let :pre_condition do
+      'include apache
+      class {"apache::mod::passenger": package => "ruby193-rubygem-passenger-native" }'
+    end
+    it { should contain_apache__mod('passenger').with_package('ruby193-rubygem-passenger-native') }
+    it { should contain_package("ruby193-rubygem-passenger-native") }
+  end
 end


### PR DESCRIPTION
In some cases, it might be needed to override the passenger package name. For
example, Foreman uses SCL to provide ruby 1.9.3 on RHEL 6.
