### PR TITLE
Update apache::params for Amazon Linux

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,7 @@
 # Sample Usage:
 #
 class apache::params {
-  # This will be 5 or 6 on RedHat, 6 or wheezy on Debian, 12 or quantal on Ubuntu, etc.
+  # This will be 5 or 6 on RedHat, 6 or wheezy on Debian, 12 or quantal on Ubuntu, 3 on Amazon, etc.
   $osr_array = split($::operatingsystemrelease,'[\/\.]')
   $distrelease = $osr_array[0]
   if ! $distrelease {
@@ -46,8 +46,8 @@ class apache::params {
     $default_ssl_cert     = '/etc/pki/tls/certs/localhost.crt'
     $default_ssl_key      = '/etc/pki/tls/private/localhost.key'
     $ssl_certs_dir        = $distrelease ? {
-      '5' => '/etc/pki/tls/certs',
-      '6' => '/etc/ssl/certs',
+      '5'     => '/etc/pki/tls/certs',
+      default => '/etc/ssl/certs',
     }
     $passenger_root       = '/usr/share/rubygems/gems/passenger-3.0.17'
     $passenger_ruby       = '/usr/bin/ruby'
@@ -57,8 +57,8 @@ class apache::params {
       'passenger'  => 'mod_passenger',
       'perl'       => 'mod_perl',
       'php5'       => $distrelease ? {
-        '5' => 'php53',
-        '6' => 'php',
+        '5'     => 'php53',
+        default => 'php',
       },
       'proxy_html' => 'mod_proxy_html',
       'python'     => 'mod_python',


### PR DESCRIPTION
Amazon Linux AMI is a lot like RedHat 6 but has an
`$operatingsystemrelease` value of `3.4.37-40.44.amzn1.x86_64`
currently which throws off the `$distrelease` in the params class.

Adding these defaults should fix this issue.

Closes #285
