### PR TITLE
Fix rewrite_base

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -103,7 +103,6 @@ define apache::vhost(
     $rack_base_uris     = undef,
     $request_headers    = undef,
     $rewrite_rule       = undef,
-    $rewrite_base       = undef,
     $rewrite_cond       = undef,
     $setenv             = [],
     $setenvif           = [],
@@ -337,7 +336,6 @@ define apache::vhost(
   #   - $request_headers
   # rewrite fragment:
   #   - $rewrite_rule
-  #   - $rewrite_base
   #   - $rewrite_cond
   # scriptalias fragment:
   #   - $scriptalias

--- a/templates/vhost/_rewrite.erb
+++ b/templates/vhost/_rewrite.erb
@@ -3,7 +3,7 @@
   ## Rewrite rules
   RewriteEngine On
 <% if @rewrite_base -%>
-  RewriteBase <%= @rewrite_base -%>
+  RewriteBase <%= @rewrite_base %>
 <% end -%>
 <% if @rewrite_cond -%>
 <% Array(@rewrite_cond).each do |cond| -%>


### PR DESCRIPTION
rewrite_base was broken because it uses -%> instead of %>, but also because
RewriteBase is only valid in a <Directory> context.
