### PR TITLE
if facter can not determine the fqdn, use the hostname fact

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,7 +26,11 @@ class apache::params {
     fail("Class['apache::params']: Unparsable \$::operatingsystemrelease: ${::operatingsystemrelease}")
   }
 
-  $servername = $::fqdn
+  if($::fqdn) {
+    $servername = $::fqdn
+  } else {
+    $servername = $::hostname
+  }
 
   if $::osfamily == 'RedHat' or $::operatingsystem == 'amazon' {
     $user                 = 'apache'


### PR DESCRIPTION
If facter can not determine the fqdn, use the hostname fact.  Apache will fail to start if the ServerName is blank.  
