### PR TITLE
mv the httpd service declaration into class apache::service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,6 +45,7 @@ class apache (
   package { 'httpd':
     ensure => installed,
     name   => $apache::params::apache_name,
+    notify => Class['Apache::Service'],
   }
 
   validate_bool($default_mods)
@@ -69,14 +70,10 @@ class apache (
     ensure  => present,
     gid     => $group,
     require => Package['httpd'],
-    before  => Service['httpd'],
   }
 
-  service { 'httpd':
-    ensure    => $service_enable,
-    name      => $apache::params::apache_name,
-    enable    => $service_enable,
-    subscribe => Package['httpd'],
+  class { 'apache::service':
+    service_enable => $service_enable,
   }
 
   # Deprecated backwards-compatibility
@@ -99,7 +96,7 @@ class apache (
     ensure  => directory,
     recurse => true,
     purge   => $purge_confd,
-    notify  => Service['httpd'],
+    notify  => Class['Apache::Service'],
     require => Package['httpd'],
   }
 
@@ -112,7 +109,7 @@ class apache (
       ensure  => directory,
       recurse => true,
       purge   => $purge_configs,
-      notify  => Service['httpd'],
+      notify  => Class['Apache::Service'],
       require => Package['httpd'],
     }
   }
@@ -127,7 +124,7 @@ class apache (
       ensure  => directory,
       recurse => true,
       purge   => $purge_configs,
-      notify  => Service['httpd'],
+      notify  => Class['Apache::Service'],
       require => Package['httpd'],
     }
   } else {
@@ -143,7 +140,7 @@ class apache (
       ensure  => directory,
       recurse => true,
       purge   => $purge_configs,
-      notify  => Service['httpd'],
+      notify  => Class['Apache::Service'],
       require => Package['httpd'],
     }
   }
@@ -158,7 +155,7 @@ class apache (
       ensure  => directory,
       recurse => true,
       purge   => $purge_configs,
-      notify  => Service['httpd'],
+      notify  => Class['Apache::Service'],
       require => Package['httpd'],
     }
   } else {
@@ -169,7 +166,7 @@ class apache (
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    notify  => Service['httpd'],
+    notify  => Class['Apache::Service'],
     require => Package['httpd'],
   }
   concat::fragment { 'Apache ports header':
@@ -216,7 +213,7 @@ class apache (
     file { "${apache::params::conf_dir}/${apache::params::conf_file}":
       ensure  => file,
       content => template($conf_template),
-      notify  => Service['httpd'],
+      notify  => Class['Apache::Service'],
       require => Package['httpd'],
     }
     class { 'apache::default_mods':

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,0 +1,29 @@
+# Class: apache::service
+#
+# Manages the Apache daemon
+#
+# Parameters:
+#
+# Actions:
+#   - Manage Apache service
+#
+# Requires:
+#
+# Sample Usage:
+#
+#    sometype { 'foo':
+#      notify => Class['apache::service],
+#    }
+#
+#
+class apache::service (
+  $service_enable = true,
+) {
+  validate_bool($service_enable)
+
+  service { 'httpd':
+    ensure => $service_enable,
+    name   => $apache::apache_name,
+    enable => $service_enable,
+  }
+}

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -10,20 +10,18 @@ describe 'apache', :type => :class do
       }
     end
     it { should include_class("apache::params") }
-    it { should contain_package("httpd") }
-    it { should contain_user("www-data") }
-    it { should contain_group("www-data") }
-    it { should contain_service("httpd").with(
-      'ensure'    => 'true',
-      'enable'    => 'true',
-      'subscribe' => 'Package[httpd]'
+    it { should contain_package("httpd").with(
+      'notify' => 'Class[Apache::Service]'
       )
     }
+    it { should contain_user("www-data") }
+    it { should contain_group("www-data") }
+    it { should contain_class("apache::service") }
     it { should contain_file("/etc/apache2/sites-enabled").with(
       'ensure'  => 'directory',
       'recurse' => 'true',
       'purge'   => 'true',
-      'notify'  => 'Service[httpd]',
+      'notify'  => 'Class[Apache::Service]',
       'require' => 'Package[httpd]'
       )
     }
@@ -31,7 +29,7 @@ describe 'apache', :type => :class do
       'ensure'  => 'directory',
       'recurse' => 'true',
       'purge'   => 'true',
-      'notify'  => 'Service[httpd]',
+      'notify'  => 'Class[Apache::Service]',
       'require' => 'Package[httpd]'
       )
     }
@@ -39,7 +37,7 @@ describe 'apache', :type => :class do
       'ensure'  => 'directory',
       'recurse' => 'true',
       'purge'   => 'true',
-      'notify'  => 'Service[httpd]',
+      'notify'  => 'Class[Apache::Service]',
       'require' => 'Package[httpd]'
       )
     }
@@ -47,7 +45,7 @@ describe 'apache', :type => :class do
       'owner'   => 'root',
       'group'   => 'root',
       'mode'    => '0644',
-      'notify'  => 'Service[httpd]'
+      'notify'  => 'Class[Apache::Service]'
       )
     }
     # Assert that load files are placed and symlinked for these mods, but no conf file.
@@ -114,20 +112,18 @@ describe 'apache', :type => :class do
       }
     end
     it { should include_class("apache::params") }
-    it { should contain_package("httpd") }
-    it { should contain_user("apache") }
-    it { should contain_group("apache") }
-    it { should contain_service("httpd").with(
-      'ensure'    => 'true',
-      'enable'    => 'true',
-      'subscribe' => 'Package[httpd]'
+    it { should contain_package("httpd").with(
+      'notify' => 'Class[Apache::Service]'
       )
     }
+    it { should contain_user("apache") }
+    it { should contain_group("apache") }
+    it { should contain_class("apache::service") }
     it { should contain_file("/etc/httpd/conf.d").with(
       'ensure'  => 'directory',
       'recurse' => 'true',
       'purge'   => 'true',
-      'notify'  => 'Service[httpd]',
+      'notify'  => 'Class[Apache::Service]',
       'require' => 'Package[httpd]'
       )
     }
@@ -135,7 +131,7 @@ describe 'apache', :type => :class do
       'owner'   => 'root',
       'group'   => 'root',
       'mode'    => '0644',
-      'notify'  => 'Service[httpd]'
+      'notify'  => 'Class[Apache::Service]'
       )
     }
     describe "Alternate confd/mod/vhosts directory" do
@@ -152,7 +148,7 @@ describe 'apache', :type => :class do
           'ensure'  => 'directory',
           'recurse' => 'true',
           'purge'   => 'true',
-          'notify'  => 'Service[httpd]',
+          'notify'  => 'Class[Apache::Service]',
           'require' => 'Package[httpd]'
         ) }
       end
@@ -210,7 +206,7 @@ describe 'apache', :type => :class do
         'ensure'  => 'directory',
         'recurse' => 'true',
         'purge'   => 'true',
-        'notify'  => 'Service[httpd]',
+        'notify'  => 'Class[Apache::Service]',
         'require' => 'Package[httpd]'
       ) }
     end

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe 'apache::service', :type => :class do
+  context "on a Debian OS" do
+    let :facts do
+      {
+        :osfamily               => 'Debian',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
+      }
+    end
+    it { should contain_service("httpd").with(
+      'ensure'    => 'true',
+      'enable'    => 'true'
+      )
+    }
+
+    context "with $service_enable => true" do
+      let (:params) {{ :service_enable => true }}
+      it { should contain_service("httpd").with(
+        'ensure'    => 'true',
+        'enable'    => 'true'
+        )
+      }
+    end
+
+    context "with $service_enable => false" do
+      let (:params) {{ :service_enable => false }}
+      it { should contain_service("httpd").with(
+        'ensure'    => 'false',
+        'enable'    => 'false'
+        )
+      }
+    end
+
+    context "$service_enable must be a bool" do
+      let (:params) {{ :service_enable => 'not-a-boolean' }}
+
+      it 'should fail' do
+        expect {
+          should include_class('apache::service')
+        }.to raise_error(Puppet::Error, /is not a boolean/)
+      end
+    end
+  end
+
+
+  context "on a RedHat 5 OS" do
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '5',
+        :concat_basedir         => '/dne',
+      }
+    end
+    it { should contain_service("httpd").with(
+      'ensure'    => 'true',
+      'enable'    => 'true'
+      )
+    }
+  end
+end


### PR DESCRIPTION
The service declaration should be in it's own class so that consumers of the
module can both require/depend on `Class['Apache']` and send notifications to
the Apache service.

Needs additional testing before being merged.
