### PR TITLE
Don't enforce docroot ownership unless explicitly requested

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -64,8 +64,6 @@ define apache::vhost(
     $ip                 = undef,
     $ip_based           = false,
     $add_listen         = true,
-    $docroot_owner      = 'root',
-    $docroot_group      = 'root',
     $serveradmin        = false,
     $ssl                = false,
     $ssl_cert           = $apache::default_ssl_cert,
@@ -143,18 +141,8 @@ define apache::vhost(
     include apache::mod::vhost_alias
   }
 
-  # This ensures that the docroot exists
+  # This ensures that the logroot exists
   # But enables it to be specified across multiple vhost resources
-  if ! defined(File[$docroot]) {
-    file { $docroot:
-      ensure  => directory,
-      owner   => $docroot_owner,
-      group   => $docroot_group,
-      require => Package['httpd'],
-    }
-  }
-
-  # Same as above, but for logroot
   if ! defined(File[$logroot]) {
     file { $logroot:
       ensure  => directory,
@@ -365,7 +353,6 @@ define apache::vhost(
     mode    => '0644',
     require => [
       Package['httpd'],
-      File[$docroot],
       File[$logroot],
     ],
     notify  => Service['httpd'],


### PR DESCRIPTION
We have an issue where access to the codebase is impossible after
a puppet run because the apache module insists on changing the owner of the
document root. The correct ownership is determined by the environment (the
one who checked out the code), but since that is variable, there is no
user/group we can 'hardcode' in puppet.

The only correct way of handling the situation is 'just ensure the directory
is there, don't touch it if it exists'. This patch seems to do just that.
