### PR TITLE
make default mods configurable

### DIFF
--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -1,5 +1,5 @@
 class apache::default_mods (
-  $all = true,
+  $all  = true,
 ) {
   # These are modules required to run the default configuration.
   # They are not configurable at this time, so we just include
@@ -66,5 +66,15 @@ class apache::default_mods (
     apache::mod { 'authz_groupfile': }
     apache::mod { 'authz_user': }
     apache::mod { 'env': }
+  } elsif $mods {
+    apache::default_mods::load { $mods: }
+  }
+}
+
+define apache::default_mods::load ($module = $title) {
+  if defined("apache::mod::${module}") {
+    include "apache::mod::${module}"
+  } else {
+    apache::mod { $module: }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,7 +47,6 @@ class apache (
     name   => $apache::params::apache_name,
   }
 
-  validate_bool($default_mods)
   validate_bool($default_vhost)
   # true/false is sufficient for both ensure and enable
   validate_bool($service_enable)
@@ -219,8 +218,18 @@ class apache (
       notify  => Service['httpd'],
       require => Package['httpd'],
     }
-    class { 'apache::default_mods':
-      all => $default_mods
+
+    # preserve back-wards compatibility to the times when default_mods was
+    # only a boolean value. Now it can be an array (too)
+    if is_array($default_mods) {
+      class { 'apache::default_mods':
+        all  => false,
+        mods => $default_mods,
+      }
+    } else {
+      class { 'apache::default_mods':
+        all => $default_mods,
+      }
     }
     if $mpm_module {
       class { "apache::mod::${mpm_module}": }

--- a/tests/mods.pp
+++ b/tests/mods.pp
@@ -1,0 +1,9 @@
+## Default mods
+
+# Base class. Declares default vhost on port 80 and default ssl
+# vhost on port 443 listening on all interfaces and serving
+# $apache::docroot, and declaring our default set of modules.
+class { 'apache':
+  default_mods => true,
+}
+

--- a/tests/mods_custom.pp
+++ b/tests/mods_custom.pp
@@ -1,0 +1,16 @@
+## custom mods
+
+# Base class. Declares default vhost on port 80 and default ssl
+# vhost on port 443 listening on all interfaces and serving
+# $apache::docroot, and declaring a custom set of modules.
+class { 'apache':
+  default_mods => [
+    'info',
+    'alias',
+    'mime',
+    'env',
+    'setenv',
+    'expires',
+  ],
+}
+


### PR DESCRIPTION
...in a backwards-compatible manner.

Right now there are two options, either to enable a rather broad batch
of modules that someone found to be a good default set, or to leave them
unmanaged all-together.

This patch provides the users wtih the ability to manage their set of
default modules, by passing it as array to default_mods.

This fixes #298

n.b.: we've added test cases here, but they aren't yet part of the
actual test spec, because I have no idea how to do that.
