### PR TITLE
Fix a2mod ruby19 bug

### DIFF
--- a/lib/puppet/provider/a2mod/a2mod.rb
+++ b/lib/puppet/provider/a2mod/a2mod.rb
@@ -11,7 +11,7 @@ Puppet::Type.type(:a2mod).provide(:a2mod, :parent => Puppet::Provider::A2mod) do
     defaultfor :operatingsystem => [:debian, :ubuntu]
 
     def self.instances
-      modules = apache2ctl("-M").collect { |line|
+      modules = apache2ctl("-M").lines.collect { |line|
         m = line.match(/(\w+)_module \(shared\)$/)
         m[1] if m
       }.compact

--- a/lib/puppet/provider/a2mod/redhat.rb
+++ b/lib/puppet/provider/a2mod/redhat.rb
@@ -35,7 +35,7 @@ Puppet::Type.type(:a2mod).provide(:redhat, :parent => Puppet::Provider::A2mod) d
   end
 
   def self.instances
-    modules = apachectl("-M").collect { |line|
+    modules = apachectl("-M").lines.collect { |line|
       m = line.match(/(\w+)_module \(shared\)$/)
       m[1] if m
     }.compact


### PR DESCRIPTION
Strings are not enumerable in ruby19. This commit splits the
string into lines first.
