### PR TITLE
Fix parameters that take hash or array of hashes

### DIFF
--- a/templates/vhost/_aliases.erb
+++ b/templates/vhost/_aliases.erb
@@ -1,6 +1,6 @@
 <% if @aliases and ! @aliases.empty? -%>
   ## Alias declarations for resources outside the DocumentRoot
-  <%- Array(@aliases).each do |alias_statement| -%>
+  <%- [@aliases].flatten.compact.each do |alias_statement| -%>
     <%- if alias_statement["alias"] != '' and alias_statement["path"] != ''-%>
   Alias <%= alias_statement["alias"] %> <%= alias_statement["path"] %>
     <%- end -%>

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -1,5 +1,5 @@
 <% if @_directories and ! @_directories.empty? -%>
-  <%- Array(@_directories).each do |directory| -%>
+  <%- [@_directories].flatten.compact.each do |directory| -%>
     <%- if directory['path'] and directory['path'] != ''-%>
 
   <Directory <%= directory['path'] %>>
@@ -25,7 +25,7 @@
     Allow from all
     <%- end -%>
     <%- if directory['addhandlers'] and ! directory['addhandlers'].empty? -%>
-      <%- Array(directory['addhandlers']).each do |addhandler| -%>
+      <%- [directory['addhandlers']].flatten.compact.each do |addhandler| -%>
     AddHandler <%= addhandler['handler'] %> <%= Array(addhandler['extensions']).join(' ') %>
       <%- end -%>
     <%- end -%>

--- a/templates/vhost/_proxy.erb
+++ b/templates/vhost/_proxy.erb
@@ -7,7 +7,7 @@
     Allow from all
   </Proxy>
 <%- end -%>
-<% Array(@proxy_pass).each do |proxy| %>
+<% [@proxy_pass].flatten.compact.each do |proxy| %>
   ProxyPass        <%= proxy['path'] %> <%= proxy['url'] %>
   ProxyPassReverse <%= proxy['path'] %> <%= proxy['url'] %>
 <% end %>


### PR DESCRIPTION
The method used to cast scalars to arrays is `Array()`. This also will
cast `nil` to an empty array, and preserve array depth for existing
arrays.

Casting hashes to arrays with `Array()` produces strange results and so
the more verbose form of `[hsh].flatten.compact` must be used when a
parameter may be one or more hashes. This updates the tests and
templates accordingly.
