### PR TITLE
Allow specifying "ensure" parameter in apache::mod::php

### DIFF
--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -1,5 +1,6 @@
 define apache::mod (
   $package = undef,
+  $package_ensure = 'present',
   $lib = undef
 ) {
   if ! defined(Class['apache']) {
@@ -33,7 +34,7 @@ define apache::mod (
   if $package_REAL {
     # $package_REAL may be an array
     package { $package_REAL:
-      ensure  => present,
+      ensure  => $package_ensure,
       require => Package['httpd'],
       before  => File["${mod_dir}/${mod}.load"],
     }

--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -1,8 +1,12 @@
-class apache::mod::php {
+class apache::mod::php (
+  $package_ensure = 'present',
+) {
   if ! defined(Class['apache::mod::prefork']) {
     fail('apache::mod::php requires apache::mod::prefork; please enable mpm_module => \'prefork\' on Class[\'apache\']')
   }
-  apache::mod { 'php5': }
+  apache::mod { 'php5':
+    package_ensure => $package_ensure,
+  }
   file { 'php5.conf':
     ensure  => file,
     path    => "${apache::mod_dir}/php5.conf",

--- a/spec/classes/mod/php_spec.rb
+++ b/spec/classes/mod/php_spec.rb
@@ -46,6 +46,17 @@ describe 'apache::mod::php', :type => :class do
         :content => "LoadModule php5_module modules/libphp5.so\n"
       ) }
     end
+    context "with specific version" do
+      let :pre_condition do
+        'class { "apache": }'
+      end
+      let :params do
+        { :package_ensure => '5.3.13'}
+      end
+      it { should contain_package("php").with(
+        :ensure => '5.3.13'
+      ) }
+    end
     context "with mpm_module => prefork" do
       let :pre_condition do
         'class { "apache": mpm_module => prefork, }'


### PR DESCRIPTION
This fixes issue #326 by adding a $package_ensure parameter that allows specifying the version of PHP. This is the same strategy used by the puppetlabs/puppetlabs-mysql module in the mysql::php class.
