### PR TITLE
Posibility to not manage service status & ensure service will not start at boot.

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ The default certificate revocation list to use, which is automatically set to 'u
 
 Determines whether the 'httpd' service is enabled when the machine is booted, meaning Puppet will check the service status to start/stop it. Defaults to 'true', meaning the service is enabled/running.
 
+#####`service_manage`
+
+Determines whether 'service_enable' also check the service status to start/stop it. This is useful when you want to let the service be managed by some other application like pacemaker. Defaults to 'true'.
+
 #####`serveradmin`
 
 Sets the server administrator. Defaults to 'root@localhost'.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,7 @@ class apache (
   $default_ssl_crl_path = undef,
   $default_ssl_crl      = undef,
   $service_enable       = true,
+  $service_manage       = true,
   $purge_configs        = true,
   $purge_vdir           = false,
   $serveradmin          = 'root@localhost',
@@ -54,6 +55,7 @@ class apache (
   validate_bool($default_vhost)
   # true/false is sufficient for both ensure and enable
   validate_bool($service_enable)
+  validate_bool($service_manage)
   if $mpm_module {
     validate_re($mpm_module, '(prefork|worker)')
   }
@@ -73,6 +75,7 @@ class apache (
 
   class { 'apache::service':
     service_enable => $service_enable,
+    service_manage => $service_manage,
   }
 
   # Deprecated backwards-compatibility

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -18,11 +18,19 @@
 #
 class apache::service (
   $service_enable = true,
+  $service_manage = true,
 ) {
   validate_bool($service_enable)
+  validate_bool($service_manage)
+
+  # Do we want to manage status of the service
+  $manage = $service_manage ? {
+    true  => $service_enable,
+    false => undef,
+  }
 
   service { 'httpd':
-    ensure => $service_enable,
+    ensure => $manage,
     name   => $apache::apache_name,
     enable => $service_enable,
   }


### PR DESCRIPTION
This is useful when you want the service to be managed by other
application like pacemaker.
Set the 'service_manage' to false, so 'service_enable' value will
not change the current state of the service.
