### PR TITLE
Remove default <proxy *> block

### DIFF
--- a/manifests/mod/proxy.pp
+++ b/manifests/mod/proxy.pp
@@ -1,6 +1,6 @@
 class apache::mod::proxy (
   $proxy_requests = 'Off',
-  $allow_from = ['127.0.0.1','::1'],
+  $allow_from = undef,
 ) {
   apache::mod { 'proxy': }
   # Template uses $proxy_requests

--- a/templates/mod/proxy.conf.erb
+++ b/templates/mod/proxy.conf.erb
@@ -8,11 +8,13 @@
   # Internet at large.
   ProxyRequests <%= @proxy_requests %>
 
+  <% if @proxy_requests != 'Off' or ( @allow_from and ! @allow_from.empty? ) -%>
   <Proxy *>
     Order deny,allow
     Deny from all
     Allow from <%= Array(@allow_from).join(" ") %>
   </Proxy>
+  <% end -%>
 
   # Enable/disable the handling of HTTP/1.1 "Via:" headers.
   # ("Full" adds the server version; "Block" removes all outgoing Via: headers)

--- a/templates/vhost/_proxy.erb
+++ b/templates/vhost/_proxy.erb
@@ -2,10 +2,6 @@
 
   ## Proxy rules
   ProxyRequests Off
-  <Proxy *>
-    Order deny,allow
-    Allow from all
-  </Proxy>
 <%- end -%>
 <% [@proxy_pass].flatten.compact.each do |proxy| %>
   ProxyPass <%= proxy['path'] %> <%= proxy['url'] %>


### PR DESCRIPTION
This is a horrible and generally useless default. Most people do _not_
use apache httpd as Forward proxy, and those who do, should explicitly
set an allow. That this is exactly what our new, and backward
compatible proxy config does, and allows, while widly simplifying the
reverse proxy configurations.

We add a test case for new proxy configuration to make sure this is
actually the case, and also fix a test case from a previious commit.
