### PR TITLE
use ensure_resource to create apache user and group

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,16 +60,18 @@ class apache (
 
   # declare the web server user and group
   # Note: requiring the package means the package ought to create them and not puppet
-  group { $group:
+  $group_params = {
     ensure  => present,
     require => Package['httpd']
   }
+  ensure_resource('group', $group, $group_params)
 
-  user { $user:
+  $user_params = {
     ensure  => present,
     gid     => $group,
     require => Package['httpd'],
   }
+  ensure_resource('user', $user, $user_params)
 
   class { 'apache::service':
     service_enable => $service_enable,


### PR DESCRIPTION
When trying to set the user to one that s laos set by another module the puppet run failed because the user was declared twice.

This can happen when apache acts a a frontend for other services, so you want apache and the service run under the same user. Same goes for the group.

Using ensure_resource from the puppet stdlib, this can be avoided.
