### PR TITLE
Fix apache::default_mods loading

### DIFF
--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -1,5 +1,6 @@
 class apache::default_mods (
   $all  = true,
+  $mods = undef,
 ) {
   # These are modules required to run the default configuration.
   # They are not configurable at this time, so we just include
@@ -68,13 +69,5 @@ class apache::default_mods (
     apache::mod { 'env': }
   } elsif $mods {
     apache::default_mods::load { $mods: }
-  }
-}
-
-define apache::default_mods::load ($module = $title) {
-  if defined("apache::mod::${module}") {
-    include "apache::mod::${module}"
-  } else {
-    apache::mod { $module: }
   }
 }

--- a/manifests/default_mods/load.pp
+++ b/manifests/default_mods/load.pp
@@ -1,0 +1,8 @@
+# private define
+define apache::default_mods::load ($module = $title) {
+  if defined("apache::mod::${module}") {
+    include "apache::mod::${module}"
+  } else {
+    apache::mod { $module: }
+  }
+}

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -267,6 +267,23 @@ describe 'apache', :type => :class do
         it { should contain_apache__mod('authz_host') }
         it { should_not contain_apache__mod('env') }
       end
+      context "custom" do
+        let :params do
+          { :default_mods => [
+            'info',
+            'alias',
+            'mime',
+            'env',
+            'setenv',
+            'expires',
+          ]}
+        end
+
+        it { should contain_apache__mod('authz_host') }
+        it { should contain_apache__mod('env') }
+        it { should contain_class('apache::mod::info') }
+        it { should contain_class('apache::mod::mime') }
+      end
     end
   end
 end

--- a/spec/system/default_mods_spec.rb
+++ b/spec/system/default_mods_spec.rb
@@ -1,0 +1,102 @@
+require 'spec_helper_system'
+
+case node.facts['osfamily']
+when 'RedHat'
+  servicename = 'httpd'
+when 'Debian'
+  servicename = 'apache2'
+else
+  raise Error, "Unconfigured OS for apache service on #{node.facts['osfamily']}"
+end
+
+describe 'apache::default_mods class' do
+  describe 'no default mods' do
+    # Using puppet_apply as a helper
+    it 'should apply with no errors' do
+      pp = <<-EOS
+        class { 'apache':
+          default_mods => false,
+        }
+      EOS
+
+      # Run it twice and test for idempotency
+      puppet_apply(pp) do |r|
+        [0,2].should include(r.exit_code)
+        r.refresh
+        r.exit_code.should be_zero
+      end
+    end
+
+    describe service(servicename) do
+      it { should be_running }
+    end
+  end
+
+  describe 'no default mods and failing' do
+    # Using puppet_apply as a helper
+    it 'should apply with errors' do
+      pp = <<-EOS
+        class { 'apache':
+          default_mods => false,
+        }
+        apache::vhost { 'defaults.example.com':
+          docroot => '/var/www/defaults',
+          aliases => {
+            alias => '/css',
+            path  => '/var/www/css',
+          },
+          setenv  => 'TEST1 one',
+        }
+      EOS
+
+      # Run it twice and test for idempotency
+      puppet_apply(pp) do |r|
+        [4,6].should include(r.exit_code)
+      end
+    end
+
+    describe "service #{servicename}" do
+      it 'should not be running' do
+        shell("pidof #{servicename}") do |r|
+          r.exit_code.should eq(1)
+        end
+      end
+    end
+  end
+
+  describe 'alternative default mods' do
+    # Using puppet_apply as a helper
+    it 'should apply with no errors' do
+      pp = <<-EOS
+        class { 'apache':
+          default_mods => [
+            'info',
+            'alias',
+            'mime',
+            'env',
+            'expires',
+          ],
+        }
+        apache::vhost { 'defaults.example.com':
+          docroot => '/var/www/defaults',
+          aliases => {
+            alias => '/css',
+            path  => '/var/www/css',
+          },
+          setenv  => 'TEST1 one',
+        }
+      EOS
+
+      # Run it twice and test for idempotency
+      puppet_apply(pp) do |r|
+        [0,2].should include(r.exit_code)
+        r.refresh
+        r.exit_code.should be_zero
+      end
+    end
+
+    describe service(servicename) do
+      it { should be_running }
+    end
+  end
+end


### PR DESCRIPTION
PR #314 was merged without tests and consequently had bugs. This moves
the `apache::default_mods::load` defined resource into
`manifests/default_mods/load.pp` and adds the missing `mods` parameter
to the `apache::default_mods` class. Also lots of tests are added.
