### PR TITLE
fix exception types in some specs

### DIFF
--- a/spec/system/default_mods_spec.rb
+++ b/spec/system/default_mods_spec.rb
@@ -6,7 +6,7 @@ when 'RedHat'
 when 'Debian'
   servicename = 'apache2'
 else
-  raise Error, "Unconfigured OS for apache service on #{node.facts['osfamily']}"
+  raise "Unconfigured OS for apache service on #{node.facts['osfamily']}"
 end
 
 describe 'apache::default_mods class' do

--- a/spec/system/prefork_worker_spec.rb
+++ b/spec/system/prefork_worker_spec.rb
@@ -6,7 +6,7 @@ when 'RedHat'
 when 'Debian'
   servicename = 'apache2'
 else
-  raise Error, "Unconfigured OS for apache service on #{node.facts['osfamily']}"
+  raise "Unconfigured OS for apache service on #{node.facts['osfamily']}"
 end
 
 describe 'apache::mod::worker class' do


### PR DESCRIPTION
Found a bug, to reproduce:

```
RSPEC_SET=centos-64-x64 bundle exec rake spec:system
```

then it tries to raise an exception about unconfigured OS but it fails with:

```
/home/ptomulik/projects/puppet-modules/puppetlabs-apache/spec/system/itk_spec.rb:9: uninitialized constant Error (NameError)
        from /home/ptomulik/projects/puppet-modules/puppetlabs-apache/vendor/bundle/ruby/1.8/gems/rspec-core-2.14.5/lib/rspec/core/configuration.rb:896:in `load'
        from /home/ptomulik/projects/puppet-modules/puppetlabs-apache/vendor/bundle/ruby/1.8/gems/rspec-core-2.14.5/lib/rspec/core/configuration.rb:896:in `load_spec_files'
        from /home/ptomulik/projects/puppet-modules/puppetlabs-apache/vendor/bundle/ruby/1.8/gems/rspec-core-2.14.5/lib/rspec/core/configuration.rb:896:in `each'
        from /home/ptomulik/projects/puppet-modules/puppetlabs-apache/vendor/bundle/ruby/1.8/gems/rspec-core-2.14.5/lib/rspec/core/configuration.rb:896:in `load_spec_files'
        from /home/ptomulik/projects/puppet-modules/puppetlabs-apache/vendor/bundle/ruby/1.8/gems/rspec-core-2.14.5/lib/rspec/core/command_line.rb:22:in `run'
        from /home/ptomulik/projects/puppet-modules/puppetlabs-apache/vendor/bundle/ruby/1.8/gems/rspec-core-2.14.5/lib/rspec/core/runner.rb:80:in `run'
        from /home/ptomulik/projects/puppet-modules/puppetlabs-apache/vendor/bundle/ruby/1.8/gems/rspec-core-2.14.5/lib/rspec/core/runner.rb:17:in `autorun'
        from /home/ptomulik/projects/puppet-modules/puppetlabs-apache/vendor/bundle/ruby/1.8/b
```

I've looked here: http://www.ruby-doc.org/core-2.0.0/Exception.html and couldn't find in fact any standard exception class named `Error`. This patch changes it do default (`RuntimeError`).
