### PR TITLE
Fix for issue #358. Including apache::mod::proxy and apache::mod::proxy_h...

### DIFF
--- a/manifests/mod/proxy_balancer.pp
+++ b/manifests/mod/proxy_balancer.pp
@@ -1,5 +1,10 @@
 class apache::mod::proxy_balancer {
+  
+  include apache::mod::proxy
+  include apache::mod::proxy_http
+  
   Class['apache::mod::proxy'] -> Class['apache::mod::proxy_balancer']
   Class['apache::mod::proxy_http'] -> Class['apache::mod::proxy_balancer']
   apache::mod { 'proxy_balancer': }
+
 }


### PR DESCRIPTION
Adds includes for required classes for balancer

Related issue: ![#358](https://github.com/puppetlabs/puppetlabs-apache/issues/358)
