### PR TITLE
Convert sendfile param to string from bool.

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Sets the servername. Defaults to fqdn provided by facter.
 
 #####`sendfile`
 
-Makes Apache use the Linux kernel 'sendfile' to serve static files. Defaults to 'false'.
+Makes Apache use the Linux kernel 'sendfile' to serve static files. Defaults to 'On'.
 
 #####`error_documents`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,7 +26,7 @@ class apache (
   $purge_configs        = true,
   $purge_vdir           = false,
   $serveradmin          = 'root@localhost',
-  $sendfile             = false,
+  $sendfile             = 'On',
   $error_documents      = false,
   $httpd_dir            = $apache::params::httpd_dir,
   $confd_dir            = $apache::params::confd_dir,
@@ -59,6 +59,7 @@ class apache (
   if $mpm_module {
     validate_re($mpm_module, '(prefork|worker|itk)')
   }
+  validate_re($sendfile, [ '^[oO]n$' , '^[oO]ff$' ])
 
   # declare the web server user and group
   # Note: requiring the package means the package ought to create them and not puppet

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -288,5 +288,30 @@ describe 'apache', :type => :class do
         it { should contain_class('apache::mod::mime') }
       end
     end
+
+    describe "sendfile" do
+      context "with invalid value" do
+        let :params do
+          { :sendfile => 'foo' }
+        end
+        it "should fail" do
+          expect do
+            subject
+          end.to raise_error(Puppet::Error, /"foo" does not match/)
+        end
+      end
+      context "On" do
+        let :params do
+          { :sendfile => 'On' }
+        end
+        it { should contain_file("/etc/httpd/conf/httpd.conf").with_content %r{^EnableSendfile On\n} }
+      end
+      context "Off" do
+        let :params do
+          { :sendfile => 'Off' }
+        end
+        it { should contain_file("/etc/httpd/conf/httpd.conf").with_content %r{^EnableSendfile Off\n} }
+      end
+    end
   end
 end

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -30,9 +30,7 @@ DefaultType none
 HostnameLookups Off
 ErrorLog <%= @logroot %>/<%= @error_log %>
 LogLevel warn
-<% if @sendfile %>
 EnableSendfile <%= @sendfile %>
-<% end %>
 
 #Listen 80
 Include <%= @mod_load_dir %>/*.load


### PR DESCRIPTION
Currently, one would assume that since the default is false, setting `sendfile => true` would cause the option to be enabled in httpd.conf, but instead it writes `EnableSendfile true` which is incorrect.  This makes the usage consistant with commit a82af5595e1e51961903873b6171bd5e08857d60.
