### PR TITLE
Added apache::mod::mime to support SSL module.

### DIFF
--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -21,6 +21,7 @@ class apache::default_mods (
       }
       'redhat': {
         include apache::mod::cache
+        include apache::mod::mime
         include apache::mod::mime_magic
         include apache::mod::vhost_alias
         apache::mod { 'actions': }


### PR DESCRIPTION
The SSL template requires the use of AddType, which is provided by mod_mime.  Seems to make sense as a default module for that reason.
