### PR TITLE
Remove vhost symlink if ensure != present.

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -398,8 +398,12 @@ define apache::vhost(
   }
   if $::osfamily == 'Debian' {
     $vhost_enable_dir = $apache::vhost_enable_dir
+    $vhost_symlink_ensure = $ensure ? {
+      present => link,
+      default => $ensure,
+    }
     file{ "${priority_real}-${filename}.conf symlink":
-      ensure  => link,
+      ensure  => $vhost_symlink_ensure,
       path    => "${vhost_enable_dir}/${priority_real}-${filename}.conf",
       target  => "${apache::vhost_dir}/${priority_real}-${filename}.conf",
       owner   => 'root',


### PR DESCRIPTION
If apache parent class is used without full management via purge_configs => false,
setting a vhost.ensure => absent leaves behind the vhost's symlink in /etc/apache2/sites-enabled (Debian/Ubuntu).
If this happens, Apache fails to restart because of missing file.
