### PR TITLE
Support FallbackResource (httpd >= 2.2.16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,18 @@ To set up a virtual host with WSGI
     }
 ```
 
+Starting 2.2.16, httpd supports [FallbackResource](https://httpd.apache.org/docs/2.2/mod/mod_dir.html#fallbackresource) which is a simple replace for common RewriteRules:
+
+```puppet
+    apache::vhost { 'wordpress.example.com':
+      port                => '80',
+      docroot             => '/var/www/wordpress',
+      fallbackresource    => '/index.php',
+    }
+```
+
+Please note that the `disabled` argument to FallbackResource is only supported since 2.2.24.
+
 To see a list of all virtual host parameters, [please go here](#defined-type-apachevhost). To see an extensive list of virtual host examples [please look here](#virtual-host-examples).
 
 ##Usage

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -94,6 +94,7 @@ define apache::vhost(
     $error_log_file              = undef,
     $error_log_pipe              = undef,
     $error_log_syslog            = undef,
+    $fallbackresource            = undef,
     $scriptalias                 = undef,
     $proxy_dest                  = undef,
     $proxy_pass                  = undef,
@@ -154,6 +155,10 @@ define apache::vhost(
 
   if $error_log_file and $error_log_pipe {
     fail("Apache::Vhost[${name}]: 'error_log_file' and 'error_log_pipe' cannot be defined at the same time")
+  }
+
+  if $fallbackresource {
+    validate_re($fallbackresource, '^/|disabled', 'Please make sure fallbackresource starts with a / (or is "disabled")')
   }
 
   if $ssl {
@@ -337,6 +342,7 @@ define apache::vhost(
   # - $_access_log_format
   # - $error_log
   # - $error_log_destination
+  # - $fallbackresource
   # - $custom_fragment
   # block fragment:
   #   - $block

--- a/spec/system/vhost_spec.rb
+++ b/spec/system/vhost_spec.rb
@@ -163,6 +163,45 @@ describe 'apache::vhost define' do
 
   end
 
+  case node.facts['lsbdistcodename']
+  when 'precise', 'wheezy'
+    context 'vhost fallbackresouce example' do
+      it 'should configure a vhost with Fallbackresource' do
+        puppet_apply(%{
+        class { 'apache': }
+        apache::vhost { 'fallback.example.net':
+          docroot         => '/var/www/fallback',
+          fallbackresource => '/index.html'
+        }
+        file { '/var/www/fallback/index.html':
+          ensure  => file,
+          content => "Hello World\\n",
+        }
+        host { 'fallback.example.net': ip => '127.0.0.1', }
+                     }) { |r| [0,2].should include r.exit_code}
+      end
+
+      describe service(service_name) do
+        it { should be_enabled }
+        it { should be_running }
+      end
+
+      it 'should answer to fallback.example.net' do
+        shell("/usr/bin/curl fallback.example.net:80/Does/Not/Exist") do |r|
+          r.stdout.should == "Hello World\n"
+          r.exit_code.should == 0
+        end
+      end
+
+    end
+  else
+    # The current stable RHEL release (6.4) comes with Apache httpd 2.2.15
+    # That was released March 6, 2010.
+    # FallbackResource was backported to 2.2.16, and released July 25, 2010.
+    # Ubuntu Lucid (10.04) comes with apache2 2.2.14, released October 3, 2009.
+    # https://svn.apache.org/repos/asf/httpd/httpd/branches/2.2.x/STATUS
+  end
+
   context 'virtual_docroot hosting separate sites' do
     it 'should configure a vhost with VirtualDocumentRoot' do
       puppet_apply(%{

--- a/templates/vhost.conf.erb
+++ b/templates/vhost.conf.erb
@@ -19,6 +19,10 @@
 
 <%= scope.function_template(['apache/vhost/_itk.erb']) -%>
 
+<% if @fallbackresource -%>
+  FallbackResource <%= @fallbackresource %>
+<% end -%>
+
   ## Directories, there should at least be a declaration for <%= @docroot %>
 <%= scope.function_template(['apache/vhost/_directories.erb']) -%>
 

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -80,6 +80,9 @@
     <%- if directory['auth_require'] -%>
     Require <%= directory['auth_require'] %>
     <%- end -%>
+    <%- if directory['fallbackresource'] -%>
+    FallbackResource <%= directory['fallbackresource'] %>
+    <%- end -%>
     <%- if directory['custom_fragment'] -%>
     <%= directory['custom_fragment'] %>
     <%- end -%>


### PR DESCRIPTION
Starting Apache httpd 2.2.16, FallbackResource is a much simpler way of
configuring a very common pattern usually implemented with RewriteRules.

Sending all requests to one router that then dispaches all requests can
now be done with a single line:

```
FallbackResource /index.php
```

We now support this directive with the apache::vhost parameter
fallbackresource, which can be used like this:

```
apache::vhost { 'wordpress.example.com':
  documentroot     => '/var/www/wp',
  fallbackresource => '/index.php',
}
```

fallbackresource is also a valid prameter in directories, where at
different levels it either can be overwritten, or `disabled`.
