### PR TITLE
EL5 and EL6 both use /etc/pki/tls/certs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -852,7 +852,7 @@ Specifies the SSL certification.
 
 #####`ssl_certs_dir`
 
-Specifies the location of the SSL certification directory. Defaults to `/etc/ssl/certs`.
+Specifies the location of the SSL certification directory. Defaults to `/etc/ssl/certs` on Debian and `/etc/pki/tls/certs` on RedHat.
 
 #####`ssl_chain`
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -49,10 +49,7 @@ class apache::params {
     $dev_packages         = 'httpd-devel'
     $default_ssl_cert     = '/etc/pki/tls/certs/localhost.crt'
     $default_ssl_key      = '/etc/pki/tls/private/localhost.key'
-    $ssl_certs_dir        = $distrelease ? {
-      '5'     => '/etc/pki/tls/certs',
-      default => '/etc/ssl/certs',
-    }
+    $ssl_certs_dir        = '/etc/pki/tls/certs'
     $passenger_root       = '/usr/share/rubygems/gems/passenger-3.0.17'
     $passenger_ruby       = '/usr/bin/ruby'
     $suphp_addhandler     = 'php5-script'


### PR DESCRIPTION
Fix `$ssl_certs_dir` for `$::osfamily == 'RedHat'` to be `/etc/pki/tls/certs`.
