### PR TITLE
Ability to define service_enable and service_ensure independently

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,11 @@ The default certificate revocation list to use, which is automatically set to 'u
 
 #####`service_enable`
 
-Determines whether the 'httpd' service is enabled when the machine is booted, meaning Puppet will check the service status to start/stop it. Defaults to 'true', meaning the service is enabled/running.
+Determines whether the 'httpd' service is enabled when the machine is booted. Defaults to 'true'.
+
+#####`service_ensure`
+
+Determines whether the service should be running. Can be set to 'undef' which is useful when you want to let the service be managed by some other application like pacemaker. Defaults to 'running'.
 
 #####`serveradmin`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,6 +23,7 @@ class apache (
   $default_ssl_crl_path = undef,
   $default_ssl_crl      = undef,
   $service_enable       = true,
+  $service_ensure       = 'running',
   $purge_configs        = true,
   $purge_vdir           = false,
   $serveradmin          = 'root@localhost',
@@ -85,6 +86,7 @@ class apache (
 
   class { 'apache::service':
     service_enable => $service_enable,
+    service_ensure => $service_ensure,
   }
 
   # Deprecated backwards-compatibility

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -18,11 +18,12 @@
 #
 class apache::service (
   $service_enable = true,
+  $service_ensure = 'running',
 ) {
   validate_bool($service_enable)
 
   service { 'httpd':
-    ensure => $service_enable,
+    ensure => $service_ensure,
     name   => $apache::apache_name,
     enable => $service_enable,
   }

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -10,7 +10,7 @@ describe 'apache::service', :type => :class do
       }
     end
     it { should contain_service("httpd").with(
-      'ensure'    => 'true',
+      'ensure'    => 'running',
       'enable'    => 'true'
       )
     }
@@ -18,7 +18,7 @@ describe 'apache::service', :type => :class do
     context "with $service_enable => true" do
       let (:params) {{ :service_enable => true }}
       it { should contain_service("httpd").with(
-        'ensure'    => 'true',
+        'ensure'    => 'running',
         'enable'    => 'true'
         )
       }
@@ -27,7 +27,7 @@ describe 'apache::service', :type => :class do
     context "with $service_enable => false" do
       let (:params) {{ :service_enable => false }}
       it { should contain_service("httpd").with(
-        'ensure'    => 'false',
+        'ensure'    => 'running',
         'enable'    => 'false'
         )
       }
@@ -42,6 +42,24 @@ describe 'apache::service', :type => :class do
         }.to raise_error(Puppet::Error, /is not a boolean/)
       end
     end
+
+    context "with $service_ensure => 'running'" do
+      let (:params) {{ :service_ensure => 'running', }}
+      it { should contain_service("httpd").with(
+        'ensure'    => 'running',
+        'enable'    => 'true'
+        )
+      }
+    end
+
+    context "with $service_ensure => 'stopped'" do
+      let (:params) {{ :service_ensure => 'stopped', }}
+      it { should contain_service("httpd").with(
+        'ensure'    => 'stopped',
+        'enable'    => 'true'
+        )
+      }
+    end
   end
 
 
@@ -54,7 +72,7 @@ describe 'apache::service', :type => :class do
       }
     end
     it { should contain_service("httpd").with(
-      'ensure'    => 'true',
+      'ensure'    => 'running',
       'enable'    => 'true'
       )
     }


### PR DESCRIPTION
Using modified code from PR #340 and added rspec tests.

Now 'service_enable' isn't intertwined with 'service_ensure' any more.
