### PR TITLE
Correct broken mime_magic config for Debian - Squashed commit for #418

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ There are many `apache::mod::[name]` classes within this module that can be decl
 * `info`
 * `ldap`
 * `mime`
-* `mime_magic`
+* `mime_magic`*
 * `mpm_event`
 * `negotiation`
 * `passenger`*

--- a/manifests/mod/mime_magic.pp
+++ b/manifests/mod/mime_magic.pp
@@ -1,6 +1,8 @@
-class apache::mod::mime_magic {
+class apache::mod::mime_magic (
+  $magic_file = "${apache::params::conf_dir}/magic"
+) {
   apache::mod { 'mime_magic': }
-  # Template uses no variables
+  # Template uses $magic_file
   file { 'mime_magic.conf':
     ensure  => file,
     path    => "${apache::mod_dir}/mime_magic.conf",

--- a/spec/classes/mod/mime_magic_spec.rb
+++ b/spec/classes/mod/mime_magic_spec.rb
@@ -1,0 +1,93 @@
+# This function is called inside the OS specific contexts
+def general_mime_magic_specs
+  it { should contain_apache__mod("mime_magic") }
+end
+
+describe 'apache::mod::mime_magic', :type => :class do
+  let :pre_condition do
+    'include apache'
+  end
+
+  context "On a Debian OS with default params" do
+    let :facts do
+      {
+        :osfamily               => 'Debian',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
+      }
+    end
+
+    general_mime_magic_specs()
+
+    it do
+      should contain_file("mime_magic.conf").with_content(
+        "MIMEMagicFile /etc/apache2/magic\n"
+      )
+    end
+
+    it { should contain_file("mime_magic.conf").with({
+      :ensure => 'file',
+      :path   => '/etc/apache2/mods-available/mime_magic.conf',
+    } ) }
+    it { should contain_file("mime_magic.conf symlink").with({
+      :ensure => 'link',
+      :path   => '/etc/apache2/mods-enabled/mime_magic.conf',
+    } ) }
+
+    context "with magic_file => /tmp/Debian_magic" do
+      let :params do
+        { :magic_file => "/tmp/Debian_magic" }
+      end
+
+      it do
+        should contain_file("mime_magic.conf").with_content(
+          "MIMEMagicFile /tmp/Debian_magic\n"
+        )
+      end
+    end
+
+  end
+
+  context "on a RedHat OS with default params" do
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
+      }
+    end
+
+    general_mime_magic_specs()
+
+    it do
+      should contain_file("mime_magic.conf").with_content(
+        "MIMEMagicFile /etc/httpd/conf/magic\n"
+      )
+    end
+
+    it { should contain_file("mime_magic.conf").with_path("/etc/httpd/conf.d/mime_magic.conf") }
+
+  end
+
+  context "with magic_file => /tmp/magic" do
+    let :facts do
+      {
+        :osfamily               => 'Debian',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
+      }
+    end
+
+    let :params do
+      { :magic_file => "/tmp/magic" }
+    end
+
+    it do
+      should contain_file("mime_magic.conf").with_content(
+        "MIMEMagicFile /tmp/magic\n"
+      )
+    end
+  end
+
+
+end

--- a/templates/mod/mime_magic.conf.erb
+++ b/templates/mod/mime_magic.conf.erb
@@ -1,1 +1,1 @@
-MIMEMagicFile conf/magic
+MIMEMagicFile <%= @magic_file %>


### PR DESCRIPTION
I've squashed my PR in #418 as requested.
#### Commit Message:

The location "conf/magic" in the mime_magic.conf template is RedHat specific
and is broken under Debian/Ubuntu. Added a class parameter with an os agnostic
default and matching template usage.

Added full testing and updated `README.md` to indicated this module has
settings and template parameters.
