### PR TITLE
satisfy mod_php inter-module dependencies

### DIFF
--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -7,6 +7,11 @@ class apache::mod::php (
   apache::mod { 'php5':
     package_ensure => $package_ensure,
   }
+
+  include apache::mod::mime
+  include apache::mod::dir
+  Class['apache::mod::mime'] -> Class['apache::mod::dir'] -> Class['apache::mod::php']
+
   file { 'php5.conf':
     ensure  => file,
     path    => "${apache::mod_dir}/php5.conf",


### PR DESCRIPTION
we try to make sure that mod_php's inter-module dependencies (mod_dir
and mod_mime) are satisfied before we try to implement any changes in
the config that would trigger those.
This fixes #408.
