### PR TITLE
update puppetlabs/concat > 1.0.0

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -9,4 +9,4 @@ project_page 'https://github.com/puppetlabs/puppetlabs-apache'
 
 ## Add dependencies, if any:
 dependency 'puppetlabs/stdlib', '>= 2.4.0'
-dependency 'puppetlabs/concat', '>= 1.0.0'
+dependency 'puppetlabs/concat', '> 1.0.0'

--- a/manifests/balancer.pp
+++ b/manifests/balancer.pp
@@ -42,7 +42,6 @@ define apache::balancer (
   $proxy_set = {},
   $collect_exported = true,
 ) {
-  include concat::setup
   include apache::mod::proxy_balancer
 
   $target = "${::apache::params::confd_dir}/balancer_${name}.conf"

--- a/spec/spec_helper_system.rb
+++ b/spec/spec_helper_system.rb
@@ -21,7 +21,7 @@ RSpec.configure do |c|
 
     # Install modules and dependencies
     puppet_module_install(:source => proj_root, :module_name => 'apache')
-    shell('puppet module install puppetlabs-concat --version 1.0.0')
+    shell('puppet module install puppetlabs-concat --version "> 1.0.0"')
     shell('puppet module install puppetlabs-stdlib --version 2.4.0')
   end
 end


### PR DESCRIPTION
This should not be merged until puppetlabs/concat > 1.0.0 is released to the forge or it will break the rspec-system tests.
