### PR TITLE
allow allow_from to be set for mod_status

### DIFF
--- a/manifests/mod/status.pp
+++ b/manifests/mod/status.pp
@@ -1,4 +1,6 @@
-class apache::mod::status {
+class apache::mod::status (
+  $allow_from = ['127.0.0.1','::1'],
+){
   apache::mod { 'status': }
   # Template uses no variables
   file { 'status.conf':

--- a/spec/classes/mod/status_spec.rb
+++ b/spec/classes/mod/status_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe 'apache::mod::status', :type => :class do
+  let :pre_condition do
+    'include apache'
+  end
+
+  let :facts do
+    {
+      :osfamily               => 'RedHat',
+      :operatingsystemrelease => '6',
+      :concat_basedir         => '/dne',
+    }
+  end
+
+  it { should contain_apache__mod('status') }
+
+  context 'default' do
+    it { should contain_file('status.conf').with_content(/Allow from 127\.0\.0\.1 ::1/) }
+  end
+
+  context 'custom allow_from (string)' do
+    let :params do
+      {
+        :allow_from => '1.2.3.4'
+      }
+    end
+    it { should contain_file('status.conf').with_content(/Allow from 1\.2\.3\.4/) }
+  end
+
+  context 'custom allow_from (array)' do
+    let :params do
+      {
+        :allow_from => [ '1.2.3.4', '2.3.4.5' ]
+      }
+    end
+    it { should contain_file('status.conf').with_content(/Allow from 1\.2\.3\.4 2\.3\.4\.5/) }
+  end
+
+end

--- a/templates/mod/status.conf.erb
+++ b/templates/mod/status.conf.erb
@@ -2,7 +2,7 @@
     SetHandler server-status
     Order deny,allow
     Deny from all
-    Allow from 127.0.0.1 ::1
+    Allow from <%= Array(@allow_from).join(" ") %>
 </Location>
 ExtendedStatus On
 


### PR DESCRIPTION
Allows allow_from to be specified for apache::mod::status
Adds spec tests to validate

Resolves #428
