### PR TITLE
ensure default vhost config files are removed when false

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,6 +59,7 @@ class apache (
   }
 
   validate_bool($default_vhost)
+  validate_bool($default_ssl_vhost)
   # true/false is sufficient for both ensure and enable
   validate_bool($service_enable)
   if $mpm_module {
@@ -247,26 +248,34 @@ class apache (
     if $mpm_module {
       class { "apache::mod::${mpm_module}": }
     }
-    if $default_vhost {
-      apache::vhost { 'default':
-        port            => 80,
-        docroot         => $docroot,
-        scriptalias     => $scriptalias,
-        serveradmin     => $serveradmin,
-        access_log_file => $access_log_file,
-        priority        => '15',
-      }
+
+    $default_vhost_ensure = $default_vhost ? {
+      true  => 'present',
+      false => 'absent'
     }
-    if $default_ssl_vhost {
-      apache::vhost { 'default-ssl':
-        port            => 443,
-        ssl             => true,
-        docroot         => $docroot,
-        scriptalias     => $scriptalias,
-        serveradmin     => $serveradmin,
-        access_log_file => "ssl_${access_log_file}",
-        priority        => '15',
-      }
+    $default_ssl_vhost_ensure = $default_ssl_vhost ? {
+      true  => 'present',
+      false => 'absent'
+    }
+
+    apache::vhost { 'default':
+      ensure          => $default_vhost_ensure,
+      port            => 80,
+      docroot         => $docroot,
+      scriptalias     => $scriptalias,
+      serveradmin     => $serveradmin,
+      access_log_file => $access_log_file,
+      priority        => '15',
+    }
+    apache::vhost { 'default-ssl':
+      ensure          => $default_ssl_vhost_ensure,
+      port            => 443,
+      ssl             => true,
+      docroot         => $docroot,
+      scriptalias     => $scriptalias,
+      serveradmin     => $serveradmin,
+      access_log_file => "ssl_${access_log_file}",
+      priority        => '15',
     }
   }
 }

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -356,4 +356,31 @@ describe 'apache', :type => :class do
       end
     end
   end
+  context 'on all OSes' do
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
+      }
+    end
+    context 'default vhost defaults' do
+      it { should contain_apache__vhost('default').with_ensure('present') }
+      it { should contain_apache__vhost('default-ssl').with_ensure('absent') }
+    end
+    context 'without default non-ssl vhost' do
+      let :params do {
+        :default_vhost  => false
+      }
+      end
+      it { should contain_apache__vhost('default').with_ensure('absent') }
+    end
+    context 'with default ssl vhost' do
+      let :params do {
+          :default_ssl_vhost  => true
+        }
+      end
+      it { should contain_apache__vhost('default').with_ensure('present') }
+    end
+  end
 end


### PR DESCRIPTION
If default_vhost or default_ssl_vhost is set to false, ensure the conf file is removed
Bool check on default_ssl_vhost

Closes #385
