### PR TITLE
vhost directories fix

### DIFF
--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -15,7 +15,7 @@
     <%- if directory['options'] -%>
     Options <%= Array(directory['options']).join(' ') %>
     <%- end -%>
-    <%- if directory['provider'] == 'directory' %>
+    <%- if directory['provider'] == 'Directory' %>
       <%- if directory['allow_override'] -%>
     AllowOverride <%= Array(directory['allow_override']).join(' ') %>
       <%- else -%>


### PR DESCRIPTION
According to Apache docs http://httpd.apache.org/docs/current/mod/core.html#allowoverride

```
AllowOverride is valid only in <Directory> sections specified without regular expressions, not in <Location>, <DirectoryMatch> or <Files> sections.
```

This was causing a warning when I started Apache.
