### PR TITLE
Added $service_name parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,10 @@ The default certificate revocation list path, which is automatically set to 'und
 
 The default certificate revocation list to use, which is automatically set to 'undef'. This default will work out of the box but must be updated with your specific certificate information before being used in production.
 
+#####`service_name`
+
+Name of apache service to run. Defaults to: `'httpd'` on RedHat and `'apache2'` on Debian.
+
 #####`service_enable`
 
 Determines whether the 'httpd' service is enabled when the machine is booted. Defaults to 'true'.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,7 @@
 # Sample Usage:
 #
 class apache (
+  $service_name         = $apache::params::service_name,
   $default_mods         = true,
   $default_vhost        = true,
   $default_ssl_vhost    = false,
@@ -86,6 +87,7 @@ class apache (
   }
 
   class { 'apache::service':
+    service_name   => $service_name,
     service_enable => $service_enable,
     service_ensure => $service_ensure,
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,6 +37,7 @@ class apache::params {
     $group                = 'apache'
     $root_group           = 'root'
     $apache_name          = 'httpd'
+    $service_name         = 'httpd'
     $httpd_dir            = '/etc/httpd'
     $conf_dir             = "${httpd_dir}/conf"
     $confd_dir            = "${httpd_dir}/conf.d"
@@ -88,6 +89,7 @@ class apache::params {
     $group            = 'www-data'
     $root_group       = 'root'
     $apache_name      = 'apache2'
+    $service_name     = 'apache2'
     $httpd_dir        = '/etc/apache2'
     $conf_dir         = $httpd_dir
     $confd_dir        = "${httpd_dir}/conf.d"

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -17,14 +17,19 @@
 #
 #
 class apache::service (
+  $service_name   = $apache::params::service_name,
   $service_enable = true,
   $service_ensure = 'running',
 ) {
+  # The base class must be included first because parameter defaults depend on it
+  if ! defined(Class['apache::params']) {
+    fail('You must include the apache::params class before using any apache defined resources')
+  }
   validate_bool($service_enable)
 
   service { 'httpd':
     ensure => $service_ensure,
-    name   => $apache::apache_name,
+    name   => $service_name,
     enable => $service_enable,
   }
 }

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
 describe 'apache::service', :type => :class do
+  let :pre_condition do
+    'include apache::params'
+  end
   context "on a Debian OS" do
     let :facts do
       {
@@ -10,14 +13,24 @@ describe 'apache::service', :type => :class do
       }
     end
     it { should contain_service("httpd").with(
+      'name'      => 'apache2',
       'ensure'    => 'running',
       'enable'    => 'true'
       )
     }
 
+    context "with $service_name => 'foo'" do
+      let (:params) {{ :service_name => 'foo' }}
+      it { should contain_service("httpd").with(
+        'name'      => 'foo'
+        )
+      }
+    end
+
     context "with $service_enable => true" do
       let (:params) {{ :service_enable => true }}
       it { should contain_service("httpd").with(
+        'name'      => 'apache2',
         'ensure'    => 'running',
         'enable'    => 'true'
         )
@@ -27,6 +40,7 @@ describe 'apache::service', :type => :class do
     context "with $service_enable => false" do
       let (:params) {{ :service_enable => false }}
       it { should contain_service("httpd").with(
+        'name'      => 'apache2',
         'ensure'    => 'running',
         'enable'    => 'false'
         )
@@ -70,6 +84,7 @@ describe 'apache::service', :type => :class do
       }
     end
     it { should contain_service("httpd").with(
+      'name'      => 'httpd',
       'ensure'    => 'running',
       'enable'    => 'true'
       )


### PR DESCRIPTION
This PR adds $service_name  parameter to apache::params class and apache::service class. These parameters are used by #342. The purpose of the whole thing is to split #342 into parts to make review process easier, see https://github.com/puppetlabs/puppetlabs-apache/pull/342#issuecomment-25423813.
