### PR TITLE
More vhost directives, only add AllowOverride default for directory container

### DIFF
--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -26,7 +26,7 @@
     <%- end -%>
     <%- if directory['order'] and directory['order'] != '' -%>
     Order <%= Array(directory['order']).join(',') %>
-    <%- elsif provider == 'Directory' -%>
+    <%- else -%>
     Order allow,deny
     <%- end -%>
     <%- if directory['deny'] and directory['deny'] != '' -%>
@@ -34,7 +34,7 @@
     <%- end -%>
     <%- if directory['allow'] and directory['allow'] != '' -%>
     Allow <%= directory['allow'] %>
-    <%- elsif provider == 'Directory' -%>
+    <%- else -%>
     Allow from all
     <%- end -%>
     <%- if directory['addhandlers'] and ! directory['addhandlers'].empty? -%>


### PR DESCRIPTION
Add directives from mod_expires and mod_mime to vhost template, omit AllowOverride when in a container that doesn't support it ([anything other than Directory](http://httpd.apache.org/docs/2.2/sections.html#whatwhere)).
