### PR TITLE
Workaround for apxs-loaded modules

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -210,6 +210,12 @@ class apache (
         fail("Unsupported osfamily ${::osfamily}")
       }
     }
+
+    $apxs_workaround = $::osfamily ? {
+      'freebsd' => true,
+      default   => false
+    }
+
     # Template uses:
     # - $httpd_dir
     # - $pidfile
@@ -224,6 +230,7 @@ class apache (
     # - $vhost_dir
     # - $error_documents
     # - $error_documents_path
+    # - $apxs_workaround
     # - $keepalive
     # - $keepalive_timeout
     file { "${apache::params::conf_dir}/${apache::params::conf_file}":

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -33,6 +33,14 @@ LogLevel warn
 EnableSendfile <%= @sendfile %>
 
 #Listen 80
+
+<% if @apxs_workaround -%>
+# Workaround: without this hack apxs would be confused about where to put
+# LoadModule directives and fail entire procedure of apache package
+# installation/reinstallation. This problem was observed on FreeBSD (apache22).
+#LoadModule fake_module libexec/apache22/mod_fake.so
+<% end -%>
+
 Include <%= @mod_load_dir %>/*.load
 <% if @mod_load_dir != @confd_dir and @mod_load_dir != @vhost_load_dir -%>
 Include <%= @mod_load_dir %>/*.conf


### PR DESCRIPTION
On some OSes (FreeBSD) apxs tool is used to put LoadModule directives
into httpd.conf during apache package (and apache modules)
insallation/reinstallation. The apxs expects some LoadModule directives
to be already present in httpd.conf (they may be commented-out) in order
to decide where to put its own directives.

This PR puts fake LoadModule directive (commented out) to httpd.conf.
The $apxs_workaround boolean parameter in apache class decides, whether
to use this workaround or not. This is used on FreeBSD, where apxs is
used by ports package provider (and perhaps all other). Without this,
the apache installation/reinstallation/deinstallation as well as
installation of additional modules would fail.

This PR was created in order to split #342 into smaller parts to make
review process easier, see
https://github.com/puppetlabs/puppetlabs-apache/pull/342#issuecomment-25423813
