### PR TITLE
Add Allow and ExtendedStatus support to mod_status (rebase of #419)

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ There are many `apache::mod::[name]` classes within this module that can be decl
 * `reqtimeout`
 * `setenvif`
 * `ssl`* (see [apache::mod::ssl](#class-apachemodssl) below)
-* `status`
+* `status`*
 * `suphp`
 * `userdir`*
 * `worker`*

--- a/manifests/mod/status.pp
+++ b/manifests/mod/status.pp
@@ -1,8 +1,36 @@
+# Class: apache::mod::status
+#
+# This class enables and configures Apache mod_status
+# See: http://httpd.apache.org/docs/current/mod/mod_status.html
+#
+# Parameters:
+# - $allow_from is an array of hosts, ip addresses, partial network numbers
+#   or networks in CIDR notation specifying what hosts can view the special
+#   /server-status URL.  Defaults to ['127.0.0.1', '::1'].
+# - $extended_status track and display extended status information. Valid
+#   values are 'On' or 'Off'.  Defaults to 'On'.
+#
+# Actions:
+# - Enable and configure Apache mod_status
+#
+# Requires:
+# - The apache class
+#
+# Sample Usage:
+#
+#  # Simple usage allowing access from localhost and a private subnet
+#  class { 'apache::mod::status':
+#    $allow_from => ['127.0.0.1', '10.10.10.10/24'],
+#  }
+#
 class apache::mod::status (
-  $allow_from = ['127.0.0.1','::1'],
+  $allow_from      = ['127.0.0.1','::1'],
+  $extended_status = 'On',
 ){
+  validate_array($allow_from)
+  validate_re(downcase($extended_status), '^(on|off)$', "${extended_status} is not supported for extended_status.  Allowed values are 'On' and 'Off'.")
   apache::mod { 'status': }
-  # Template uses no variables
+  # Template uses $allow_from, $extended_status
   file { 'status.conf':
     ensure  => file,
     path    => "${apache::mod_dir}/status.conf",

--- a/spec/classes/mod/status_spec.rb
+++ b/spec/classes/mod/status_spec.rb
@@ -1,40 +1,166 @@
 require 'spec_helper'
 
+# Helper function for testing the contents of `status.conf`
+def status_conf_spec(allow_from, extended_status)
+  it do
+    should contain_file("status.conf").with_content(
+      "<Location /server-status>\n"\
+      "    SetHandler server-status\n"\
+      "    Order deny,allow\n"\
+      "    Deny from all\n"\
+      "    Allow from #{Array(allow_from).join(' ')}\n"\
+      "</Location>\n"\
+      "ExtendedStatus #{extended_status}\n"\
+      "\n"\
+      "<IfModule mod_proxy.c>\n"\
+      "    # Show Proxy LoadBalancer status in mod_status\n"\
+      "    ProxyStatus On\n"\
+      "</IfModule>\n"
+    )
+  end
+end
+
 describe 'apache::mod::status', :type => :class do
   let :pre_condition do
     'include apache'
   end
 
-  let :facts do
-    {
-      :osfamily               => 'RedHat',
-      :operatingsystemrelease => '6',
-      :concat_basedir         => '/dne',
-    }
-  end
-
-  it { should contain_apache__mod('status') }
-
-  context 'default' do
-    it { should contain_file('status.conf').with_content(/Allow from 127\.0\.0\.1 ::1/) }
-  end
-
-  context 'custom allow_from (string)' do
-    let :params do
+  context "on a Debian OS with default params" do
+    let :facts do
       {
-        :allow_from => '1.2.3.4'
+        :osfamily               => 'Debian',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
       }
     end
-    it { should contain_file('status.conf').with_content(/Allow from 1\.2\.3\.4/) }
+
+    it { should contain_apache__mod("status") }
+
+    status_conf_spec(["127.0.0.1", "::1"], "On")
+
+    it { should contain_file("status.conf").with({
+      :ensure => 'file',
+      :path   => '/etc/apache2/mods-available/status.conf',
+    } ) }
+
+    it { should contain_file("status.conf symlink").with({
+      :ensure => 'link',
+      :path   => '/etc/apache2/mods-enabled/status.conf',
+    } ) }
+
   end
 
-  context 'custom allow_from (array)' do
-    let :params do
+  context "on a RedHat OS with default params" do
+    let :facts do
       {
-        :allow_from => [ '1.2.3.4', '2.3.4.5' ]
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
       }
     end
-    it { should contain_file('status.conf').with_content(/Allow from 1\.2\.3\.4 2\.3\.4\.5/) }
+
+    it { should contain_apache__mod("status") }
+
+    status_conf_spec(["127.0.0.1", "::1"], "On")
+
+    it { should contain_file("status.conf").with_path("/etc/httpd/conf.d/status.conf") }
+
+  end
+
+  context "with custom parameters $allow_from => ['10.10.10.10','11.11.11.11'], $extended_status => 'Off'" do
+    let :facts do
+      {
+        :osfamily               => 'Debian',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
+      }
+    end
+    let :params do
+      {
+        :allow_from => ['10.10.10.10','11.11.11.11'],
+        :extended_status => 'Off',
+      }
+    end
+
+    status_conf_spec(["10.10.10.10", "11.11.11.11"], "Off")
+
+  end
+
+  context "with valid parameter type $allow_from => ['10.10.10.10']" do
+    let :facts do
+      {
+        :osfamily               => 'Debian',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
+      }
+    end
+    let :params do
+      { :allow_from => ['10.10.10.10'] }
+    end
+    it 'should expect to succeed array validation' do
+      expect {
+        should contain_file("status.conf")
+      }.not_to raise_error()
+    end
+  end
+
+  context "with invalid parameter type $allow_from => '10.10.10.10'" do
+    let :facts do
+      {
+        :osfamily               => 'Debian',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
+      }
+    end
+    let :params do
+      { :allow_from => '10.10.10.10' }
+    end
+    it 'should expect to fail array validation' do
+      expect {
+        should contain_file("status.conf")
+      }.to raise_error(Puppet::Error)
+    end
+  end
+
+  # Only On or Off are valid options
+  ['On', 'Off'].each do |valid_param|
+    context "with valid value $extended_status => '#{valid_param}'" do
+      let :facts do
+        {
+          :osfamily               => 'Debian',
+          :operatingsystemrelease => '6',
+          :concat_basedir         => '/dne',
+        }
+      end
+      let :params do
+        { :extended_status => valid_param }
+      end
+      it 'should expect to succeed regular expression validation' do
+        expect {
+          should contain_file("status.conf")
+        }.not_to raise_error()
+      end
+    end
+  end
+
+  ['Yes', 'No'].each do |invalid_param|
+    context "with invalid value $extended_status => '#{invalid_param}'" do
+      let :facts do
+        {
+          :osfamily               => 'Debian',
+          :operatingsystemrelease => '6',
+          :concat_basedir         => '/dne',
+        }
+      end
+      let :params do
+        { :extended_status => invalid_param }
+      end
+      it 'should expect to fail regular expression validation' do
+        expect {
+          should contain_file("status.conf")
+        }.to raise_error(Puppet::Error)
+      end
+    end
   end
 
 end

--- a/templates/mod/status.conf.erb
+++ b/templates/mod/status.conf.erb
@@ -4,7 +4,7 @@
     Deny from all
     Allow from <%= Array(@allow_from).join(" ") %>
 </Location>
-ExtendedStatus On
+ExtendedStatus <%= @extended_status %>
 
 <IfModule mod_proxy.c>
     # Show Proxy LoadBalancer status in mod_status


### PR DESCRIPTION
This is a rebase of 555e0f7 submitted in #419 against the most recent mod_status changes.  I also added class docs and cleaned up the testing a bit as well as added a couple of extra test cases.  `rake spec` finishes cleanly.

**_Commit Message:**_

I've extended the apache::mod::status class to accept an `$allow_from`
parameter similar to the existing apache::mod::info class, as well as
added an `$extended_status` parameter to control the ExtendedStatus
directive.

Added module docs and full testing support as well as updated the
README.md to indicate that the status class accepts additional
parameters.
