### PR TITLE
Add new params to apache::mod::mime class

### DIFF
--- a/manifests/mod/mime.pp
+++ b/manifests/mod/mime.pp
@@ -1,6 +1,9 @@
-class apache::mod::mime {
+class apache::mod::mime (
+  $mime_support_package = $apache::params::mime_support_package,
+  $mime_types_config    = $apache::params::mime_types_config,
+) {
   apache::mod { 'mime': }
-  # Template uses no variables
+  # Template uses $mime_types_config
   file { 'mime.conf':
     ensure  => file,
     path    => "${apache::mod_dir}/mime.conf",
@@ -8,5 +11,11 @@ class apache::mod::mime {
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],
     notify  => Service['httpd'],
+  }
+  if $mime_support_package {
+    package { $mime_support_package:
+      ensure => 'installed',
+      before => File["${apache::mod_dir}/mime.conf"],
+    }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -87,6 +87,8 @@ class apache::params {
     $keepalive            = 'Off'
     $keepalive_timeout    = 15
     $fastcgi_lib_path     = undef
+    $mime_support_package = 'mailcap'
+    $mime_types_config    = '/etc/mime.types'
   } elsif $::osfamily == 'Debian' {
     $user             = 'www-data'
     $group            = 'www-data'
@@ -138,6 +140,8 @@ class apache::params {
     $keepalive         = 'Off'
     $keepalive_timeout = 15
     $fastcgi_lib_path  = '/var/lib/apache2/fastcgi'
+    $mime_support_package = 'mime-support'
+    $mime_types_config = '/etc/mime.types'
   } else {
     fail("Class['apache::params']: Unsupported osfamily: ${::osfamily}")
   }

--- a/templates/mod/mime.conf.erb
+++ b/templates/mod/mime.conf.erb
@@ -1,4 +1,4 @@
-TypesConfig /etc/mime.types
+TypesConfig <%= @mime_types_config %>
 
 AddType application/x-compress .Z
 AddType application/x-gzip .gz .tgz


### PR DESCRIPTION
This changeset adds $mime_support_package and $mime_types_config parameters to class `apache::mod::mime`. Their purpose is following:
- `$mime_support_package` - install this package, as it provides mime.conf
  file (definition of mime types used by mod_mime),
- `$mime_types_config` - used to substitute as TypesConfig in
  mod/mime.conf.erb template.

This PR was created in order to plit #342 into smaller parts to make review process easier, see https://github.com/puppetlabs/puppetlabs-apache/pull/342#issuecomment-25423813
