### PR TITLE
Revert unnecessary `$default_ssl_vhost` validation change.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,6 +56,7 @@ class apache (
 ) inherits apache::params {
 
   validate_bool($default_vhost)
+  validate_bool($default_ssl_vhost)
   validate_bool($default_confd_files)
   # true/false is sufficient for both ensure and enable
   validate_bool($service_enable)
@@ -80,7 +81,6 @@ class apache (
       name   => $apache::params::apache_name,
       notify => Class['Apache::Service'],
     }
-  validate_bool($default_ssl_vhost)
   }
   validate_re($sendfile, [ '^[oO]n$' , '^[oO]ff$' ])
 


### PR DESCRIPTION
The `validate_bool($default_ssl_vhost)` call was moved in
112437730f70e18daf3aed9cedffd0c46348204d making it FreeBSD centric, but
it should be validated outside of any other condition.
