### PR TITLE
Fix spec test for `default_ssl_vhost  => true`

### DIFF
--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -458,7 +458,7 @@ describe 'apache', :type => :class do
           :default_ssl_vhost  => true
         }
       end
-      it { should contain_apache__vhost('default').with_ensure('present') }
+      it { should contain_apache__vhost('default-ssl').with_ensure('present') }
     end
   end
 end


### PR DESCRIPTION
The spec test for `default_ssl_vhost  => true` was retesting the test
for `default_vhost  => true` instead.
