### PR TITLE
Add mod_rpaf support

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,7 @@ There are many `apache::mod::[name]` classes within this module that can be decl
 * `python`
 * `reqtimeout`
 * `rewrite`
+* `rpaf`*
 * `setenvif`
 * `ssl`* (see [apache::mod::ssl](#class-apachemodssl) below)
 * `status`*

--- a/manifests/mod/rpaf.pp
+++ b/manifests/mod/rpaf.pp
@@ -1,0 +1,20 @@
+class apache::mod::rpaf (
+  $sethostname = true,
+  $proxy_ips   = [ '127.0.0.1' ],
+  $header      = 'X-Forwarded-For'
+) {
+  apache::mod { 'rpaf': }
+
+  # Template uses:
+  # - $sethostname
+  # - $proxy_ips
+  # - $header
+  file { 'rpaf.conf':
+    ensure  => file,
+    path    => "${apache::mod_dir}/rpaf.conf",
+    content => template('apache/mod/rpaf.conf.erb'),
+    require => Exec["mkdir ${apache::mod_dir}"],
+    before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -120,18 +120,19 @@ class apache::params {
     $mod_packages     = {
       'auth_kerb'   => 'libapache2-mod-auth-kerb',
       'authnz_ldap' => 'libapache2-mod-authz-ldap',
+      'dav_svn'     => 'libapache2-svn',
       'fastcgi'     => 'libapache2-mod-fastcgi',
       'fcgid'       => 'libapache2-mod-fcgid',
+      'nss'         => 'libapache2-mod-nss',
       'passenger'   => 'libapache2-mod-passenger',
       'perl'        => 'libapache2-mod-perl2',
       'php5'        => 'libapache2-mod-php5',
       'proxy_html'  => 'libapache2-mod-proxy-html',
       'python'      => 'libapache2-mod-python',
-      'wsgi'        => 'libapache2-mod-wsgi',
-      'dav_svn'     => 'libapache2-svn',
+      'rpaf'        => 'libapache2-mod-rpaf',
       'suphp'       => 'libapache2-mod-suphp',
+      'wsgi'        => 'libapache2-mod-wsgi',
       'xsendfile'   => 'libapache2-mod-xsendfile',
-      'nss'         => 'libapache2-mod-nss',
     }
     $mod_libs         = {
       'php5' => 'libphp5.so',

--- a/spec/classes/mod/rpaf_spec.rb
+++ b/spec/classes/mod/rpaf_spec.rb
@@ -1,0 +1,42 @@
+describe 'apache::mod::rpaf', :type => :class do
+  let :pre_condition do
+    [
+      'include apache',
+    ]
+  end
+  context "on a Debian OS" do
+    let :facts do
+      {
+        :osfamily               => 'Debian',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
+      }
+    end
+    it { should include_class("apache::params") }
+    it { should contain_apache__mod('rpaf') }
+    it { should contain_package("libapache2-mod-rpaf") }
+    it { should contain_file('rpaf.conf').with({
+      'path' => '/etc/apache2/mods-available/rpaf.conf',
+    }) }
+    it { should contain_file('rpaf.conf').with_content(/^RPAFenable On$/) }
+
+    describe "with sethostname => true" do
+      let :params do
+        { :sethostname => 'true' }
+      end
+      it { should contain_file('rpaf.conf').with_content(/^RPAFsethostname On$/) }
+    end
+    describe "with proxy_ips => [ 10.42.17.8, 10.42.18.99 ]" do
+      let :params do
+        { :proxy_ips => [ '10.42.17.8', '10.42.18.99' ] }
+      end
+      it { should contain_file('rpaf.conf').with_content(/^RPAFproxy_ips 10.42.17.8 10.42.18.99$/) }
+    end
+    describe "with header => X-Real-IP" do
+      let :params do
+        { :header => 'X-Real-IP' }
+      end
+      it { should contain_file('rpaf.conf').with_content(/^RPAFheader X-Real-IP$/) }
+    end
+  end
+end

--- a/templates/mod/rpaf.conf.erb
+++ b/templates/mod/rpaf.conf.erb
@@ -1,0 +1,15 @@
+# Enable reverse proxy add forward
+RPAFenable On
+# RPAFsethostname will, when enabled, take the incoming X-Host header and
+# update the virtual host settings accordingly. This allows to have the same
+# hostnames as in the "real" configuration for the forwarding proxy.
+<% if @sethostname -%>
+RPAFsethostname On
+<% else -%>
+RPAFsethostname Off
+<% end -%>
+# Which IPs are forwarding requests to us
+RPAFproxy_ips <%= Array(@proxy_ips).join(" ") %>
+# Setting RPAFheader allows you to change the header name to parse from the
+# default X-Forwarded-For to something of your choice.
+RPAFheader <%= @header %>


### PR DESCRIPTION
Contains basic spec tests. Note that there seems to be no mod_rpaf
package for RHEL or FreeBSD systems available, only Debian/Ubuntu.
Not quite sure what to do in this situation.

From apt-cache show libapache2-mod-rpaf:

Rpaf is short for reverse proxy add forward. It changes the remote
address of the client visible to other Apache modules when two
conditions are satisfied. First condition is that the remote client is
actually a proxy that is defined in httpd.conf. Secondly if there is an
incoming X-Forwarded-For header and the proxy is in its list of known
proxies it takes the last IP from the incoming X-Forwarded-For header
and changes the remote address of the client in the request structure.
