### PR TITLE
Fix allways listen 80,443 ports

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -266,7 +266,7 @@ define apache::vhost(
       }
     }
   }
-  if $add_listen {
+  if $add_listen and $ensure == 'present' {
     if $ip and defined(Apache::Listen[$port]) {
       fail("Apache::Vhost[${name}]: Mixing IP and non-IP Listen directives is not possible; check the add_listen parameter of the apache::vhost define to disable this")
     }
@@ -274,7 +274,7 @@ define apache::vhost(
       apache::listen { $listen_addr_port: }
     }
   }
-  if ! $ip_based {
+  if ! $ip_based and $ensure == 'present' {
     if ! defined(Apache::Namevirtualhost[$nvh_addr_port]) {
       apache::namevirtualhost { $nvh_addr_port: }
     }


### PR DESCRIPTION
Allways listen 80, 443 posts. It should not use ports.
default_vhost is false, and only use other ports(8080,etc...).

Allready binded 80 port by Nginx in my environment.
please, merge.
