### PR TITLE
Remove extra empty lines in _directories template

### DIFF
--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -1,7 +1,6 @@
 <% if @_directories and ! @_directories.empty? -%>
   <%- [@_directories].flatten.compact.each do |directory| -%>
     <%- if directory['path'] and directory['path'] != '' -%>
-
   <%- if directory['provider'] and [ 'directory', 'location', 'files' ].include?(directory['provider']) -%>
     <%- provider = directory['provider'].capitalize -%>
   <%- else -%>
@@ -17,7 +16,7 @@
     <%- if directory['options'] -%>
     Options <%= Array(directory['options']).join(' ') %>
     <%- end -%>
-    <%- if provider == 'Directory' %>
+    <%- if provider == 'Directory' -%>
       <%- if directory['index_options'] -%>
     IndexOptions <%= Array(directory['index_options']).join(' ') %>
       <%- end -%>
@@ -114,7 +113,6 @@
     <%= directory['custom_fragment'] %>
     <%- end -%>
   </<%= provider %>>
-
     <%- end -%>
   <%- end -%>
 <% end -%>


### PR DESCRIPTION
When managing directories (or locations, files) through the
`directories` parameter the resulting vhost configuration file contains
a few empty lines too many. This cleans up these unnecessary empty
lines, leaving just one between Directory blocks. This is a purely
cosmetic change.
