### PR TITLE
Add support for AliasMatch directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,13 +472,16 @@ Setting `add_listen` to 'false' stops the vhost from creating a listen statement
 
 #####`aliases`
 
-Passes a list of hashes to the vhost to create `Alias` statements as per the [`mod_alias` documentation](http://httpd.apache.org/docs/current/mod/mod_alias.html). Each hash is expected to be of the form:
+Passes a list of hashes to the vhost to create `Alias` or `AliasMatch` statements as per the [`mod_alias` documentation](http://httpd.apache.org/docs/current/mod/mod_alias.html). Each hash is expected to be of the form:
 
-```puppet
-aliases => [ { alias => '/alias', path => '/path/to/directory' } ],
+```
+aliases => [
+  { aliasmatch => '^/image/(.*)\.jpg$', path => '/files/jpg.images/$1.jpg' }
+  { alias      => '/image',             path => '/ftp/pub/image' },
+],
 ```
 
-For `Alias` to work, each will need a corresponding `<Directory /path/to/directory>` or `<Location /path/to/directory>` block.
+For `Alias` and `AliasMatch` to work, each will need a corresponding `<Directory /path/to/directory>` or `<Location /path/to/directory>` block. The `Alias` and `AliasMatch` directives are created in the order specified in the `aliases` paramter. As described in the [`mod_alias` documentation](http://httpd.apache.org/docs/current/mod/mod_alias.html) more specific `Alias` or `AliasMatch` directives should come before the more general ones to avoid shadowing.
 
 **Note:** If `apache::mod::passenger` is loaded and `PassengerHighPerformance true` is set, then `Alias` may have issues honouring the `PassengerEnabled off` statement. See [this article](http://www.conandalton.net/2010/06/passengerenabled-off-not-working.html) for details.
 

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -359,6 +359,32 @@ describe 'apache::vhost', :type => :define do
           ],
         },
         {
+          :title => 'should accept an aliasmatch hash',
+          :attr  => 'aliases',
+          ## XXX As mentioned above, rspec-puppet drops the $1. Thus, these
+          # tests don't work.
+          #:value => { 'aliasmatch' => '^/image/(.*).gif', 'path' => '/files/gifs/$1.gif' },
+          #:match => [/^  AliasMatch \^\/image\/\(\.\*\)\.gif \/files\/gifs\/\$1\.gif$/],
+        },
+        {
+          :title => 'should accept a array of alias and aliasmatch hashes mixed',
+          :attr  => 'aliases',
+          ## XXX As mentioned above, rspec-puppet drops the $1. Thus, these
+          # tests don't work.
+          #:value => [
+          #  { 'alias' => '/css', 'path' => '/files/css' },
+          #  { 'aliasmatch' => '^/image/(.*).gif', 'path' => '/files/gifs/$1.gif' },
+          #  { 'aliasmatch' => '^/image/(.*).jpg', 'path' => '/files/jpgs/$1.jpg' },
+          #  { 'alias' => '/image', 'path' => '/files/images' },
+          #],
+          #:match => [
+          #  /^  Alias \/css \/files\/css$/,
+          #  /^  AliasMatch \^\/image\/\(.\*\)\.gif \/files\/gifs\/\$1\.gif$/,
+          #  /^  AliasMatch \^\/image\/\(.\*\)\.jpg \/files\/jpgs\/\$1\.jpg$/,
+          #  /^  Alias \/image \/files\/images$/
+          #],
+        },
+        {
           :title => 'should accept a suPHP_Engine',
           :attr  => 'suphp_engine',
           :value => 'on',

--- a/templates/vhost/_aliases.erb
+++ b/templates/vhost/_aliases.erb
@@ -1,8 +1,12 @@
 <% if @aliases and ! @aliases.empty? -%>
   ## Alias declarations for resources outside the DocumentRoot
   <%- [@aliases].flatten.compact.each do |alias_statement| -%>
-    <%- if alias_statement["alias"] != '' and alias_statement["path"] != ''-%>
+    <%- if alias_statement["path"] != '' -%>
+      <%- if alias_statement["alias"] and alias_statement["alias"] != '' -%>
   Alias <%= alias_statement["alias"] %> <%= alias_statement["path"] %>
+      <%- elsif alias_statement["aliasmatch"] and alias_statement["aliasmatch"] != '' -%>
+  AliasMatch <%= alias_statement["aliasmatch"] %> <%= alias_statement["path"] %>
+      <%- end -%>
     <%- end -%>
   <%- end -%>
 <% end -%>


### PR DESCRIPTION
(#479) Extend the _aliases.erb template so that the list of hashes in
`apache::vhost`'s `aliases` parameter can contain the usual `alias`
hashes but also `aliasmatch` hashes, which get translated to
`AliasMatch` directives.

Includes basic spec tests and updated documentation in README.md.

Note: The tests for this seem to fail on my machine because of what is probably a bug in rpsec-puppet. Will see what Travis says.
