### PR TITLE
No implicit <Directory> entry for ScriptAlias path

### DIFF
--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -264,7 +264,6 @@ describe 'apache::vhost', :type => :define do
           :value => '/usr/scripts',
           :match => [
             /^  ScriptAlias \/cgi-bin\/ \/usr\/scripts$/,
-            /^  <Directory \/usr\/scripts>$/,
           ],
         },
         {
@@ -273,7 +272,6 @@ describe 'apache::vhost', :type => :define do
           :value    => { 'alias' => '/blah/', 'path' => '/usr/scripts' },
           :match    => [
             /^  ScriptAlias \/blah\/ \/usr\/scripts$/,
-            /^  <Directory \/usr\/scripts>$/,
           ],
           :nomatch  => [/ScriptAlias \/cgi\-bin\//],
         },
@@ -284,7 +282,6 @@ describe 'apache::vhost', :type => :define do
           :match    => [
             /^  ScriptAlias \/blah \/usr\/scripts$/,
             /^  ScriptAlias \/blah2 \/usr\/scripts$/,
-            /^  <Directory \/usr\/scripts>$/,
           ],
           :nomatch  => [/ScriptAlias \/cgi\-bin\//],
         },
@@ -295,7 +292,6 @@ describe 'apache::vhost', :type => :define do
           :match    => [
             /^  ScriptAlias \/blah \/usr\/scripts$/,
             /^  ScriptAlias \/blah2\/ \/usr\/scripts2\/$/,
-            /^  <Directory \/usr\/scripts>$/,
           ],
           :nomatch  => [/ScriptAlias \/cgi\-bin\//],
         },

--- a/templates/vhost/_scriptalias.erb
+++ b/templates/vhost/_scriptalias.erb
@@ -11,24 +11,8 @@
 <%# for backward compatibility and ease of implementation -%>
 <% aliases << { 'alias' => '/cgi-bin/', 'path' => @scriptalias } if @scriptalias -%>
 <% aliases.flatten.compact! %>
-<%# Multiple paths could be provided for the same directory, make sure we only -%>
-<%# add a single <Directory> entry per path -%>
-<% dirs = aliases.map { |h| h['path'] }.uniq.compact -%>
 <% aliases.each do |salias| -%>
   ## Script alias directives
   ScriptAlias <%= salias['alias'] %> <%= salias['path'] %>
 <% end -%>
-
-<% dirs.sort.each do |dir| -%>
-  <Directory <%= dir %>>
-    AllowOverride None
-    Options +ExecCGI -MultiViews +SymLinksIfOwnerMatch
-    Order allow,deny
-    Allow from all
-<% if @ssl -%>
-    SSLOptions +StdEnvVars
-<% end -%>
-  </Directory>
-<% end -%>
-
 <% end -%>


### PR DESCRIPTION
Support for ScriptAlias currently implicitly and automatically creates
<Directory> configuration directives for the path component in a given
ScriptAlias directive. These are not useful or needed, according to the
mod_alias documentation. Fixes issue #486.

This change also indirectly relates to #487 because the implicitly
created <Directory> entry for each ScriptAlias path also had
`SSLOptions +StdEnvVars` set for that directory.
