### PR TITLE
Set SSLOptions StdEnvVars in server context

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,10 +409,13 @@ The modules mentioned above, and other Apache modules that have templates, will 
 
 ####Class: `apache::mod::ssl`
 
-Installs Apache SSL capabilities and utilizes `ssl.conf.erb` template
+Installs Apache SSL capabilities and utilizes `ssl.conf.erb` template. These are the defaults:
 
 ```puppet
-	class { 'apache::mod::ssl': }
+    class { 'apache::mod::ssl':
+      ssl_compression => false,
+      ssl_options     => [ 'StdEnvVars' ],
+  }
 ```
 
 To *use* SSL with a virtual host, you must either set the`default_ssl_vhost` parameter in `apache` to 'true' or set the `ssl` parameter in `apache::vhost` to 'true'.
@@ -727,6 +730,20 @@ Sets the value for the `PassengerEnabled` directory to `on` or `off` as per the 
 **Note:** This directive requires `apache::mod::passenger` to be active, Apache may not start with an unrecognised directive without it.
 
 **Note:** Be aware that there is an [issue](http://www.conandalton.net/2010/06/passengerenabled-off-not-working.html) using the `PassengerEnabled` directive with the `PassengerHighPerformance` directive.
+
+######`ssl_options`
+
+String or list of [`SSLOptions`](https://httpd.apache.org/docs/2.2/mod/mod_ssl.html#ssloptions) for the given `<Directory>` block. This overrides, or refines the [`SSLOptions`](https://httpd.apache.org/docs/2.2/mod/mod_ssl.html#ssloptions) of the parent block (either vhost, or server).
+
+```puppet
+    apache::vhost { 'secure.example.net':
+      docroot     => '/path/to/directory',
+      directories => [
+        { path => '/path/to/directory', ssl_options => '+ExportCertData' }
+        { path => '/path/to/different/dir', ssl_options => [ '-StdEnvVars', '+ExportCertData'] },
+      ],
+    }
+```
 
 ######`custom_fragment`
 
@@ -1071,12 +1088,12 @@ An example:
 
 #####`ssl_options`
 
-Sets `SSLVerifyOptions` directives as per the [Apache Core documentation](http://httpd.apache.org/docs/2.2/mod/mod_ssl.html#ssloptions). This is the global setting for the vhost and can be a string or an array. Defaults to undef. A single string example:
+Sets `SSLOptions` directives as per the [Apache Core documentation](http://httpd.apache.org/docs/2.2/mod/mod_ssl.html#ssloptions). This is the global setting for the vhost and can be a string or an array. Defaults to undef. A single string example:
 
 ```puppet
     apache::vhost { 'sample.example.net':
       …
-      ssl_options => '+StdEnvVars',
+      ssl_options => '+ExportCertData',
     }
 ```
 
@@ -1085,7 +1102,7 @@ An array of strings example:
 ```puppet
     apache::vhost { 'sample.example.net':
       …
-      ssl_options => [ '+StdEnvVars', '+ExportCertData' ],
+      ssl_options => [ '+StrictRequire', '+ExportCertData' ],
     }
 ```
 

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -1,5 +1,6 @@
 class apache::mod::ssl (
   $ssl_compression = false,
+  $ssl_options     = [ 'StdEnvVars' ],
 ) {
   $session_cache = $::osfamily ? {
     'debian'  => '${APACHE_RUN_DIR}/ssl_scache(512000)',
@@ -13,7 +14,7 @@ class apache::mod::ssl (
   }
   apache::mod { 'ssl': }
 
-  # Template uses $ssl_compression, $session_cache, $ssl_mutex
+  # Template uses $ssl_compression, $ssl_options, $session_cache, $ssl_mutex
   file { 'ssl.conf':
     ensure  => file,
     path    => "${apache::mod_dir}/ssl.conf",

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -709,8 +709,20 @@ describe 'apache::vhost', :type => :define do
         {
             :title => 'should accept setting SSLOptions with an array',
             :attr  => 'ssl_options',
-            :value => ['+StdEnvVars','+ExportCertData'],
-            :match => [/^  SSLOptions \+StdEnvVars \+ExportCertData/],
+            :value => ['+StrictRequire','+ExportCertData'],
+            :match => [/^  SSLOptions \+StrictRequire \+ExportCertData/],
+        },
+        {
+            :title => 'should accept setting SSLOptions with a string in directories',
+            :attr  => 'directories',
+            :value => { 'path' => '/srv/www', 'ssl_options' => '+ExportCertData'},
+            :match => [/^    SSLOptions \+ExportCertData$/],
+        },
+        {
+            :title => 'should accept setting SSLOptions with an array in directories',
+            :attr  => 'directories',
+            :value => { 'path' => '/srv/www', 'ssl_options' => ['-StdEnvVars','+ExportCertData']},
+            :match => [/^    SSLOptions -StdEnvVars \+ExportCertData/],
         },
       ].each do |param|
         describe "when #{param[:attr]} is #{param[:value]} with SSL" do

--- a/templates/mod/ssl.conf.erb
+++ b/templates/mod/ssl.conf.erb
@@ -18,4 +18,7 @@
   SSLHonorCipherOrder On
   SSLCipherSuite HIGH:MEDIUM:!aNULL:!MD5
   SSLProtocol all -SSLv2
+<% if @ssl_options -%>
+  SSLOptions <%= @ssl_options.compact.join(' ') %>
+<% end -%>
 </IfModule>

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -117,6 +117,9 @@
     <%- if directory['force_type'] -%>
     ForceType <%= directory['force_type'] %>
     <%- end -%>
+    <%- if directory['ssl_options'] -%>
+    SSLOptions <%= Array(directory['ssl_options']).join(' ') %>
+    <%- end -%>
     <%- if directory['custom_fragment'] -%>
     <%= directory['custom_fragment'] %>
     <%- end -%>

--- a/templates/vhost/_ssl.erb
+++ b/templates/vhost/_ssl.erb
@@ -38,7 +38,4 @@
 <% if @ssl_options -%>
   SSLOptions <%= Array(@ssl_options).join(' ') %>
 <% end -%>
-  <FilesMatch "\.(cgi|shtml|phtml|php)$">
-    SSLOptions +StdEnvVars
-  </FilesMatch>
 <% end -%>


### PR DESCRIPTION
We set `SSLOptions` now in server context and we set it to `StdEnvVars`.
Thus, we no longer need the <FilesMatch > in server context to set it
for php, CGI and SSI applications.
We allow it to be overridden by the `apache::mod::ssl` class parameter
`ssl_options`. Further, we allow it to be overridden in directory
context.
Documentation for all of these has been extended and tests have been
adapted to make sense in this new context. This commit fixes #487
