### PR TITLE
Working mod_authnz_ldap support on Debian/Ubuntu

### DIFF
--- a/manifests/mod/authnz_ldap.pp
+++ b/manifests/mod/authnz_ldap.pp
@@ -1,22 +1,19 @@
-class apache::mod::authnz_ldap(
+class apache::mod::authnz_ldap (
   $verifyServerCert = true,
 ) {
-  include apache::mod::ldap
+  include 'apache::mod::ldap'
   apache::mod { 'authnz_ldap': }
 
-  if $verifyServerCert == true {
-    file { 'authnz_ldap.conf':
-      ensure  => absent,
-      path    => "${apache::mod_dir}/authnz_ldap.conf",
-      notify  => Service['httpd'],
-    }
-  } else {
-    file { 'authnz_ldap.conf':
-      ensure  => file,
-      path    => "${apache::mod_dir}/authnz_ldap.conf",
-      content => 'LDAPVerifyServerCert off',
-      before  => File[$apache::mod_dir],
-      notify  => Service['httpd'],
-    }
+  validate_bool($verifyServerCert)
+
+  # Template uses:
+  # - $verifyServerCert
+  file { 'authnz_ldap.conf':
+    ensure  => file,
+    path    => "${apache::mod_dir}/authnz_ldap.conf",
+    content => template('apache/mod/authnz_ldap.conf.erb'),
+    require => Exec["mkdir ${apache::mod_dir}"],
+    before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -119,7 +119,6 @@ class apache::params {
     $suphp_configpath  = '/etc/php5/apache2'
     $mod_packages     = {
       'auth_kerb'   => 'libapache2-mod-auth-kerb',
-      'authnz_ldap' => 'libapache2-mod-authz-ldap',
       'dav_svn'     => 'libapache2-svn',
       'fastcgi'     => 'libapache2-mod-fastcgi',
       'fcgid'       => 'libapache2-mod-fcgid',

--- a/spec/classes/mod/authnz_ldap_spec.rb
+++ b/spec/classes/mod/authnz_ldap_spec.rb
@@ -16,12 +16,12 @@ describe 'apache::mod::authnz_ldap', :type => :class do
     it { should contain_apache__mod('authnz_ldap') }
 
     context 'default verifyServerCert' do
-      it { should contain_file('authnz_ldap.conf').with_ensure('absent') }
+      it { should contain_file('authnz_ldap.conf').with_content(/^LDAPVerifyServerCert On$/) }
     end
 
     context 'verifyServerCert = false' do
       let(:params) { { :verifyServerCert => false } }
-      it { should contain_file('authnz_ldap.conf').with_content('LDAPVerifyServerCert off') }
+      it { should contain_file('authnz_ldap.conf').with_content(/^LDAPVerifyServerCert Off$/) }
     end
 
     context 'verifyServerCert = wrong' do
@@ -45,12 +45,12 @@ describe 'apache::mod::authnz_ldap', :type => :class do
     it { should contain_apache__mod('authnz_ldap') }
 
     context 'default verifyServerCert' do
-      it { should contain_file('authnz_ldap.conf').with_ensure('absent') }
+      it { should contain_file('authnz_ldap.conf').with_content(/^LDAPVerifyServerCert On$/) }
     end
 
     context 'verifyServerCert = false' do
       let(:params) { { :verifyServerCert => false } }
-      it { should contain_file('authnz_ldap.conf').with_content('LDAPVerifyServerCert off') }
+      it { should contain_file('authnz_ldap.conf').with_content(/^LDAPVerifyServerCert Off$/) }
     end
 
     context 'verifyServerCert = wrong' do

--- a/templates/mod/authnz_ldap.conf.erb
+++ b/templates/mod/authnz_ldap.conf.erb
@@ -1,0 +1,5 @@
+<% if @verifyServerCert == true -%>
+LDAPVerifyServerCert On
+<% else -%>
+LDAPVerifyServerCert Off
+<% end -%>


### PR DESCRIPTION
Remove the `authnz_ldap` key from $mod_packages in `apache::params` so
an installation of the non-existent package `libapache2-mod-authz-ldap`
is not attempted.

Properly manage the `authnz_ldap.conf` file template and set the
`LDAPVerifyServerCert` directive according to $verifyServerCert
in `apache::mod::authnz_ldap`.

This fixes only the superficial problems in issue #494. Better support
for mod_ldap and mod_authnz_ldap is required, as discussed there.
