### PR TITLE
Add suPHP_UserGroup directive to directory context

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ To set up a virtual host with suPHP
       suphp_addhandler    => 'x-httpd-php',
       suphp_engine        => 'on',
       suphp_configpath    => '/etc/php5/apache2',
+      directories         => { path => '/home/appuser/myphpapp',
+        'suphp'           => { user => 'myappuser', group => 'myappgroup' },
+      }
     }
 ```
 
@@ -741,6 +744,20 @@ String or list of [`SSLOptions`](https://httpd.apache.org/docs/2.2/mod/mod_ssl.h
       directories => [
         { path => '/path/to/directory', ssl_options => '+ExportCertData' }
         { path => '/path/to/different/dir', ssl_options => [ '-StdEnvVars', '+ExportCertData'] },
+      ],
+    }
+```
+
+######`suphp`
+
+An array containing two values: User and group for the [suPHP_UserGroup](http://www.suphp.org/DocumentationView.html?file=apache/CONFIG) setting.
+This directive must be used with `suphp_engine => on` in the vhost declaration. This directive only works in `<Directory>` or `<Location>`.
+
+```puppet
+    apache::vhost { 'secure.example.net':
+      docroot     => '/path/to/directory',
+      directories => [
+        { path => '/path/to/directory', suphp => { user =>  'myappuser', group => 'myappgroup' }
       ],
     }
 ```

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -877,6 +877,20 @@ describe 'apache::vhost', :type => :define do
         end
       end
 
+      describe 'when suphp_engine is on and suphp { user & group } is specified' do
+        let :params do default_params.merge({
+          :suphp_engine     => 'on',
+          :directories      => { 'path' => '/srv/www',
+            'suphp' => { 'user' => 'myappuser', 'group' => 'myappgroup' },
+          }
+        }) end
+        it 'should set suphp_UserGroup' do
+          should contain_file("25-#{title}.conf").with_content(
+            /^    suPHP_UserGroup myappuser myappgroup/
+          )
+        end
+      end
+
       describe 'priority/default settings' do
         describe 'when neither priority/default is specified' do
           let :params do default_params end

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -120,6 +120,9 @@
     <%- if directory['ssl_options'] -%>
     SSLOptions <%= Array(directory['ssl_options']).join(' ') %>
     <%- end -%>
+    <%- if directory['suphp'] and @suphp_engine == 'on' -%>
+    suPHP_UserGroup <%= directory['suphp']['user'] %> <%= directory['suphp']['group'] %>
+    <%- end -%>
     <%- if directory['custom_fragment'] -%>
     <%= directory['custom_fragment'] %>
     <%- end -%>


### PR DESCRIPTION
suPHP_UserGroup is only supported in per-direcctory context. We add this
directive analogous to the per-vhost suphp_ directives, by making sure
that suphp_engine is actually enabled.

With documentation and tests in place, this should fix #451
