### PR TITLE
Add support for overriding ErrorDocument

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,19 @@ Sets an `Deny` directive as per the [Apache Core documentation](http://httpd.apa
       directories => [ { path => '/path/to/directory', deny => 'from example.org' } ],
     }
 ```
+######`error_documents`
+
+A list of hashes which can be used to override the [ErrorDocument](https://httpd.apache.org/docs/2.2/mod/core.html#errordocument) settings for this directory. Example:
+
+```puppet
+    apache::vhost { 'sample.example.net':
+      directories => [ { path => '/srv/www'
+        error_documents => [
+          { 'error_code' => '503', 'document' => '/service-unavail' },
+        ],
+      }]
+    }
+```
 
 ######`headers`
 
@@ -751,6 +764,19 @@ Specifies a pipe to send error log messages to. Defaults to 'undef'.
 #####`error_log_syslog`
 
 Sends all error log messages to syslog. Defaults to 'undef'.
+
+#####`error_documents`
+
+A list of hashes which can be used to override the [ErrorDocument](https://httpd.apache.org/docs/2.2/mod/core.html#errordocument) settings for this vhost. Defaults to `[]`. Example:
+
+```puppet
+    apache::vhost { 'sample.example.net':
+      error_documents => [
+        { 'error_code' => '503', 'document' => '/service-unavail' },
+        { 'error_code' => '407', 'document' => 'https://example.com/proxy/login' },
+      ],
+    }
+```
 
 #####`ensure`
 

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -104,6 +104,7 @@ define apache::vhost(
     $error_log_file              = undef,
     $error_log_pipe              = undef,
     $error_log_syslog            = undef,
+    $error_documents             = [],
     $fallbackresource            = undef,
     $scriptalias                 = undef,
     $scriptaliases               = [],
@@ -366,6 +367,7 @@ define apache::vhost(
   # - $_access_log_format
   # - $error_log
   # - $error_log_destination
+  # - $error_documents
   # - $fallbackresource
   # - $custom_fragment
   # - $additional_includes

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -222,6 +222,43 @@ describe 'apache::vhost', :type => :define do
           :notmatch => [/ErrorLog.+$/],
         },
         {
+          :title    => 'should set ErrorDocument 503',
+          :attr     => 'error_documents',
+          :value    => [ { 'error_code' => '503', 'document' => '"Go away, the backend is broken."'}],
+          :match => [/^  ErrorDocument 503 "Go away, the backend is broken."$/],
+        },
+        {
+          :title    => 'should set ErrorDocuments 503 407',
+          :attr     => 'error_documents',
+          :value    => [
+            { 'error_code' => '503', 'document' => '/service-unavail'},
+            { 'error_code' => '407', 'document' => 'https://example.com/proxy/login'},
+          ],
+          :match => [
+            /^  ErrorDocument 503 \/service-unavail$/,
+            /^  ErrorDocument 407 https:\/\/example\.com\/proxy\/login$/,
+          ],
+        },
+        {
+          :title    => 'should set ErrorDocument 503 in directory',
+          :attr     => 'directories',
+          :value    => { 'path' => '/srv/www', 'error_documents' => [{ 'error_code' => '503', 'document' => '"Go away, the backend is broken."'}] },
+          :match => [/^    ErrorDocument 503 "Go away, the backend is broken."$/],
+        },
+        {
+          :title    => 'should set ErrorDocuments 503 407 in directory',
+          :attr     => 'directories',
+          :value    => { 'path' => '/srv/www', 'error_documents' =>
+          [
+            { 'error_code' => '503', 'document' => '/service-unavail'},
+            { 'error_code' => '407', 'document' => 'https://example.com/proxy/login'},
+          ]},
+          :match => [
+            /^    ErrorDocument 503 \/service-unavail$/,
+            /^    ErrorDocument 407 https:\/\/example\.com\/proxy\/login$/,
+          ],
+        },
+        {
           :title => 'should accept a scriptalias',
           :attr  => 'scriptalias',
           :value => '/usr/scripts',

--- a/templates/vhost.conf.erb
+++ b/templates/vhost.conf.erb
@@ -41,6 +41,7 @@
   CustomLog <%= @access_log_destination %> <%= @_access_log_format %>
 <% end -%>
 <%= scope.function_template(['apache/vhost/_block.erb']) -%>
+<%= scope.function_template(['apache/vhost/_error_document.erb']) -%>
 <%= scope.function_template(['apache/vhost/_proxy.erb']) -%>
 <%= scope.function_template(['apache/vhost/_rack.erb']) -%>
 <%= scope.function_template(['apache/vhost/_redirect.erb']) -%>

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -56,6 +56,11 @@
     <%- if directory['directoryindex'] and directory['directoryindex'] != '' -%>
     DirectoryIndex <%= directory['directoryindex'] %>
     <%- end -%>
+    <%- if directory['error_documents'] and ! directory['error_documents'].empty? -%>
+      <%- [directory['error_documents']].flatten.compact.each do |error_document| -%>
+    ErrorDocument <%= error_document['error_code'] %> <%= error_document['document'] %>
+      <%- end -%>
+    <%- end -%>
     <%- if directory['auth_type'] -%>
     AuthType <%= directory['auth_type'] %>
     <%- end -%>
@@ -110,6 +115,9 @@
     <%- end -%>
     <%- end -%>
     <%- if directory['force_type'] -%>
+    ForceType <%= directory['force_type'] %>
+    <%- end -%>
+    <%- if directory['error_documents'] -%>
     ForceType <%= directory['force_type'] %>
     <%- end -%>
     <%- if directory['custom_fragment'] -%>

--- a/templates/vhost/_error_document.erb
+++ b/templates/vhost/_error_document.erb
@@ -1,0 +1,7 @@
+<% if @error_documents and ! @error_documents.empty? -%>
+  <%- [@error_documents].flatten.compact.each do |error_document| -%>
+    <%- if error_document["error_code"] != '' and error_document["document"] != '' -%>
+  ErrorDocument <%= error_document["error_code"] %> <%= error_document["document"] %>
+    <%- end -%>
+  <%- end -%>
+<% end -%>


### PR DESCRIPTION
add support for overriding ErrorDocument settings in both, vhost and
directory context.
With documentation and tests included this fixes #474
