### PR TITLE
Remove eronous duplication of ForceType

### DIFF
--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -117,9 +117,6 @@
     <%- if directory['force_type'] -%>
     ForceType <%= directory['force_type'] %>
     <%- end -%>
-    <%- if directory['error_documents'] -%>
-    ForceType <%= directory['force_type'] %>
-    <%- end -%>
     <%- if directory['custom_fragment'] -%>
     <%= directory['custom_fragment'] %>
     <%- end -%>


### PR DESCRIPTION
c42c41d introduced a sloppy copy/paste error in the _directories.erb
template. This removes it, thus fixing #500
