### PR TITLE
Add support for ScriptAliasMatch directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -957,29 +957,30 @@ Defines a directory of CGI scripts to be aliased to the path '/cgi-bin'
 
 #####`scriptaliases`
 
-Takes an array hashes with the keys containing the alias and path.  For example:
-
-Usage will typically look like:
+Passes a list of hashes to the vhost to create `ScriptAlias` or `ScriptAliasMatch` statements as per the [`mod_alias` documentation](http://httpd.apache.org/docs/current/mod/mod_alias.html). Each hash is expected to be of the form:
 
 ```puppet
-    apache::vhost { 'sample.example.net':
-      docroot     => '/path/to/directory',
-      scriptaliases => [
-        {
-          alias => '/myscript/',
-          path  => '/usr/share/myscript',
-        },
-        {
-          alias => '/oldscript/',
-          path  => '/usr/share/myscript',
-        },
-        {
-          alias => '/neatscript/',
-          path  => '/usr/share/neatscript',
-        },
-      ]
-    }
+    scriptaliases => [
+      {
+        alias => '/myscript',
+        path  => '/usr/share/myscript',
+      },
+      {
+        aliasmatch => '^/foo(.*)',
+        path       => '/usr/share/fooscripts$1',
+      },
+      {
+        aliasmatch => '^/bar/(.*)',
+        path       => '/usr/share/bar/wrapper.sh/$1',
+      },
+      {
+        alias => '/neatscript',
+        path  => '/usr/share/neatscript',
+      },
+    ]
 ```
+
+These directives are created in the order specified. As with `Alias` and `AliasMatch` directives the more specific aliases should come before the more general ones to avoid shadowing.
 
 #####`serveradmin`
 

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -296,6 +296,51 @@ describe 'apache::vhost', :type => :define do
           :nomatch  => [/ScriptAlias \/cgi\-bin\//],
         },
         {
+          :title    => 'should accept a ScriptAliasMatch directive',
+          :attr     => 'scriptaliases',
+          ## XXX As mentioned above, rspec-puppet drops constructs like $1.
+          ## Thus, these tests don't work as they should. As a workaround we
+          ## use FOO instead of $1 here.
+          :value    => [ { 'aliasmatch' => '^/cgi-bin(.*)', 'path' => '/usr/local/apache/cgi-binFOO' } ],
+          :match    => [
+            /^  ScriptAliasMatch \^\/cgi-bin\(\.\*\) \/usr\/local\/apache\/cgi-binFOO$/
+          ],
+        },
+        {
+          :title    => 'should accept multiple ScriptAliasMatch directives',
+          :attr     => 'scriptaliases',
+          ## XXX As mentioned above, rspec-puppet drops constructs like $1.
+          ## Thus, these tests don't work as they should. As a workaround we
+          ## use FOO instead of $1 here.
+          :value    => [
+            { 'aliasmatch' => '^/cgi-bin(.*)', 'path' => '/usr/local/apache/cgi-binFOO' },
+            { 'aliasmatch' => '"(?x)^/git/(.*/(HEAD|info/refs|objects/(info/[^/]+|[0-9a-f]{2}/[0-9a-f]{38}|pack/pack-[0-9a-f]{40}\.(pack|idx))|git-(upload|receive)-pack))"', 'path' => '/var/www/bin/gitolite-suexec-wrapper/FOO' },
+          ],
+          :match    => [
+            /^  ScriptAliasMatch \^\/cgi-bin\(\.\*\) \/usr\/local\/apache\/cgi-binFOO$/,
+            /^  ScriptAliasMatch "\(\?x\)\^\/git\/\(\.\*\/\(HEAD\|info\/refs\|objects\/\(info\/\[\^\/\]\+\|\[0-9a-f\]\{2\}\/\[0-9a-f\]\{38\}\|pack\/pack-\[0-9a-f\]\{40\}\\\.\(pack\|idx\)\)\|git-\(upload\|receive\)-pack\)\)" \/var\/www\/bin\/gitolite-suexec-wrapper\/FOO$/,
+          ],
+        },
+        {
+          :title    => 'should accept mixed ScriptAlias and ScriptAliasMatch directives',
+          :attr     => 'scriptaliases',
+          ## XXX As mentioned above, rspec-puppet drops constructs like $1.
+          ## Thus, these tests don't work as they should. As a workaround we
+          ## use FOO instead of $1 here.
+          :value    => [
+            { 'aliasmatch' => '"(?x)^/git/(.*/(HEAD|info/refs|objects/(info/[^/]+|[0-9a-f]{2}/[0-9a-f]{38}|pack/pack-[0-9a-f]{40}\.(pack|idx))|git-(upload|receive)-pack))"', 'path' => '/var/www/bin/gitolite-suexec-wrapper/FOO' },
+            { 'alias' => '/git', 'path' => '/var/www/gitweb/index.cgi' },
+            { 'aliasmatch' => '^/cgi-bin(.*)', 'path' => '/usr/local/apache/cgi-binFOO' },
+            { 'alias' => '/trac', 'path' => '/etc/apache2/trac.fcgi' },
+          ],
+          :match    => [
+            /^  ScriptAliasMatch "\(\?x\)\^\/git\/\(\.\*\/\(HEAD\|info\/refs\|objects\/\(info\/\[\^\/\]\+\|\[0-9a-f\]\{2\}\/\[0-9a-f\]\{38\}\|pack\/pack-\[0-9a-f\]\{40\}\\\.\(pack\|idx\)\)\|git-\(upload\|receive\)-pack\)\)" \/var\/www\/bin\/gitolite-suexec-wrapper\/FOO$/,
+            /^  ScriptAlias \/git \/var\/www\/gitweb\/index\.cgi$/,
+            /^  ScriptAliasMatch \^\/cgi-bin\(\.\*\) \/usr\/local\/apache\/cgi-binFOO$/,
+            /^  ScriptAlias \/trac \/etc\/apache2\/trac.fcgi$/,
+          ],
+        },
+        {
           :title    => 'should accept proxy destinations',
           :attr     => 'proxy_dest',
           :value    => 'http://fake.com',

--- a/templates/vhost/_scriptalias.erb
+++ b/templates/vhost/_scriptalias.erb
@@ -1,18 +1,24 @@
-<% if @scriptaliases.is_a?(Array) -%>
-<%  aliases = @scriptaliases -%>
-<% elsif @scriptaliases.is_a?(Hash) -%>
-<%  aliases = [@scriptaliases] -%>
-<% else -%>
-<%  # Nothing to do with any other data type -%>
-<%  aliases = [] -%>
-<% end -%>
-<% if @scriptalias or !aliases.empty? -%>
+<%- if @scriptaliases.is_a?(Array) -%>
+<%-  aliases = @scriptaliases -%>
+<%- elsif @scriptaliases.is_a?(Hash) -%>
+<%-  aliases = [@scriptaliases] -%>
+<%- else -%>
+<%-  # Nothing to do with any other data type -%>
+<%-  aliases = [] -%>
+<%- end -%>
+<%- if @scriptalias or !aliases.empty? -%>
+  ## Script alias directives
 <%# Combine scriptalais and scriptaliases into a single data structure -%>
 <%# for backward compatibility and ease of implementation -%>
-<% aliases << { 'alias' => '/cgi-bin/', 'path' => @scriptalias } if @scriptalias -%>
-<% aliases.flatten.compact! %>
-<% aliases.each do |salias| -%>
-  ## Script alias directives
+<%- aliases << { 'alias' => '/cgi-bin/', 'path' => @scriptalias } if @scriptalias -%>
+<%- aliases.flatten.compact! -%>
+<%- aliases.each do |salias| -%>
+  <%- if salias["path"] != '' -%>
+    <%- if salias["alias"] and salias["alias"] != '' -%>
   ScriptAlias <%= salias['alias'] %> <%= salias['path'] %>
-<% end -%>
-<% end -%>
+    <%- elsif salias["aliasmatch"] and salias["aliasmatch"] != '' -%>
+  ScriptAliasMatch <%= salias['aliasmatch'] %> <%= salias['path'] %>
+    <%- end -%>
+  <%- end -%>
+<%- end -%>
+<%- end -%>


### PR DESCRIPTION
Much like in PR #483 extend the _scriptalias.rb template so that the
`scriptalias` parameter in `apache::vhost` can contain `aliasmatch`
hashes which get translated to `ScriptAliasMatch` directives. Fixes
issue #480.

Includes basic spec tests and updated documentation in README.md.

Note again that puppet-rspec silently drops `$1` when specifying test
values so we match `FOO` instead of `$1`. From a simple spec test
perspective there shouldn't be a difference and this is better than
having no tests at all.
