### PR TITLE
Make LogLevel configurable for vhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -850,6 +850,10 @@ Enables an IP-based vhost. This parameter inhibits the creation of a NameVirtual
 
 Specifies the location of the virtual host's logfiles. Defaults to `/var/log/<apache log location>/`.
 
+#####`log_level`
+
+Specifies the verbosity level of the error log. Defaults to `warn` for the global server configuration and can be overridden on a per-vhost basis using this parameter. Valid value for `log_level` is one of `emerg`, `alert`, `crit`, `error`, `warn`, `notice`, `info` or `debug`.
+
 #####`no_proxy_uris`
 
 Specifies URLs you do not want to proxy. This parameter is meant to be used in combination with `proxy_dest`.

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -17,6 +17,9 @@
 # - The $vhost_name for name based virtualhosting, defaulting to *
 # - The $logroot specifies the location of the virtual hosts logfiles, default
 #   to /var/log/<apache log location>/
+# - The $log_level specifies the verbosity of the error log for this vhost. Not
+#   set by default for the vhost, instead the global server configuration default
+#   of 'warn' is used.
 # - The $access_log specifies if *_access.log directives should be configured.
 # - The $ensure specifies if vhost file is present or absent.
 # - The $request_headers is a list of RequestHeader statement strings as per http://httpd.apache.org/docs/2.2/mod/mod_headers.html#requestheader
@@ -93,6 +96,7 @@ define apache::vhost(
     $directoryindex              = '',
     $vhost_name                  = '*',
     $logroot                     = $apache::logroot,
+    $log_level                   = undef,
     $access_log                  = true,
     $access_log_file             = undef,
     $access_log_pipe             = undef,
@@ -162,6 +166,11 @@ define apache::vhost(
   }
   if $itk {
     validate_hash($itk)
+  }
+
+  if $log_level {
+    validate_re($log_level, '^(emerg|alert|crit|error|warn|notice|info|debug)$',
+    "Log level '${log_level}' is not one of the supported Apache HTTP Server log levels.")
   }
 
   if $access_log_file and $access_log_pipe {
@@ -362,6 +371,7 @@ define apache::vhost(
   # - $name
   # - $aliases
   # - $_directories
+  # - $log_level
   # - $access_log
   # - $access_log_destination
   # - $_access_log_format

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -168,6 +168,12 @@ describe 'apache::vhost', :type => :define do
           :match => [/CustomLog \/fake\/log\//,/ErrorLog \/fake\/log\//],
         },
         {
+          :title => 'should accept log_level',
+          :attr  => 'log_level',
+          :value => 'info',
+          :match => [/LogLevel info/],
+        },
+        {
           :title => 'should accept pipe destination for access log',
           :attr  => 'access_log_pipe',
           :value => '| /bin/fake/logging',

--- a/templates/vhost.conf.erb
+++ b/templates/vhost.conf.erb
@@ -35,7 +35,9 @@
 <% if @error_log -%>
   ErrorLog <%= @error_log_destination %>
 <% end -%>
-  LogLevel warn
+<% if @log_level -%>
+  LogLevel <%= @log_level %>
+<% end -%>
   ServerSignature Off
 <% if @access_log -%>
   CustomLog <%= @access_log_destination %> <%= @_access_log_format %>


### PR DESCRIPTION
Add a `loglevel` parameter, which defaults to `undef`, in
`apache::vhost` to allow overriding the global server configuration's
log level (warn) on a per-vhost basis. Includes updated documentation
and basic spec tests. Fixes issue #510.
