### PR TITLE
Make LogLevel configurable for server

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,10 @@ Amount of time the server will wait for subsequent requests on a persistent conn
 
 Changes the location of the directory Apache log files are placed in. Defaut is based on your OS.
 
+#####`log_level`
+
+Changes the verbosity level of the error log. Defaults to 'warn'. Valid values are `emerg`, `alert`, `crit`, `error`, `warn`, `notice`, `info` or `debug`.
+
 #####`ports_file`
 
 Changes the name of the file containing Apache ports configuration. Default is `${conf_dir}/ports.conf`.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,7 @@ class apache (
   $keepalive            = $apache::params::keepalive,
   $keepalive_timeout    = $apache::params::keepalive_timeout,
   $logroot              = $apache::params::logroot,
+  $log_level            = $apache::params::log_level,
   $ports_file           = $apache::params::ports_file,
   $server_tokens        = 'OS',
   $server_signature     = 'On',
@@ -103,6 +104,11 @@ class apache (
       require => Package['httpd']
     }
   }
+
+  $valid_log_level_re = '(emerg|alert|crit|error|warn|notice|info|debug)'
+
+  validate_re($log_level, $valid_log_level_re,
+  "Log level '${log_level}' is not one of the supported Apache HTTP Server log levels.")
 
   class { 'apache::service':
     service_name   => $service_name,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,6 +32,9 @@ class apache::params {
     $servername = $::hostname
   }
 
+  # The default error log level
+  $log_level = 'warn'
+
   if $::osfamily == 'RedHat' or $::operatingsystem == 'amazon' {
     $user                 = 'apache'
     $group                = 'apache'

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -29,7 +29,7 @@ AccessFileName .htaccess
 DefaultType none
 HostnameLookups Off
 ErrorLog <%= @logroot %>/<%= @error_log %>
-LogLevel warn
+LogLevel <%= @log_level %>
 EnableSendfile <%= @sendfile %>
 
 #Listen 80


### PR DESCRIPTION
Add a class parameter `log_level` to `apache`, which defaults to `warn`.
This sets `LogLevel warn` server-wide in httpd.conf, which can then be
overridden on a per-vhost basis. Includes updated documentation.
