### PR TITLE
Support environment variable control for CustomLog

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,6 +488,10 @@ Sends all access log messages to syslog. Defaults to 'undef'.
 
 Specifies either a LogFormat nickname or custom format string for access log. Defaults to 'undef'.
 
+#####`access_log_env_var`
+
+Adds writing control of access log via environment variable of the access. Defaults to 'undef'.
+
 #####`add_listen`
 
 Determines whether the vhost creates a listen statement. The default value is 'true'.

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -126,6 +126,7 @@ define apache::vhost(
     $access_log_pipe             = undef,
     $access_log_syslog           = undef,
     $access_log_format           = undef,
+    $access_log_env_var          = undef,
     $aliases                     = undef,
     $directories                 = undef,
     $error_log                   = true,
@@ -294,6 +295,9 @@ define apache::vhost(
     $_access_log_format = 'combined'
   }
 
+  if $access_log_env_var {
+    $_access_log_env_var = "env=${access_log_env_var}"
+  }
 
   if $ip {
     if $port {
@@ -418,6 +422,7 @@ define apache::vhost(
   # - $access_log
   # - $access_log_destination
   # - $_access_log_format
+  # - $_access_log_env_var
   # - $error_log
   # - $error_log_destination
   # - $error_documents

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -720,6 +720,12 @@ describe 'apache::vhost', :type => :define do
             /^  VirtualDocumentRoot \/not\/default$/,
           ],
         },
+        {
+          :title => 'should contain environment variables',
+          :attr  => 'access_log_env_var',
+          :value => 'admin',
+          :match => [/CustomLog \/var\/log\/.+_access\.log combined env=admin$/]
+        },
 
       ].each do |param|
         describe "when #{param[:attr]} is #{param[:value]}" do

--- a/templates/vhost.conf.erb
+++ b/templates/vhost.conf.erb
@@ -39,7 +39,9 @@
   LogLevel <%= @log_level %>
 <% end -%>
   ServerSignature Off
-<% if @access_log -%>
+<% if @access_log and @_access_log_env_var -%>
+  CustomLog <%= @access_log_destination %> <%= @_access_log_format %> <%= @_access_log_env_var %>
+<% elsif @access_log -%>
   CustomLog <%= @access_log_destination %> <%= @_access_log_format %>
 <% end -%>
 <%= scope.function_template(['apache/vhost/_block.erb']) -%>

--- a/tests/vhost.pp
+++ b/tests/vhost.pp
@@ -227,3 +227,11 @@ apache::vhost { 'securedomain.com':
         ssl_honorcipherorder  => 'On',
         add_listen            => 'false',
 }
+
+# Vhost with access log environment variables writing control
+apache::vhost { 'twentyfirst.example.com':
+  port               => '80',
+  docroot            => '/var/www/twentyfirst',
+  access_log_env_var => 'admin',
+}
+


### PR DESCRIPTION
I tried to test, refering to `CONTRIBUTING.md`. Though I failed `rake spec:system` spec.

Could you tell me if testing command changed?

Thanks.
