### PR TITLE
Fix rspec-puppet deprecation warnings

### DIFF
--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -9,7 +9,7 @@ describe 'apache', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_package("httpd").with(
       'notify' => 'Class[Apache::Service]',
       'ensure' => 'installed'
@@ -132,7 +132,7 @@ describe 'apache', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_package("httpd").with(
       'notify' => 'Class[Apache::Service]',
       'ensure' => 'installed'
@@ -370,7 +370,7 @@ describe 'apache', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_class("apache::package").with({'ensure' => 'present'}) }
     it { should contain_user("www") }
     it { should contain_group("www") }

--- a/spec/classes/dev_spec.rb
+++ b/spec/classes/dev_spec.rb
@@ -8,7 +8,7 @@ describe 'apache::dev', :type => :class do
         :operatingsystemrelease => '6',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_package("libaprutil1-dev") }
     it { should contain_package("libapr1-dev") }
     it { should contain_package("apache2-prefork-dev") }
@@ -20,7 +20,7 @@ describe 'apache::dev', :type => :class do
         :operatingsystemrelease => '6',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_package("httpd-devel") }
   end
   context "on a FreeBSD OS" do
@@ -33,6 +33,6 @@ describe 'apache::dev', :type => :class do
         :operatingsystemrelease => '9',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
   end
 end

--- a/spec/classes/mod/auth_kerb_spec.rb
+++ b/spec/classes/mod/auth_kerb_spec.rb
@@ -10,7 +10,7 @@ describe 'apache::mod::auth_kerb', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod("auth_kerb") }
     it { should contain_package("libapache2-mod-auth-kerb") }
   end
@@ -22,7 +22,7 @@ describe 'apache::mod::auth_kerb', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod("auth_kerb") }
     it { should contain_package("mod_auth_kerb") }
   end
@@ -34,7 +34,7 @@ describe 'apache::mod::auth_kerb', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod("auth_kerb") }
     it { should contain_package("www/mod_auth_kerb2") }
   end

--- a/spec/classes/mod/authnz_ldap_spec.rb
+++ b/spec/classes/mod/authnz_ldap_spec.rb
@@ -11,8 +11,8 @@ describe 'apache::mod::authnz_ldap', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
-    it { should include_class("apache::mod::ldap") }
+    it { should contain_class("apache::params") }
+    it { should contain_class("apache::mod::ldap") }
     it { should contain_apache__mod('authnz_ldap') }
 
     context 'default verifyServerCert' do
@@ -40,8 +40,8 @@ describe 'apache::mod::authnz_ldap', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
-    it { should include_class("apache::mod::ldap") }
+    it { should contain_class("apache::params") }
+    it { should contain_class("apache::mod::ldap") }
     it { should contain_apache__mod('authnz_ldap') }
 
     context 'default verifyServerCert' do

--- a/spec/classes/mod/dav_svn_spec.rb
+++ b/spec/classes/mod/dav_svn_spec.rb
@@ -10,7 +10,7 @@ describe 'apache::mod::dav_svn', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod('dav_svn') }
     it { should contain_package("libapache2-svn") }
   end
@@ -22,7 +22,7 @@ describe 'apache::mod::dav_svn', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod('dav_svn') }
     it { should contain_package("mod_dav_svn") }
   end
@@ -34,7 +34,7 @@ describe 'apache::mod::dav_svn', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod('dav_svn') }
     it { should contain_package("devel/subversion") }
   end

--- a/spec/classes/mod/dev_spec.rb
+++ b/spec/classes/mod/dev_spec.rb
@@ -17,7 +17,7 @@ describe 'apache::mod::dev', :type => :class do
           :operatingsystemrelease => operatingsystemrelease,
         }
       end
-      it { should include_class('apache::dev') }
+      it { should contain_class('apache::dev') }
     end
   end
 end

--- a/spec/classes/mod/dir_spec.rb
+++ b/spec/classes/mod/dir_spec.rb
@@ -13,7 +13,7 @@ describe 'apache::mod::dir', :type => :class do
       }
     end
     context "passing no parameters" do
-      it { should include_class("apache::params") }
+      it { should contain_class("apache::params") }
       it { should contain_apache__mod('dir') }
       it { should contain_file('dir.conf').with_content(/^DirectoryIndex /) }
       it { should contain_file('dir.conf').with_content(/ index\.html /) }
@@ -40,7 +40,7 @@ describe 'apache::mod::dir', :type => :class do
       }
     end
     context "passing no parameters" do
-      it { should include_class("apache::params") }
+      it { should contain_class("apache::params") }
       it { should contain_apache__mod('dir') }
       it { should contain_file('dir.conf').with_content(/^DirectoryIndex /) }
       it { should contain_file('dir.conf').with_content(/ index\.html /) }
@@ -67,7 +67,7 @@ describe 'apache::mod::dir', :type => :class do
       }
     end
     context "passing no parameters" do
-      it { should include_class("apache::params") }
+      it { should contain_class("apache::params") }
       it { should contain_apache__mod('dir') }
       it { should contain_file('dir.conf').with_content(/^DirectoryIndex /) }
       it { should contain_file('dir.conf').with_content(/ index\.html /) }

--- a/spec/classes/mod/event_spec.rb
+++ b/spec/classes/mod/event_spec.rb
@@ -10,7 +10,7 @@ describe 'apache::mod::event', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should_not contain_apache__mod('event') }
     it { should contain_file("/usr/local/etc/apache22/Modules/event.conf").with_ensure('file') }
   end

--- a/spec/classes/mod/fastcgi_spec.rb
+++ b/spec/classes/mod/fastcgi_spec.rb
@@ -10,7 +10,7 @@ describe 'apache::mod::fastcgi', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod('fastcgi') }
     it { should contain_package("libapache2-mod-fastcgi") }
     it { should contain_file('fastcgi.conf') }
@@ -24,7 +24,7 @@ describe 'apache::mod::fastcgi', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod('fastcgi') }
     it { should contain_package("mod_fastcgi") }
     it { should_not contain_file('fastcgi.conf') }

--- a/spec/classes/mod/fcgid_spec.rb
+++ b/spec/classes/mod/fcgid_spec.rb
@@ -10,7 +10,7 @@ describe 'apache::mod::fcgid', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod('fcgid') }
     it { should contain_package("libapache2-mod-fcgid") }
   end
@@ -22,7 +22,7 @@ describe 'apache::mod::fcgid', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod('fcgid') }
     it { should contain_package("mod_fcgid") }
   end
@@ -34,7 +34,7 @@ describe 'apache::mod::fcgid', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod('fcgid') }
     it { should contain_package("www/mod_fcgid") }
   end

--- a/spec/classes/mod/itk_spec.rb
+++ b/spec/classes/mod/itk_spec.rb
@@ -10,7 +10,7 @@ describe 'apache::mod::itk', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should_not contain_apache__mod('itk') }
     it { should contain_file("/etc/apache2/mods-available/itk.conf").with_ensure('file') }
     it { should contain_file("/etc/apache2/mods-enabled/itk.conf").with_ensure('link') }
@@ -24,7 +24,7 @@ describe 'apache::mod::itk', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should_not contain_apache__mod('itk') }
     it { should contain_file("/usr/local/etc/apache22/Modules/itk.conf").with_ensure('file') }
   end

--- a/spec/classes/mod/passenger_spec.rb
+++ b/spec/classes/mod/passenger_spec.rb
@@ -10,7 +10,7 @@ describe 'apache::mod::passenger', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod('passenger') }
     it { should contain_package("libapache2-mod-passenger") }
     it { should contain_file('passenger.conf').with({
@@ -88,7 +88,7 @@ describe 'apache::mod::passenger', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod('passenger') }
     it { should contain_package("mod_passenger") }
     it { should contain_file('passenger.conf').with({
@@ -105,7 +105,7 @@ describe 'apache::mod::passenger', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod('passenger') }
     it { should contain_package("www/rubygem-passenger") }
   end

--- a/spec/classes/mod/perl_spec.rb
+++ b/spec/classes/mod/perl_spec.rb
@@ -10,7 +10,7 @@ describe 'apache::mod::perl', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod('perl') }
     it { should contain_package("libapache2-mod-perl2") }
   end
@@ -22,7 +22,7 @@ describe 'apache::mod::perl', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod('perl') }
     it { should contain_package("mod_perl") }
   end
@@ -34,7 +34,7 @@ describe 'apache::mod::perl', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod('perl') }
     it { should contain_package("www/mod_perl2") }
   end

--- a/spec/classes/mod/peruser_spec.rb
+++ b/spec/classes/mod/peruser_spec.rb
@@ -10,7 +10,7 @@ describe 'apache::mod::peruser', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should_not contain_apache__mod('peruser') }
     it { should contain_file("/usr/local/etc/apache22/Modules/peruser.conf").with_ensure('file') }
   end

--- a/spec/classes/mod/php_spec.rb
+++ b/spec/classes/mod/php_spec.rb
@@ -11,7 +11,7 @@ describe 'apache::mod::php', :type => :class do
       let :pre_condition do
         'class { "apache": mpm_module => prefork, }'
       end
-      it { should include_class("apache::params") }
+      it { should contain_class("apache::params") }
       it { should contain_apache__mod('php5') }
       it { should contain_package("libapache2-mod-php5") }
       it { should contain_file("php5.load").with(
@@ -39,7 +39,7 @@ describe 'apache::mod::php', :type => :class do
       let :pre_condition do
         'class { "apache": }'
       end
-      it { should include_class("apache::params") }
+      it { should contain_class("apache::params") }
       it { should contain_apache__mod('php5') }
       it { should contain_package("php") }
       it { should contain_file("php5.load").with(
@@ -61,7 +61,7 @@ describe 'apache::mod::php', :type => :class do
       let :pre_condition do
         'class { "apache": mpm_module => prefork, }'
       end
-      it { should include_class("apache::params") }
+      it { should contain_class("apache::params") }
       it { should contain_apache__mod('php5') }
       it { should contain_package("php") }
       it { should contain_file("php5.load").with(
@@ -81,7 +81,7 @@ describe 'apache::mod::php', :type => :class do
       let :pre_condition do
         'class { "apache": mpm_module => prefork, }'
       end
-      it { should include_class('apache::params') }
+      it { should contain_class('apache::params') }
       it { should contain_apache__mod('php5') }
       it { should contain_package("lang/php5") }
       it { should contain_file('php5.load') }

--- a/spec/classes/mod/prefork_spec.rb
+++ b/spec/classes/mod/prefork_spec.rb
@@ -10,7 +10,7 @@ describe 'apache::mod::prefork', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should_not contain_apache__mod('prefork') }
     it { should contain_file("/etc/apache2/mods-available/prefork.conf").with_ensure('file') }
     it { should contain_file("/etc/apache2/mods-enabled/prefork.conf").with_ensure('link') }
@@ -24,7 +24,7 @@ describe 'apache::mod::prefork', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should_not contain_apache__mod('prefork') }
     it { should contain_file("/etc/httpd/conf.d/prefork.conf").with_ensure('file') }
     it { should contain_file_line("/etc/sysconfig/httpd prefork enable").with({
@@ -40,7 +40,7 @@ describe 'apache::mod::prefork', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should_not contain_apache__mod('prefork') }
     it { should contain_file("/usr/local/etc/apache22/Modules/prefork.conf").with_ensure('file') }
   end

--- a/spec/classes/mod/proxy_html_spec.rb
+++ b/spec/classes/mod/proxy_html_spec.rb
@@ -14,7 +14,7 @@ describe 'apache::mod::proxy_html', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod('proxy_html') }
     it { should contain_package("libapache2-mod-proxy-html") }
   end
@@ -26,7 +26,7 @@ describe 'apache::mod::proxy_html', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod('proxy_html') }
     it { should contain_package("mod_proxy_html") }
   end
@@ -38,7 +38,7 @@ describe 'apache::mod::proxy_html', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod('proxy_html') }
     it { should contain_package("www/mod_proxy_html") }
   end

--- a/spec/classes/mod/python_spec.rb
+++ b/spec/classes/mod/python_spec.rb
@@ -10,7 +10,7 @@ describe 'apache::mod::python', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod("python") }
     it { should contain_package("libapache2-mod-python") }
   end
@@ -22,7 +22,7 @@ describe 'apache::mod::python', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod("python") }
     it { should contain_package("mod_python") }
   end
@@ -34,7 +34,7 @@ describe 'apache::mod::python', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod("python") }
     it { should contain_package("www/mod_python3") }
   end

--- a/spec/classes/mod/rpaf_spec.rb
+++ b/spec/classes/mod/rpaf_spec.rb
@@ -12,7 +12,7 @@ describe 'apache::mod::rpaf', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod('rpaf') }
     it { should contain_package("libapache2-mod-rpaf") }
     it { should contain_file('rpaf.conf').with({
@@ -47,7 +47,7 @@ describe 'apache::mod::rpaf', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod('rpaf') }
     it { should contain_package("www/mod_rpaf2") }
     it { should contain_file('rpaf.conf').with({

--- a/spec/classes/mod/ssl_spec.rb
+++ b/spec/classes/mod/ssl_spec.rb
@@ -21,7 +21,7 @@ describe 'apache::mod::ssl', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class('apache::params') }
+    it { should contain_class('apache::params') }
     it { should contain_apache__mod('ssl') }
     it { should contain_package('mod_ssl') }
   end
@@ -34,7 +34,7 @@ describe 'apache::mod::ssl', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class('apache::params') }
+    it { should contain_class('apache::params') }
     it { should contain_apache__mod('ssl') }
     it { should_not contain_package('libapache2-mod-ssl') }
   end
@@ -47,7 +47,7 @@ describe 'apache::mod::ssl', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class('apache::params') }
+    it { should contain_class('apache::params') }
     it { should contain_apache__mod('ssl') }
   end
 end

--- a/spec/classes/mod/suphp_spec.rb
+++ b/spec/classes/mod/suphp_spec.rb
@@ -10,7 +10,7 @@ describe 'apache::mod::suphp', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_package("libapache2-mod-suphp") }
   end
   context "on a RedHat OS" do
@@ -21,7 +21,7 @@ describe 'apache::mod::suphp', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_package("mod_suphp") }
   end
 end

--- a/spec/classes/mod/worker_spec.rb
+++ b/spec/classes/mod/worker_spec.rb
@@ -10,7 +10,7 @@ describe 'apache::mod::worker', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should_not contain_apache__mod('worker') }
     it { should contain_file("/etc/apache2/mods-available/worker.conf").with_ensure('file') }
     it { should contain_file("/etc/apache2/mods-enabled/worker.conf").with_ensure('link') }
@@ -24,7 +24,7 @@ describe 'apache::mod::worker', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should_not contain_apache__mod('worker') }
     it { should contain_file("/etc/httpd/conf.d/worker.conf").with_ensure('file') }
     it { should contain_file_line("/etc/sysconfig/httpd worker enable") }
@@ -37,7 +37,7 @@ describe 'apache::mod::worker', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should_not contain_apache__mod('worker') }
     it { should contain_file("/usr/local/etc/apache22/Modules/worker.conf").with_ensure('file') }
   end

--- a/spec/classes/mod/wsgi_spec.rb
+++ b/spec/classes/mod/wsgi_spec.rb
@@ -10,7 +10,7 @@ describe 'apache::mod::wsgi', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod('wsgi') }
     it { should contain_package("libapache2-mod-wsgi") }
   end
@@ -22,7 +22,7 @@ describe 'apache::mod::wsgi', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod('wsgi') }
     it { should contain_package("mod_wsgi") }
 
@@ -47,7 +47,7 @@ describe 'apache::mod::wsgi', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should include_class("apache::params") }
+    it { should contain_class("apache::params") }
     it { should contain_apache__mod('wsgi') }
     it { should contain_package("www/mod_wsgi") }
   end

--- a/spec/defines/mod_spec.rb
+++ b/spec/defines/mod_spec.rb
@@ -17,7 +17,7 @@ describe 'apache::mod', :type => :define do
       let :title do
         'spec_m'
       end
-      it { should include_class("apache::params") }
+      it { should contain_class("apache::params") }
       it "should manage the module load file" do
         should contain_file('spec_m.load').with({
           :path    => '/etc/httpd/conf.d/spec_m.load',
@@ -37,7 +37,7 @@ describe 'apache::mod', :type => :define do
       # parameters
       let(:params) { {:package => 'mod_xsendfile'} }
 
-      it { should include_class("apache::params") }
+      it { should contain_class("apache::params") }
       it { should contain_package('mod_xsendfile') }
     end
   end
@@ -55,7 +55,7 @@ describe 'apache::mod', :type => :define do
       let :title do
         'spec_m'
       end
-      it { should include_class("apache::params") }
+      it { should contain_class("apache::params") }
       it "should manage the module load file" do
         should contain_file('spec_m.load').with({
           :path    => '/etc/apache2/mods-available/spec_m.load',
@@ -90,7 +90,7 @@ describe 'apache::mod', :type => :define do
       let :title do
         'spec_m'
       end
-      it { should include_class("apache::params") }
+      it { should contain_class("apache::params") }
       it "should manage the module load file" do
         should contain_file('spec_m.load').with({
           :path    => '/usr/local/etc/apache22/Modules/spec_m.load',

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -24,8 +24,8 @@ describe 'apache::vhost', :type => :define do
       end
       let :params do default_params end
       let :facts do default_facts end
-      it { should include_class("apache") }
-      it { should include_class("apache::params") }
+      it { should contain_class("apache") }
+      it { should contain_class("apache::params") }
     end
     context "on Debian based systems" do
       let :default_facts do
@@ -37,8 +37,8 @@ describe 'apache::vhost', :type => :define do
       end
       let :params do default_params end
       let :facts do default_facts end
-      it { should include_class("apache") }
-      it { should include_class("apache::params") }
+      it { should contain_class("apache") }
+      it { should contain_class("apache::params") }
       it { should contain_file("25-rspec.example.com.conf").with(
         :ensure => 'present',
         :path   => '/etc/apache2/sites-available/25-rspec.example.com.conf'
@@ -59,8 +59,8 @@ describe 'apache::vhost', :type => :define do
       end
       let :params do default_params end
       let :facts do default_facts end
-      it { should include_class("apache") }
-      it { should include_class("apache::params") }
+      it { should contain_class("apache") }
+      it { should contain_class("apache::params") }
       it { should contain_file("25-rspec.example.com.conf").with(
         :ensure => 'present',
         :path   => '/usr/local/etc/apache22/Vhosts/25-rspec.example.com.conf'
@@ -77,8 +77,8 @@ describe 'apache::vhost', :type => :define do
     end
     describe 'basic assumptions' do
       let :params do default_params end
-      it { should include_class("apache") }
-      it { should include_class("apache::params") }
+      it { should contain_class("apache") }
+      it { should contain_class("apache::params") }
       it { should contain_apache__listen(params[:port]) }
       it { should contain_apache__namevirtualhost("*:#{params[:port]}") }
     end


### PR DESCRIPTION
This commit changes all the spec tests to use contain_class
instead of include_class which is deprecated.
