### PR TITLE
Pass this through to directories.

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -114,8 +114,6 @@ define apache::vhost(
     $servername                  = $name,
     $serveraliases               = [],
     $options                     = ['Indexes','FollowSymLinks','MultiViews'],
-    $index_options               = [],
-    $index_order_default         = [],
     $override                    = ['None'],
     $directoryindex              = '',
     $vhost_name                  = '*',


### PR DESCRIPTION
The current code allows you to set index_options but then ignores it.
Based on the git log for the commit that added this option it was
intended to be passed into directories.  The test that caught this
will be merged into spec/acceptance/vhost_spec.rb in a seperate PR.

You can reproduce the original failure with:

``` puppet
class { 'apache': }
host { 'test.server': ip => '127.0.0.1' }
apache::vhost { 'test.server':
  docroot    => '/tmp',
  index_options    => ['Charset=UTF-8'],
}
```
