### PR TITLE
#538 - variables do not conform to Puppet 3.4 naming rules

### DIFF
--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -18,35 +18,35 @@ define apache::mod (
   $mod_libs = $apache::params::mod_libs
   $mod_lib = $mod_libs[$mod] # 2.6 compatibility hack
   if $lib {
-    $_lib = $lib
+    $my_lib = $lib
   } elsif "${mod_lib}" {
-    $_lib = $mod_lib
+    $my_lib = $mod_lib
   } else {
-    $_lib = "mod_${mod}.so"
+    $my_lib = "mod_${mod}.so"
   }
 
   # Determine if declaration specified a path to the module
   if $path {
-    $_path = $path
+    $my_path = $path
   } else {
-    $_path = "${lib_path}/${_lib}"
+    $my_path = "${lib_path}/${my_lib}"
   }
 
   if $id {
-    $_id = $id
+    $my_id = $id
   } else {
-    $_id = "${mod}_module"
+    $my_id = "${mod}_module"
   }
 
   # Determine if we have a package
   $mod_packages = $apache::params::mod_packages
   $mod_package = $mod_packages[$mod] # 2.6 compatibility hack
   if $package {
-    $_package = $package
+    $my_package = $package
   } elsif "${mod_package}" {
-    $_package = $mod_package
+    $my_package = $mod_package
   }
-  if $_package and ! defined(Package[$_package]) {
+  if $my_package and ! defined(Package[$my_package]) {
     # note: FreeBSD/ports uses apxs tool to activate modules; apxs clutters
     # httpd.conf with 'LoadModule' directives; here, by proper resource
     # ordering, we ensure that our version of httpd.conf is reverted after
@@ -58,8 +58,8 @@ define apache::mod (
       ],
       default => File["${mod_dir}/${mod}.load"],
     }
-    # $_package may be an array
-    package { $_package:
+    # $my_package may be an array
+    package { $my_package:
       ensure  => $package_ensure,
       require => Package['httpd'],
       before  => $package_before,
@@ -72,7 +72,7 @@ define apache::mod (
     owner   => 'root',
     group   => $apache::params::root_group,
     mode    => '0644',
-    content => "LoadModule ${_id} ${_path}\n",
+    content => "LoadModule ${my_id} ${my_path}\n",
     require => [
       Package['httpd'],
       Exec["mkdir ${mod_dir}"],

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -290,13 +290,13 @@ define apache::vhost(
 
   # Set access log format
   if $access_log_format {
-    $_access_log_format = "\"${access_log_format}\""
+    $my_access_log_format = "\"${access_log_format}\""
   } else {
-    $_access_log_format = 'combined'
+    $my_access_log_format = 'combined'
   }
 
   if $access_log_env_var {
-    $_access_log_env_var = "env=${access_log_env_var}"
+    $my_access_log_env_var = "env=${access_log_env_var}"
   }
 
   if $ip {
@@ -393,9 +393,9 @@ define apache::vhost(
 
   ## Create a default directory list if none defined
   if $directories {
-    $_directories = $directories
+    $my_directories = $directories
   } else {
-    $_directories = [ {
+    $my_directories = [ {
       provider       => 'directory',
       path           => $docroot,
       options        => $options,
@@ -417,12 +417,12 @@ define apache::vhost(
   # - $logroot
   # - $name
   # - $aliases
-  # - $_directories
+  # - $my_directories
   # - $log_level
   # - $access_log
   # - $access_log_destination
-  # - $_access_log_format
-  # - $_access_log_env_var
+  # - $my_access_log_format
+  # - $my_access_log_env_var
   # - $error_log
   # - $error_log_destination
   # - $error_documents

--- a/templates/vhost.conf.erb
+++ b/templates/vhost.conf.erb
@@ -39,10 +39,10 @@
   LogLevel <%= @log_level %>
 <% end -%>
   ServerSignature Off
-<% if @access_log and @_access_log_env_var -%>
-  CustomLog <%= @access_log_destination %> <%= @_access_log_format %> <%= @_access_log_env_var %>
+<% if @access_log and @my_access_log_env_var -%>
+  CustomLog <%= @access_log_destination %> <%= @my_access_log_format %> <%= @my_access_log_env_var %>
 <% elsif @access_log -%>
-  CustomLog <%= @access_log_destination %> <%= @_access_log_format %>
+  CustomLog <%= @access_log_destination %> <%= @my_access_log_format %>
 <% end -%>
 <%= scope.function_template(['apache/vhost/_block.erb']) -%>
 <%= scope.function_template(['apache/vhost/_error_document.erb']) -%>

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -1,5 +1,5 @@
-<% if @_directories and ! @_directories.empty? -%>
-  <%- [@_directories].flatten.compact.each do |directory| -%>
+<% if @my_directories and ! @my_directories.empty? -%>
+  <%- [@my_directories].flatten.compact.each do |directory| -%>
     <%- if directory['path'] and directory['path'] != '' -%>
   <%- if directory['provider'] and [ 'directory', 'location', 'files' ].include?(directory['provider']) -%>
     <%- provider = directory['provider'].capitalize -%>


### PR DESCRIPTION
I simply replaced all variable names beginning with an underscore using:

```
find . -name \*.pp | xargs sed -i -e 's/$_/$my_/g' -e 's/${_/${my_/g'
find . -name \*.erb | xargs sed -i -e 's/@_/@my_/g'
```

Not exhaustively tested, but works for my vhost config with puppet 3.3.2 and 3.4.0rc2.
