### PR TITLE
Update alias.pp to let users of Amazon Linux use the module

### DIFF
--- a/manifests/mod/alias.pp
+++ b/manifests/mod/alias.pp
@@ -1,7 +1,8 @@
 class apache::mod::alias {
-  $icons_path = $::osfamily ? {
+  $icons_path = $::osfamily or $::operatingsystem ? {
     'debian'  => '/usr/share/apache2/icons',
     'redhat'  => '/var/www/icons',
+    'amazon'  => '/var/www/icons',
     'freebsd' => '/usr/local/www/apache22/icons',
   }
   apache::mod { 'alias': }


### PR DESCRIPTION
Fixed to all module to be used with Amazon Linux (fork of RHEL/CentOS)

facter osfamily operatingsystem
operatingsystem => Amazon
osfamily => Linux
