### PR TITLE
Fix the servername used in log file name

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -268,9 +268,9 @@ define apache::vhost(
     $access_log_destination = $access_log_syslog
   } else {
     if $ssl {
-      $access_log_destination = "${logroot}/${servername}_access_ssl.log"
+      $access_log_destination = "${logroot}/${name}_access_ssl.log"
     } else {
-      $access_log_destination = "${logroot}/${servername}_access.log"
+      $access_log_destination = "${logroot}/${name}_access.log"
     }
   }
 
@@ -282,9 +282,9 @@ define apache::vhost(
     $error_log_destination = $error_log_syslog
   } else {
     if $ssl {
-      $error_log_destination = "${logroot}/${servername}_error_ssl.log"
+      $error_log_destination = "${logroot}/${name}_error_ssl.log"
     } else {
-      $error_log_destination = "${logroot}/${servername}_error.log"
+      $error_log_destination = "${logroot}/${name}_error.log"
     }
   }
 


### PR DESCRIPTION
The servername can be [schema://]hostname.domain[:port]. In the case of servername including schema and port, it is not appropriate to use as log file name. It will generate something like this: "ErrorLog /var/log/httpd/https://domain_error.log", which cause httpd failed to refresh/start.
