### PR TITLE
Use IncludeOptional for config files

### DIFF
--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -52,7 +52,7 @@ LogFormat "%h %l %u %t \"%r\" %>s %b" common
 LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
 
-Include <%= @confd_dir %>/*.conf
+IncludeOptional <%= @confd_dir %>/*.conf
 <% if @vhost_load_dir != @confd_dir -%>
 Include <%= @vhost_load_dir %>/*.conf
 <% end -%>


### PR DESCRIPTION
If the *.conf not match any files apache will not display errors
