### PR TITLE
Don't purge mods-available dir when separate enable dir is used

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -145,10 +145,12 @@ class apache (
       creates => $mod_dir,
       require => Package['httpd'],
     }
+    # Don't purge available modules if an enable dir is used
+    $purge_mod_dir = $purge_configs and !$mod_enable_dir
     file { $mod_dir:
       ensure  => directory,
       recurse => true,
-      purge   => $purge_configs,
+      purge   => $purge_mod_dir,
       notify  => Class['Apache::Service'],
       require => Package['httpd'],
     }

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -37,7 +37,7 @@ describe 'apache', :type => :class do
     it { should contain_file("/etc/apache2/mods-available").with(
       'ensure'  => 'directory',
       'recurse' => 'true',
-      'purge'   => 'true',
+      'purge'   => 'false',
       'notify'  => 'Class[Apache::Service]',
       'require' => 'Package[httpd]'
       )


### PR DESCRIPTION
Purging /etc/apache2/mods-available on Debian when there are separate available/enabled directories is poor behaviour, since this isn't active configuration.  When purged, you lose track of which modules are available but that this module doesn't handle.

This patch disables the purge behaviour on the module config directory, but only when there is also a separate module enabled directory.
