### PR TITLE
Configure Passenger in separate .conf file on RH so PassengerRoot isn't lost

### DIFF
--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -1,4 +1,6 @@
 class apache::mod::passenger (
+  $passenger_conf_file            = $apache::params::passenger_conf_file,
+  $passenger_conf_package_file    = $apache::params::passenger_conf_package_file,
   $passenger_high_performance     = undef,
   $passenger_pool_idle_time       = undef,
   $passenger_max_requests         = undef,
@@ -17,6 +19,14 @@ class apache::mod::passenger (
   } else {
     apache::mod { 'passenger': }
   }
+
+  # Managed by the package, but declare it to avoid purging
+  if $passenger_conf_package_file {
+    file { 'passenger_package.conf':
+      path => "${apache::mod_dir}/${passenger_conf_package_file}",
+    }
+  }
+
   # Template uses:
   # - $passenger_root
   # - $passenger_ruby
@@ -29,7 +39,7 @@ class apache::mod::passenger (
   # - $rails_autodetect
   file { 'passenger.conf':
     ensure  => file,
-    path    => "${apache::mod_dir}/passenger.conf",
+    path    => "${apache::mod_dir}/${passenger_conf_file}",
     content => template('apache/mod/passenger.conf.erb'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -56,8 +56,10 @@ class apache::params {
     $default_ssl_cert     = '/etc/pki/tls/certs/localhost.crt'
     $default_ssl_key      = '/etc/pki/tls/private/localhost.key'
     $ssl_certs_dir        = '/etc/pki/tls/certs'
-    $passenger_root       = '/usr/share/rubygems/gems/passenger-3.0.17'
-    $passenger_ruby       = '/usr/bin/ruby'
+    $passenger_conf_file  = 'passenger_extra.conf'
+    $passenger_conf_package_file = 'passenger.conf'
+    $passenger_root       = undef
+    $passenger_ruby       = undef
     $suphp_addhandler     = 'php5-script'
     $suphp_engine         = 'off'
     $suphp_configpath     = undef
@@ -115,6 +117,8 @@ class apache::params {
     $default_ssl_cert = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
     $default_ssl_key  = '/etc/ssl/private/ssl-cert-snakeoil.key'
     $ssl_certs_dir    = '/etc/ssl/certs'
+    $passenger_conf_file = 'passenger.conf'
+    $passenger_conf_package_file = undef
     $passenger_root   = '/usr'
     $passenger_ruby   = '/usr/bin/ruby'
     $suphp_addhandler  = 'x-httpd-php'
@@ -168,6 +172,8 @@ class apache::params {
     $default_ssl_cert = '/usr/local/etc/apache22/server.crt'
     $default_ssl_key  = '/usr/local/etc/apache22/server.key'
     $ssl_certs_dir    = '/usr/local/etc/apache22'
+    $passenger_conf_file = 'passenger.conf'
+    $passenger_conf_package_file = undef
     $passenger_root   = '/usr/local/lib/ruby/gems/1.9/gems/passenger-4.0.10'
     $passenger_ruby   = '/usr/bin/ruby'
     $suphp_addhandler = 'php5-script'

--- a/spec/classes/mod/passenger_spec.rb
+++ b/spec/classes/mod/passenger_spec.rb
@@ -91,11 +91,28 @@ describe 'apache::mod::passenger', :type => :class do
     it { should contain_class("apache::params") }
     it { should contain_apache__mod('passenger') }
     it { should contain_package("mod_passenger") }
-    it { should contain_file('passenger.conf').with({
+    it { should contain_file('passenger_package.conf').with({
       'path' => '/etc/httpd/conf.d/passenger.conf',
     }) }
-    it { should contain_file('passenger.conf').with_content(/^  PassengerRoot \/usr\/share\/rubygems\/gems\/passenger-3.0.17$/) }
-    it { should contain_file('passenger.conf').with_content(/^  PassengerRuby \/usr\/bin\/ruby$/) }
+    it { should contain_file('passenger_package.conf').without_content }
+    it { should contain_file('passenger_package.conf').without_source }
+    it { should contain_file('passenger.conf').with({
+      'path' => '/etc/httpd/conf.d/passenger_extra.conf',
+    }) }
+    it { should contain_file('passenger.conf').without_content(/PassengerRoot/) }
+    it { should contain_file('passenger.conf').without_content(/PassengerRuby/) }
+    describe "with passenger_root => '/usr/lib/example'" do
+      let :params do
+        { :passenger_root => '/usr/lib/example' }
+      end
+      it { should contain_file('passenger.conf').with_content(/^  PassengerRoot \/usr\/lib\/example$/) }
+    end
+    describe "with passenger_ruby => /user/lib/example/ruby" do
+      let :params do
+        { :passenger_ruby => '/user/lib/example/ruby' }
+      end
+      it { should contain_file('passenger.conf').with_content(/^  PassengerRuby \/user\/lib\/example\/ruby$/) }
+    end
   end
   context "on a FreeBSD OS" do
     let :facts do

--- a/templates/mod/passenger.conf.erb
+++ b/templates/mod/passenger.conf.erb
@@ -1,8 +1,12 @@
 # The Passanger Apache module configuration file is being
 # managed by Puppet and changes will be overwritten.
 <IfModule mod_passenger.c>
+  <%- if @passenger_root -%>
   PassengerRoot <%= @passenger_root %>
+  <%- end -%>
+  <%- if @passenger_ruby -%>
   PassengerRuby <%= @passenger_ruby %>
+  <%- end -%>
   <%- if @passenger_high_performance -%>
   PassengerHighPerformance <%= @passenger_high_performance %>
   <%- end -%>


### PR DESCRIPTION
The mod_passenger RPM supplies /etc/httpd/conf.d/passenger.conf with the
correct PassengerRoot for the version of the package installed.  The most
reliable way to keep the PassengerRoot accurate is to leave this file in
place and then to install a second file (passenger_extra.conf) for other
Passenger customisations.

Hardcoding the PassengerRoot in the module means it gets out of step with
package repositories (3.0.21 is in EPEL6 at the time of writing, while the
module assumes .17).  Passenger 4.x refuses to start if the PassengerRoot is
incorrect.  The user of apache::mod::passenger is also able to override this
value, but they shouldn't be forced to, just to get a functioning install.

Fixes #560
