### PR TITLE
Use correct SSL mutex setting for Apache 2.4

### DIFF
--- a/lib/facter/apache_version.rb
+++ b/lib/facter/apache_version.rb
@@ -1,0 +1,32 @@
+commands = ["/usr/sbin/httpd", "/usr/sbin/apachectl", "/usr/sbin/apache2", "/usr/local/sbin/apachectl"]
+
+commands.each do |cmd|
+  if File.exists?(cmd)
+    output = Facter::Util::Resolution.exec(cmd + " -v").to_s
+    matches = /Apache\/([0-9]).([0-9]).([0-9]+)/.match(output)
+    version = matches.nil? ? nil : matches.captures
+    unless version.nil?
+      Facter.add("apache_version") do
+        setcode do
+          version.join(".")
+        end
+      end
+      Facter.add("apache_major") do
+        setcode do
+          version[0]
+        end
+      end
+      Facter.add("apache_minor") do
+        setcode do
+          version[1]
+        end
+      end
+      Facter.add("apache_revision") do
+        setcode do
+          version[2]
+        end
+      end
+      break
+    end
+  end
+end

--- a/templates/mod/ssl.conf.erb
+++ b/templates/mod/ssl.conf.erb
@@ -13,7 +13,11 @@
 <% if @ssl_compression -%>
   SSLCompression Off
 <% end -%>
+<% if @apache_major.to_i == 2 and @apache_minor.to_i >= 4 -%>
+  Mutex sysvsem <%= @ssl_mutex %>
+<% else -%> 
   SSLMutex <%= @ssl_mutex %>
+<% end -%>
   SSLCryptoDevice builtin
   SSLHonorCipherOrder On
   SSLCipherSuite HIGH:MEDIUM:!aNULL:!MD5


### PR DESCRIPTION
This fixes #564

With quite a few syntax changes between Apache 2.2 and 2.4, I've also created a fact here so we can know what version we're running, does that make sense to do?
