### PR TITLE
Add mod_perl file/template with three arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,16 @@ Installs Apache SSL capabilities and utilizes `ssl.conf.erb` template. These are
 
 To *use* SSL with a virtual host, you must either set the`default_ssl_vhost` parameter in `apache` to 'true' or set the `ssl` parameter in `apache::vhost` to 'true'.
 
+####Class: `apache::mod::perl`
+
+```puppet
+    class { 'apache::mod::perl':
+      perl_set_var     => "foo bar",
+      perl_switches    => '-wT',
+      perl_load_module => 'SOME::Perl::Module',
+    }
+```
+
 ####Class: `apache::mod::wsgi`
 
 ```puppet

--- a/manifests/mod/perl.pp
+++ b/manifests/mod/perl.pp
@@ -1,3 +1,21 @@
-class apache::mod::perl {
+class apache::mod::perl (
+  $perl_load_module = undef,
+  $perl_set_var     = undef,
+  $perl_switches    = undef,
+) {
+
   apache::mod { 'perl': }
+
+  # Template uses:
+  # - $perl_load_module
+  # - $perl_set_var
+  # - $perl_switches
+  file { 'perl.conf':
+    ensure  => file,
+    path    => "${apache::mod_dir}/perl.conf",
+    content => template('apache/mod/perl.conf.erb'),
+    require => Exec["mkdir ${apache::mod_dir}"],
+    before  => File[$apache::mod_dir],
+    notify  => Service['httpd'],
+  }
 }

--- a/spec/classes/mod/perl_spec.rb
+++ b/spec/classes/mod/perl_spec.rb
@@ -25,6 +25,24 @@ describe 'apache::mod::perl', :type => :class do
     it { should contain_class("apache::params") }
     it { should contain_apache__mod('perl') }
     it { should contain_package("mod_perl") }
+    describe "with custom perl_switches" do
+      let :params do
+        { :perl_switches => '-I' }
+      end
+      it { should contain_file('perl.conf').with_content(/^  PerlSwitches -I/)}
+    end
+    describe "with custom perl_load_module" do
+      let :params do
+        { :perl_load_module => 'SOME::Perl::Module' }
+      end
+      it { should contain_file('perl.conf').with_content(/^  PerlLoadModule SOME::Perl::Module/)}
+    end
+    describe "with custom perl_set_var" do
+      let :params do
+        { :perl_set_var => 'MasonMultipleConfig 1' }
+      end
+      it { should contain_file('perl.conf').with_content(/^  PerlSetVar MasonMultipleConfig 1/)}
+    end
   end
   context "on a FreeBSD OS" do
     let :facts do

--- a/templates/mod/perl.conf.erb
+++ b/templates/mod/perl.conf.erb
@@ -1,0 +1,14 @@
+# The Perl Apache module configuration file is being
+# managed by Puppet an changes will be overwritten.
+
+<IfModule mod_perl.c>
+<% if @perl_switches -%>
+  PerlSwitches <%= @perl_switches %>
+<% end -%>
+<% if @perl_load_module -%>
+  PerlLoadModule <%= @perl_load_module %>
+<% end -%>
+<% if @perl_set_var -%>
+  PerlSetVar <%= @perl_set_var %>
+<% end -%>
+</IfModule>


### PR DESCRIPTION
Add mod_perl file/template with three arguments:
- perl_switches
- perl_set_var
- perl_load_module

Update documentation with feature example

Update spec tests with new arguments
