### PR TITLE
Fix typos in templates/vhost/_itk.erb

### DIFF
--- a/templates/vhost/_itk.erb
+++ b/templates/vhost/_itk.erb
@@ -4,11 +4,11 @@
      <%- if @itk["user"] and @itk["group"] -%>
      AssignUserId <%= @itk["user"] %> <%= @itk["group"] %>
      <%- end -%>
-     <%- if @itk["assignuieridexpr"] -%>
-     AssignUserIdExpr <%= @itk["assignuieridexpr"] %>
+     <%- if @itk["assignuseridexpr"] -%>
+     AssignUserIdExpr <%= @itk["assignuseridexpr"] %>
      <%- end -%>
-     <%- if @itk["assignuiergroupexpr"] -%>
-     AssignGroupIdExpr <%= @itk["assignuiergroupexpr"] %>
+     <%- if @itk["assigngroupidexpr"] -%>
+     AssignGroupIdExpr <%= @itk["assigngroupidexpr"] %>
      <%- end -%>
      <%- if @itk["maxclientvhost"] -%>
      MaxClientsVHost <%= @itk["maxclientvhost"] %>


### PR DESCRIPTION
Basically, this wouldn't have worked because of mass typos. FTFY
