### PR TITLE
templates/vhost/_proxy.erb misconfigures ProxyPassReverse

### DIFF
--- a/templates/vhost/_proxy.erb
+++ b/templates/vhost/_proxy.erb
@@ -6,7 +6,7 @@
 <% [@proxy_pass].flatten.compact.each do |proxy| %>
   ProxyPass <%= proxy['path'] %> <%= proxy['url'] %>
   <Location <%= proxy['path']%>>
-    ProxyPassReverse /
+    ProxyPassReverse <%= proxy['url'] %>
   </Location>
 <% end %>
 <% if @proxy_dest -%>
@@ -15,6 +15,6 @@
 <% end %>
   ProxyPass          / <%= @proxy_dest %>/
   <Location          />
-    ProxyPassReverse /
+    ProxyPassReverse <%= @proxy_dest %>/
   </Location>
 <% end -%>


### PR DESCRIPTION
See here:
http://httpd.apache.org/docs/2.2/mod/mod_proxy.html#proxypassreverse

When enclosing ProxyPassReverse in a <Location> directive, you drop the
_first_ argument, as it will be taken from the enclosing Location. The
second argument is the URL to which we are attempting to proxy.

Very simple change. Tested in my environment, works.
