### PR TITLE
Remove duplicate server_root documentation entry.

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,10 +278,6 @@ A value to be set as `ServerRoot` in main configuration file (`httpd.conf`). Def
 
 Makes Apache use the Linux kernel 'sendfile' to serve static files. Defaults to 'On'.
 
-#####`server_root`
-
-A value to be set as `ServerRoot` in main configuration file (`httpd.conf`). Defaults to `/etc/httpd` on RedHat and `/etc/apache2` on Debian.
-
 #####`error_documents`
 
 Enables custom error documents. Defaults to 'false'.


### PR DESCRIPTION
I've removed a duplicate documentation entry for the apache class `server_root` variable.  I left the more complete entry (including FreeBSD instructions) and deleted the less complete entry.
