### PR TITLE
Fix typo in mod passenger documentation

### DIFF
--- a/README.passenger.md
+++ b/README.passenger.md
@@ -49,13 +49,13 @@ Sets how often Passenger performs file system checks, at most once every _x_ sec
 
 http://www.modrails.com/documentation/Users%20guide%20Apache.html#_passengerstatthrottlerate_lt_integer_gt
 
-## rack_auto_detect
+## rack_autodetect
 
 Should Passenger automatically detect if the document root of a virtual host is a Rack application. The default is `on`
 
 http://www.modrails.com/documentation/Users%20guide%20Apache.html#_rackautodetect_lt_on_off_gt
 
-## rails_auto_detect
+## rails_autodetect
 
 Should Passenger automatically detect if the document root of a virtual host is a Rails application. The default is on.
 


### PR DESCRIPTION
The rails_auto_detect and rack_auto_detect should not have an underscore between auto and detect.
