### PR TITLE
Ensure socache_shmcb is enabled on all Apache 2.4 OSes

### DIFF
--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -27,7 +27,7 @@ class apache::mod::ssl (
 
   apache::mod { 'ssl': }
 
-  if $apache_version >= 2.4 and $::operatingsystem == 'Ubuntu' {
+  if $apache_version >= 2.4 {
     apache::mod { 'socache_shmcb': }
   }
 


### PR DESCRIPTION
The SSLSessionCache option is specified as socache_shmcb, so the module must
be enabled.

<pre>
Feb 07 11:57:45 foreman-f19.example.com httpd[13215]: AH00526: Syntax error on line 11 of /etc/httpd/conf.d/ssl.conf:
Feb 07 11:57:45 foreman-f19.example.com httpd[13215]: SSLSessionCache: 'shmcb' session cache not supported (known names: ). Maybe you need to load the appropriate socache module (mod_socache_shmcb?).
</pre>
