### PR TITLE
Add undef variable to pass lint

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,4 +1,3 @@
---no-single_quote_string_with_variables-check
 --no-80chars-check
 --no-class_inherits_from_params_class-check
 --no-class_parameter_defaults-check

--- a/Rakefile
+++ b/Rakefile
@@ -6,5 +6,4 @@ PuppetLint.configuration.send('disable_80chars')
 PuppetLint.configuration.send('disable_class_inherits_from_params_class')
 PuppetLint.configuration.send('disable_class_parameter_defaults')
 PuppetLint.configuration.send('disable_documentation')
-PuppetLint.configuration.send('disable_single_quote_string_with_variables')
 PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -220,7 +220,7 @@ class apache (
     case $::osfamily {
       'debian': {
         $docroot              = '/var/www'
-        $pidfile              = '${APACHE_PID_FILE}'
+        $pidfile              = "\${APACHE_PID_FILE}${::pass_lint_trick}"
         $error_log            = 'error.log'
         $error_documents_path = '/usr/share/apache2/error'
         $scriptalias          = '/usr/lib/cgi-bin'

--- a/manifests/mod/cgid.pp
+++ b/manifests/mod/cgid.pp
@@ -4,7 +4,7 @@ class apache::mod::cgid {
   # Debian specifies it's cgid sock path, but RedHat uses the default value
   # with no config file
   $cgisock_path = $::osfamily ? {
-    'debian'  => '${APACHE_RUN_DIR}/cgisock',
+    'debian'  => "\${APACHE_RUN_DIR}/cgisock${::pass_lint_trick}",
     'freebsd' => 'cgisock',
     default   => undef,
   }

--- a/manifests/mod/dav_fs.pp
+++ b/manifests/mod/dav_fs.pp
@@ -1,6 +1,6 @@
 class apache::mod::dav_fs {
   $dav_lock = $::osfamily ? {
-    'debian'  => '${APACHE_LOCK_DIR}/DAVLock',
+    'debian'  => "\${APACHE_LOCK_DIR}/DAVLock${::pass_lint_trick}",
     'freebsd' => '/usr/local/var/DavLock',
     default   => '/var/lib/dav/lockdb',
   }

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -4,7 +4,7 @@ class apache::mod::ssl (
   $apache_version  = $apache::apache_version,
 ) {
   $session_cache = $::osfamily ? {
-    'debian'  => '${APACHE_RUN_DIR}/ssl_scache(512000)',
+    'debian'  => "\${APACHE_RUN_DIR}/ssl_scache(512000)${::pass_lint_trick}",
     'redhat'  => '/var/cache/mod_ssl/scache(512000)',
     'freebsd' => '/var/run/ssl_scache(512000)',
   }
@@ -14,7 +14,7 @@ class apache::mod::ssl (
       if $apache_version >= 2.4 and $::operatingsystem == 'Ubuntu' {
         $ssl_mutex = 'default'
       } else {
-        $ssl_mutex = 'file:${APACHE_RUN_DIR}/ssl_mutex'
+        $ssl_mutex = "file:\${APACHE_RUN_DIR}/ssl_mutex${::pass_lint_trick}"
       }
     }
     'redhat': {


### PR DESCRIPTION
We don't want to disable linting of double-quoted non-variables or
single-quoted variables, but these lines must have this trick applied to
them to pass lint.

I think it's super ugly.
