### PR TITLE
Array/Hash mutating operations deprecated

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -417,13 +417,17 @@ define apache::vhost(
     }
 
     if $apache_version == 2.4 {
-      $_directory[require] = 'all granted'
+      $_directory_version = {
+        require => 'all granted',
+      }
     } else {
-      $_directory[order] = 'allow,deny'
-      $_directory[allow] = 'from all'
+      $_directory_version = {
+        order => 'allow,deny',
+        allow => 'from all',
+      }
     }
 
-    $_directories = [ $_directory ]
+    $_directories = [ merge($_directory, $_directory_version) ]
   }
 
   # Template uses:


### PR DESCRIPTION
Puppet 3.5.0 will deprecate mutating arrays and hashes, as found here (from the Apache 2.4 merge): https://github.com/puppetlabs/puppetlabs-apache/blob/e8348ff5/manifests/vhost.pp#L419-L424

This leads to warnings while running Puppet:

```
The use of mutating operations on Array/Hash is deprecated at /usr/share/foreman-installer/modules/apache/manifests/vhost.pp:422. See http://links.puppetlabs.com/puppet-mutation-deprecation
```

More info: https://tickets.puppetlabs.com/browse/PUP-864
