### PR TITLE
Add rewrite_base functionality to rewrites

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -153,6 +153,7 @@ define apache::vhost(
     $headers                     = undef,
     $request_headers             = undef,
     $rewrites                    = undef,
+    $rewrite_base                = undef,
     $rewrite_rule                = undef,
     $rewrite_cond                = undef,
     $setenv                      = [],
@@ -199,6 +200,9 @@ define apache::vhost(
   }
 
   # Deprecated backwards-compatibility
+  if $rewrite_base {
+    warning('Apache::Vhost: parameter rewrite_base is deprecated in favor of rewrites')
+  }
   if $rewrite_rule {
     warning('Apache::Vhost: parameter rewrite_rule is deprecated in favor of rewrites')
   }

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -1138,7 +1138,8 @@ describe 'apache::vhost', :type => :define do
         let :params do default_params.merge({
           :rewrites => [
             {
-              'comment'       => 'test rewrites',
+              'comment'      => 'test rewrites',
+              'rewrite_base' => '/mytestpath/',
               'rewrite_cond' => ['%{HTTP_USER_AGENT} ^Lynx/ [OR]', '%{HTTP_USER_AGENT} ^Mozilla/[12]'],
               'rewrite_rule' => ['^index\.html$ welcome.html', '^index\.cgi$ index.php'],
             }
@@ -1150,6 +1151,9 @@ describe 'apache::vhost', :type => :define do
           )
           should contain_file("25-#{title}.conf").with_content(
             /^  RewriteCond %\{HTTP_USER_AGENT\} \^Lynx\/ \[OR\]$/
+          )
+          should contain_file("25-#{title}.conf").with_content(
+            /^  RewriteBase \/mytestpath\/$/
           )
           should contain_file("25-#{title}.conf").with_content(
             /^  RewriteCond %\{HTTP_USER_AGENT\} \^Mozilla\/\[12\]$/

--- a/templates/vhost/_rewrite.erb
+++ b/templates/vhost/_rewrite.erb
@@ -1,28 +1,31 @@
-<% if @rewrites -%>
+<%- if @rewrites -%>
   ## Rewrite rules
   RewriteEngine On
-<% if @rewrite_base -%>
+  <%- if @rewrite_base -%>
   RewriteBase <%= @rewrite_base %>
-<% end -%>
+  <%- end -%>
 
-<% [@rewrites].flatten.compact.each do |rewrite_details| -%>
-<% if rewrite_details['comment'] -%>
+  <%- [@rewrites].flatten.compact.each do |rewrite_details| -%>
+    <%- if rewrite_details['comment'] -%>
   #<%= rewrite_details['comment'] %>
-<% end -%>
-<% if rewrite_details['rewrite_cond'] -%>
-<%- Array(rewrite_details['rewrite_cond']).each do |commands| -%>
-<%- Array(commands).each do |command| -%>
+    <%- end -%>
+    <%- if rewrite_details['rewrite_base'] -%>
+  RewriteBase <%= rewrite_details['rewrite_base'] %>
+    <%- end -%>
+    <%- if rewrite_details['rewrite_cond'] -%>
+      <%- Array(rewrite_details['rewrite_cond']).each do |commands| -%>
+        <%- Array(commands).each do |command| -%>
   RewriteCond <%= command %>
-<%- end -%>
-<% end -%>
-<% end -%>
-<%- Array(rewrite_details['rewrite_rule']).each do |commands| -%>
-<%- Array(commands).each do |command| -%>
+        <%- end -%>
+      <%- end -%>
+    <%- end -%>
+    <%- Array(rewrite_details['rewrite_rule']).each do |commands| -%>
+      <%- Array(commands).each do |command| -%>
   RewriteRule <%= command %>
-<%- end -%>
+      <%- end -%>
 
-<% end -%>
-<% end -%>
+    <%- end -%>
+  <%- end -%>
 <%- end -%>
 <%# reverse compatibility %>
 <% if @rewrite_rule and !@rewrites -%>


### PR DESCRIPTION
Previously rewrite_base was a parameter to vhost, but was removed incorrectly. When rewrites was created to replace rewrite_\* parameters, rewrite_base was forgotten. This adds back the deprecated rewrite_base parameter and adds the rewrite_base support to the rewrites parameter.

Closes #554
