### PR TITLE
Fix WSGI import_script and mod_ssl issues on Lucid

### DIFF
--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -13,6 +13,8 @@ class apache::mod::ssl (
     'debian': {
       if $apache_version >= 2.4 and $::operatingsystem == 'Ubuntu' {
         $ssl_mutex = 'default'
+      } elsif $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '10.04' {
+        $ssl_mutex = 'file:/var/run/apache2/ssl_mutex'
       } else {
         $ssl_mutex = 'file:${APACHE_RUN_DIR}/ssl_mutex'
       }

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -44,9 +44,6 @@ describe 'apache::vhost define', :unless => UNSUPPORTED_PLATFORMS.include?(fact(
 
   context 'default vhost with ssl' do
     it 'should create default vhost configs' do
-      # Doesn't work on Ubuntu 10.04 because ssl.conf should contain
-      # 'file:/var/run/apache2/ssl_mutex' but contains
-      # 'file:${APACHE_RUN_DIR}/ssl_mutex'
       pp = <<-EOS
         file { '#{$run_dir}':
           ensure  => 'directory',
@@ -866,7 +863,24 @@ describe 'apache::vhost define', :unless => UNSUPPORTED_PLATFORMS.include?(fact(
   end
 
   describe 'wsgi' do
-    it 'applies cleanly' do
+    it 'import_script applies cleanly' do
+      pp = <<-EOS
+        class { 'apache': }
+        class { 'apache::mod::wsgi': }
+        host { 'test.server': ip => '127.0.0.1' }
+        apache::vhost { 'test.server':
+          docroot                     => '/tmp',
+          wsgi_application_group      => '%{GLOBAL}',
+          wsgi_daemon_process         => 'wsgi',
+          wsgi_daemon_process_options => {processes => '2'},
+          wsgi_process_group          => 'nobody',
+          wsgi_script_aliases         => { '/test' => '/test1' },
+        }
+      EOS
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    it 'import_script applies cleanly', :unless => fact('lsbcodename') == 'lucid' do
       pp = <<-EOS
         class { 'apache': }
         class { 'apache::mod::wsgi': }


### PR DESCRIPTION
The WSGIImportScript directive can't be used directly inside a VirtualHost on Lucid, says the apache daemon.
