### PR TITLE
Add support for mod_speling

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ There are many `apache::mod::[name]` classes within this module that can be decl
 * `rewrite`
 * `rpaf`*
 * `setenvif`
+* `speling`
 * `ssl`* (see [`apache::mod::ssl`](#class-apachemodssl) below)
 * `status`*
 * `suphp`

--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -27,6 +27,7 @@ class apache::default_mods (
         include ::apache::mod::mime_magic
         include ::apache::mod::vhost_alias
         include ::apache::mod::rewrite
+        include ::apache::mod::speling
         ::apache::mod { 'auth_digest': }
         ::apache::mod { 'authn_anon': }
         ::apache::mod { 'authn_dbm': }
@@ -36,7 +37,6 @@ class apache::default_mods (
         ::apache::mod { 'ext_filter': }
         ::apache::mod { 'include': }
         ::apache::mod { 'logio': }
-        ::apache::mod { 'speling': }
         ::apache::mod { 'substitute': }
         ::apache::mod { 'suexec': }
         ::apache::mod { 'usertrack': }
@@ -65,6 +65,7 @@ class apache::default_mods (
         include ::apache::mod::rewrite
         include ::apache::mod::userdir
         include ::apache::mod::vhost_alias
+        include ::apache::mod::speling
 
         ::apache::mod { 'asis': }
         ::apache::mod { 'auth_digest': }
@@ -83,7 +84,6 @@ class apache::default_mods (
         ::apache::mod { 'imagemap':}
         ::apache::mod { 'include': }
         ::apache::mod { 'logio': }
-        ::apache::mod { 'speling': }
         ::apache::mod { 'unique_id': }
         ::apache::mod { 'usertrack': }
         ::apache::mod { 'version': }

--- a/manifests/mod/speling.pp
+++ b/manifests/mod/speling.pp
@@ -1,0 +1,3 @@
+class apache::mod::speling {
+  ::apache::mod { 'speling': }
+}

--- a/spec/classes/mod/speling_spec.rb
+++ b/spec/classes/mod/speling_spec.rb
@@ -1,0 +1,26 @@
+describe 'apache::mod::speling', :type => :class do
+  let :pre_condition do
+    'include apache'
+  end
+  context "on a Debian OS" do
+    let :facts do
+      {
+        :osfamily               => 'Debian',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
+      }
+    end
+    it { should contain_apache__mod('speling') }
+  end
+
+  context "on a RedHat OS" do
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
+      }
+    end
+    it { should contain_apache__mod('speling') }
+  end
+end


### PR DESCRIPTION
This commit adds support for [mod_speling](http://httpd.apache.org/docs/2.2/mod/mod_speling.html). Speling is an Apache module which attempts to correct URLs that users might have entered by ignoring capitalization and by allowing up to one misspelling. The speling module is included in the vendor packages for both Debian and RHEL based distributions, so no extra packages are required to be installed for these platforms; I'm not sure about other distributions.

The module does have two boolean configuration options, documented in the Apache HTTP Server docs. The puppet class provided does not include support for these options. They are omitted simply because the use case seems similar to mod_xsendfile, the puppet class for which also omits its options.

This commit has been tested against my own needs on both Oracle Linux 6 and Debian 7 (Wheezy). Automated tests were not included because a) I am not familiar with the test format for puppet, and b) there are no tests for the xsendfile class on which the speling class is based.
