### PR TITLE
Adds "Release Notes/Known Bugs" to Changelog, updates file format to markdown, standardizes the format of previous entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,36 +187,36 @@ worker/prefork
 - Fix formatting in vhost template
 - Fix spec tests such that they pass
 
-    2012-05-08 Puppet Labs <info@puppetlabs.com> - 0.0.4
-    e62e362 Fix broken tests for ssl, vhost, vhost::*
-    42c6363 Changes to match style guide and pass puppet-lint without error
-    42bc8ba changed name => path for file resources in order to name namevar by it's name
-    72e13de One end too much
-    0739641 style guide fixes: 'true' <> true, $operatingsystem needs to be $::operatingsystem, etc.
-    273f94d fix tests
-    a35ede5 (#13860) Make a2enmod/a2dismo commands optional
-    98d774e (#13860) Autorequire Package['httpd']
-    05fcec5 (#13073) Add missing puppet spec tests
-    541afda (#6899) Remove virtual a2mod definition
-    976cb69 (#13072) Move mod python and wsgi package names to params
-    323915a (#13060) Add .gitignore to repo
-    fdf40af (#13060) Remove pkg directory from source tree
-    fd90015 Add LICENSE file and update the ModuleFile
-    d3d0d23 Re-enable local php class
-    d7516c7 Make management of firewalls configurable for vhosts
-    60f83ba Explicitly lookup scope of apache_name in templates.
-    f4d287f (#12581) Add explicit ordering for vdir directory
-    88a2ac6 (#11706) puppetlabs-apache depends on puppetlabs-firewall
-    a776a8b (#11071) Fix to work with latest firewall module
-    2b79e8b (#11070) Add support for Scientific Linux
-    405b3e9 Fix for a2mod
-    57b9048 Commit apache::vhost::redirect Manifest
-    8862d01 Commit apache::vhost::proxy Manifest
-    d5c1fd0 Commit apache::mod::wsgi Manifest
-    a825ac7 Commit apache::mod::python Manifest
-    b77062f Commit Templates
-    9a51b4a Vhost File Declarations
-    6cf7312 Defaults for Parameters
-    6a5b11a Ensure installed
-    f672e46 a2mod fix
-    8a56ee9 add pthon support to apache
+##2012-05-08 Puppet Labs <info@puppetlabs.com> - 0.0.4
+* e62e362 Fix broken tests for ssl, vhost, vhost::*
+* 42c6363 Changes to match style guide and pass puppet-lint without error
+* 42bc8ba changed name => path for file resources in order to name namevar by it's name
+* 72e13de One end too much
+* 0739641 style guide fixes: 'true' <> true, $operatingsystem needs to be $::operatingsystem, etc.
+* 273f94d fix tests
+* a35ede5 (#13860) Make a2enmod/a2dismo commands optional
+* 98d774e (#13860) Autorequire Package['httpd']
+* 05fcec5 (#13073) Add missing puppet spec tests
+* 541afda (#6899) Remove virtual a2mod definition
+* 976cb69 (#13072) Move mod python and wsgi package names to params
+* 323915a (#13060) Add .gitignore to repo
+* fdf40af (#13060) Remove pkg directory from source tree
+* fd90015 Add LICENSE file and update the ModuleFile
+* d3d0d23 Re-enable local php class
+* d7516c7 Make management of firewalls configurable for vhosts
+* 60f83ba Explicitly lookup scope of apache_name in templates.
+* f4d287f (#12581) Add explicit ordering for vdir directory
+* 88a2ac6 (#11706) puppetlabs-apache depends on puppetlabs-firewall
+* a776a8b (#11071) Fix to work with latest firewall module
+* 2b79e8b (#11070) Add support for Scientific Linux
+* 405b3e9 Fix for a2mod
+* 57b9048 Commit apache::vhost::redirect Manifest
+* 8862d01 Commit apache::vhost::proxy Manifest
+* d5c1fd0 Commit apache::mod::wsgi Manifest
+* a825ac7 Commit apache::mod::python Manifest
+* b77062f Commit Templates
+* 9a51b4a Vhost File Declarations
+* 6cf7312 Defaults for Parameters
+* 6a5b11a Ensure installed
+* f672e46 a2mod fix
+* 8a56ee9 add pthon support to apache


### PR DESCRIPTION
Per a request to have initial release notes that specifically listed known issues for this PE 3.2 release, and barred by time constraints from automating a pull from open issues in JIRA, this commit adds a Release Note and Known Bug section to the Changelog for the imminent 3.2 release. As it will display on the Forge, updates file type to markdown and standardizes previous entries. Adds template for release notes to be filled in later.
