### PR TITLE
Fix to the apache version fo Ubuntu 13.10

### DIFF
--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -9,7 +9,7 @@ class apache::version {
   if ! $distrelease {
     fail("Class['apache::params']: Unparsable \$::operatingsystemrelease: ${::operatingsystemrelease}")
   }
-  
+
   case $::osfamily {
     'RedHat': {
       if ($::operatingsystem == 'Fedora' and $distrelease >= 18) or ($::operatingsystem != 'Fedora' and $distrelease >= 7) {
@@ -19,7 +19,8 @@ class apache::version {
       }
     }
     'Debian': {
-      if $::operatingsystem == 'Ubuntu' and $distrelease >= 13.10 {
+      # We need the operatingsystemrelease here not the distrelease
+      if $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease >= 13.10 {
         $default = 2.4
       } else {
         $default = 2.2


### PR DESCRIPTION
The version.pp for Ubuntu 13.10 no longer works.

Apache 2.4 install no longer worked.

$distrelease is an integer and not decimal value
$::operatingsystemrelease mst be used

Also seems to break acceptance:
RS_SET=ubuntu-server-1310-x64 RS_DESTROY=onpass bundle exec rspec spec/acceptance/
