### PR TITLE
modified variable used for Ubuntu OS release (to lsbdistrelease)

### DIFF
--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -19,7 +19,7 @@ class apache::version {
       }
     }
     'Debian': {
-      if $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease >= 13.10 {
+      if $::operatingsystem == 'Ubuntu' and $::lsbdistrelease >= 13.10 {
         $default = 2.4
       } else {
         $default = 2.2


### PR DESCRIPTION
I think this line is problematic. The 'operatingsystemrelease' fact is not formatted the same way as distrelease. On Ubuntu 12.04:
lsbdistrelease => 12.04
operatingsystemrelease => 3.2.0-29-generic
That means that the puppet run will throw a type error:
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: comparison of String with Float failed at /etc/puppet/modules/apache/manifests/version.pp:22 on node
