### PR TITLE
Add extra parameters to mod::php

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
         * [Defined Type: apache::mod](#defined-type-apachemod)
         * [Classes: apache::mod::*](#classes-apachemodname)
         * [Class: apache::mod::pagespeed](#class-apachemodpagespeed)
+        * [Class: apache::mod::php](#class-apachemodphp)
         * [Class: apache::mod::ssl](#class-apachemodssl)
         * [Class: apache::mod::wsgi](#class-apachemodwsgi)
         * [Defined Type: apache::vhost](#defined-type-apachevhost)
@@ -522,6 +523,18 @@ These are the defaults:
 ```
 
 Full documentation for mod_pagespeed is available from [Google](http://modpagespeed.com).
+
+####Class: `apache::mod::php`
+
+Installs and configures mod_php. The defaults are OS-dependant.
+
+Overriding the package name:
+```
+  class {'::apache::mod::php':
+    package_name => "php54-php",
+    path         => "${::apache::params::lib_path}/libphp54-php5.so",
+  }
+```
 
 ####Class: `apache::mod::ssl`
 

--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -1,5 +1,5 @@
 class apache::mod::php (
-  $package        = undef,
+  $package_name   = undef,
   $package_ensure = 'present',
   $path           = undef,
 ) {
@@ -7,7 +7,7 @@ class apache::mod::php (
     fail('apache::mod::php requires apache::mod::prefork; please enable mpm_module => \'prefork\' on Class[\'apache\']')
   }
   ::apache::mod { 'php5':
-    package        => $package,
+    package        => $package_name,
     package_ensure => $package_ensure,
     path           => $path,
   }

--- a/spec/classes/mod/php_spec.rb
+++ b/spec/classes/mod/php_spec.rb
@@ -46,6 +46,24 @@ describe 'apache::mod::php', :type => :class do
         :content => "LoadModule php5_module modules/libphp5.so\n"
       ) }
     end
+    context "with alternative package name" do let :pre_condition do
+        'class { "apache": }'
+      end
+      let :params do
+        { :package_name => 'php54'}
+      end
+      it { should contain_package("php54") }
+    end
+    context "with alternative path" do let :pre_condition do
+        'class { "apache": }'
+      end
+      let :params do
+        { :path => 'alternative-path'}
+      end
+      it { should contain_file("php5.load").with(
+        :content => "LoadModule php5_module alternative-path\n"
+      ) }
+    end
     context "with specific version" do
       let :pre_condition do
         'class { "apache": }'


### PR DESCRIPTION
These extra parameters allow us to override the package name so we can install php54 via http://wiki.centos.org/AdditionalResources/Repositories/SCL
