### PR TITLE
Add rewrites to vhost directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1371,6 +1371,31 @@ Sets the value for the [PassengerEnabled](http://www.modrails.com/documentation/
 
 `php_admin_value` sets the value of the directory, and `php_admin_flag` uses a boolean to configure the directory. Further information can be found [here](http://php.net/manual/en/configuration.changes.php).
 
+######`rewrites`
+
+Creates URL [`rewrites`](#rewrites) rules in vhost directories. Expects an array of hashes, and the hash keys can be any of 'comment', 'rewrite_base', 'rewrite_cond', or 'rewrite_rule'.
+
+```puppet
+    apache::vhost { 'secure.example.net':
+      docroot     => '/path/to/directory',
+      directories => [
+        { path        => '/path/to/directory',
+          rewrites => [ { comment      => 'Permalink Rewrites',
+                          rewrite_base => '/'
+                        },
+                        { rewrite_rule => [ '^index\.php$ - [L]' ]
+                        },
+                        { rewrite_cond => [ '%{REQUEST_FILENAME} !-f',
+                                            '%{REQUEST_FILENAME} !-d',
+                                          ],
+                          rewrite_rule => [ '. /index.php [L]' ],
+                        }
+                      ],
+        },
+      ],
+    }
+```
+
 ######`ssl_options`
 
 String or list of [SSLOptions](https://httpd.apache.org/docs/current/mod/mod_ssl.html#ssloptions), which configure SSL engine run-time options. This handler takes precedence over SSLOptions set in the parent block of the vhost.

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -740,6 +740,40 @@ describe 'apache::vhost', :type => :define do
           ],
         },
         {
+          :title  => 'should accept directory directives with rewrites array',
+          :attr   => 'directories',
+          :value  => [
+            {
+              'path'      => '/opt/app3',
+              'rewrites'  => [
+                {
+                  'comment' => 'Permalink Rewrites',
+                  'rewrite_base' => '/',
+                  'rewrite_rule' => [ '^index\.php$ - [L]' ],
+                },
+                {
+                  'rewrite_cond' => [
+                    '%{REQUEST_FILENAME} !-f',
+                    '%{REQUEST_FILENAME} !-d',
+                  ],
+                  'rewrite_rule' => [ '. /index.php [L]' ],
+                }
+              ]
+            }
+          ],
+          :match  => [
+            /^  <Directory "\/opt\/app3">$/,
+            /^    #Permalink Rewrites$/,
+            /^    RewriteEngine On$/,
+            /^    RewriteBase \/$/,
+            /^    RewriteRule \^index\\.php\$ - \[L\]$/,
+            /^    RewriteCond %{REQUEST_FILENAME} !-f$/,
+            /^    RewriteCond %{REQUEST_FILENAME} !-d$/,
+            /^    RewriteRule . \/index.php \[L\]$/,
+            /^  <\/Directory>$/,
+          ],
+        },
+        {
           :title => 'should accept location for provider',
           :attr  => 'directories',
           :value => {
@@ -876,6 +910,40 @@ describe 'apache::vhost', :type => :define do
             /^    AllowOverride None$/,
             /^    Require all granted$/,
             /^    AddHandler cgi-script .cgi$/,
+            /^  <\/Directory>$/,
+          ],
+        },
+        {
+          :title  => 'should accept directory directives with rewrites array',
+          :attr   => 'directories',
+          :value  => [
+            {
+              'path'      => '/opt/app3',
+              'rewrites'  => [
+                {
+                  'comment' => 'Permalink Rewrites',
+                  'rewrite_base' => '/',
+                  'rewrite_rule' => [ '^index\.php$ - [L]' ],
+                },
+                {
+                  'rewrite_cond' => [
+                    '%{REQUEST_FILENAME} !-f',
+                    '%{REQUEST_FILENAME} !-d',
+                  ],
+                  'rewrite_rule' => [ '. /index.php [L]' ],
+                }
+              ]
+            }
+          ],
+          :match  => [
+            /^  <Directory "\/opt\/app3">$/,
+            /^    #Permalink Rewrites$/,
+            /^    RewriteEngine On$/,
+            /^    RewriteBase \/$/,
+            /^    RewriteRule \^index\\.php\$ - \[L\]$/,
+            /^    RewriteCond %{REQUEST_FILENAME} !-f$/,
+            /^    RewriteCond %{REQUEST_FILENAME} !-d$/,
+            /^    RewriteRule . \/index.php \[L\]$/,
             /^  <\/Directory>$/,
           ],
         },

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -153,6 +153,30 @@
     <%- if directory['suphp'] and @suphp_engine == 'on' -%>
     suPHP_UserGroup <%= directory['suphp']['user'] %> <%= directory['suphp']['group'] %>
     <%- end -%>
+    <%- if directory['rewrites'] -%>
+    # Rewrite rules
+    RewriteEngine On
+    <%- directory['rewrites'].flatten.compact.each do |rewrite_details| -%>
+      <%- if rewrite_details['comment'] -%>
+    #<%= rewrite_details['comment'] %>
+      <%- end -%>
+      <%- if rewrite_details['rewrite_base'] -%>
+    RewriteBase <%= rewrite_details['rewrite_base'] %>
+     <%- end -%>
+      <%- if rewrite_details['rewrite_cond'] -%>
+        <%- Array(rewrite_details['rewrite_cond']).each do |commands| -%>
+          <%- Array(commands).each do |command| -%>
+    RewriteCond <%= command %>
+          <%- end -%>
+        <%- end -%>
+      <%- end -%>
+      <%- Array(rewrite_details['rewrite_rule']).each do |commands| -%>
+       <%- Array(commands).each do |command| -%>
+    RewriteRule <%= command %>
+       <%- end -%>
+      <%- end -%>
+    <%- end -%>
+    <%- end -%>
     <%- if directory['custom_fragment'] -%>
     <%= directory['custom_fragment'] %>
     <%- end -%>


### PR DESCRIPTION
[#MODULES-111](https://tickets.puppetlabs.com/browse/MODULES-111): Duplicate rewrites parameter from apache::vhost
as an array of hashes placed in the directories parameter
to enable use of mod_rewrite directives in vhost directories.

Add documentation to Parameter directories for apache::vhost for
rewrites array.

---

This doesn't achieve the fully desired goal of  "support configuration via the other `templates/vhost/_*.erb` template fragments, ie `_rewrite.erb` and `_custom_fragment.erb` via the matching parameters for the fragment without code duplication."  from  MODULES-111    as it duplicated code.

However it achieves mod_rewrite functionality, and  custom_fragment  functionality in directories was added in a very similar manner. 
