### PR TITLE
Added support for SVN authentication (mod_authz_svn)

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ There are many `apache::mod::[name]` classes within this module that can be decl
 * `cgid`
 * `dav`
 * `dav_fs`
-* `dav_svn`
+* `dav_svn`*
 * `deflate`
 * `dev`
 * `dir`*

--- a/manifests/mod/dav_svn.pp
+++ b/manifests/mod/dav_svn.pp
@@ -1,5 +1,14 @@
-class apache::mod::dav_svn {
-  Class['::apache::mod::dav'] -> Class['::apache::mod::dav_svn']
-  include ::apache::mod::dav
-  ::apache::mod { 'dav_svn': }
+class apache::mod::dav_svn (
+  $authz_svn_enabled = false,
+) {
+    Class['::apache::mod::dav'] -> Class['::apache::mod::dav_svn']
+    include ::apache::mod::dav
+    ::apache::mod { 'dav_svn': } 
+    
+    if $authz_svn_enabled {
+      ::apache::mod { 'authz_svn':
+        loadfile_name => 'dav_svn_authz_svn.load',
+        require       => Apache::Mod['dav_svn'],
+      }
+    }
 }

--- a/spec/acceptance/mod_dav_svn_spec.rb
+++ b/spec/acceptance/mod_dav_svn_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper_acceptance'
+
+describe 'apache::mod::dav_svn class' do
+  case fact('osfamily')
+  when 'Debian'
+    mod_dir      = '/etc/apache2/mods-available'
+    service_name = 'apache2'
+  when 'RedHat'
+    mod_dir      = '/etc/httpd/conf.d'
+    service_name = 'httpd'
+  when 'FreeBSD'
+    mod_dir      = '/usr/local/etc/apache22/Modules'
+    service_name = 'apache22'
+  end
+
+  context "default dav_svn config" do
+    it 'succeeds in puppeting dav_svn' do
+      pp= <<-EOS
+        class { 'apache': }
+        include apache::mod::dav_svn
+      EOS
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    describe service(service_name) do
+      it { should be_enabled }
+      it { should be_running }
+    end
+
+    describe file("#{mod_dir}/dav_svn.load") do
+      it { should contain "LoadModule dav_svn_module" }
+    end
+  end
+
+  context "dav_svn with enabled authz_svn config" do
+    it 'succeeds in puppeting dav_svn' do
+      pp= <<-EOS
+        class { 'apache': }
+        class { 'apache::mod::dav_svn':
+            authz_svn_enabled => true,
+        }
+      EOS
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    describe service(service_name) do
+      it { should be_enabled }
+      it { should be_running }
+    end
+
+    describe file("#{mod_dir}/authz_svn.load") do
+      it { should contain "LoadModule authz_svn_module" }
+    end
+  end
+end


### PR DESCRIPTION
I actually don't know why this isn't implement, but i've now added support for the authz_svn module. Since this is useless without dav_svn, i've decided against implementing an extra apache::mod class. Hope this is ok.

Regards,
Matthias
