### PR TITLE
add docroot_mode parameter to vhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,6 +674,10 @@ Sets group access to the docroot directory. Defaults to 'root'.
 
 Sets individual user access to the docroot directory. Defaults to 'root'.
 
+#####`docroot_mode`
+
+Sets access permissions of the docroot directory. Defaults to 'undef'.
+
 #####`error_log`
 
 Specifies whether `*_error.log` directives should be configured. Defaults to 'true'.

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -94,6 +94,7 @@ define apache::vhost(
     $add_listen                  = true,
     $docroot_owner               = 'root',
     $docroot_group               = $::apache::params::root_group,
+    $docroot_mode                = undef,
     $serveradmin                 = undef,
     $ssl                         = false,
     $ssl_cert                    = $::apache::default_ssl_cert,
@@ -262,6 +263,7 @@ define apache::vhost(
       ensure  => directory,
       owner   => $docroot_owner,
       group   => $docroot_group,
+      mode    => $docroot_mode,
       require => Package['httpd'],
     }
   }

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -427,6 +427,7 @@ describe 'apache::vhost define', :unless => UNSUPPORTED_PLATFORMS.include?(fact(
           docroot       => '/tmp/test',
           docroot_owner => 'test_owner',
           docroot_group => 'test_group',
+          docroot_mode  => '0750',
         }
       EOS
       apply_manifest(pp, :catch_failures => true)
@@ -436,6 +437,7 @@ describe 'apache::vhost define', :unless => UNSUPPORTED_PLATFORMS.include?(fact(
       it { should be_directory }
       it { should be_owned_by 'test_owner' }
       it { should be_grouped_into 'test_group' }
+      it { should be_mode '0750' }
     end
   end
 

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -1096,16 +1096,18 @@ describe 'apache::vhost', :type => :define do
           expect { subject }.to raise_error(Puppet::Error, /'error_log_file' and 'error_log_pipe' cannot be defined at the same time/)
         end
       end
-      describe 'when docroot owner is specified' do
+      describe 'when docroot owner and mode is specified' do
         let :params do default_params.merge({
           :docroot_owner => 'testuser',
           :docroot_group => 'testgroup',
+          :docroot_mode  => '0750',
         }) end
-        it 'should set vhost ownership' do
+        it 'should set vhost ownership and permissions' do
           should contain_file(params[:docroot]).with({
             :ensure => :directory,
             :owner  => 'testuser',
             :group  => 'testgroup',
+            :mode   => '0750',
           })
         end
       end

--- a/tests/vhost.pp
+++ b/tests/vhost.pp
@@ -13,12 +13,13 @@ apache::vhost { 'first.example.com':
   docroot => '/var/www/first',
 }
 
-# Vhost with different docroot owner/group
+# Vhost with different docroot owner/group/mode
 apache::vhost { 'second.example.com':
   port          => '80',
   docroot       => '/var/www/second',
   docroot_owner => 'third',
   docroot_group => 'third',
+  docroot_mode  => '0770',
 }
 
 # Vhost with serveradmin


### PR DESCRIPTION
It can be useful to set the docroot directory to a specific mode, for example to allow write access to a group of users, or block read access from "others".
