### PR TITLE
revert apache::mod::passenger default parameters for RedHat

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -49,10 +49,10 @@ class apache::params inherits ::apache::version {
     $default_ssl_cert     = '/etc/pki/tls/certs/localhost.crt'
     $default_ssl_key      = '/etc/pki/tls/private/localhost.key'
     $ssl_certs_dir        = '/etc/pki/tls/certs'
-    $passenger_conf_file  = 'passenger.conf'
-    $passenger_conf_package_file = undef
-    $passenger_root       = '/usr/lib/ruby/gems/1.8/gems/passenger-3.0.19'
-    $passenger_ruby       = '/usr/bin/ruby'
+    $passenger_conf_file  = 'passenger_extra.conf'
+    $passenger_conf_package_file = 'passenger.conf'
+    $passenger_root       = undef
+    $passenger_ruby       = undef
     $suphp_addhandler     = 'php5-script'
     $suphp_engine         = 'off'
     $suphp_configpath     = undef

--- a/spec/classes/mod/passenger_spec.rb
+++ b/spec/classes/mod/passenger_spec.rb
@@ -118,11 +118,16 @@ describe 'apache::mod::passenger', :type => :class do
     it { should contain_class("apache::params") }
     it { should contain_apache__mod('passenger') }
     it { should contain_package("mod_passenger") }
+    it { should contain_file('passenger_package.conf').with({
+      'path' => '/etc/httpd/conf.d/passenger.conf',
+    }) }
+    it { should contain_file('passenger_package.conf').without_content }
+    it { should contain_file('passenger_package.conf').without_source }
     it { should contain_file('passenger.load').with({
       'path' => '/etc/httpd/conf.d/passenger.load',
     }) }
-    it { should contain_file('passenger.conf').with_content(/^  PassengerRoot "\/usr\/lib\/ruby\/gems\/1.8\/gems\/passenger-3\.0\.19"$/) }
-    it { should contain_file('passenger.conf').with_content(/^  PassengerRuby "\/usr\/bin\/ruby"/) }
+    it { should contain_file('passenger.conf').without_content(/PassengerRoot/) }
+    it { should contain_file('passenger.conf').without_content(/PassengerRuby/) }
     describe "with passenger_root => '/usr/lib/example'" do
       let :params do
         { :passenger_root => '/usr/lib/example' }


### PR DESCRIPTION
My [prior PR](https://github.com/puppetlabs/puppetlabs-apache/pull/687) modified the default parameters for mod::passenger for
RedHat, hardcoding paths related to the installed package; these changes
cause issues and are reverted by this commit.

The changes were originally prompted by (new) spec acceptance tests
leveraging passenger-status (to verify that passenger is running); these
tests were not working under RedHat; revisiting with the original
default parameters revealed that the RedHat tests were misconfigured
(the required PASSENGER_TMPDIR environment was not being set), so those
have been corrected.

Also, spec/class tests expecting the default parameters have been
reverted as well.
