### PR TITLE
Fixing typo with braces in the rewrite section of the markdown file

### DIFF
--- a/README.md
+++ b/README.md
@@ -927,7 +927,7 @@ Multiple rewrites and conditions are also possible
           rewrite_cond => ['%{HTTP_USER_AGENT} ^MSIE'],
           rewrite_rule => ['^index\.html$ /index.IE.html [L]'],
         },
-        }
+        {
           rewrite_base => /apps/,
           rewrite_rule => ['^index\.cgi$ index.php', '^index\.html$ index.php', '^index\.asp$ index.html'],
         },


### PR DESCRIPTION
In reading the documentation, I noticed what I believe to be a typo in the docs with two consecutive closing curly braces, separated by a comma on line 930. Fixed by changing close brace to open brace.
