### PR TITLE
turning MaxKeepAliveRequests into a variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Enables persistent connections.
 
 Sets the amount of time the server will wait for subsequent requests on a persistent connection. Defaults to '15'.
 
-#####`maxkeepaliverequests`
+#####`max_keepalive_requests`
 
 Sets the limit of the number of requests allowed per connection when KeepAlive is on. Defaults to '100'.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,7 +49,7 @@ class apache (
   $group                = $::apache::params::group,
   $keepalive            = $::apache::params::keepalive,
   $keepalive_timeout    = $::apache::params::keepalive_timeout,
-  $maxkeepaliverequests = $apache::params::maxkeepaliverequests,
+  $max_keepalive_requests = $apache::params::max_keepalive_requests,
   $logroot              = $::apache::params::logroot,
   $log_level            = $::apache::params::log_level,
   $log_formats          = {},
@@ -271,7 +271,7 @@ class apache (
     # - $apxs_workaround
     # - $keepalive
     # - $keepalive_timeout
-    # - $maxkeepaliverequests
+    # - $max_keepalive_requests
     # - $server_root
     # - $server_tokens
     # - $server_signature

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -85,7 +85,7 @@ class apache::params inherits ::apache::version {
     $conf_template        = 'apache/httpd.conf.erb'
     $keepalive            = 'Off'
     $keepalive_timeout    = 15
-    $maxkeepaliverequests = 100
+    $max_keepalive_requests = 100
     $fastcgi_lib_path     = undef
     $mime_support_package = 'mailcap'
     $mime_types_config    = '/etc/mime.types'
@@ -142,7 +142,7 @@ class apache::params inherits ::apache::version {
     $conf_template     = 'apache/httpd.conf.erb'
     $keepalive         = 'Off'
     $keepalive_timeout = 15
-    $maxkeepaliverequests = 100
+    $max_keepalive_requests = 100
     $fastcgi_lib_path  = '/var/lib/apache2/fastcgi'
     $mime_support_package = 'mime-support'
     $mime_types_config = '/etc/mime.types'
@@ -201,7 +201,7 @@ class apache::params inherits ::apache::version {
     $conf_template        = 'apache/httpd.conf.erb'
     $keepalive            = 'Off'
     $keepalive_timeout    = 15
-    $maxkeepaliverequests = 100
+    $max_keepalive_requests = 100
     $fastcgi_lib_path     = undef # TODO: revisit
     $mime_support_package = 'misc/mime-support'
     $mime_types_config    = '/usr/local/etc/mime.types'

--- a/spec/acceptance/apache_parameters_spec.rb
+++ b/spec/acceptance/apache_parameters_spec.rb
@@ -312,7 +312,7 @@ describe 'apache parameters', :unless => UNSUPPORTED_PLATFORMS.include?(fact('os
   describe 'keepalive' do
     describe 'setup' do
       it 'applies cleanly' do
-        pp = "class { 'apache': keepalive => 'On', keepalive_timeout => '30', maxkeepaliverequests => '200' }"
+        pp = "class { 'apache': keepalive => 'On', keepalive_timeout => '30', max_keepalive_requests => '200' }"
         apply_manifest(pp, :catch_failures => true)
       end
     end

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -8,7 +8,7 @@ ServerRoot "<%= @server_root %>"
 PidFile <%= @pidfile %>
 Timeout <%= @timeout %>
 KeepAlive <%= @keepalive %>
-MaxKeepAliveRequests <%= @maxkeepaliverequests %>
+MaxKeepAliveRequests <%= @max_keepalive_requests %>
 KeepAliveTimeout <%= @keepalive_timeout %>
 
 User <%= @user %>


### PR DESCRIPTION
For the 1.8 release of Subversion , it is now suggested to increase MaxKeepAliveRequests beyond its usual setting of 100 [1].  To allow the apache module to handle this situation this setting needs to be made into a variable.

[1]  https://subversion.apache.org/docs/release-notes/1.8.html#neon-deleted
