### PR TITLE
Don't include the NameVirtualHost directives in apache >= 2.4, and add t...

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -348,7 +348,7 @@ define apache::vhost(
     }
   }
   if ! $ip_based {
-    if ! defined(Apache::Namevirtualhost[$nvh_addr_port]) and $ensure == 'present' {
+    if ! defined(Apache::Namevirtualhost[$nvh_addr_port]) and $ensure == 'present' and $apache_version < 2.4 {
       ::apache::namevirtualhost { $nvh_addr_port: }
     }
   }

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -484,6 +484,16 @@ describe 'apache::vhost define', :unless => UNSUPPORTED_PLATFORMS.include?(fact(
       apply_manifest(pp, :catch_failures => true)
     end
 
+    describe file($ports_file) do
+      it { should be_file }
+      case fact('lsbdistcodename')
+      when 'saucy', 'trusty'
+        it { should_not contain 'NameVirtualHost test.server' }
+      else
+        it { should contain 'NameVirtualHost test.server' }
+      end
+    end
+
     describe file("#{$vhost_dir}/10-test.server.conf") do
       it { should be_file }
     end


### PR DESCRIPTION
...ests for this that will at least work with Ubuntu 13.10 and Ubuntu 14.04.

Tests will still work anywhere with apache < 2.4, but haven't been updated to support RHEL7 yet.
