### PR TITLE
Fix platform for centos-6.5

### DIFF
--- a/spec/acceptance/nodesets/centos-65-x64.yml
+++ b/spec/acceptance/nodesets/centos-65-x64.yml
@@ -2,7 +2,7 @@ HOSTS:
   centos-65-x64:
     roles:
       - master
-    platform: el-6-x86_65
+    platform: el-6-x86_64
     box : centos-65-x64-virtualbox-nocm
     box_url : http://puppet-vagrant-boxes.puppetlabs.com/centos-65-x64-virtualbox-nocm.box
     hypervisor : vagrant


### PR DESCRIPTION
It looks like an accidental replace from 64 to 65 in the platform.
