### PR TITLE
Add suexec support

### DIFF
--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -26,6 +26,7 @@ class apache::default_mods (
         include ::apache::mod::mime
         include ::apache::mod::mime_magic
         include ::apache::mod::vhost_alias
+        include ::apache::mod::suexec
         include ::apache::mod::rewrite
         ::apache::mod { 'auth_digest': }
         ::apache::mod { 'authn_anon': }
@@ -38,7 +39,6 @@ class apache::default_mods (
         ::apache::mod { 'logio': }
         ::apache::mod { 'speling': }
         ::apache::mod { 'substitute': }
-        ::apache::mod { 'suexec': }
         ::apache::mod { 'usertrack': }
         ::apache::mod { 'version': }
 

--- a/manifests/mod/suexec.pp
+++ b/manifests/mod/suexec.pp
@@ -1,0 +1,3 @@
+class apache::mod::suexec {
+  ::apache::mod { 'suexec': }
+}

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -174,7 +174,8 @@ define apache::vhost(
     $fastcgi_socket              = undef,
     $fastcgi_dir                 = undef,
     $additional_includes         = [],
-    $apache_version              = $::apache::apache_version
+    $apache_version              = $::apache::apache_version,
+    $suexec_user_group           = undef,
   ) {
   # The base class must be included first because it is used by parameter defaults
   if ! defined(Class['apache']) {
@@ -198,6 +199,11 @@ define apache::vhost(
   if $rewrites {
     validate_array($rewrites)
     validate_hash($rewrites[0])
+  }
+
+  if $suexec_user_group {
+    validate_re($suexec_user_group, '^\w+ \w+$',
+    "${suexec_user_group} is not supported for suexec_user_group.  Must be 'user group'.")
   }
 
   # Deprecated backwards-compatibility
@@ -253,6 +259,10 @@ define apache::vhost(
 
   if $wsgi_daemon_process {
     include ::apache::mod::wsgi
+  }
+
+  if $suexec_user_group {
+    include ::apache::mod::suexec
   }
 
   # This ensures that the docroot exists

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -1308,6 +1308,16 @@ describe 'apache::vhost', :type => :define do
         end
       end
 
+      describe 'when suexec_user_group is specified' do
+        let :params do
+          default_params.merge({
+            :suexec_user_group => 'nobody nogroup',
+          })
+        end
+
+        it { should contain_file("25-#{title}.conf").with_content %r{^  SuexecUserGroup nobody nogroup$} }
+      end
+
       describe 'redirect rules' do
         describe 'without lockstep arrays' do
           let :params do

--- a/templates/vhost.conf.erb
+++ b/templates/vhost.conf.erb
@@ -62,4 +62,5 @@
 <%= scope.function_template(['apache/vhost/_wsgi.erb']) -%>
 <%= scope.function_template(['apache/vhost/_custom_fragment.erb']) -%>
 <%= scope.function_template(['apache/vhost/_fastcgi.erb']) -%>
+<%= scope.function_template(['apache/vhost/_suexec.erb']) -%>
 </VirtualHost>

--- a/templates/vhost/_suexec.erb
+++ b/templates/vhost/_suexec.erb
@@ -1,0 +1,4 @@
+<% if @suexec_user_group -%>
+
+  SuexecUserGroup <%= @suexec_user_group %>
+<% end -%>


### PR DESCRIPTION
This adds the suexec_user_group parameter to vhost and introduces a class
apache::mod::suexec, which is included when the parameter is used.
