### PR TITLE
Recursive docroot creation

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -249,16 +249,18 @@ define apache::vhost(
   # This ensures that the docroot exists
   # But enables it to be specified across multiple vhost resources
   if ! defined(File[$docroot]) {
-    exec { "mkdocroot":
-      command => 'mkdir -p $docroot',
+    exec { $docroot:
+      command => "mkdir -p $docroot",
       creates => $docroot,
+      path    => ["/bin", "/usr/bin"],
       require => Package['httpd'],
     }
     file { $docroot:
       ensure  => directory,
       owner   => $docroot_owner,
       group   => $docroot_group,
-      require => Exec['mkdocroot'],
+      mode    => $docroot_mode,
+      require => Exec[$docroot],
     }
   }
 


### PR DESCRIPTION
This PR uses an 'exec' resource to recursively create the $docroot.  Previously, if $docroot = '/srv/www/site1.example.com/htdocs' and site1.example.com didn't already exist, the module would fail since the parent didn't exist and the File resource can't create directories recursively. 
