### PR TITLE
Add fcgid options

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
         * [Class: apache::mod::php](#class-apachemodphp)
         * [Class: apache::mod::ssl](#class-apachemodssl)
         * [Class: apache::mod::wsgi](#class-apachemodwsgi)
+        * [Class: apache::mod::fcgid](#class-apachemodfcgid)
         * [Defined Type: apache::vhost](#defined-type-apachevhost)
         * [Parameter: `directories` for apache::vhost](#parameter-directories-for-apachevhost)
         * [SSL parameters for apache::vhost](#ssl-parameters-for-apachevhost)
@@ -577,6 +578,41 @@ For customized parameters, which tell Apache how Python is currently configured 
 ```
 
 More information about [WSGI](http://modwsgi.readthedocs.org/en/latest/).
+
+####Class: `apache::mod::fcgid`
+
+Installs and configures mod_fcgid.
+
+The class makes no effort to list all available options, but rather uses an options hash to allow for ultimate flexibility:
+
+```puppet
+    class { 'apache::mod::fcgid':
+      options => {
+        'FcgidIPCDir'  => '/var/run/fcgidsock',
+        'SharememPath' => '/var/run/fcgid_shm',
+        'AddHandler'   => 'fcgid-script .fcgi',
+      },
+    }
+```
+
+For a full list op options, see the [official mod_fcgid documentation](https://httpd.apache.org/mod_fcgid/mod/mod_fcgid.html).
+
+It is also possible to set the FcgidWrapper per directory per vhost. You must ensure the fcgid module is loaded because there is no auto loading.
+
+```puppet
+    include apache::mod::fcgid
+    apache::vhost { 'example.org':
+      docroot     => '/var/www/html',
+      directories => {
+        path        => '/var/www/html',
+        fcgiwrapper => {
+          command => '/usr/local/bin/fcgiwrapper',
+        }
+      },
+    }
+```
+
+See [FcgidWrapper documentation](https://httpd.apache.org/mod_fcgid/mod/mod_fcgid.html#fcgidwrapper) for more information.
 
 ####Defined Type: `apache::vhost`
 

--- a/manifests/mod/fcgid.pp
+++ b/manifests/mod/fcgid.pp
@@ -1,3 +1,16 @@
-class apache::mod::fcgid {
+class apache::mod::fcgid(
+  $options = {},
+) {
   ::apache::mod { 'fcgid': }
+
+  # Template uses:
+  # - $options
+  file { 'fcgid.conf':
+    ensure  => file,
+    path    => "${::apache::mod_dir}/fcgid.conf",
+    content => template('apache/mod/fcgid.conf.erb'),
+    require => Exec["mkdir ${::apache::mod_dir}"],
+    before  => File[$::apache::mod_dir],
+    notify  => Service['httpd'],
+  }
 }

--- a/spec/acceptance/mod_fcgid_spec.rb
+++ b/spec/acceptance/mod_fcgid_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper_acceptance'
+
+describe 'apache::mod::fcgid class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+  case fact('osfamily')
+  when 'Debian'
+    # Not implemented
+  when 'RedHat'
+    context "default fcgid config" do
+      it 'succeeds in puppeting fcgid' do
+        pp = <<-EOS
+          class { 'epel': } # mod_fcgid lives in epel
+          class { 'apache': }
+          class { 'apache::mod::php': } # For /usr/bin/php-cgi
+          class { 'apache::mod::fcgid':
+            options => {
+              'FcgidIPCDir'  => '/var/run/fcgidsock',
+            },
+          }
+          apache::vhost { 'fcgid.example.com':
+            port        => '80',
+            docroot     => '/var/www/fcgid',
+            directories => {
+              path        => '/var/www/fcgid',
+              options     => '+ExecCGI',
+              addhandlers => {
+                handler    => 'fcgid-script',
+                extensions => '.php',
+              },
+              fcgiwrapper => {
+                command => '/usr/bin/php-cgi',
+                suffix  => '.php',
+              }
+            },
+          }
+          file { '/var/www/fcgid/index.php':
+            ensure  => file,
+            owner   => 'root',
+            group   => 'root',
+            content => "<?php echo 'Hello world'; ?>\\n",
+          }
+        EOS
+        apply_manifest(pp, :catch_failures => true)
+      end
+
+      describe service('httpd') do
+        it { should be_enabled }
+        it { should be_running }
+      end
+
+      it 'should answer to fcgid.example.com' do
+        shell("/usr/bin/curl -H 'Host: fcgid.example.com' 127.0.0.1:80") do |r|
+          r.stdout.should =~ /^Hello world$/
+          r.exit_code.should == 0
+        end
+      end
+
+      it 'should run a php-cgi process' do
+        shell("pgrep -u apache php-cgi", :acceptable_exit_codes => [0])
+      end
+    end
+  end
+end

--- a/spec/classes/mod/fcgid_spec.rb
+++ b/spec/classes/mod/fcgid_spec.rb
@@ -1,7 +1,10 @@
-describe 'apache::mod::fcgid', :type => :class do
+require 'spec_helper'
+
+describe 'apache::mod::fcgid' do
   let :pre_condition do
     'include apache'
   end
+
   context "on a Debian OS" do
     let :facts do
       {
@@ -14,6 +17,7 @@ describe 'apache::mod::fcgid', :type => :class do
     it { should contain_apache__mod('fcgid') }
     it { should contain_package("libapache2-mod-fcgid") }
   end
+
   context "on a RedHat OS" do
     let :facts do
       {
@@ -22,10 +26,37 @@ describe 'apache::mod::fcgid', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
-    it { should contain_class("apache::params") }
-    it { should contain_apache__mod('fcgid') }
-    it { should contain_package("mod_fcgid") }
+
+    describe 'without parameters' do
+      it { should contain_class("apache::params") }
+      it { should contain_apache__mod('fcgid') }
+      it { should contain_package("mod_fcgid") }
+    end
+
+    describe 'with parameters' do
+      let :params do {
+        :options                     => {
+          'FcgidIPCDir'               => '/var/run/fcgidsock',
+          'SharememPath'              => '/var/run/fcgid_shm',
+          'FcgidMinProcessesPerClass' => '0',
+          'AddHandler'                => 'fcgid-script .fcgi',
+        }
+      } end
+
+      it 'should contain the correct config' do
+        content = subject.resource('file', 'fcgid.conf').send(:parameters)[:content]
+        content.split("\n").reject { |c| c =~ /(^#|^$)/ }.should == [
+          '<IfModule mod_fcgid.c>',
+          '  AddHandler fcgid-script .fcgi',
+          '  FcgidIPCDir /var/run/fcgidsock',
+          '  FcgidMinProcessesPerClass 0',
+          '  SharememPath /var/run/fcgid_shm',
+          '</IfModule>',
+        ]
+      end
+    end
   end
+
   context "on a FreeBSD OS" do
     let :facts do
       {
@@ -34,6 +65,7 @@ describe 'apache::mod::fcgid', :type => :class do
         :concat_basedir         => '/dne',
       }
     end
+
     it { should contain_class("apache::params") }
     it { should contain_apache__mod('fcgid') }
     it { should contain_package("www/mod_fcgid") }

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -1280,6 +1280,42 @@ describe 'apache::vhost', :type => :define do
         end
       end
 
+      describe 'fcgid directory options' do
+        describe 'No fcgiwrapper' do
+          let :params do
+            default_params.merge({
+              :directories      => { 'path' => '/srv/www' },
+            })
+          end
+
+          it { should_not contain_file("25-#{title}.conf").with_content(%r{FcgidWrapper}) }
+        end
+
+        describe 'Only a command' do
+          let :params do
+            default_params.merge({
+              :directories      => { 'path' => '/srv/www',
+                'fcgiwrapper' => { 'command' => '/usr/local/bin/fcgiwrapper' },
+              }
+            })
+          end
+
+          it { should contain_file("25-#{title}.conf").with_content(%r{^    FcgidWrapper /usr/local/bin/fcgiwrapper  $}) }
+        end
+
+        describe 'All parameters' do
+          let :params do
+            default_params.merge({
+              :directories    => { 'path' => '/srv/www',
+                'fcgiwrapper' => { 'command' => '/usr/local/bin/fcgiwrapper', 'suffix' => '.php', 'virtual' => 'virtual' },
+              }
+            })
+          end
+
+          it { should contain_file("25-#{title}.conf").with_content(%r{^    FcgidWrapper /usr/local/bin/fcgiwrapper .php virtual$}) }
+        end
+      end
+
       describe 'various ip/port combos' do
         describe 'when ip_based is true' do
           let :params do default_params.merge({ :ip_based => true }) end

--- a/templates/mod/fcgid.conf.erb
+++ b/templates/mod/fcgid.conf.erb
@@ -1,0 +1,5 @@
+<IfModule mod_fcgid.c>
+<% @options.sort_by {|key, value| key}.each do |key, value| -%>
+  <%= key %> <%= value %>
+<% end -%>
+</IfModule>

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -153,6 +153,9 @@
     <%- if directory['suphp'] and @suphp_engine == 'on' -%>
     suPHP_UserGroup <%= directory['suphp']['user'] %> <%= directory['suphp']['group'] %>
     <%- end -%>
+    <%- if directory['fcgiwrapper'] -%>
+    FcgidWrapper <%= directory['fcgiwrapper']['command'] %> <%= directory['fcgiwrapper']['suffix'] %> <%= directory['fcgiwrapper']['virtual'] %>
+    <%- end -%>
     <%- if directory['custom_fragment'] -%>
     <%= directory['custom_fragment'] %>
     <%- end -%>


### PR DESCRIPTION
This adds fcgid.conf to configure the fcgid module. It also adds the 
FcgidWrapper option to vhost's directories.

The vhost option lacks any validation and allows users to shoot themselves in
the foot, but without iteration from the puppet future parser I don't see a
way to add the validation. Iteration would also allow auto including
apache::mod::fcgid.
