### PR TITLE
Add options to mod info

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
         * [Class: apache::default_mods](#class-apachedefault_mods)
         * [Defined Type: apache::mod](#defined-type-apachemod)
         * [Classes: apache::mod::*](#classes-apachemodname)
+        * [Class: apache::mod::info](#class-apachemodinfo)
         * [Class: apache::mod::pagespeed](#class-apachemodpagespeed)
         * [Class: apache::mod::php](#class-apachemodphp)
         * [Class: apache::mod::ssl](#class-apachemodssl)
@@ -465,7 +466,7 @@ There are many `apache::mod::[name]` classes within this module that can be decl
 * `fcgid`
 * `headers`
 * `include`
-* `info`
+* `info`*
 * `itk`
 * `ldap`
 * `mime`
@@ -501,6 +502,53 @@ There are many `apache::mod::[name]` classes within this module that can be decl
 Modules noted with a * indicate that the module has settings and, thus, a template that includes parameters. These parameters control the module's configuration. Most of the time, these parameters will not require any configuration or attention.
 
 The modules mentioned above, and other Apache modules that have templates, will cause template files to be dropped along with the mod install and the module will not work without the template. Any module without a template will install the package but drop no files.
+
+####Class: `apache::mod::info`
+
+Installs and manages mod_info which provides a comprehensive overview of the server configuration. 
+
+Full documentation for mod_info is available from [Apache](http://httpd.apache.org/docs/2.2/mod/mod_info.html).
+
+These are the default settings:
+
+```puppet
+  $allow_from      = ['127.0.0.1','::1'],
+  $apache_version  = $::apache::apache_version,
+  $restrict_access = true,
+```
+
+To set the addresses that are allowed to access /server-info add the following:
+
+```puppet
+  class {'apache::mod::info':
+    allow_from      => [
+      '10.10.36',
+      '10.10.38',
+      '127.0.0.1',
+    ],
+  }
+```
+
+To disable the access restrictions add the following:
+
+```puppet
+  class {'apache::mod::info':
+    restrict_access => false,
+  }
+```
+
+It is not recommended to leave this set to false though it can be very useful for testing. For this reason, you can insert this setting in your normal code to temporarily disable the restrictions like so:
+
+```puppet
+  class {'apache::mod::info':
+    restrict_access => false, # false disables the block below
+    allow_from      => [
+      '10.10.36',
+      '10.10.38',
+      '127.0.0.1',
+    ],
+  }
+```
 
 ####Class: `apache::mod::pagespeed`
 

--- a/manifests/mod/info.pp
+++ b/manifests/mod/info.pp
@@ -1,6 +1,7 @@
 class apache::mod::info (
-  $allow_from = ['127.0.0.1','::1'],
-  $apache_version = $::apache::apache_version,
+  $allow_from      = ['127.0.0.1','::1'],
+  $apache_version  = $::apache::apache_version,
+  $restrict_access = true,
 ){
   apache::mod { 'info': }
   # Template uses

--- a/spec/classes/mod/info_spec.rb
+++ b/spec/classes/mod/info_spec.rb
@@ -1,27 +1,73 @@
-require 'spec_helper'
-
 # This function is called inside the OS specific contexts
 def general_info_specs
-  it { is_expected.to contain_apache__mod("info") }
+  it { is_expected.to contain_apache__mod('info') }
 
-  it do
-    is_expected.to contain_file("info.conf").with_content(
-      "<Location /server-info>\n"\
-      "    SetHandler server-info\n"\
-      "    Order deny,allow\n"\
-      "    Deny from all\n"\
-      "    Allow from 127.0.0.1 ::1\n"\
-      "</Location>\n"
-    )
+  context 'passing no parameters' do
+    it {
+      is_expected.to contain_file('info.conf').with_content(
+        "<Location /server-info>\n"\
+        "    SetHandler server-info\n"\
+        "    Order deny,allow\n"\
+        "    Deny from all\n"\
+        "    Allow from 127.0.0.1\n"\
+        "    Allow from ::1\n"\
+        "</Location>\n"
+      )
+    }
+  end
+  context 'passing restrict_access => false' do
+    let :params do {
+      :restrict_access => false
+    }
+    end
+    it {
+      is_expected.to contain_file('info.conf').with_content(
+        "<Location /server-info>\n"\
+        "    SetHandler server-info\n"\
+        "</Location>\n"
+      )
+    }
+  end
+  context "passing allow_from => ['10.10.1.2', '192.168.1.2', '127.0.0.1']" do
+    let :params do
+      {:allow_from => ['10.10.1.2', '192.168.1.2', '127.0.0.1']}
+    end
+    it {
+      is_expected.to contain_file('info.conf').with_content(
+        "<Location /server-info>\n"\
+        "    SetHandler server-info\n"\
+        "    Order deny,allow\n"\
+        "    Deny from all\n"\
+        "    Allow from 10.10.1.2\n"\
+        "    Allow from 192.168.1.2\n"\
+        "    Allow from 127.0.0.1\n"\
+        "</Location>\n"
+      )
+    }
+  end
+  context 'passing both restrict_access and allow_from' do
+    let :params do
+      {
+        :restrict_access => false,
+        :allow_from      => ['10.10.1.2', '192.168.1.2', '127.0.0.1']
+      }
+    end
+    it {
+      is_expected.to contain_file('info.conf').with_content(
+        "<Location /server-info>\n"\
+        "    SetHandler server-info\n"\
+        "</Location>\n"
+      )
+    }
   end
 end
 
 describe 'apache::mod::info', :type => :class do
   let :pre_condition do
-    'include apache'
+    "class { 'apache': default_mods => false, }"
   end
 
-  context "On a Debian OS with default params" do
+  context 'On a Debian OS' do
     let :facts do
       {
         :osfamily               => 'Debian',
@@ -38,17 +84,17 @@ describe 'apache::mod::info', :type => :class do
     # Load the more generic tests for this context
     general_info_specs()
 
-    it { is_expected.to contain_file("info.conf").with({
+    it { is_expected.to contain_file('info.conf').with({
       :ensure => 'file',
       :path   => '/etc/apache2/mods-available/info.conf',
     } ) }
-    it { is_expected.to contain_file("info.conf symlink").with({
+    it { is_expected.to contain_file('info.conf symlink').with({
       :ensure => 'link',
       :path   => '/etc/apache2/mods-enabled/info.conf',
     } ) }
   end
 
-  context "on a RedHat OS with default params" do
+  context 'on a RedHat OS' do
     let :facts do
       {
         :osfamily               => 'RedHat',
@@ -64,10 +110,13 @@ describe 'apache::mod::info', :type => :class do
     # Load the more generic tests for this context
     general_info_specs()
 
-    it { is_expected.to contain_file("info.conf").with_path("/etc/httpd/conf.d/info.conf") }
+    it { is_expected.to contain_file('info.conf').with({
+      :ensure => 'file',
+      :path   => '/etc/httpd/conf.d/info.conf',
+      } ) }
   end
 
-  context "On a FreeBSD OS with default params" do
+  context 'on a FreeBSD OS' do
     let :facts do
       {
         :osfamily               => 'FreeBSD',
@@ -83,37 +132,10 @@ describe 'apache::mod::info', :type => :class do
     # Load the more generic tests for this context
     general_info_specs()
 
-    it { is_expected.to contain_file("info.conf").with({
+    it { is_expected.to contain_file('info.conf').with({
       :ensure => 'file',
       :path   => '/usr/local/etc/apache22/Modules/info.conf',
     } ) }
   end
 
-  context "with $allow_from => ['10.10.10.10','11.11.11.11']" do
-    let :facts do
-      {
-        :osfamily               => 'Debian',
-        :operatingsystemrelease => '6',
-        :concat_basedir         => '/dne',
-        :lsbdistcodename        => 'squeeze',
-        :operatingsystem        => 'Debian',
-        :id                     => 'root',
-        :kernel                 => 'Linux',
-        :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-      }
-    end
-    let :params do
-      { :allow_from => ['10.10.10.10','11.11.11.11'] }
-    end
-    it do
-      is_expected.to contain_file("info.conf").with_content(
-        "<Location /server-info>\n"\
-        "    SetHandler server-info\n"\
-        "    Order deny,allow\n"\
-        "    Deny from all\n"\
-        "    Allow from 10.10.10.10 11.11.11.11\n"\
-        "</Location>\n"
-      )
-    end
-  end
 end

--- a/templates/mod/info.conf.erb
+++ b/templates/mod/info.conf.erb
@@ -1,10 +1,19 @@
 <Location /server-info>
     SetHandler server-info
-    <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
+<%- if @restrict_access -%>
+  <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
     Require ip <%= Array(@allow_from).join(" ") %>
-    <%- else -%>
+  <%- else -%>
     Order deny,allow
     Deny from all
-    Allow from <%= Array(@allow_from).join(" ") %>
+    <%- if @allow_from and ! @allow_from.empty? -%>
+      <%- @allow_from.each do |allowed| -%>
+    Allow from <%= allowed %>
+      <%- end -%>
+    <%- else -%>
+    Allow from 127.0.0.1
+    Allow from ::1
     <%- end -%>
+  <%- end -%>
+<%- end -%>
 </Location>


### PR DESCRIPTION
While using this wonderful module at work today I ran into an issue where there was no way to modify the info.conf file created by `include apache::mod::info`  The purpose of this PR is to add that functionality.
