### PR TITLE
Allow global setting of ssl_protocol + doc. ssl_cipher

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,8 @@ Installs Apache SSL capabilities and uses the ssl.conf.erb template. These are t
 ```puppet
     class { 'apache::mod::ssl':
       ssl_compression => false,
+      ssl_cipher      => 'HIGH:MEDIUM:!aNULL:!MD5',
+      ssl_protocol    => 'all -SSLv2'
       ssl_options     => [ 'StdEnvVars' ],
   }
 ```

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -2,6 +2,7 @@ class apache::mod::ssl (
   $ssl_compression = false,
   $ssl_options     = [ 'StdEnvVars' ],
   $ssl_cipher      = 'HIGH:MEDIUM:!aNULL:!MD5',
+  $ssl_protocol    = 'all -SSLv2',
   $apache_version  = $::apache::apache_version,
 ) {
   $session_cache = $::osfamily ? {

--- a/templates/mod/ssl.conf.erb
+++ b/templates/mod/ssl.conf.erb
@@ -21,7 +21,7 @@
   SSLCryptoDevice builtin
   SSLHonorCipherOrder On
   SSLCipherSuite <%= @ssl_cipher %>
-  SSLProtocol all -SSLv2
+  SSLProtocol <%= @ssl_protocol %>
 <% if @ssl_options -%>
   SSLOptions <%= @ssl_options.compact.join(' ') %>
 <% end -%>


### PR DESCRIPTION
ssl_protocol is setable per vhost already, this makes it an option
that can be sent once per the entire configuration instead of per
each vhost.

Also include at least a line on the README on both the recently
added global ssl_cipher and this new ssl_protocol parameters.
