### PR TITLE
(MODULES-910) Convert @apache_version to a string

### DIFF
--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -9,7 +9,7 @@ class apache::default_mods (
   case $::osfamily {
     'redhat', 'freebsd': {
       ::apache::mod { 'log_config': }
-      if $apache_version >= 2.4 {
+      if versioncmp($apache_version, '2.4') >= 0 {
         # Lets fork it
         ::apache::mod { 'systemd': }
         ::apache::mod { 'unixd': }
@@ -47,7 +47,7 @@ class apache::default_mods (
         ::apache::mod { 'usertrack': }
         ::apache::mod { 'version': }
 
-        if $apache_version >= 2.4 {
+        if versioncmp($apache_version, '2.4') >= 0 {
           ::apache::mod { 'authn_core': }
         }
         else {
@@ -114,7 +114,7 @@ class apache::default_mods (
     ::apache::mod { 'auth_basic': }
     ::apache::mod { 'authn_file': }
 
-    if $apache_version >= 2.4 {
+      if versioncmp($apache_version, '2.4') >= 0 {
       # authz_core is needed for 'Require' directive
       ::apache::mod { 'authz_core':
         id => 'authz_core_module',
@@ -135,7 +135,7 @@ class apache::default_mods (
   } elsif $mods {
     ::apache::default_mods::load { $mods: }
 
-    if $apache_version >= 2.4 {
+    if versioncmp($apache_version, '2.4') >= 0 {
       # authz_core is needed for 'Require' directive
       ::apache::mod { 'authz_core':
         id => 'authz_core_module',
@@ -145,7 +145,7 @@ class apache::default_mods (
       ::apache::mod { 'filter': }
     }
   } else {
-    if $apache_version >= 2.4 {
+    if versioncmp($apache_version, '2.4') >= 0 {
       # authz_core is needed for 'Require' directive
       ::apache::mod { 'authz_core':
         id => 'authz_core_module',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,7 +67,7 @@ class apache (
   validate_bool($service_enable)
 
   $valid_mpms_re = $apache_version ? {
-    2.4     => '(event|itk|peruser|prefork|worker)',
+    '2.4'   => '(event|itk|peruser|prefork|worker)',
     default => '(event|itk|prefork|worker)'
   }
 

--- a/manifests/mod/event.pp
+++ b/manifests/mod/event.pp
@@ -44,7 +44,7 @@ class apache::mod::event (
 
   case $::osfamily {
     'redhat': {
-      if $apache_version >= 2.4 {
+      if versioncmp($apache_version, '2.4') >= 0 {
         apache::mpm{ 'event':
           apache_version => $apache_version,
         }

--- a/manifests/mod/pagespeed.pp
+++ b/manifests/mod/pagespeed.pp
@@ -35,7 +35,7 @@ class apache::mod::pagespeed (
 ){
 
   $_lib = $::apache::apache_version ? {
-    2.4     => 'mod_pagespeed_ap24.so',
+    '2.4'   => 'mod_pagespeed_ap24.so',
     default => undef
   }
 

--- a/manifests/mod/prefork.pp
+++ b/manifests/mod/prefork.pp
@@ -42,7 +42,7 @@ class apache::mod::prefork (
 
   case $::osfamily {
     'redhat': {
-      if $apache_version >= 2.4 {
+      if versioncmp($apache_version, '2.4') >= 0 {
         ::apache::mpm{ 'prefork':
           apache_version => $apache_version,
         }

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -12,7 +12,7 @@ class apache::mod::ssl (
 
   case $::osfamily {
     'debian': {
-      if $apache_version >= 2.4 and $::operatingsystem == 'Ubuntu' {
+      if versioncmp($apache_version, '2.4') >= 0 and $::operatingsystem == 'Ubuntu' {
         $ssl_mutex = 'default'
       } elsif $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '10.04' {
         $ssl_mutex = 'file:/var/run/apache2/ssl_mutex'
@@ -33,7 +33,7 @@ class apache::mod::ssl (
 
   ::apache::mod { 'ssl': }
 
-  if $apache_version >= 2.4 {
+  if versioncmp($apache_version, '2.4') >= 0 {
     ::apache::mod { 'socache_shmcb': }
   }
 

--- a/manifests/mod/worker.pp
+++ b/manifests/mod/worker.pp
@@ -44,7 +44,7 @@ class apache::mod::worker (
 
   case $::osfamily {
     'redhat': {
-      if $apache_version >= 2.4 {
+      if versioncmp($apache_version, '2.4') >= 0 {
         ::apache::mpm{ 'worker':
           apache_version => $apache_version,
         }

--- a/manifests/mpm.pp
+++ b/manifests/mpm.pp
@@ -13,7 +13,7 @@ define apache::mpm (
   $_path = "${lib_path}/${_lib}"
   $_id   = "mpm_${mpm}_module"
 
-  if $apache_version >= 2.4 {
+  if versioncmp($apache_version, '2.4') >= 0 {
     file { "${mod_dir}/${mpm}.load":
       ensure  => file,
       path    => "${mod_dir}/${mpm}.load",
@@ -37,7 +37,7 @@ define apache::mpm (
         notify  => Service['httpd'],
       }
 
-      if $apache_version >= 2.4 {
+      if versioncmp($apache_version, '2.4') >= 0 {
         file { "${::apache::mod_enable_dir}/${mpm}.load":
           ensure  => link,
           target  => "${::apache::mod_dir}/${mpm}.load",
@@ -47,7 +47,7 @@ define apache::mpm (
         }
       }
 
-      if $apache_version < 2.4 {
+      if versioncmp($apache_version, '2.4') < 0 {
         package { "apache2-mpm-${mpm}":
           ensure => present,
         }

--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -13,20 +13,20 @@ class apache::version {
   case $::osfamily {
     'RedHat': {
       if ($::operatingsystem == 'Fedora' and $distrelease >= 18) or ($::operatingsystem != 'Fedora' and $distrelease >= 7) {
-        $default = 2.4
+        $default = '2.4'
       } else {
-        $default = 2.2
+        $default = '2.2'
       }
     }
     'Debian': {
       if $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease >= 13.10 {
-        $default = 2.4
+        $default = '2.4'
       } else {
-        $default = 2.2
+        $default = '2.2'
       }
     }
     'FreeBSD': {
-      $default = 2.2
+      $default = '2.2'
     }
     default: {
       fail("Class['apache::version']: Unsupported osfamily: ${::osfamily}")

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -350,7 +350,7 @@ define apache::vhost(
     }
   }
   if ! $ip_based {
-    if ! defined(Apache::Namevirtualhost[$nvh_addr_port]) and $ensure == 'present' and $apache_version < 2.4 {
+    if ! defined(Apache::Namevirtualhost[$nvh_addr_port]) and $ensure == 'present' and (versioncmp($apache_version, '2.4') < 0) {
       ::apache::namevirtualhost { $nvh_addr_port: }
     }
   }
@@ -427,7 +427,7 @@ define apache::vhost(
       directoryindex => $directoryindex,
     }
 
-    if $apache_version == 2.4 {
+    if versioncmp($apache_version, '2.4') >= 0 {
       $_directory_version = {
         require => 'all granted',
       }

--- a/spec/acceptance/apache_parameters_spec.rb
+++ b/spec/acceptance/apache_parameters_spec.rb
@@ -218,7 +218,7 @@ describe 'apache parameters', :unless => UNSUPPORTED_PLATFORMS.include?(fact('os
       end
     end
 
-    if $apache_version >= 2.4
+    if $apache_version == '2.4'
       describe file($conf_file) do
         it { should be_file }
         it { should contain 'IncludeOptional "/tmp/root/*.conf"' }

--- a/spec/acceptance/version.rb
+++ b/spec/acceptance/version.rb
@@ -17,9 +17,9 @@ when 'RedHat'
   $suphp_configpath = 'undef'
 
   if (_operatingsystem == 'Fedora' and _operatingsystemrelease >= 18) or (_operatingsystem != 'Fedora' and _operatingsystemrelease >= 7)
-    $apache_version = 2.4
+    $apache_version = '2.4'
   else
-    $apache_version = 2.2
+    $apache_version = '2.2'
   end
 when 'Debian'
   $confd_dir        = '/etc/apache2/mods-available'
@@ -35,9 +35,9 @@ when 'Debian'
   $suphp_configpath = '/etc/php5/apache2'
 
   if _operatingsystem == 'Ubuntu' and _operatingsystemrelease >= 13.10
-    $apache_version = 2.4
+    $apache_version = '2.4'
   else
-    $apache_version = 2.2
+    $apache_version = '2.2'
   end
 when 'FreeBSD'
   $confd_dir        = '/usr/local/etc/apache22/Includes'
@@ -50,8 +50,8 @@ when 'FreeBSD'
   $package_name     = 'apache22'
   $error_log        = 'http-error.log'
 
-  $apache_version = 2.2
+  $apache_version = '2.2'
 else
-  $apache_version = 0
+  $apache_version = '0'
 end
 

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -165,7 +165,7 @@ describe 'apache::vhost define', :unless => UNSUPPORTED_PLATFORMS.include?(fact(
         pp = <<-EOS
           class { 'apache': }
 
-          if $apache::apache_version >= 2.4 {
+          if versioncmp($apache::apache_version, '2.4') >= 0 {
             $_files_match_directory = { 'path' => '(\.swp|\.bak|~)$', 'provider' => 'filesmatch', 'require' => 'all denied', }
           } else {
             $_files_match_directory = { 'path' => '(\.swp|\.bak|~)$', 'provider' => 'filesmatch', 'deny' => 'from all', }
@@ -209,7 +209,7 @@ describe 'apache::vhost define', :unless => UNSUPPORTED_PLATFORMS.include?(fact(
         pp = <<-EOS
           class { 'apache': }
 
-          if $apache::apache_version >= 2.4 {
+          if versioncmp($apache::apache_version, '2.4') >= 0 {
             $_files_match_directory = { 'path' => 'private.html$', 'provider' => 'filesmatch', 'require' => 'all denied' }
           } else {
             $_files_match_directory = { 'path' => 'private.html$', 'provider' => 'filesmatch', 'deny' => 'from all' }

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -75,7 +75,7 @@ describe 'apache', :type => :class do
 
     context "with Apache version < 2.4" do
       let :params do
-        { :apache_version => 2.2 }
+        { :apache_version => '2.2' }
       end
 
       it { should contain_file("/etc/apache2/apache2.conf").with_content %r{^Include "/etc/apache2/conf\.d/\*\.conf"$} }
@@ -83,7 +83,7 @@ describe 'apache', :type => :class do
 
     context "with Apache version >= 2.4" do
       let :params do
-        { :apache_version => 2.4 }
+        { :apache_version => '2.4' }
       end
 
       it { should contain_file("/etc/apache2/apache2.conf").with_content %r{^IncludeOptional "/etc/apache2/conf\.d/\*\.conf"$} }
@@ -279,7 +279,7 @@ describe 'apache', :type => :class do
 
       context "with Apache version < 2.4" do
         let :params do
-          { :apache_version => 2.2 }
+          { :apache_version => '2.2' }
         end
 
         it { should contain_file("/etc/httpd/conf/httpd.conf").with_content %r{^Include "/etc/httpd/conf\.d/\*\.conf"$} }
@@ -287,7 +287,7 @@ describe 'apache', :type => :class do
 
       context "with Apache version >= 2.4" do
         let :params do
-          { :apache_version => 2.4 }
+          { :apache_version => '2.4' }
         end
 
         it { should contain_file("/etc/httpd/conf/httpd.conf").with_content %r{^IncludeOptional "/etc/httpd/conf\.d/\*\.conf"$} }

--- a/spec/classes/mod/event_spec.rb
+++ b/spec/classes/mod/event_spec.rb
@@ -31,7 +31,7 @@ describe 'apache::mod::event', :type => :class do
     context "with Apache version < 2.4" do
       let :params do
         {
-          :apache_version => 2.2,
+          :apache_version => '2.2',
         }
       end
 
@@ -44,7 +44,7 @@ describe 'apache::mod::event', :type => :class do
     context "with Apache version >= 2.4" do
       let :params do
         {
-          :apache_version => 2.4,
+          :apache_version => '2.4',
         }
       end
 
@@ -68,7 +68,7 @@ describe 'apache::mod::event', :type => :class do
     context "with Apache version >= 2.4" do
       let :params do
         {
-          :apache_version => 2.4,
+          :apache_version => '2.4',
         }
       end
 

--- a/spec/classes/mod/itk_spec.rb
+++ b/spec/classes/mod/itk_spec.rb
@@ -18,7 +18,7 @@ describe 'apache::mod::itk', :type => :class do
     context "with Apache version < 2.4" do
       let :params do
         {
-          :apache_version => 2.2,
+          :apache_version => '2.2',
         }
       end
 
@@ -31,7 +31,7 @@ describe 'apache::mod::itk', :type => :class do
     context "with Apache version >= 2.4" do
       let :params do
         {
-          :apache_version => 2.4,
+          :apache_version => '2.4',
         }
       end
 

--- a/spec/classes/mod/prefork_spec.rb
+++ b/spec/classes/mod/prefork_spec.rb
@@ -18,7 +18,7 @@ describe 'apache::mod::prefork', :type => :class do
     context "with Apache version < 2.4" do
       let :params do
         {
-          :apache_version => 2.2,
+          :apache_version => '2.2',
         }
       end
 
@@ -31,7 +31,7 @@ describe 'apache::mod::prefork', :type => :class do
     context "with Apache version >= 2.4" do
       let :params do
         {
-          :apache_version => 2.4,
+          :apache_version => '2.4',
         }
       end
 
@@ -58,7 +58,7 @@ describe 'apache::mod::prefork', :type => :class do
     context "with Apache version < 2.4" do
       let :params do
         {
-          :apache_version => 2.2,
+          :apache_version => '2.2',
         }
       end
 
@@ -71,7 +71,7 @@ describe 'apache::mod::prefork', :type => :class do
     context "with Apache version >= 2.4" do
       let :params do
         {
-          :apache_version => 2.4,
+          :apache_version => '2.4',
         }
       end
 

--- a/spec/classes/mod/worker_spec.rb
+++ b/spec/classes/mod/worker_spec.rb
@@ -18,7 +18,7 @@ describe 'apache::mod::worker', :type => :class do
     context "with Apache version < 2.4" do
       let :params do
         {
-          :apache_version => 2.2,
+          :apache_version => '2.2',
         }
       end
 
@@ -31,7 +31,7 @@ describe 'apache::mod::worker', :type => :class do
     context "with Apache version >= 2.4" do
       let :params do
         {
-          :apache_version => 2.4,
+          :apache_version => '2.4',
         }
       end
 
@@ -58,7 +58,7 @@ describe 'apache::mod::worker', :type => :class do
     context "with Apache version < 2.4" do
       let :params do
         {
-          :apache_version => 2.2,
+          :apache_version => '2.2',
         }
       end
 
@@ -71,7 +71,7 @@ describe 'apache::mod::worker', :type => :class do
     context "with Apache version >= 2.4" do
       let :params do
         {
-          :apache_version => 2.4,
+          :apache_version => '2.4',
         }
       end
 

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -788,7 +788,7 @@ describe 'apache::vhost', :type => :define do
         describe "when #{param[:attr]} is #{param[:value]}" do
           let :params do default_params.merge({
             param[:attr].to_sym => param[:value],
-            :apache_version => 2.2,
+            :apache_version => '2.2',
           }) end
 
           it { should contain_file("25-#{title}.conf").with_mode('0644') }
@@ -925,7 +925,7 @@ describe 'apache::vhost', :type => :define do
         describe "when #{param[:attr]} is #{param[:value]}" do
           let :params do default_params.merge({
             param[:attr].to_sym => param[:value],
-            :apache_version => 2.4,
+            :apache_version => '2.4',
           }) end
 
           it { should contain_file("25-#{title}.conf").with_mode('0644') }

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -16,7 +16,7 @@ Group <%= @group %>
 
 AccessFileName .htaccess
 <FilesMatch "^\.ht">
-<%- if @apache_version >= '2.4' -%>
+<%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
     Require all denied
 <%- else -%>
      Order allow,deny
@@ -61,7 +61,7 @@ LogFormat "<%= format -%>" <%= nickname %>
   <%- end -%>
 <% end -%>
 
-<%- if @apache_version >= '2.4' -%>
+<%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
 IncludeOptional "<%= @confd_dir %>/*.conf"
 <%- else -%>
 Include "<%= @confd_dir %>/*.conf"
@@ -79,7 +79,7 @@ Alias /error/ "<%= @error_documents_path %>/"
   Options IncludesNoExec
   AddOutputFilter Includes html
   AddHandler type-map var
-<%- if @apache_version == '2.4' -%>
+<%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
   Require all granted
 <%- else -%>
   Order allow,deny

--- a/templates/mod/alias.conf.erb
+++ b/templates/mod/alias.conf.erb
@@ -3,7 +3,7 @@ Alias /icons/ "<%= @icons_path %>/"
 <Directory "<%= @icons_path %>">
     Options Indexes MultiViews
     AllowOverride None
-<%- if @apache_version == '2.4' -%>
+<%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
     Require all granted
 <%- else -%>
      Order allow,deny

--- a/templates/mod/info.conf.erb
+++ b/templates/mod/info.conf.erb
@@ -1,6 +1,6 @@
 <Location /server-info>
     SetHandler server-info
-    <%- if @apache_version >= '2.4' -%>
+    <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
     Require ip <%= Array(@allow_from).join(" ") %>
     <%- else -%>
     Order deny,allow

--- a/templates/mod/ssl.conf.erb
+++ b/templates/mod/ssl.conf.erb
@@ -13,7 +13,7 @@
 <% if @ssl_compression -%>
   SSLCompression On
 <% end -%>
-  <% if @apache_version >= '2.4' -%>
+  <% if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
   Mutex <%= @ssl_mutex %>
   <% else -%>
   SSLMutex <%= @ssl_mutex %>

--- a/templates/vhost/_block.erb
+++ b/templates/vhost/_block.erb
@@ -4,7 +4,7 @@
 <% if @block.include? 'scm' -%>
   # Block access to SCM directories.
   <DirectoryMatch .*\.(svn|git|bzr)/.*>
-  <%- if @apache_version >= '2.4' -%>
+  <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
     Require all denied
   <%- else -%>
     Deny From All

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -34,7 +34,7 @@
     AllowOverride None
       <%- end -%>
     <%- end -%>
-    <%- if @apache_version == '2.4' -%>
+    <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
       <%- if directory['require'] and directory['require'] != '' -%>
     Require <%= Array(directory['require']).join(' ') %>
       <%- else -%>

--- a/templates/vhost/_fastcgi.erb
+++ b/templates/vhost/_fastcgi.erb
@@ -8,7 +8,7 @@
     Options +ExecCGI
     AllowOverride All
     SetHandler fastcgi-script
-  <%- if @apache_version >= '2.4' -%>
+  <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
     Require all granted
   <%- else -%>
     Order allow,deny


### PR DESCRIPTION
Three part version numbers cannot be floats and must
be represented as strings. This commit changes all instances
of $apache_version and any comparsions to use strings and the
versioncmp function.
