### PR TITLE
MODULES-956 Added loadfile_name parameter to apache::mod.

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,10 @@ Sets the amount of time the server will wait for subsequent requests on a persis
 
 Sets the limit of the number of requests allowed per connection when KeepAlive is on. Defaults to '100'.
 
+#####`loadfile_name`
+
+Sets the file name for the module loadfile. Should be in the format *.load.  This can be used to set the module load order.
+
 #####`log_level`
 
 Changes the verbosity level of the error log. Defaults to 'warn'. Valid values are 'emerg', 'alert', 'crit', 'error', 'warn', 'notice', 'info', or 'debug'.

--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -1,11 +1,12 @@
 define apache::mod (
-  $package = undef,
+  $package        = undef,
   $package_ensure = 'present',
-  $lib = undef,
-  $lib_path = $::apache::params::lib_path,
-  $id = undef,
-  $path = undef,
-  $loadfiles = undef,
+  $lib            = undef,
+  $lib_path       = $::apache::params::lib_path,
+  $id             = undef,
+  $path           = undef,
+  $loadfile_name  = undef,
+  $loadfiles      = undef,
 ) {
   if ! defined(Class['apache']) {
     fail('You must include the apache base class before using any apache defined resources')
@@ -39,6 +40,12 @@ define apache::mod (
     $_id = "${mod}_module"
   }
 
+  if $loadfile_name {
+    $_loadfile_name = $loadfile_name
+  } else {
+    $_loadfile_name = "${mod}.load"
+  }
+
   # Determine if we have a package
   $mod_packages = $::apache::params::mod_packages
   $mod_package = $mod_packages[$mod] # 2.6 compatibility hack
@@ -69,7 +76,7 @@ define apache::mod (
 
   file { "${mod}.load":
     ensure  => file,
-    path    => "${mod_dir}/${mod}.load",
+    path    => "${mod_dir}/${_loadfile_name}",
     owner   => 'root',
     group   => $::apache::params::root_group,
     mode    => '0644',
@@ -86,8 +93,8 @@ define apache::mod (
     $enable_dir = $::apache::mod_enable_dir
     file{ "${mod}.load symlink":
       ensure  => link,
-      path    => "${enable_dir}/${mod}.load",
-      target  => "${mod_dir}/${mod}.load",
+      path    => "${enable_dir}/${_loadfile_name}",
+      target  => "${mod_dir}/${_loadfile_name}",
       owner   => 'root',
       group   => $::apache::params::root_group,
       mode    => '0644',

--- a/spec/acceptance/default_mods_spec.rb
+++ b/spec/acceptance/default_mods_spec.rb
@@ -2,10 +2,13 @@ require 'spec_helper_acceptance'
 
 case fact('osfamily')
 when 'RedHat'
+  mod_dir     = '/etc/httpd/conf.d'
   servicename = 'httpd'
 when 'Debian'
+  mod_dir     = '/etc/apache2/mods-available'
   servicename = 'apache2'
 when 'FreeBSD'
+  mod_dir     = '/usr/local/etc/apache22/Modules'
   servicename = 'apache22'
 end
 
@@ -90,6 +93,28 @@ describe 'apache::default_mods class', :unless => UNSUPPORTED_PLATFORMS.include?
 
     describe service(servicename) do
       it { should be_running }
+    end
+  end
+
+  describe 'change loadfile name' do
+    it 'should apply with no errors' do
+      pp = <<-EOS
+        class { 'apache': default_mods => false }
+        ::apache::mod { 'auth_basic': 
+          loadfile_name => 'zz_auth_basic.load',
+        }
+      EOS
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      expect(apply_manifest(pp, :catch_failures => true).exit_code).to be_zero
+    end
+
+    describe service(servicename) do
+      it { should be_running }
+    end
+
+    describe file("#{mod_dir}/zz_auth_basic.load") do
+      it { should be_file }
     end
   end
 end


### PR DESCRIPTION
This will allow for more control over the module load order, since
they appear to be loaded alphabetically.
