### PR TITLE
Mod rewrite duplicate error

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -357,8 +357,8 @@ define apache::vhost(
 
   # Load mod_rewrite if needed and not yet loaded
   if $rewrites or $rewrite_cond {
-    if ! defined(Apache::Mod['rewrite']) {
-      ::apache::mod { 'rewrite': }
+    if ! defined(Class['apache::mod::rewrite']) {
+      include ::apache::mod::rewrite
     }
   }
 


### PR DESCRIPTION
As in PR #412, if we include ::apache::mod{'rewrite:'} instead of ::apache::mod::rewrite we can have a "duplicate class" error. It seems the error happens when you have more than 1 vhost with rewrite rules.
This is fixed in this PR.
