### PR TITLE
Provide configuration file for php module

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,6 +554,29 @@ Overriding the package name:
   }
 ```
 
+Overriding the default configuartion:
+```puppet
+  class {'::apache::mod::php':
+    source => 'puppet:///modules/apache/my_php.conf',
+  }
+```
+
+or 
+```puppet
+  class {'::apache::mod::php':
+    template => 'apache/php.conf.erb',
+  }
+```
+
+or
+
+```puppet
+  class {'::apache::mod::php':
+    content => '
+AddHandler php5-script .php
+AddType text/html .php',
+  }
+```
 ####Class: `apache::mod::ssl`
 
 Installs Apache SSL capabilities and uses the ssl.conf.erb template. These are the defaults:

--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -3,11 +3,29 @@ class apache::mod::php (
   $package_ensure = 'present',
   $path           = undef,
   $extensions     = ['.php'],
+  $content        = undef,
+  $template       = 'apache/mod/php5.conf.erb',
+  $source         = undef,
 ) {
   if ! defined(Class['apache::mod::prefork']) {
     fail('apache::mod::php requires apache::mod::prefork; please enable mpm_module => \'prefork\' on Class[\'apache\']')
   }
   validate_array($extensions)
+
+  if $source and ($content or $template != 'apache/mod/php5.conf.erb') {
+    warning('source and content or template parameters are provided. source parameter will be used')
+  } elsif $content and $template != 'apache/mod/php5.conf.erb' {
+    warning('content and template parameters are provided. content parameter will be used')
+  }
+
+  $manage_content = $source ? {
+    undef   => $content ? {
+      undef   => template($template),
+      default => $content,
+    },
+    default => undef,
+  }
+
   ::apache::mod { 'php5':
     package        => $package_name,
     package_ensure => $package_ensure,
@@ -22,7 +40,11 @@ class apache::mod::php (
   file { 'php5.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/php5.conf",
-    content => template('apache/mod/php5.conf.erb'),
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => $manage_content,
+    source  => $source,
     require => [
       Class['::apache::mod::prefork'],
       Exec["mkdir ${::apache::mod_dir}"],

--- a/spec/acceptance/mod_php_spec.rb
+++ b/spec/acceptance/mod_php_spec.rb
@@ -94,4 +94,80 @@ describe 'apache::mod::php class', :unless => UNSUPPORTED_PLATFORMS.include?(fac
       end
     end
   end
+
+  context "provide custom config file" do
+    it 'succeeds in puppeting php' do
+      pp= <<-EOS
+        class {'apache':
+          mpm_module => 'prefork',
+        }
+        class {'apache::mod::php':
+          content => '# somecontent',
+        }
+      EOS
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    describe file("#{mod_dir}/php5.conf") do
+      it { should contain "# somecontent" }
+    end
+  end
+
+  context "provide content and template config file" do
+    it 'succeeds in puppeting php' do
+      pp= <<-EOS
+        class {'apache':
+          mpm_module => 'prefork',
+        }
+        class {'apache::mod::php':
+          content  => '# somecontent',
+          template => 'apache/mod/php5.conf.erb',
+        }
+      EOS
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    describe file("#{mod_dir}/php5.conf") do
+      it { should contain "# somecontent" }
+    end
+  end
+
+  context "provide source has priority over content" do
+    it 'succeeds in puppeting php' do
+      pp= <<-EOS
+        class {'apache':
+          mpm_module => 'prefork',
+        }
+        class {'apache::mod::php':
+          content => '# somecontent',
+          source  => 'puppet:///modules/apache/spec',
+        }
+      EOS
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    describe file("#{mod_dir}/php5.conf") do
+      it { should contain "# This is a file only for spec testing" }
+    end
+  end
+
+  context "provide source has priority over template" do
+    it 'succeeds in puppeting php' do
+      pp= <<-EOS
+        class {'apache':
+          mpm_module => 'prefork',
+        }
+        class {'apache::mod::php':
+          template => 'apache/mod/php5.conf.erb',
+          source   => 'puppet:///modules/apache/spec',
+        }
+      EOS
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    describe file("#{mod_dir}/php5.conf") do
+      it { should contain "# This is a file only for spec testing" }
+    end
+  end
+
 end

--- a/spec/classes/mod/php_spec.rb
+++ b/spec/classes/mod/php_spec.rb
@@ -122,4 +122,88 @@ describe 'apache::mod::php', :type => :class do
       end
     end
   end
+  describe "OS independent tests" do
+    let :facts do
+      {
+        :osfamily               => 'Debian',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
+      }
+    end
+    context 'with content param' do
+      let :pre_condition do
+        'class { "apache": mpm_module => prefork, }'
+      end
+      let :params do
+        { :content => 'somecontent' }
+      end
+      it { should contain_file('php5.conf').with(
+        :content => 'somecontent'
+      ) }
+    end
+    context 'with template param' do
+      let :pre_condition do
+        'class { "apache": mpm_module => prefork, }'
+      end
+      let :params do
+        { :template => 'apache/mod/php5.conf.erb' }
+      end
+      it { should contain_file('php5.conf').with(
+        :content => /^# PHP is an HTML-embedded scripting language which attempts to make it/
+      ) }
+    end
+    context 'with source param' do
+      let :pre_condition do
+        'class { "apache": mpm_module => prefork, }'
+      end
+      let :params do
+        { :source => 'some-path' }
+      end
+      it { should contain_file('php5.conf').with(
+        :source => 'some-path'
+      ) }
+    end
+    context 'content has priority over template' do
+      let :pre_condition do
+        'class { "apache": mpm_module => prefork, }'
+      end
+      let :params do
+        {
+          :template => 'apache/mod/php5.conf.erb',
+          :content  => 'somecontent'
+        }
+      end
+      it { should contain_file('php5.conf').with(
+        :content => 'somecontent'
+      ) }
+    end
+    context 'source has priority over template' do
+      let :pre_condition do
+        'class { "apache": mpm_module => prefork, }'
+      end
+      let :params do
+        {
+          :template => 'apache/mod/php5.conf.erb',
+          :source   => 'some-path'
+        }
+      end
+      it { should contain_file('php5.conf').with(
+        :source => 'some-path'
+      ) }
+    end
+    context 'source has priority over content' do
+      let :pre_condition do
+        'class { "apache": mpm_module => prefork, }'
+      end
+      let :params do
+        {
+          :content => 'somecontent',
+          :source  => 'some-path'
+        }
+      end
+      it { should contain_file('php5.conf').with(
+        :source => 'some-path'
+      ) }
+    end
+  end
 end

--- a/spec/fixtures/files/spec
+++ b/spec/fixtures/files/spec
@@ -1,0 +1,1 @@
+# This is a file only for spec testing


### PR DESCRIPTION
I have modified php define so you could provide a configuration file with `source`, `template` or `content` parameters.

I have also pulled another similar request for the negotiation module. I think that this approach could be useful for the rest of module's defines. I could patch them the same way that this module.
