### PR TITLE
Add package parameters to the dav_svn mod.

### DIFF
--- a/manifests/mod/dav_svn.pp
+++ b/manifests/mod/dav_svn.pp
@@ -7,7 +7,10 @@ class apache::mod::dav_svn (
     
     if $authz_svn_enabled {
       ::apache::mod { 'authz_svn':
-        loadfile_name => 'dav_svn_authz_svn.load',
+        loadfile_name => $::osfamily ? {
+          'Debian' => undef,
+          default  => 'dav_svn_authz_svn.load',
+        },
         require       => Apache::Mod['dav_svn'],
       }
     }

--- a/spec/acceptance/mod_dav_svn_spec.rb
+++ b/spec/acceptance/mod_dav_svn_spec.rb
@@ -3,14 +3,17 @@ require 'spec_helper_acceptance'
 describe 'apache::mod::dav_svn class' do
   case fact('osfamily')
   when 'Debian'
-    mod_dir      = '/etc/apache2/mods-available'
-    service_name = 'apache2'
+    mod_dir             = '/etc/apache2/mods-available'
+    service_name        = 'apache2'
+    authz_svn_load_file = 'authz_svn.load'
   when 'RedHat'
-    mod_dir      = '/etc/httpd/conf.d'
-    service_name = 'httpd'
+    mod_dir             = '/etc/httpd/conf.d'
+    service_name        = 'httpd'
+    authz_svn_load_file = 'dav_svn_authz_svn.load'
   when 'FreeBSD'
-    mod_dir      = '/usr/local/etc/apache22/Modules'
-    service_name = 'apache22'
+    mod_dir             = '/usr/local/etc/apache22/Modules'
+    service_name        = 'apache22'
+    authz_svn_load_file = 'dav_svn_authz_svn.load'
   end
 
   context "default dav_svn config" do
@@ -48,7 +51,7 @@ describe 'apache::mod::dav_svn class' do
       it { is_expected.to be_running }
     end
 
-    describe file("#{mod_dir}/dav_svn_authz_svn.load") do
+    describe file("#{mod_dir}/#{authz_svn_load_file}") do
       it { is_expected.to contain "LoadModule authz_svn_module" }
     end
   end


### PR DESCRIPTION
Add package parameters to the dav_svn mod to be more convenient.

I also removed the custom loadfile_name as it produces a duplicate load file on Debian.
It's because load files installed by packages aren't purged on Debian.
