### PR TITLE
Add support for custom vhost block templates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,6 +714,31 @@ For `alias` and `aliasmatch` to work, each will need a corresponding context, su
 
 Specifies the list of things Apache will block access to. The default is an empty set, '[]'. Currently, the only option is 'scm', which blocks web access to .svn, .git and .bzr directories.
 
+#####`custom_blocks`
+
+Set a list of custom configuration blocks to use. Each value must be a valid path to an erb file. Defaults to an empty set, '[]'.
+
+Let imagine that we have the following template located in site_apache/custom_template.erb :
+```
+<% if @custom_blocks_parameters['some_var'] -%>
+
+  # A custom variable <%= @custom_blocks_parameters['some_var'] %>
+<% end -%>
+```
+To use this template, the following vhost definition is needed :
+```apache::vhost {
+        "website.mydomain.org_80":
+            servername => "website.mydomain.org",
+            port => 80,
+            custom_blocks => ["site_apache/custom_template.erb"],
+            custom_blocks_parameters => { 'some_var' => 'some_string' },
+}
+```
+
+#####`custom_blocks_parameters`
+
+Set a hash of parameters to be used by custom blocks defined by `custom_blocks_parameters`. Defaults to an empty hash, '{}'.
+
 #####`custom_fragment`
 
 Passes a string of custom configuration directives to be placed at the end of the vhost configuration. Defaults to 'undef'.

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -169,6 +169,8 @@ define apache::vhost(
     $additional_includes         = [],
     $apache_version              = $::apache::apache_version,
     $suexec_user_group           = undef,
+    $custom_blocks               = [],
+    $custom_blocks_parameters    = {},
   ) {
   # The base class must be included first because it is used by parameter defaults
   if ! defined(Class['apache']) {
@@ -443,6 +445,14 @@ define apache::vhost(
     }
 
     $_directories = [ merge($_directory, $_directory_version) ]
+  }
+
+  if $custom_blocks {
+      validate_array($custom_blocks)
+  }
+
+  if $custom_blocks_parameters {
+      validate_hash($custom_blocks_parameters)
   }
 
   # Template uses:

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -1009,6 +1009,47 @@ describe 'apache::vhost define', :unless => UNSUPPORTED_PLATFORMS.include?(fact(
     end
   end
 
+  describe 'single custom_blocks' do
+    it 'applies cleanly' do
+      pp = <<-EOS
+        class { 'apache': }
+        host { 'test.server': ip => '127.0.0.1' }
+        apache::vhost { 'test.server':
+          docroot  => '/tmp',
+          custom_blocks => ['site_apache/custom_template.erb'],
+          custom_blocks_parameters => { 'some_var' => 'some_string' },
+        }
+      EOS
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    describe file("#{$vhost_dir}/25-test.server.conf") do
+      it { should be_file }
+      it { should contain '# A custom variable : some_string' }
+    end
+  end
+
+  describe 'multiple custom_blocks' do
+    it 'applies cleanly' do
+      pp = <<-EOS
+        class { 'apache': }
+        host { 'test.server': ip => '127.0.0.1' }
+        apache::vhost { 'test.server':
+          docroot  => '/tmp',
+          custom_blocks => ['site_apache/custom_template.erb', 'site_apache/custom_template2.erb'],
+          custom_blocks_parameters => { 'some_var' => 'some_string', 'another_var' => 'another_string' },
+        }
+      EOS
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    describe file("#{$vhost_dir}/25-test.server.conf") do
+      it { should be_file }
+      it { should contain '# A custom variable : some_string' }
+      it { should contain '# Another custom variable : another_string' }
+    end
+  end
+
   describe 'itk' do
     it 'applies cleanly' do
       pp = <<-EOS

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -1464,6 +1464,31 @@ describe 'apache::vhost', :type => :define do
           it { should contain_file("25-#{title}.conf").with_content %r{DirectoryIndex index.php} }
 	end
       end
+      
+      describe 'when a single custom_block and its parameter are defined' do
+        let :params do default_params.merge({
+          :custom_blocks => ['site_apache/custom_template.erb'],
+          :custom_blocks_parameters => { 'some_var' => 'some_string' },
+        }) end
+        it 'should add the defined custom block with its parameters' do
+          should contain_file("25-#{title}.conf").with_content(
+            /^  # A custom variable : some_string$/
+          )
+        end
+      end
+
+      describe 'when multiple custom_blocks and their parameters are defined' do
+        let :params do default_params.merge({
+          :custom_blocks => ['site_apache/custom_template.erb', 'site_apache/custom_template2.erb'],
+          :custom_blocks_parameters => { 'some_var' => 'some_string', 'another_var' => 'another_string' },
+        }) end
+        it 'should add the defined custom block with its parameters' do
+          should contain_file("25-#{title}.conf").with_content(
+            /^  # A custom variable : some_string$/,
+            /^  # Another custom variable : another_string$/,
+          )
+        end
+      end
     end
   end
 end

--- a/spec/fixtures/modules/site_apache/templates/custom_template.erb
+++ b/spec/fixtures/modules/site_apache/templates/custom_template.erb
@@ -1,0 +1,4 @@
+<% if @custom_blocks_parameters['some_var'] -%>
+
+  # A custom variable : <%= @custom_blocks_parameters['some_var'] %>
+<% end -%> 

--- a/spec/fixtures/modules/site_apache/templates/custom_template2.erb
+++ b/spec/fixtures/modules/site_apache/templates/custom_template2.erb
@@ -1,0 +1,4 @@
+<% if @custom_blocks_parameters['another_var'] -%>
+
+  # Another custom variable : <%= @custom_blocks_parameters['another_var'] %>
+<% end -%> 

--- a/templates/vhost.conf.erb
+++ b/templates/vhost.conf.erb
@@ -63,4 +63,7 @@
 <%= scope.function_template(['apache/vhost/_custom_fragment.erb']) -%>
 <%= scope.function_template(['apache/vhost/_fastcgi.erb']) -%>
 <%= scope.function_template(['apache/vhost/_suexec.erb']) -%>
+<% if @custom_blocks and ! @custom_blocks.empty? -%>
+<%= scope.function_template(@custom_blocks) -%>
+<% end -%>
 </VirtualHost>


### PR DESCRIPTION
Implement a new mechanism to use custom blocks from external erb files.
Block specific parameters needs to be set in custom_blocks_parameters.
