### PR TITLE
MODULES-1065: Add ThreadLimit to mod::worker

### DIFF
--- a/manifests/mod/worker.pp
+++ b/manifests/mod/worker.pp
@@ -6,6 +6,7 @@ class apache::mod::worker (
   $threadsperchild     = '25',
   $maxrequestsperchild = '0',
   $serverlimit         = '25',
+  $threadlimit         = '64',
   $apache_version      = $::apache::apache_version,
 ) {
   if defined(Class['apache::mod::event']) {
@@ -34,6 +35,7 @@ class apache::mod::worker (
   # - $threadsperchild
   # - $maxrequestsperchild
   # - $serverlimit
+  # - $threadLimit
   file { "${::apache::mod_dir}/worker.conf":
     ensure  => file,
     content => template('apache/mod/worker.conf.erb'),

--- a/spec/classes/mod/worker_spec.rb
+++ b/spec/classes/mod/worker_spec.rb
@@ -96,4 +96,51 @@ describe 'apache::mod::worker', :type => :class do
     it { should_not contain_apache__mod('worker') }
     it { should contain_file("/usr/local/etc/apache22/Modules/worker.conf").with_ensure('file') }
   end
+
+  # Template config doesn't vary by distro
+  context "on all distros" do
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
+      }
+    end
+
+    context 'defaults' do
+      it { should contain_file('/etc/httpd/conf.d/worker.conf').with(:content => /^<IfModule mpm_worker_module>$/) }
+      it { should contain_file('/etc/httpd/conf.d/worker.conf').with(:content => /^\s+ServerLimit\s+25$/) }
+      it { should contain_file('/etc/httpd/conf.d/worker.conf').with(:content => /^\s+StartServers\s+2$/) }
+      it { should contain_file('/etc/httpd/conf.d/worker.conf').with(:content => /^\s+MaxClients\s+150$/) }
+      it { should contain_file('/etc/httpd/conf.d/worker.conf').with(:content => /^\s+MinSpareThreads\s+25$/) }
+      it { should contain_file('/etc/httpd/conf.d/worker.conf').with(:content => /^\s+MaxSpareThreads\s+75$/) }
+      it { should contain_file('/etc/httpd/conf.d/worker.conf').with(:content => /^\s+ThreadsPerChild\s+25$/) }
+      it { should contain_file('/etc/httpd/conf.d/worker.conf').with(:content => /^\s+MaxRequestsPerChild\s+0$/) }
+      it { should contain_file('/etc/httpd/conf.d/worker.conf').with(:content => /^\s+ThreadLimit\s+64$/) }
+    end
+
+    context 'setting params' do
+      let :params do
+        {
+          :serverlimit          => 10,
+          :startservers         => 11,
+          :maxclients           => 12,
+          :minsparethreads      => 13,
+          :maxsparethreads      => 14,
+          :threadsperchild      => 15,
+          :maxrequestsperchild  => 16,
+          :threadlimit          => 17
+        }
+      end
+      it { should contain_file('/etc/httpd/conf.d/worker.conf').with(:content => /^<IfModule mpm_worker_module>$/) }
+      it { should contain_file('/etc/httpd/conf.d/worker.conf').with(:content => /^\s+ServerLimit\s+10$/) }
+      it { should contain_file('/etc/httpd/conf.d/worker.conf').with(:content => /^\s+StartServers\s+11$/) }
+      it { should contain_file('/etc/httpd/conf.d/worker.conf').with(:content => /^\s+MaxClients\s+12$/) }
+      it { should contain_file('/etc/httpd/conf.d/worker.conf').with(:content => /^\s+MinSpareThreads\s+13$/) }
+      it { should contain_file('/etc/httpd/conf.d/worker.conf').with(:content => /^\s+MaxSpareThreads\s+14$/) }
+      it { should contain_file('/etc/httpd/conf.d/worker.conf').with(:content => /^\s+ThreadsPerChild\s+15$/) }
+      it { should contain_file('/etc/httpd/conf.d/worker.conf').with(:content => /^\s+MaxRequestsPerChild\s+16$/) }
+      it { should contain_file('/etc/httpd/conf.d/worker.conf').with(:content => /^\s+ThreadLimit\s+17$/) }
+    end
+  end
 end

--- a/templates/mod/worker.conf.erb
+++ b/templates/mod/worker.conf.erb
@@ -6,4 +6,5 @@
   MaxSpareThreads     <%= @maxsparethreads %>
   ThreadsPerChild     <%= @threadsperchild %>
   MaxRequestsPerChild <%= @maxrequestsperchild %>
+  ThreadLimit         <%= @threadlimit %>
 </IfModule>


### PR DESCRIPTION
Added threadLimit to mod::worker.  Set the default to 64 per this documentation: http://httpd.apache.org/docs/current/mod/mpm_common.html#threadlimit
