### PR TITLE
MODULES-957: Add more Apache 2.4 conditional blocks to configuration templates

### DIFF
--- a/manifests/mod/ldap.pp
+++ b/manifests/mod/ldap.pp
@@ -1,6 +1,8 @@
-class apache::mod::ldap {
+class apache::mod::ldap (
+  $apache_version = $::apache::apache_version,
+){
   ::apache::mod { 'ldap': }
-  # Template uses no variables
+  # Template uses $apache_version
   file { 'ldap.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/ldap.conf",

--- a/manifests/mod/pagespeed.pp
+++ b/manifests/mod/pagespeed.pp
@@ -32,6 +32,7 @@ class apache::mod::pagespeed (
   $allow_pagespeed_message       = [],
   $message_buffer_size           = 100000,
   $additional_configuration      = {},
+  $apache_version                = $::apache::apache_version,
 ){
 
   $_lib = $::apache::apache_version ? {

--- a/manifests/mod/proxy.pp
+++ b/manifests/mod/proxy.pp
@@ -1,9 +1,10 @@
 class apache::mod::proxy (
   $proxy_requests = 'Off',
   $allow_from = undef,
+  $apache_version = $::apache::apache_version,
 ) {
   ::apache::mod { 'proxy': }
-  # Template uses $proxy_requests
+  # Template uses $proxy_requests, $apache_version
   file { 'proxy.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/proxy.conf",

--- a/manifests/mod/status.pp
+++ b/manifests/mod/status.pp
@@ -26,11 +26,12 @@
 class apache::mod::status (
   $allow_from      = ['127.0.0.1','::1'],
   $extended_status = 'On',
+  $apache_version = $::apache::apache_version,
 ){
   validate_array($allow_from)
   validate_re(downcase($extended_status), '^(on|off)$', "${extended_status} is not supported for extended_status.  Allowed values are 'On' and 'Off'.")
   ::apache::mod { 'status': }
-  # Template uses $allow_from, $extended_status
+  # Template uses $allow_from, $extended_status, $apache_version
   file { 'status.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/status.conf",

--- a/manifests/mod/userdir.pp
+++ b/manifests/mod/userdir.pp
@@ -2,10 +2,11 @@ class apache::mod::userdir (
   $home = '/home',
   $dir = 'public_html',
   $disable_root = true,
+  $apache_version = $::apache::apache_version,
 ) {
   ::apache::mod { 'userdir': }
 
-  # Template uses $home, $dir, $disable_root
+  # Template uses $home, $dir, $disable_root, $apache_version
   file { 'userdir.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/userdir.conf",

--- a/templates/mod/ldap.conf.erb
+++ b/templates/mod/ldap.conf.erb
@@ -1,7 +1,11 @@
 <Location /ldap-status>
     SetHandler ldap-status
+    <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
+    Require ip 127.0.0.1 ::1
+    <%- else -%>
     Order deny,allow
     Deny from all
     Allow from 127.0.0.1 ::1
     Satisfy all
+    <%- end -%>
 </Location>

--- a/templates/mod/pagespeed.conf.erb
+++ b/templates/mod/pagespeed.conf.erb
@@ -54,7 +54,6 @@ ModPagespeedNumExpensiveRewriteThreads <%= @num_expensive_rewrite_threads %>
 ModPagespeedStatistics <%= @collect_statistics %>
 
 <Location /mod_pagespeed_statistics>
-    Order allow,deny
     # You may insert other "Allow from" lines to add hosts you want to
     # allow to look at generated statistics.  Another possibility is
     # to comment out the "Order" and "Allow" options from the config
@@ -62,37 +61,35 @@ ModPagespeedStatistics <%= @collect_statistics %>
     # statistics.  This might be appropriate in an experimental setup or
     # if the Apache server is protected by a reverse proxy that will
     # filter URLs in some fashion.
-    Allow from localhost
-    Allow from 127.0.0.1
-    Allow from ::1
-    <% @allow_view_stats.each do |host| -%>
-    Allow from <%= host %>
-    <% end -%>
+    <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
+    Require ip 127.0.0.1 ::1 <%= Array(@allow_view_stats).join(" ") %>
+    <%- else -%>
+    Order allow,deny
+    Allow from 127.0.0.1 ::1 <%= Array(@allow_view_stats).join(" ") %>
+    <%- end -%>
     SetHandler mod_pagespeed_statistics
 </Location>
 
 ModPagespeedStatisticsLogging <%= @statistics_logging %>
 <Location /pagespeed_console>
+    <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
+    Require ip 127.0.0.1 ::1 <%= Array(@allow_pagespeed_console).join(" ") %>
+    <%- else -%>
     Order allow,deny
-    Allow from localhost
-    Allow from 127.0.0.1
-    Allow from ::1
-    <% @allow_pagespeed_console.each do |host| -%>
-    Allow from <%= host %>
-    <% end -%>
+    Allow from 127.0.0.1 ::1 <%= Array(@allow_pagespeed_console).join(" ") %>
+    <%- end -%>
     SetHandler pagespeed_console
 </Location>
 
 ModPagespeedMessageBufferSize <%= @message_buffer_size %>
 
 <Location /mod_pagespeed_message>
+    <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
+    Require ip 127.0.0.1 ::1 <%= Array(@allow_pagespeed_message).join(" ") %>
+    <%- else -%>
     Order allow,deny
-    Allow from localhost
-    Allow from 127.0.0.1
-    Allow from ::1
-    <% @allow_pagespeed_message.each do |host| -%>
-    Allow from <%= host %>
-    <% end -%>
+    Allow from 127.0.0.1 ::1 <%= Array(@allow_pagespeed_message).join(" ") %>
+    <%- end -%>
     SetHandler mod_pagespeed_message
 </Location>
 

--- a/templates/mod/proxy.conf.erb
+++ b/templates/mod/proxy.conf.erb
@@ -10,9 +10,13 @@
 
   <% if @proxy_requests != 'Off' or ( @allow_from and ! @allow_from.empty? ) -%>
   <Proxy *>
+    <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
+    Require ip <%= Array(@allow_from).join(" ") %>
+    <%- else -%>
     Order deny,allow
     Deny from all
     Allow from <%= Array(@allow_from).join(" ") %>
+    <%- end -%>
   </Proxy>
   <% end -%>
 

--- a/templates/mod/status.conf.erb
+++ b/templates/mod/status.conf.erb
@@ -1,8 +1,12 @@
 <Location /server-status>
     SetHandler server-status
+    <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
+    Require ip <%= Array(@allow_from).join(" ") %>
+    <%- else -%>
     Order deny,allow
     Deny from all
     Allow from <%= Array(@allow_from).join(" ") %>
+    <%- end -%>
 </Location>
 ExtendedStatus <%= @extended_status %>
 

--- a/templates/mod/userdir.conf.erb
+++ b/templates/mod/userdir.conf.erb
@@ -8,12 +8,20 @@
     AllowOverride FileInfo AuthConfig Limit Indexes
     Options MultiViews Indexes SymLinksIfOwnerMatch IncludesNoExec
     <Limit GET POST OPTIONS>
+      <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
+      Require all denied
+      <%- else -%>
       Order allow,deny
       Allow from all
+      <%- end -%>
     </Limit>
     <LimitExcept GET POST OPTIONS>
-      Order deny,allow
-      Deny from all
+      <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
+      Require all denied
+      <%- else -%>
+      Order allow,deny
+      Allow from all
+      <%- end -%>
     </LimitExcept>
   </Directory>
 </IfModule>


### PR DESCRIPTION
Adds conditional blocks that check for Apache 2.4 in templates referenced in [MODULES-957](https://tickets.puppetlabs.com/browse/MODULES-957) (that didn't already have them) as well as pagespeed.
