### PR TITLE
Add DeflateFilterNote directives

### DIFF
--- a/spec/acceptance/mod_deflate_spec.rb
+++ b/spec/acceptance/mod_deflate_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper_acceptance'
+
+describe 'apache::mod::deflate class' do
+  case fact('osfamily')
+  when 'Debian'
+    mod_dir      = '/etc/apache2/mods-available'
+    service_name = 'apache2'
+  when 'RedHat'
+    mod_dir      = '/etc/httpd/conf.d'
+    service_name = 'httpd'
+  when 'FreeBSD'
+    mod_dir      = '/usr/local/etc/apache22/Modules'
+    service_name = 'apache22'
+  end
+
+  context "default deflate config" do
+    it 'succeeds in puppeting deflate' do
+      pp= <<-EOS
+        class { 'apache': }
+        include apache::mod::deflate
+      EOS
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    describe service(service_name) do
+      it { should be_enabled }
+      it { should be_running }
+    end
+
+    describe file("#{mod_dir}/deflate.conf") do
+      it { should contain "AddOutputFilterByType DEFLATE text/html text/plain text/xml" }
+      it { should contain "AddOutputFilterByType DEFLATE text/css" }
+      it { should contain "AddOutputFilterByType DEFLATE application/x-javascript application/javascript application/ecmascript" }
+      it { should contain "AddOutputFilterByType DEFLATE application/rss+xml" }
+      it { should contain "DeflateFilterNote Input instream" }
+      it { should contain "DeflateFilterNote Output outstream" }
+      it { should contain "DeflateFilterNote Ratio ratio" }
+    end
+  end
+end

--- a/spec/classes/mod/deflate_spec.rb
+++ b/spec/classes/mod/deflate_spec.rb
@@ -1,0 +1,78 @@
+# This function is called inside the OS specific contexts
+def general_deflate_specs
+  it { should contain_apache__mod("deflate") }
+
+  it do
+    should contain_file("deflate.conf").with_content(
+      "AddOutputFilterByType DEFLATE text/html text/plain text/xml\n"\
+      "AddOutputFilterByType DEFLATE text/css\n"\
+      "AddOutputFilterByType DEFLATE application/x-javascript application/javascript application/ecmascript\n"\
+      "AddOutputFilterByType DEFLATE application/rss+xml\n"\
+      "\n"\
+      "DeflateFilterNote Input instream\n"\
+      "DeflateFilterNote Output outstream\n"\
+      "DeflateFilterNote Ratio ratio\n"
+    )
+  end
+end
+
+describe 'apache::mod::deflate', :type => :class do
+  let :pre_condition do
+    'include apache'
+  end
+
+  context "On a Debian OS with default params" do
+    let :facts do
+      {
+        :osfamily               => 'Debian',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
+      }
+    end
+
+    # Load the more generic tests for this context
+    general_deflate_specs()
+
+    it { should contain_file("deflate.conf").with({
+      :ensure => 'file',
+      :path   => '/etc/apache2/mods-available/deflate.conf',
+    } ) }
+    it { should contain_file("deflate.conf symlink").with({
+      :ensure => 'link',
+      :path   => '/etc/apache2/mods-enabled/deflate.conf',
+    } ) }
+  end
+
+  context "on a RedHat OS with default params" do
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
+      }
+    end
+
+    # Load the more generic tests for this context
+    general_deflate_specs()
+
+    it { should contain_file("deflate.conf").with_path("/etc/httpd/conf.d/deflate.conf") }
+  end
+
+  context "On a FreeBSD OS with default params" do
+    let :facts do
+      {
+        :osfamily               => 'FreeBSD',
+        :operatingsystemrelease => '9',
+        :concat_basedir         => '/dne',
+      }
+    end
+
+    # Load the more generic tests for this context
+    general_deflate_specs()
+
+    it { should contain_file("deflate.conf").with({
+      :ensure => 'file',
+      :path   => '/usr/local/etc/apache22/Modules/deflate.conf',
+    } ) }
+  end
+end

--- a/templates/mod/deflate.conf.erb
+++ b/templates/mod/deflate.conf.erb
@@ -2,3 +2,7 @@ AddOutputFilterByType DEFLATE text/html text/plain text/xml
 AddOutputFilterByType DEFLATE text/css
 AddOutputFilterByType DEFLATE application/x-javascript application/javascript application/ecmascript
 AddOutputFilterByType DEFLATE application/rss+xml
+
+DeflateFilterNote Input instream
+DeflateFilterNote Output outstream
+DeflateFilterNote Ratio ratio


### PR DESCRIPTION
Add the three standard DeflateFilterNote directives when using mod_deflate
based on the examples in the documentation here:

http://httpd.apache.org/docs/2.2/mod/mod_deflate.html

I needed to add these so I can refer to them in custom log formats.
