### PR TITLE
Remove an unnecessary empty line in directories

### DIFF
--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -10,7 +10,7 @@
   <%- else -%>
     <%- provider = 'Directory' -%>
   <%- end -%>
-  <%- path = directory['path'] %>
+  <%- path = directory['path'] -%>
 
   <<%= provider %> "<%= path %>">
     <%- if directory['headers'] -%>


### PR DESCRIPTION
This just replaces a closing `%>` with a `-%>` in `_directories.erb`.
