### PR TITLE
Fix tests for fastcgi

### DIFF
--- a/manifests/fastcgi/server.pp
+++ b/manifests/fastcgi/server.pp
@@ -2,22 +2,23 @@ define apache::fastcgi::server (
   $host          = '127.0.0.1:9000',
   $timeout       = 15,
   $flush         = false,
-  $faux_path     = "/var/www/$name.fcgi",
-  $alias         = "/$name.fcgi",
+  $faux_path     = "/var/www/${name}.fcgi",
+  $alias         = "/${name}.fcgi",
   $file_type     = 'application/x-httpd-php'
 ) {
+  include apache::mod::fastcgi
 
-  Apache::Mod['fastcgi'] -> Apache::Fastcgi::Server["$title"]
+  Apache::Mod['fastcgi'] -> Apache::Fastcgi::Server[$title]
 
-  file { "fastcgi-pool-$name.conf":
+  file { "fastcgi-pool-${name}.conf":
     ensure  => present,
-    path    => "${::apache::confd_dir}/fastcgi-pool-$name.conf",
+    path    => "${::apache::confd_dir}/fastcgi-pool-${name}.conf",
     owner   => 'root',
     group   => $::apache::params::root_group,
     mode    => '0644',
     content => template('apache/fastcgi/server.erb'),
     require => Exec["mkdir ${::apache::confd_dir}"],
     before  => File[$::apache::confd_dir],
-    notify  => Service['httpd']
+    notify  => Class['apache::service'],
   }
 }


### PR DESCRIPTION
The fastcgi server define wasn't including apache::mod::fastcgi, but
this is idempotent and required, since it declares a dependency on
Apache::Mod['fastcgi'].

I also cleaned up some linting things and put the notify on the service
class instead of the service resource (as is the newer pattern).
