### PR TITLE
Adds @ to faux_path template variable

### DIFF
--- a/templates/fastcgi/server.erb
+++ b/templates/fastcgi/server.erb
@@ -1,3 +1,3 @@
 FastCGIExternalServer <%= @faux_path %> -idle-timeout <%= @timeout %> <%= if @flush then '-flush' end %> -host <%= @host %>
-Alias <%= @alias %> <%= faux_path %>
+Alias <%= @alias %> <%= @faux_path %>
 Action <%= @file_type %> <%= @alias %>


### PR DESCRIPTION
```
Warning: Variable access via 'faux_path' is deprecated. Use '@faux_path' instead. template[/tmp/vagrant-puppet-3/modules-0/apache/templates/fastcgi/server.erb]:2
(at /tmp/vagrant-puppet-3/modules-0/apache/templates/fastcgi/server.erb:2:in `block in result')
```
