### PR TITLE
function to munge booleans to httpd's On/Off

### DIFF
--- a/lib/puppet/parser/functions/bool2httpd.rb
+++ b/lib/puppet/parser/functions/bool2httpd.rb
@@ -1,0 +1,30 @@
+Puppet::Parser::Functions::newfunction(:bool2httpd, :type => :rvalue, :doc => <<-EOS
+Transform a supposed boolean to On or Off. Pass all other values through.
+Given a nil value (undef), bool2httpd will return 'Off'
+
+Example:
+
+    $trace_enable     = false
+    $server_signature = 'mail'
+
+    bool2httpd($trace_enable)
+    # => 'Off'
+    bool2httpd($server_signature)
+    # => 'mail'
+    bool2httpd(undef)
+    # => 'Off'
+
+EOS
+) do |args|
+  raise(Puppet::ParseError, "bool2httpd() wrong number of arguments. Given: #{args.size} for 1)") if args.size != 1
+
+  arg = args[0]
+
+  if arg.nil? or arg == false or arg =~ /false/i or arg == :undef
+    return 'Off'
+  elsif arg == true or arg =~ /true/i
+    return 'On'
+  end
+
+  return arg.to_s
+end

--- a/spec/unit/puppet/parser/functions/bool2httpd_spec.rb
+++ b/spec/unit/puppet/parser/functions/bool2httpd_spec.rb
@@ -1,0 +1,54 @@
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper'
+
+describe "the bool2httpd function" do
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+  it "should exist" do
+    expect(Puppet::Parser::Functions.function("bool2httpd")).to eq("function_bool2httpd")
+  end
+
+  it "should raise a ParseError if there is less than 1 arguments" do
+    expect { scope.function_bool2httpd([]) }.to( raise_error(Puppet::ParseError))
+  end
+
+  it "should convert true to 'On'" do
+    result = scope.function_bool2httpd([true])
+    expect(result).to(eq('On'))
+  end
+
+  it "should convert true to a string" do
+    result = scope.function_bool2httpd([true])
+    expect(result.class).to(eq(String))
+  end
+
+  it "should convert false to 'Off'" do
+    result = scope.function_bool2httpd([false])
+    expect(result).to(eq('Off'))
+  end
+
+  it "should convert false to a string" do
+    result = scope.function_bool2httpd([false])
+    expect(result.class).to(eq(String))
+  end
+
+  it "should accept (and return) any string" do
+    result = scope.function_bool2httpd(["mail"])
+    expect(result).to(eq('mail'))
+  end
+
+  it "should accept a nil value (and return Off)" do
+    result = scope.function_bool2httpd([nil])
+    expect(result).to(eq('Off'))
+  end
+
+  it "should accept an undef value (and return 'Off')" do
+    result = scope.function_bool2httpd([:undef])
+    expect(result).to(eq('Off'))
+  end
+
+  it "should return a default value on non-matches" do
+    result = scope.function_bool2httpd(['foo'])
+    expect(result).to(eq('foo'))
+  end
+end


### PR DESCRIPTION
this function tries to recognize booleans of any kind and convert
(normalize) them httpd's accepted On/Off.
Failing that, it will simply return the string it was passed. As such it
can be used, for instance for:

``` puppet
    $server_signature = true
    $server_signature = false
    $server_signature = 'mail'
```
