### PR TITLE
Allow ssl_certs_dir to be unset.

### DIFF
--- a/templates/vhost/_ssl.erb
+++ b/templates/vhost/_ssl.erb
@@ -7,7 +7,9 @@
 <% if @ssl_chain -%>
   SSLCertificateChainFile "<%= @ssl_chain %>"
 <% end -%>
+<% if @ssl_certs_dir -%>
   SSLCACertificatePath    "<%= @ssl_certs_dir %>"
+<% end -%>
 <% if @ssl_ca -%>
   SSLCACertificateFile    "<%= @ssl_ca %>"
 <% end -%>


### PR DESCRIPTION
In some cases we don't want SSLCACertificatePath to be set at all. If we're using SSLCACertificateFile instead to verify clients we might want that to be the only CA used. Most other options in this template are optional, so I don't see why this one can't be too.
