### PR TITLE
Removed stray quotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ To set up a virtual host with a wildcard alias for the subdomain mapped to a sam
     apache::vhost { 'subdomain.loc':
       vhost_name       => '*',
       port             => '80',
-      virtual_docroot' => '/var/www/%-2+',
+      virtual_docroot  => '/var/www/%-2+',
       docroot          => '/var/www',
       serveraliases    => ['*.loc',],
     }


### PR DESCRIPTION
There was a typo in the readme. An extra '.

I've just removed it.
