### PR TITLE
vhost: Create the $logroot only when necessary.

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -273,7 +273,7 @@ define apache::vhost(
   }
 
   # Same as above, but for logroot
-  if ! defined(File[$logroot]) {
+  if ! defined(File[$logroot]) and $ensure == 'present' {
     file { $logroot:
       ensure  => directory,
       mode    => $logroot_mode,


### PR DESCRIPTION
Currently, there is no way to specify default `$logroot` directory permissions.
It will always take the one from default.

Admitting we specify `apache::default_vhost: false`, this will ensure
`default_vhost_ensure` is set to absent. Then it will call
`apache::vhost { 'default'` with `ensure = absent`.

The problem is that the file resource that defines `$logroot` is surrounded
only by an `if !defined()`, so since when default pass it is not defined - yet,
it is true, it then enters and create the `$logroot` with default permissions.

Even if I specify `apache::default_vhost: false` and specify the `$logroot_mode`
of my custom `apache::vhost`, it will never make it in, since it as already be defined.
