### PR TITLE
Exposed $logroot_mode in init.pp

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ Changes the directory where Apache log files for the virtual host are placed. De
 
 #####`logroot_mode`
 
-Overrides the mode the logroot directory is set to. Defaults to undef. Do NOT give people write access to the directory the logs are stored
+Overrides the mode the default logroot directory is set to ($::apache::logroot). Defaults to undef. Do NOT give people write access to the directory the logs are stored
 in without being aware of the consequences; see http://httpd.apache.org/docs/2.4/logs.html#security for details.
 
 #####`manage_group`
@@ -971,6 +971,15 @@ Usage will typically look like:
 #####`logroot`
 
 Specifies the location of the virtual host's logfiles. Defaults to '/var/log/<apache log location>/'.
+
+#####`$logroot_ensure`
+
+Determines whether or not to remove the logroot directory for a virtual host. Valid values are 'directory', or 'absent'.
+
+#####`logroot_mode`
+
+Overrides the mode the logroot directory is set to. Defaults to undef. Do NOT give people write access to the directory the logs are stored
+in without being aware of the consequences; see http://httpd.apache.org/docs/2.4/logs.html#security for details.
 
 #####`log_level`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,6 +53,7 @@ class apache (
   $keepalive_timeout    = $::apache::params::keepalive_timeout,
   $max_keepalive_requests = $apache::params::max_keepalive_requests,
   $logroot              = $::apache::params::logroot,
+  $logroot_mode         = $::apache::params::logroot_mode,
   $log_level            = $::apache::params::log_level,
   $log_formats          = {},
   $ports_file           = $::apache::params::ports_file,
@@ -321,6 +322,7 @@ class apache (
       access_log_file => $access_log_file,
       priority        => '15',
       ip              => $ip,
+      logroot_mode    => $logroot_mode,
     }
     $ssl_access_log_file = $::osfamily ? {
       'freebsd' => $access_log_file,
@@ -336,6 +338,7 @@ class apache (
       access_log_file => $ssl_access_log_file,
       priority        => '15',
       ip              => $ip,
+      logroot_mode    => $logroot_mode,
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -45,6 +45,7 @@ class apache::params inherits ::apache::version {
     $conf_file            = 'httpd.conf'
     $ports_file           = "${conf_dir}/ports.conf"
     $logroot              = '/var/log/httpd'
+    $logroot_mode         = undef
     $lib_path             = 'modules'
     $mpm_module           = 'prefork'
     $dev_packages         = 'httpd-devel'
@@ -109,6 +110,7 @@ class apache::params inherits ::apache::version {
     $conf_file           = 'apache2.conf'
     $ports_file          = "${conf_dir}/ports.conf"
     $logroot             = '/var/log/apache2'
+    $logroot_mode        = undef
     $lib_path            = '/usr/lib/apache2/modules'
     $mpm_module          = 'worker'
     $dev_packages        = ['libaprutil1-dev', 'libapr1-dev', 'apache2-prefork-dev']
@@ -209,6 +211,7 @@ class apache::params inherits ::apache::version {
     $conf_file        = 'httpd.conf'
     $ports_file       = "${conf_dir}/ports.conf"
     $logroot          = '/var/log/apache22'
+    $logroot_mode     = undef
     $lib_path         = '/usr/local/libexec/apache22'
     $mpm_module       = 'prefork'
     $dev_packages     = undef

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -35,6 +35,7 @@ define apache::vhost(
   $directoryindex              = '',
   $vhost_name                  = '*',
   $logroot                     = $::apache::logroot,
+  $logroot_ensure              = 'directory',
   $logroot_mode                = undef,
   $log_level                   = undef,
   $access_log                  = true,
@@ -154,6 +155,10 @@ define apache::vhost(
   if $itk {
     validate_hash($itk)
   }
+  
+  validate_re($logroot_ensure, '^(directory|absent)$',
+  "${logroot_ensure} is not supported for logroot_ensure.
+  Allowed values are 'directory' and 'absent'.")
 
   if $log_level {
     validate_re($log_level, '^(emerg|alert|crit|error|warn|notice|info|debug)$',
@@ -220,9 +225,9 @@ define apache::vhost(
   }
 
   # Same as above, but for logroot
-  if ! defined(File[$logroot]) and $ensure == 'present' {
+  if ! defined(File[$logroot]) {
     file { $logroot:
-      ensure  => directory,
+      ensure  => $logroot_ensure,
       mode    => $logroot_mode,
       require => Package['httpd'],
       before  => Concat["${priority_real}-${filename}.conf"],

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -137,6 +137,7 @@ describe 'apache::vhost', :type => :define do
           'directoryindex'              => 'index.html',
           'vhost_name'                  => 'test',
           'logroot'                     => '/var/www/logs',
+          'logroot_ensure'              => 'directory',
           'logroot_mode'                => '0600',
           'log_level'                   => 'crit',
           'access_log'                  => false,
@@ -252,7 +253,11 @@ describe 'apache::vhost', :type => :define do
       it { is_expected.to contain_class('apache::mod::vhost_alias') }
       it { is_expected.to contain_class('apache::mod::wsgi') }
       it { is_expected.to contain_class('apache::mod::suexec') }
-      it { is_expected.to contain_file('/var/www/logs') }
+      it { is_expected.to contain_file('/var/www/logs').with({
+        'ensure' => 'directory',
+        'mode'   => '0600',
+      })
+      }
       it { is_expected.to contain_class('apache::mod::rewrite') }
       it { is_expected.to contain_class('apache::mod::alias') }
       it { is_expected.to contain_class('apache::mod::proxy') }
@@ -308,6 +313,7 @@ describe 'apache::vhost', :type => :define do
           'ensure'          => 'absent',
           'manage_docroot'  => true,
           'logroot'         => '/tmp/logroot',
+          'logroot_ensure'  => 'absent',
         }
       end
       let :facts do
@@ -336,7 +342,10 @@ describe 'apache::vhost', :type => :define do
       it { is_expected.to_not contain_class('apache::mod::passenger') }
       it { is_expected.to_not contain_class('apache::mod::headers') }
       it { is_expected.to contain_file('/var/www/foo') }
-      it { is_expected.to_not contain_file('/tmp/logroot') }
+      it { is_expected.to contain_file('/tmp/logroot').with({
+        'ensure' => 'absent',
+      })
+      }
       it { is_expected.to contain_concat('25-rspec.example.com.conf').with({
         'ensure' => 'absent',
       })
@@ -519,6 +528,16 @@ describe 'apache::vhost', :type => :define do
         {
           'docroot' => '/rspec/docroot',
           'itk'     => 'bogus',
+        }
+      end
+      let :facts do default_facts end
+      it { expect { is_expected.to compile }.to raise_error }
+    end
+    context 'bad logroot_ensure' do
+      let :params do
+        {
+          'docroot'   => '/rspec/docroot',
+          'log_level' => 'bogus',
         }
       end
       let :facts do default_facts end


### PR DESCRIPTION
This commit now allows you to set the directory permissions on the $logroot
directory. It also resolves a catalog compilation issue when specifying the
apache class with default_vhost => false, and no other vhost resources.
