### PR TITLE
Support itk with mod php

### DIFF
--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -7,8 +7,14 @@ class apache::mod::php (
   $template       = 'apache/mod/php5.conf.erb',
   $source         = undef,
 ) {
-  if ! defined(Class['apache::mod::prefork']) {
-    fail('apache::mod::php requires apache::mod::prefork; please enable mpm_module => \'prefork\' on Class[\'apache\']')
+  if defined(Class['apache::mod::prefork']) {
+    Class['::apache::mod::prefork']->File['php5.conf']
+  }
+  elsif defined(Class['apache::mod::itk']) {
+    Class['::apache::mod::itk']->File['php5.conf']
+  }
+  else {
+    fail('apache::mod::php requires apache::mod::prefork or apache::mod::itk; please enable mpm_module => \'prefork\' or mpm_module => \'itk\' on Class[\'apache\']')
   }
   validate_array($extensions)
 
@@ -46,7 +52,6 @@ class apache::mod::php (
     content => $manage_content,
     source  => $source,
     require => [
-      Class['::apache::mod::prefork'],
       Exec["mkdir ${::apache::mod_dir}"],
     ],
     before  => File[$::apache::mod_dir],

--- a/spec/classes/mod/php_spec.rb
+++ b/spec/classes/mod/php_spec.rb
@@ -19,19 +19,24 @@ describe 'apache::mod::php', :type => :class do
         'class { "apache": mpm_module => prefork, }'
       end
       it { is_expected.to contain_class("apache::params") }
+      it { is_expected.to contain_class("apache::mod::prefork") }
       it { is_expected.to contain_apache__mod('php5') }
       it { is_expected.to contain_package("libapache2-mod-php5") }
       it { is_expected.to contain_file("php5.load").with(
         :content => "LoadModule php5_module /usr/lib/apache2/modules/libphp5.so\n"
       ) }
     end
-    context 'with mpm_module => worker' do
+    context "with mpm_module => itk" do
       let :pre_condition do
-        'class { "apache": mpm_module => worker, }'
+        'class { "apache": mpm_module => itk, }'
       end
-      it 'should raise an error' do
-        expect { subject }.to raise_error Puppet::Error, /mpm_module => 'prefork'/
-      end
+      it { is_expected.to contain_class("apache::params") }
+      it { is_expected.to contain_class("apache::mod::itk") }
+      it { is_expected.to contain_apache__mod('php5') }
+      it { is_expected.to contain_package("libapache2-mod-php5") }
+      it { is_expected.to contain_file("php5.load").with(
+        :content => "LoadModule php5_module /usr/lib/apache2/modules/libphp5.so\n"
+      ) }
     end
   end
   describe "on a RedHat OS" do
@@ -99,11 +104,20 @@ describe 'apache::mod::php', :type => :class do
         'class { "apache": mpm_module => prefork, }'
       end
       it { is_expected.to contain_class("apache::params") }
+      it { is_expected.to contain_class("apache::mod::prefork") }
       it { is_expected.to contain_apache__mod('php5') }
       it { is_expected.to contain_package("php") }
       it { is_expected.to contain_file("php5.load").with(
         :content => "LoadModule php5_module modules/libphp5.so\n"
       ) }
+    end
+    context "with mpm_module => itk" do
+      let :pre_condition do
+        'class { "apache": mpm_module => itk, }'
+      end
+      it 'should raise an error' do
+        expect { expect(subject).to contain_class("apache::mod::itk") }.to raise_error Puppet::Error, /Unsupported osfamily RedHat/
+      end
     end
   end
   describe "on a FreeBSD OS" do
@@ -127,14 +141,15 @@ describe 'apache::mod::php', :type => :class do
       it { is_expected.to contain_package("lang/php5") }
       it { is_expected.to contain_file('php5.load') }
     end
-    # FIXME: not sure about the following context
-    context 'with mpm_module => worker' do
+    context "with mpm_module => itk" do
       let :pre_condition do
-        'class { "apache": mpm_module => worker, }'
+        'class { "apache": mpm_module => itk, }'
       end
-      it 'should raise an error' do
-        expect { expect(subject).to contain_apache__mod('php5') }.to raise_error Puppet::Error, /mpm_module => 'prefork'/
-      end
+      it { is_expected.to contain_class('apache::params') }
+      it { is_expected.to contain_class('apache::mod::itk') }
+      it { is_expected.to contain_apache__mod('php5') }
+      it { is_expected.to contain_package("lang/php5") }
+      it { is_expected.to contain_file('php5.load') }
     end
   end
   describe "OS independent tests" do
@@ -223,6 +238,14 @@ describe 'apache::mod::php', :type => :class do
       it { should contain_file('php5.conf').with(
         :source => 'some-path'
       ) }
+    end
+    context 'with mpm_module => worker' do
+      let :pre_condition do
+        'class { "apache": mpm_module => worker, }'
+      end
+      it 'should raise an error' do
+        expect { expect(subject).to contain_apache__mod('php5') }.to raise_error Puppet::Error, /mpm_module => 'prefork' or mpm_module => 'itk'/
+      end
     end
   end
 end


### PR DESCRIPTION
We have the company policy to use itk on all our production php installations. The restriction to mpm prefork renders the Puppetlabs apache module unusable for our cause.

I extended the integrity checks in mod::php so it also can be used with itk.
