### PR TITLE
ssl mutex directory needs to be set for Debian

### DIFF
--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -12,7 +12,7 @@ class apache::mod::ssl (
 
   case $::osfamily {
     'debian': {
-      if versioncmp($apache_version, '2.4') >= 0 and $::operatingsystem == 'Ubuntu' {
+      if versioncmp($apache_version, '2.4') >= 0 {
         $ssl_mutex = 'default'
       } elsif $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '10.04' {
         $ssl_mutex = 'file:/var/run/apache2/ssl_mutex'


### PR DESCRIPTION
Currently the ssl mutex directory is only set for Apache > 2.4 on Ubuntu. However, this is also required for Debian installations, else the directory that it attempts to use is `/var/run/apache2/ssl_mutex` using Debian Wheezy Backports.
