### PR TITLE
Call install_* methods only once in spec_helper_acceptance

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -3,10 +3,9 @@ require 'beaker-rspec/helpers/serverspec'
 
 
 unless ENV['RS_PROVISION'] == 'no'
-  foss_opts = { :version        => '3.6.2',
-                :facter_version => '2.1.0',
-                :hiera_version  => '1.3.4',
-                :default_action => 'gem_install' }
+  # This will install the latest available package on el and deb based
+  # systems fail on windows and osx, and install via gem on other *nixes
+  foss_opts = { :default_action => 'gem_install' }
 
   if default.is_pe?; then install_pe; else install_puppet( foss_opts ); end
 


### PR DESCRIPTION
Previously, we were calling `install_pe()` or `install_puppet()` for each host even though that helper installs puppet across all hosts. This causes errors on multi host config setups. This also updates the `install_puppet()` invocation to install native packages on windows, osx and fall back to gem on other platforms.

**note in local testing I got past the puppet installation (the affected code) but my run hung on the module install, so someone with a local setup should verify.
