### PR TITLE
Call @proxy_set insteat of proxy_set in inline_template

### DIFF
--- a/manifests/balancer.pp
+++ b/manifests/balancer.pp
@@ -71,7 +71,7 @@ define apache::balancer (
     ensure  => present,
     target  => $target,
     order   => '19',
-    content => inline_template("<% proxy_set.keys.sort.each do |key| %> Proxyset <%= key %>=<%= proxy_set[key] %>\n<% end %>"),
+    content => inline_template("<% @proxy_set.keys.sort.each do |key| %> Proxyset <%= key %>=<%= @proxy_set[key] %>\n<% end %>"),
   }
 
   concat::fragment { "01-${name}-footer":


### PR DESCRIPTION
This commit removes the following depreciation message:
Variable access via 'proxy_set' is deprecated. Use '@proxy_set' instead.
