### PR TITLE
Allow other manifests to define ::apache::mod{ 'ssl': }.

### DIFF
--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -3,6 +3,7 @@ class apache::mod::ssl (
   $ssl_options     = [ 'StdEnvVars' ],
   $ssl_cipher      = 'HIGH:MEDIUM:!aNULL:!MD5',
   $apache_version  = $::apache::apache_version,
+  $package_name    = undef,
 ) {
   $session_cache = $::osfamily ? {
     'debian'  => '${APACHE_RUN_DIR}/ssl_scache(512000)',
@@ -31,7 +32,9 @@ class apache::mod::ssl (
     }
   }
 
-  ::apache::mod { 'ssl': }
+  ::apache::mod { 'ssl':
+    package => $package_name,
+  }
 
   if versioncmp($apache_version, '2.4') >= 0 {
     ::apache::mod { 'socache_shmcb': }

--- a/spec/classes/mod/ssl_spec.rb
+++ b/spec/classes/mod/ssl_spec.rb
@@ -34,6 +34,15 @@ describe 'apache::mod::ssl', :type => :class do
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('ssl') }
     it { is_expected.to contain_package('mod_ssl') }
+    context 'with a custom package_name parameter' do
+      let :params do
+        { :package_name => 'httpd24-mod_ssl' }
+      end
+      it { is_expected.to contain_class('apache::params') }
+      it { is_expected.to contain_apache__mod('ssl') }
+      it { is_expected.to contain_package('httpd24-mod_ssl') }
+      it { is_expected.not_to contain_package('mod_ssl') }
+    end
   end
 
   context 'on a Debian OS' do


### PR DESCRIPTION
This will allow Apache from the httpd24 SCL on RHELish systems to include the proper mod_ssl package while still letting SSL-enabled `::apache::vhost` defines work as expected.

puppetlabs-apache works quite well with the RHEL/CentOS SCLs, like so:

``` puppet
  softwarecollectionsorg { 'httpd24': }
  class { '::apache':
    service_name   => 'httpd24-httpd',
    apache_version => '2.4',
    mpm_module     => 'event',
    httpd_dir      => '/opt/rh/httpd24/root/etc/httpd',
    vhost_dir      => '/opt/rh/httpd24/root/etc/httpd/conf.d',
    require        => Softwarecollectionsorg['httpd24'],
  }
```

That said, its mod_ssl package is named httpd24-mod_ssl. This can also be worked around on its own:

``` puppet
  apache::mod { 'ssl':
    package => 'httpd24-mod_ssl',
    require => Softwarecollectionsorg['httpd24'],
  }
```

When an `apache::vhost` is instantiated with the SSL parameter set to true, however, it will include `::apache::mod::ssl`, which happens to instantiate `::apache::mod { 'ssl': }` without any parameters. This PR allows the details of which package to use for `::apache::mod { 'ssl': }` to be defined and still allow SSL-enabled `::apache::vhost` defines to work.
