### PR TITLE
Allow overriding the detected $apache_name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,10 @@ Controls how TRACE requests per RFC 2616 are handled. More information about [Tr
 
 Changes the location of the configuration directory your virtual host configuration files are placed in. Defaults to 'etc/httpd/conf.d' on RedHat, '/etc/apache2/sites-available' on Debian, and '/usr/local/etc/apache22/Vhosts' on FreeBSD.
 
+#####`apache_name`
+
+The name of the Apache package to install. This is automatically detected in `::apache::params`. You may need to override this if you are using a non-standard Apache package, such as those from Red Hat's software collections.
+
 ####Class: `apache::default_mods`
 
 Installs default Apache modules based on what OS you are running.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,7 @@
 # Sample Usage:
 #
 class apache (
+  $apache_name          = $::apache::params::apache_name,
   $service_name         = $::apache::params::service_name,
   $default_mods         = true,
   $default_vhost        = true,
@@ -83,7 +84,7 @@ class apache (
   if $::osfamily != 'FreeBSD' {
     package { 'httpd':
       ensure => $package_ensure,
-      name   => $::apache::params::apache_name,
+      name   => $apache_name,
       notify => Class['Apache::Service'],
     }
   }

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -541,6 +541,18 @@ describe 'apache', :type => :class do
         :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
       }
     end
+    context 'with a custom apache_name parameter' do
+      let :params do {
+        :apache_name => 'httpd24-httpd'
+      }
+      end
+      it { is_expected.to contain_package("httpd").with(
+        'notify' => 'Class[Apache::Service]',
+        'ensure' => 'installed',
+        'name'   => 'httpd24-httpd'
+        )
+      }
+    end
     context 'default vhost defaults' do
       it { is_expected.to contain_apache__vhost('default').with_ensure('present') }
       it { is_expected.to contain_apache__vhost('default-ssl').with_ensure('absent') }


### PR DESCRIPTION
This will mainly be useful for supporting Red Hat Software Collections, where 'httpd24-httpd' installs Apache 2.4 alongside Apache 2.2 in the base repository. The $service_name parameter already allows customization of the service to use, but not the package.

With this PR, the following can be used to set up and run Apache 2.4 on RHELish systems. (The config snippet I mentioned in #818 was missing this.)

``` puppet
  softwarecollectionsorg { 'httpd24': }
  class { '::apache':
    apache_name    => 'httpd24-httpd',
    service_name   => 'httpd24-httpd',
    apache_version => '2.4',
    mpm_module     => 'event',
    httpd_dir      => '/opt/rh/httpd24/root/etc/httpd',
    vhost_dir      => '/opt/rh/httpd24/root/etc/httpd/conf.d',
    require        => Softwarecollectionsorg['httpd24'],
  }
```
