### PR TITLE
Finish SCL support for RHEL/CentOS 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,10 @@ You may establish a default vhost in this class, the `vhost` class, or both. You
 
 Configures the behavior of the module templates, package names, and default mods by setting the Apache version. Default is determined by the class `apache::version` using the OS family and release. It should not be configured manually without special reason.
 
+#####`conf_dir`
+
+Changes the location of the configuration directory the main configuration file is placed in. Defaults to '/etc/httpd/conf' on RedHat, '/etc/apache2' on Debian, and '/usr/local/etc/apache22' on FreeBSD.
+
 #####`confd_dir`
 
 Changes the location of the configuration directory your custom configuration files are placed in. Defaults to '/etc/httpd/conf' on RedHat, '/etc/apache2' on Debian, and '/usr/local/etc/apache22' on FreeBSD.

--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -11,7 +11,10 @@ class apache::default_mods (
       ::apache::mod { 'log_config': }
       if versioncmp($apache_version, '2.4') >= 0 {
         # Lets fork it
-        ::apache::mod { 'systemd': }
+        # Do not try to load mod_systemd on RHEL/CentOS 6 SCL.
+        if !($::osfamily == 'redhat' and versioncmp($::operatingsystemrelease, '7.0') == -1) {
+          ::apache::mod { 'systemd': }
+        }
         ::apache::mod { 'unixd': }
       }
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,6 +36,7 @@ class apache (
   $timeout              = '120',
   $httpd_dir            = $::apache::params::httpd_dir,
   $server_root          = $::apache::params::server_root,
+  $conf_dir             = $::apache::params::conf_dir,
   $confd_dir            = $::apache::params::confd_dir,
   $vhost_dir            = $::apache::params::vhost_dir,
   $vhost_enable_dir     = $::apache::params::vhost_enable_dir,
@@ -219,7 +220,7 @@ class apache (
     content => template('apache/ports_header.erb')
   }
 
-  if $::apache::params::conf_dir and $::apache::params::conf_file {
+  if $::apache::conf_dir and $::apache::params::conf_file {
     case $::osfamily {
       'debian': {
         $docroot              = '/var/www'
@@ -276,7 +277,7 @@ class apache (
     # - $server_tokens
     # - $server_signature
     # - $trace_enable
-    file { "${::apache::params::conf_dir}/${::apache::params::conf_file}":
+    file { "${::apache::conf_dir}/${::apache::params::conf_file}":
       ensure  => file,
       content => template($conf_template),
       notify  => Class['Apache::Service'],

--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -64,7 +64,7 @@ define apache::mod (
     $package_before = $::osfamily ? {
       'freebsd' => [
         File[$_loadfile_name],
-        File["${::apache::params::conf_dir}/${::apache::params::conf_file}"]
+        File["${::apache::conf_dir}/${::apache::params::conf_file}"]
       ],
       default => File[$_loadfile_name],
     }

--- a/manifests/mod/mime_magic.pp
+++ b/manifests/mod/mime_magic.pp
@@ -1,5 +1,5 @@
 class apache::mod::mime_magic (
-  $magic_file = "${::apache::params::conf_dir}/magic"
+  $magic_file = "${::apache::conf_dir}/magic"
 ) {
   apache::mod { 'mime_magic': }
   # Template uses $magic_file

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -310,6 +310,18 @@ describe 'apache', :type => :class do
       it { is_expected.to contain_file("/etc/httpd/conf/httpd.conf").with_content %r{^Include "/etc/httpd/mod\.d/\*\.load"$} }
     end
 
+    describe "Alternate conf directory" do
+      let :params do
+        { :conf_dir => '/opt/rh/root/etc/httpd/conf' }
+      end
+
+      it { is_expected.to contain_file("/opt/rh/root/etc/httpd/conf/httpd.conf").with(
+        'ensure'  => 'file',
+        'notify'  => 'Class[Apache::Service]',
+        'require' => 'Package[httpd]'
+      ) }
+    end
+
     describe "Alternate conf.d directory" do
       let :params do
         { :confd_dir => '/etc/httpd/special_conf.d' }


### PR DESCRIPTION
This commit, along with #818 and #819, have allowed me to successfully use puppetlabs-apache to install and manage the httpd24 package from Software Collections on Red Hat 6.

I would like to let the current test suite pass, and then I know I owe a README update and some tests for the new `$::apache::conf_dir` parameter.
