### PR TITLE
Add support for specifying the docroot option for RHEL SCL httpd24

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,6 +55,7 @@ class apache (
   $log_level            = $::apache::params::log_level,
   $log_formats          = {},
   $ports_file           = $::apache::params::ports_file,
+  $docroot              = $::apache::params::docroot,
   $apache_version       = $::apache::version::default,
   $server_tokens        = 'OS',
   $server_signature     = 'On',
@@ -222,7 +223,6 @@ class apache (
   if $::apache::params::conf_dir and $::apache::params::conf_file {
     case $::osfamily {
       'debian': {
-        $docroot              = '/var/www'
         $pidfile              = '${APACHE_PID_FILE}'
         $error_log            = 'error.log'
         $error_documents_path = '/usr/share/apache2/error'
@@ -230,7 +230,6 @@ class apache (
         $access_log_file      = 'access.log'
       }
       'redhat': {
-        $docroot              = '/var/www/html'
         $pidfile              = 'run/httpd.pid'
         $error_log            = 'error_log'
         $error_documents_path = '/var/www/error'
@@ -238,7 +237,6 @@ class apache (
         $access_log_file      = 'access_log'
       }
       'freebsd': {
-        $docroot              = '/usr/local/www/apache22/data'
         $pidfile              = '/var/run/httpd.pid'
         $error_log            = 'httpd-error.log'
         $error_documents_path = '/usr/local/www/apache22/error'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -92,6 +92,7 @@ class apache::params inherits ::apache::version {
     $fastcgi_lib_path     = undef
     $mime_support_package = 'mailcap'
     $mime_types_config    = '/etc/mime.types'
+    $docroot              = '/var/www/html'
   } elsif $::osfamily == 'Debian' {
     $user                = 'www-data'
     $group               = 'www-data'
@@ -145,6 +146,7 @@ class apache::params inherits ::apache::version {
     $fastcgi_lib_path       = '/var/lib/apache2/fastcgi'
     $mime_support_package = 'mime-support'
     $mime_types_config    = '/etc/mime.types'
+    $docroot              = '/var/www'
 
     #
     # Passenger-specific settings
@@ -252,6 +254,7 @@ class apache::params inherits ::apache::version {
     $fastcgi_lib_path     = undef # TODO: revisit
     $mime_support_package = 'misc/mime-support'
     $mime_types_config    = '/usr/local/etc/mime.types'
+    $docroot              = '/usr/local/www/apache22/data'
   } else {
     fail("Class['apache::params']: Unsupported osfamily: ${::osfamily}")
   }


### PR DESCRIPTION
The pattern of defining these variables in the init.pp goes back into 2012.
However, it's much better to use the params.pp pattern for this purpose, and
it's also required to make this work with the RHEL's Software Collections.
Without this patch, the Apache::Vhost['default'] is instantiated (regardless
whether it's with ensure => absent or present) and bails out due to /var/www
being missing on asystem which has never had RHEL6's regular httpd package
installed.
