### PR TITLE
Allow multiple balancermember with the same url

### DIFF
--- a/manifests/balancermember.pp
+++ b/manifests/balancermember.pp
@@ -45,7 +45,7 @@ define apache::balancermember(
   $options = [],
 ) {
 
-  concat::fragment { "BalancerMember ${url}":
+  concat::fragment { "BalancerMember ${name}":
     ensure  => present,
     target  => "${::apache::params::confd_dir}/balancer_${balancer_cluster}.conf",
     content => inline_template(" BalancerMember ${url} <%= @options.join ' ' %>\n"),

--- a/spec/defines/balancermember_spec.rb
+++ b/spec/defines/balancermember_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe 'apache::balancermember', :type => :define do
+  let :pre_condition do
+    'include apache
+    apache::balancer {"balancer":}
+    apache::balancer {"balancer-external":}
+    apache::balancermember {"http://127.0.0.1:8080-external": url => "http://127.0.0.1:8080/", balancer_cluster => "balancer-external"}
+    '
+  end
+  let :title do
+    'http://127.0.0.1:8080/'
+  end
+  let :params do
+    {
+      :options          => [],
+      :url              => 'http://127.0.0.1:8080/',
+      :balancer_cluster => 'balancer-internal'
+    }
+  end
+  let :facts do
+    {
+      :osfamily               => 'Debian',
+      :operatingsystem        => 'Debian',
+      :operatingsystemrelease => '6',
+      :lsbdistcodename        => 'squeeze',
+      :id                     => 'root',
+      :concat_basedir         => '/dne',
+      :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      :kernel                 => 'Linux',
+    }
+  end
+  describe "allows multiple balancermembers with the same url" do
+    it { should contain_concat__fragment('BalancerMember http://127.0.0.1:8080/') }
+  end
+end


### PR DESCRIPTION
Currently you can't set multiple balancermembers with the same url even
if they are bind to different balancers.

This commit fixes that unwanted behaviour.
