### PR TITLE
force class definition checks to use absolute scope

### DIFF
--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -7,10 +7,10 @@ class apache::mod::php (
   $template       = 'apache/mod/php5.conf.erb',
   $source         = undef,
 ) {
-  if defined(Class['apache::mod::prefork']) {
+  if defined(Class['::apache::mod::prefork']) {
     Class['::apache::mod::prefork']->File['php5.conf']
   }
-  elsif defined(Class['apache::mod::itk']) {
+  elsif defined(Class['::apache::mod::itk']) {
     Class['::apache::mod::itk']->File['php5.conf']
   }
   else {


### PR DESCRIPTION
Fix for: https://tickets.puppetlabs.com/browse/FM-1826

Applied same fix as much as possible to v1.1.1 on the forge and catalogue still compiles and runs but don't have the student code to fully replicate the original error condition and confirm resolution.

Needs comprehensive testing before merge
