### PR TITLE
Ensure that mod packages are installed before conf

### DIFF
--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -68,6 +68,8 @@ define apache::mod (
       ],
       default => File[$_loadfile_name],
     }
+    # if there are any packages, they should be installed before the associated conf file
+    Package[$_package] -> File<| title == "${mod}.conf" |>
     # $_package may be an array
     package { $_package:
       ensure  => $package_ensure,


### PR DESCRIPTION
Currently, there is no strict ordering that ensures
that the conf file is only created after a mods
packages are installed.

This means that it is possible for the .conf file to be
created before package installation.

In the case of libapache2-mod-wsgi (3.4-4ubuntu2.1.14.04.1),
this lead to a package install failure on Ubuntu Trusty

dpkg: error processing package libapache2-mod-wsgi (--configure):
subprocess installed post-installation script returned error exit status 1
Errors were encountered while processing:
  libapache2-mod-wsgi
  Sub-process /usr/bin/dpkg returned an error code (1)

The order is ensured by this patch by assuming that the mod.conf
file is named: "${mod}.conf" (the same assumption made by the related
symlink) and placing a conditional dependency on all packages indicated
being required for the installation of the module.
