### PR TITLE
fix allowes for directories

### DIFF
--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -54,10 +54,10 @@
       <%- if directory['allow'] and ! [ false, 'false', '' ].include?(directory['allow']) -%>
         <%- if directory['allow'].kind_of?(Array) -%>
           <%- Array(directory['allow']).each do |access| -%>
-    Allow <%=  access %>
+    Allow from <%= access %>
         <%- end -%>
       <%- else -%>
-    Allow <%= directory['allow'] %>
+    Allow from <%= directory['allow'] %>
       <%- end -%>
       <%- elsif [ 'from all', 'from All' ].include?(directory['deny']) -%>
       <%- elsif ! directory['deny'] and [ false, 'false', '' ].include?(directory['allow']) -%>

--- a/tests/vhost_directories.pp
+++ b/tests/vhost_directories.pp
@@ -42,3 +42,14 @@ apache::vhost { 'files.example.net':
   ],
 }
 
+# allow from test
+apache::vhost { 'allowtest.example.net':
+  docroot     => '/var/www/readme',
+  directories => [
+    {
+      'path'  => '/usr/share/empty',
+      'allow' => ['127.0.0.1', '10.0.0.1'],
+    },
+  ],
+}
+


### PR DESCRIPTION
There is typo in template for vhost, in apache configuration allow requires two arguments, 'from' and ip/hostname.