### PR TITLE
Fix formatting of sethandler description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1629,6 +1629,7 @@ Sets a `Satisfy` directive as per the [Apache Core documentation](http://httpd.a
         }
       ],
     }
+```
 
 ######`sethandler`
 


### PR DESCRIPTION
The code example in the `satisfy` section didn't close the code block.
