### PR TITLE
(FM-1876) Remove trailing whitespace from manifests/vhost.pp

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -155,7 +155,7 @@ define apache::vhost(
   if $itk {
     validate_hash($itk)
   }
-  
+
   validate_re($logroot_ensure, '^(directory|absent)$',
   "${logroot_ensure} is not supported for logroot_ensure.
   Allowed values are 'directory' and 'absent'.")


### PR DESCRIPTION
This commit allows apache's lint tests to pass.
