### PR TITLE
Fix duplicate declarations when puppet manages logroot for vhosts

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -35,6 +35,7 @@ define apache::vhost(
   $directoryindex              = '',
   $vhost_name                  = '*',
   $logroot                     = $::apache::logroot,
+  $manage_logroot              = true,
   $logroot_ensure              = 'directory',
   $logroot_mode                = undef,
   $log_level                   = undef,
@@ -225,7 +226,7 @@ define apache::vhost(
   }
 
   # Same as above, but for logroot
-  if ! defined(File[$logroot]) {
+  if ! defined(File[$logroot]) and $manage_logroot {
     file { $logroot:
       ensure  => $logroot_ensure,
       mode    => $logroot_mode,


### PR DESCRIPTION
Getting duplicate declaration errors for logroots managed from puppet and _not_ apache even though it tries to create it _only_ if not defined.
