### PR TITLE
Revert "strict_variables fix" -- accidentally merged onto 1.1.x

### DIFF
--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -46,8 +46,6 @@ define apache::mod (
     $_package = $package
   } elsif $mod_package {
     $_package = $mod_package
-  } else {
-    $_package = undef
   }
   if $_package and ! defined(Package[$_package]) {
     # note: FreeBSD/ports uses apxs tool to activate modules; apxs clutters

--- a/manifests/mod/proxy_html.pp
+++ b/manifests/mod/proxy_html.pp
@@ -6,7 +6,6 @@ class apache::mod::proxy_html {
   case $::osfamily {
     /RedHat|FreeBSD/: {
       ::apache::mod { 'xml2enc': }
-      $loadfiles = undef
     }
     'Debian': {
       $gnu_path = $::hardwaremodel ? {

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -1,7 +1,7 @@
 class apache::package (
   $ensure     = 'present',
   $mpm_module = $::apache::params::mpm_module,
-) inherits ::apache::params {
+) {
   case $::osfamily {
     'freebsd' : {
       $all_mpms = [

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,9 +39,7 @@ class apache::params inherits ::apache::version {
     $conf_dir             = "${httpd_dir}/conf"
     $confd_dir            = "${httpd_dir}/conf.d"
     $mod_dir              = "${httpd_dir}/conf.d"
-    $mod_enable_dir       = undef
     $vhost_dir            = "${httpd_dir}/conf.d"
-    $vhost_enable_dir     = undef
     $conf_file            = 'httpd.conf'
     $ports_file           = "${conf_dir}/ports.conf"
     $logroot              = '/var/log/httpd'

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -325,7 +325,6 @@ define apache::vhost(
       $listen_addr_port = "${ip}:${port}"
       $nvh_addr_port = "${ip}:${port}"
     } else {
-      $listen_addr_port = undef
       $nvh_addr_port = $ip
       if ! $servername and ! $ip_based {
         fail("Apache::Vhost[${name}]: must pass 'ip' and/or 'port' parameters for name-based vhosts")
@@ -336,7 +335,6 @@ define apache::vhost(
       $listen_addr_port = $port
       $nvh_addr_port = "${vhost_name}:${port}"
     } else {
-      $listen_addr_port = undef
       $nvh_addr_port = $name
       if ! $servername {
         fail("Apache::Vhost[${name}]: must pass 'ip' and/or 'port' parameters, and/or 'servername' parameter")


### PR DESCRIPTION
Reverts puppetlabs/puppetlabs-apache#835

i'm pretty sure we're not supposed to do that.
