### PR TITLE
Modify behaviour of MODULES-1294

### DIFF
--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -39,7 +39,7 @@
     <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
       <%- if directory['require'] and directory['require'] != '' -%>
     Require <%= Array(directory['require']).join(' ') %>
-      <%- else -%>
+      <%- elsif directory['require'].nil? -%>
     Require all granted
       <%- end -%>
     <%- else -%>


### PR DESCRIPTION
This change makes it so that "Require all granted" is only added to directory entries if the require property is undefined, keeping default behaviour. But if the require property is defined as an empty string or false (or any "falsey" value) it will not add the line.