### PR TITLE
(#MODULES-1332) set osfamily default for wsgi_socket_prefix

### DIFF
--- a/manifests/mod/wsgi.pp
+++ b/manifests/mod/wsgi.pp
@@ -1,5 +1,5 @@
 class apache::mod::wsgi (
-  $wsgi_socket_prefix = undef,
+  $wsgi_socket_prefix = $::apache::params::wsgi_socket_prefix,
   $wsgi_python_path   = undef,
   $wsgi_python_home   = undef,
 ){

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -93,6 +93,11 @@ class apache::params inherits ::apache::version {
     $fastcgi_lib_path     = undef
     $mime_support_package = 'mailcap'
     $mime_types_config    = '/etc/mime.types'
+    if $::osfamily == "RedHat" {
+      $wsgi_socket_prefix = '/var/run/wsgi'
+    } else {
+      $wsgi_socket_prefix = undef
+    }
   } elsif $::osfamily == 'Debian' {
     $user                = 'www-data'
     $group               = 'www-data'
@@ -194,6 +199,7 @@ class apache::params inherits ::apache::version {
         }
       }
     }
+    $wsgi_socket_prefix = undef
   } elsif $::osfamily == 'FreeBSD' {
     $user             = 'www'
     $group            = 'www'
@@ -255,6 +261,7 @@ class apache::params inherits ::apache::version {
     $fastcgi_lib_path     = undef # TODO: revisit
     $mime_support_package = 'misc/mime-support'
     $mime_types_config    = '/usr/local/etc/mime.types'
+    $wsgi_socket_prefix   = undef
   } else {
     fail("Class['apache::params']: Unsupported osfamily: ${::osfamily}")
   }

--- a/spec/classes/mod/wsgi_spec.rb
+++ b/spec/classes/mod/wsgi_spec.rb
@@ -18,7 +18,10 @@ describe 'apache::mod::wsgi', :type => :class do
       }
     end
     it { is_expected.to contain_class("apache::params") }
-    it { is_expected.to contain_apache__mod('wsgi') }
+    it { is_expected.to contain_class('apache::mod::wsgi').with(
+        'wsgi_socket_prefix' => nil
+      )
+    }
     it { is_expected.to contain_package("libapache2-mod-wsgi") }
   end
   context "on a RedHat OS" do
@@ -34,7 +37,10 @@ describe 'apache::mod::wsgi', :type => :class do
       }
     end
     it { is_expected.to contain_class("apache::params") }
-    it { is_expected.to contain_apache__mod('wsgi') }
+    it { is_expected.to contain_class('apache::mod::wsgi').with(
+        'wsgi_socket_prefix' => '/var/run/wsgi'
+      )
+    }
     it { is_expected.to contain_package("mod_wsgi") }
 
     describe "with custom WSGISocketPrefix" do
@@ -63,7 +69,10 @@ describe 'apache::mod::wsgi', :type => :class do
       }
     end
     it { is_expected.to contain_class("apache::params") }
-    it { is_expected.to contain_apache__mod('wsgi') }
+    it { is_expected.to contain_class('apache::mod::wsgi').with(
+        'wsgi_socket_prefix' => nil
+      )
+    }
     it { is_expected.to contain_package("www/mod_wsgi") }
   end
 end


### PR DESCRIPTION
Add an osfamily based default class parameter value for the
wsgi_socket_prefix parameter of apache::mod::wsgi.  The default
value on RedHat osfamily platforms is '/var/run/wsgi'.  On other
platforms, use the Apache default.
