### PR TITLE
enable apache::mod to set prefix to ensure certain load order of modules...

### DIFF
--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -44,14 +44,14 @@ class apache::default_mods (
 
         if $apache_version >= 2.4 {
           # Lets fork it
-          ::apache::mod { 'systemd': }
+          ::apache::mod { 'systemd': prefix => '00-' }
 
-          ::apache::mod { 'unixd': }
-          ::apache::mod { 'authn_core': }
+          ::apache::mod { 'unixd': prefix => '00-' }
+          ::apache::mod { 'authn_core': prefix => '00-' }
         }
         else {
-          ::apache::mod { 'authn_alias': }
-          ::apache::mod { 'authn_default': }
+          ::apache::mod { 'authn_alias': prefix => '00-' }
+          ::apache::mod { 'authn_default': prefix => '00-' }
         }
       }
       'freebsd': {

--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -1,5 +1,6 @@
 define apache::mod (
   $package = undef,
+  $prefix = '',
   $package_ensure = 'present',
   $lib = undef,
   $lib_path = $::apache::params::lib_path,
@@ -69,7 +70,7 @@ define apache::mod (
 
   file { "${mod}.load":
     ensure  => file,
-    path    => "${mod_dir}/${mod}.load",
+    path    => "${mod_dir}/${prefix}${mod}.load",
     owner   => 'root',
     group   => $::apache::params::root_group,
     mode    => '0644',


### PR DESCRIPTION
... and ensure that default_mods is loaded before other mods.

This fixes the issue, that f.ex. fcgid in apache on centos 7 - loads in wrong order (see https://tickets.puppetlabs.com/browse/MODULES-1331 )
