### PR TITLE
Change $port to interpolated string "${port}" to fix "Cannot use Fixnu...

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -302,7 +302,7 @@ define apache::vhost(
     }
   }
   if $add_listen {
-    if $ip and defined(Apache::Listen[$port]) {
+    if $ip and defined(Apache::Listen["${port}"]) {
       fail("Apache::Vhost[${name}]: Mixing IP and non-IP Listen directives is not possible; check the add_listen parameter of the apache::vhost define to disable this")
     }
     if ! defined(Apache::Listen["${listen_addr_port}"]) and $listen_addr_port and $ensure == 'present' {


### PR DESCRIPTION
...m where String is expected" errors under Puppet 3.7.x
