### PR TITLE
(FM-1907) Fix mod_negotation system tests

### DIFF
--- a/spec/acceptance/mod_negotiation_spec.rb
+++ b/spec/acceptance/mod_negotiation_spec.rb
@@ -19,13 +19,13 @@ describe 'apache::mod::negotiation class', :unless => UNSUPPORTED_PLATFORMS.incl
   context "default negotiation config" do
     it 'succeeds in puppeting negotiation' do
       pp= <<-EOS
-        class { '::apache': }
+        class { '::apache': default_mods => false }
         class { '::apache::mod::negotiation': }
       EOS
       apply_manifest(pp, :catch_failures => true)
     end
 
-    describe file("#{$mod_dir}/negotiation.conf") do
+    describe file("#{mod_dir}/negotiation.conf") do
       it { should contain "LanguagePriority en ca cs da de el eo es et fr he hr it ja ko ltz nl nn no pl pt pt-BR ru sv zh-CN zh-TW
 ForceLanguagePriority Prefer Fallback" }
     end
@@ -39,7 +39,7 @@ ForceLanguagePriority Prefer Fallback" }
   context "with alternative force_language_priority" do
     it 'succeeds in puppeting negotiation' do
       pp= <<-EOS
-        class { '::apache': }
+        class { '::apache': default_mods => false }
         class { '::apache::mod::negotiation':
           force_language_priority => 'Prefer',
         }
@@ -47,7 +47,7 @@ ForceLanguagePriority Prefer Fallback" }
       apply_manifest(pp, :catch_failures => true)
     end
 
-    describe file("#{$mod_dir}/negotiation.conf") do
+    describe file("#{mod_dir}/negotiation.conf") do
       it { should contain "ForceLanguagePriority Prefer" }
     end
 
@@ -60,7 +60,7 @@ ForceLanguagePriority Prefer Fallback" }
   context "with alternative language_priority" do
     it 'succeeds in puppeting negotiation' do
       pp= <<-EOS
-        class { '::apache': }
+        class { '::apache': default_mods => false }
         class { '::apache::mod::negotiation':
           language_priority => [ 'en', 'es' ],
         }
@@ -68,7 +68,7 @@ ForceLanguagePriority Prefer Fallback" }
       apply_manifest(pp, :catch_failures => true)
     end
 
-    describe file("#{$mod_dir}/negotiation.conf") do
+    describe file("#{mod_dir}/negotiation.conf") do
       it { should contain "LanguagePriority en es" }
     end
 


### PR DESCRIPTION
Previously we were including the base apache class and then including the
'apache::mod::negotiation' class. However the apache class includes
'apache::mod::negoatiation' by default. Telling apache not to use its
default mods fixes this error.

There was also a reference to '$mod_dir' when finding the negotiation.conf
instead of just 'mod_dir'.

s/puppet code/ruby code/g fixed the issue. :)
