### PR TITLE
(FM-1908) fixup mod_php tests

### DIFF
--- a/spec/acceptance/mod_php_spec.rb
+++ b/spec/acceptance/mod_php_spec.rb
@@ -132,42 +132,4 @@ describe 'apache::mod::php class', :unless => UNSUPPORTED_PLATFORMS.include?(fac
     end
   end
 
-  context "provide source has priority over content" do
-    it 'succeeds in puppeting php' do
-      pp= <<-EOS
-        class {'apache':
-          mpm_module => 'prefork',
-        }
-        class {'apache::mod::php':
-          content => '# somecontent',
-          source  => 'puppet:///modules/apache/spec',
-        }
-      EOS
-      apply_manifest(pp, :catch_failures => true)
-    end
-
-    describe file("#{mod_dir}/php5.conf") do
-      it { should contain "# This is a file only for spec testing" }
-    end
-  end
-
-  context "provide source has priority over template" do
-    it 'succeeds in puppeting php' do
-      pp= <<-EOS
-        class {'apache':
-          mpm_module => 'prefork',
-        }
-        class {'apache::mod::php':
-          template => 'apache/mod/php5.conf.erb',
-          source   => 'puppet:///modules/apache/spec',
-        }
-      EOS
-      apply_manifest(pp, :catch_failures => true)
-    end
-
-    describe file("#{mod_dir}/php5.conf") do
-      it { should contain "# This is a file only for spec testing" }
-    end
-  end
-
 end


### PR DESCRIPTION
Previously we were testing that the source attribute for
apache::mod::php overrode the content and template attributes. This
began failing with the removal of files/spec file (it was the target
used by the source attribute in testing. These are the kinds of tests
that are slated for removal with the test refactor, best course is to
remove them now.

Note: I _think_ this is the correct course of action....
