### PR TITLE
(FM-1911) Fixup passenger system test

### DIFF
--- a/spec/acceptance/mod_passenger_spec.rb
+++ b/spec/acceptance/mod_passenger_spec.rb
@@ -262,7 +262,7 @@ describe 'apache::mod::passenger class', :unless => UNSUPPORTED_PLATFORMS.includ
           end
 
           it 'should output status via passenger-memory-stats' do
-            shell("sudo /usr/bin/passenger-memory-stats") do |r|
+            shell("sudo /usr/bin/passenger-memory-stats", :pty => true) do |r|
               expect(r.stdout).to match(/Apache processes/)
               expect(r.stdout).to match(/Nginx processes/)
               expect(r.stdout).to match(/Passenger processes/)


### PR DESCRIPTION
Previously we were running a command via sudo, which requires a TTY. The
testing framework does not allocate a TTY by default, passing the
`:pty => true` option corrects this.
