### PR TITLE
Update default_mods.pp

### DIFF
--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -12,7 +12,7 @@ class apache::default_mods (
       if versioncmp($apache_version, '2.4') >= 0 {
         # Lets fork it
         # Do not try to load mod_systemd on RHEL/CentOS 6 SCL.
-        if !($::osfamily == 'redhat' and versioncmp($::operatingsystemrelease, '7.0') == -1) {
+        if ( !($::osfamily == 'redhat' and versioncmp($::operatingsystemrelease, '7.0') == -1) and !($::operatingsystem == 'Amazon' and versioncmp($::operatingsystemrelease, '2014.09') <= 0  ) ) {
           ::apache::mod { 'systemd': }
         }
         ::apache::mod { 'unixd': }


### PR DESCRIPTION
This should cover the case that on a Amazon AWS Image that is based on RHEL6/CentOS6 but the Apache in version 2.4 should be used, to avoid to load the non existing systemd Apache module.
