### PR TITLE
MODULES-1348 - apache::vhost concat ordering

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -395,6 +395,7 @@ define apache::vhost(
     owner   => 'root',
     group   => $::apache::params::root_group,
     mode    => '0644',
+    order   => 'numeric',
     require => Package['httpd'],
     notify  => Service['httpd'],
   }


### PR DESCRIPTION
Need to set `order => 'numeric'` for the concat resource in
apache::vhost so that the fragments get concatenated in the correct
order.
