### PR TITLE
Revert "Remove deprecated purge_vdir; Rename variables"

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,6 +30,7 @@ class apache (
   $service_ensure       = 'running',
   $purge_configs        = true,
   $purge_vhost_dir      = undef,
+  $purge_vdir           = false,
   $serveradmin          = 'root@localhost',
   $sendfile             = 'On',
   $error_documents      = false,
@@ -121,11 +122,19 @@ class apache (
     service_ensure => $service_ensure,
   }
 
+  # Deprecated backwards-compatibility
+  if $purge_vdir {
+    warning('Class[\'apache\'] parameter purge_vdir is deprecated in favor of purge_configs')
+    $purge_confd = $purge_vdir
+  } else {
+    $purge_confd = $purge_configs
+  }
+
   # Set purge vhostd appropriately
   if $purge_vhost_dir == undef {
-    $_purge_vhost_dir = $purge_configs
+    $purge_vhostd = $purge_confd
   } else {
-    $_purge_vhost_dir = $purge_vhost_dir
+    $purge_vhostd = $purge_vhost_dir
   }
 
   Exec {
@@ -139,7 +148,7 @@ class apache (
   file { $confd_dir:
     ensure  => directory,
     recurse => true,
-    purge   => $purge_configs,
+    purge   => $purge_confd,
     notify  => Class['Apache::Service'],
     require => Package['httpd'],
   }
@@ -185,7 +194,7 @@ class apache (
     file { $vhost_dir:
       ensure  => directory,
       recurse => true,
-      purge   => $_purge_vhost_dir,
+      purge   => $purge_vhostd,
       notify  => Class['Apache::Service'],
       require => Package['httpd'],
     }
@@ -200,7 +209,7 @@ class apache (
     file { $vhost_enable_dir:
       ensure  => directory,
       recurse => true,
-      purge   => $_purge_vhost_dir,
+      purge   => $purge_vhostd,
       notify  => Class['Apache::Service'],
       require => Package['httpd'],
     }


### PR DESCRIPTION
Reverts puppetlabs/puppetlabs-apache#789

We're not ready for a backwards-incompatible release of apache, and this looks to be the only breaking change that has been merged since 1.1.1.
