### PR TITLE
Remove deprecated concat::setup class

### DIFF
--- a/manifests/balancer.pp
+++ b/manifests/balancer.pp
@@ -42,7 +42,6 @@ define apache::balancer (
   $proxy_set = {},
   $collect_exported = true,
 ) {
-  include concat::setup
   include ::apache::mod::proxy_balancer
 
   $target = "${::apache::params::confd_dir}/balancer_${name}.conf"

--- a/metadata.json
+++ b/metadata.json
@@ -74,7 +74,7 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.1.0"
+      "version_requirement": ">= 1.1.1"
     }
   ]
 }


### PR DESCRIPTION
This commit removes the deprecated concat::setup and bumps the
dependency on concat to >= 1.1.1 to avoid an idempotency bug in v1.1.0
