### PR TITLE
Fix Shib setting rules.

### DIFF
--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -199,9 +199,9 @@
       <%- if directory['shib_require_session'] and ! directory['shib_require_session'].empty? -%>
     ShibRequireSession <%= directory['shib_require_session'] %>
       <%- end -%>
-      <%- if directory['shib_request_settings'] -%>
-        <%- Array(directory['shib_request_settings']).each do |setting| -%>
-    ShibRequestSetting <%= setting %>
+      <%- if directory['shib_request_settings'] and ! directory['shib_request_settings'].empty? -%>
+        <%- directory['shib_request_settings'].each do |key,value| -%>
+    ShibRequestSetting <%= key %> <%= value %>
         <%- end -%>
       <%- end -%>
       <%- if directory['shib_use_headers'] and ! directory['shib_use_headers'].empty? -%>


### PR DESCRIPTION
I think ShibRequireSetting was a mental mixup between ShibRequireSession
and ShibRequestSetting. I've replaced it with separate options for both. The latter is
an array as you can set multiple different settings, while the former is a simple
On or Off value. Each item in the settings array should be the name and value of the setting,
e.g. ['requireSession false', 'applicationId myresource']
