### PR TITLE
Changes to address the changed cache_root and module name in Apache 2.4.

### DIFF
--- a/manifests/mod/disk_cache.pp
+++ b/manifests/mod/disk_cache.pp
@@ -1,9 +1,21 @@
 class apache::mod::disk_cache {
-  $cache_root = $::osfamily ? {
-    'debian'  => '/var/cache/apache2/mod_disk_cache',
-    'redhat'  => '/var/cache/mod_proxy',
-    'freebsd' => '/var/cache/mod_disk_cache',
+  if $::apache::apache_version >= 2.4 {
+    $cache_root = $::osfamily ? {
+      'debian'  => '/var/cache/apache2/mod_cache_disk',
+      'redhat'  => '/var/cache/httpd/proxy',
+      'freebsd' => '/var/cache/mod_disk_cache', # TODO: Confirm
+    }
+    apache::mod { 'cache_disk': }
   }
+  else {
+    $cache_root = $::osfamily ? {
+      'debian'  => '/var/cache/apache2/mod_disk_cache',
+      'redhat'  => '/var/cache/mod_proxy',
+      'freebsd' => '/var/cache/mod_disk_cache',
+    }
+    apache::mod { 'disk_cache': }
+  }
+
   if $::osfamily != 'FreeBSD' {
     # FIXME: investigate why disk_cache was dependent on proxy
     # NOTE: on FreeBSD disk_cache is compiled by default but proxy is not
@@ -11,7 +23,6 @@ class apache::mod::disk_cache {
   }
   Class['::apache::mod::cache'] -> Class['::apache::mod::disk_cache']
 
-  apache::mod { 'disk_cache': }
   # Template uses $cache_root
   file { 'disk_cache.conf':
     ensure  => file,

--- a/manifests/mod/disk_cache.pp
+++ b/manifests/mod/disk_cache.pp
@@ -12,7 +12,7 @@ class apache::mod::disk_cache {
   Class['::apache::mod::cache'] -> Class['::apache::mod::disk_cache']
 
   apache::mod { 'disk_cache': }
-  # Template uses $cache_proxy
+  # Template uses $cache_root
   file { 'disk_cache.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/disk_cache.conf",

--- a/templates/mod/disk_cache.conf.erb
+++ b/templates/mod/disk_cache.conf.erb
@@ -1,8 +1,4 @@
-<IfModule mod_proxy.c>
-  <IfModule mod_disk_cache.c>
-     CacheEnable disk /
-     CacheRoot "<%= @cache_root %>"
-     CacheDirLevels 2
-     CacheDirLength 1
-  </IfModule>
-</IfModule>
+CacheEnable disk /
+CacheRoot "<%= @cache_root %>"
+CacheDirLevels 2
+CacheDirLength 1


### PR DESCRIPTION
A new mod_name variable is included in apache::mod::disk_cache as it changed from mod_disk_cache to mod_cache_disk. This is used to load the correct module and by the disk_cache.conf template.

The default cache_root changed from /var/cache/mod_proxy to /var/cache/httpd/proxy (on Redhat).

TODO: confirm if the default cache root changed on either Debian or FreeBSD.