### PR TITLE
Allow specifying all alias directives in `aliases`

### DIFF
--- a/README.md
+++ b/README.md
@@ -894,20 +894,31 @@ Specifies paths to additional static, vhost-specific Apache configuration files.
 
 #####`aliases`
 
-Passes a list of hashes to the vhost to create Alias or AliasMatch directives as per the [mod_alias documentation](http://httpd.apache.org/docs/current/mod/mod_alias.html). These hashes are formatted as follows:
+Passes a list of hashes to the vhost to create Alias, AliasMatch, ScriptAlias or ScriptAliasMatch directives as per the [mod_alias documentation](http://httpd.apache.org/docs/current/mod/mod_alias.html). These hashes are formatted as follows:
 
 ```puppet
 aliases => [
-  { aliasmatch => '^/image/(.*)\.jpg$', 
-    path       => '/files/jpg.images/$1.jpg',
+  { aliasmatch       => '^/image/(.*)\.jpg$',
+    path             => '/files/jpg.images/$1.jpg',
   }
-  { alias      => '/image',
-    path       => '/ftp/pub/image', 
+  { alias            => '/image',
+    path             => '/ftp/pub/image',
+  },
+  { scriptaliasmatch => '^/cgi-bin(.*)',
+    path             => '/usr/local/share/cgi-bin$1',
+  },
+  { scriptalias      => '/nagios/cgi-bin/',
+    path             => '/usr/lib/nagios/cgi-bin/',
+  },
+  { alias            => '/nagios',
+    path             => '/usr/share/nagios/html',
   },
 ],
 ```
 
-For `alias` and `aliasmatch` to work, each needs a corresponding context, such as '< Directory /path/to/directory>' or '<Location /path/to/directory>'. The Alias and AliasMatch directives are created in the order specified in the `aliases` parameter. As described in the [`mod_alias` documentation](http://httpd.apache.org/docs/current/mod/mod_alias.html), more specific `alias` or `aliasmatch` parameters should come before the more general ones to avoid shadowing.
+For `alias`, `aliasmatch`, `scriptalias` and `scriptaliasmatch` to work, each needs a corresponding context, such as `<Directory /path/to/directory>` or `<Location /some/location/here>`. The directives are created in the order specified in the `aliases` parameter. As described in the [`mod_alias` documentation](http://httpd.apache.org/docs/current/mod/mod_alias.html), more specific `alias`, `aliasmatch`, `scriptalias` or `scriptaliasmatch` parameters should come before the more general ones to avoid shadowing.
+
+*Note*: Using the `aliases` parameter is preferred over the `scriptaliases` parameter since here the order of the various alias directives among each other can be controlled precisely. Defining ScriptAliases using the `scriptaliases` parameter means *all* ScriptAlias directives will come after *all* Alias directives, which can lead to Alias directives shadowing ScriptAlias directives. This is often problematic, for example in case of Nagios.
 
 *Note:* If `apache::mod::passenger` is loaded and `PassengerHighPerformance => true` is set, then Alias might have issues honoring the `PassengerEnabled => off` statement. See [this article](http://www.conandalton.net/2010/06/passengerenabled-off-not-working.html) for details.
 
@@ -1241,6 +1252,8 @@ Refer to the [`mod_rewrite` documentation](http://httpd.apache.org/docs/current/
 Defines a directory of CGI scripts to be aliased to the path '/cgi-bin', for example: '/usr/scripts'. Defaults to 'undef'.
 
 #####`scriptaliases`
+
+*Note*: This parameter is deprecated in favour of the `aliases` parameter.
 
 Passes an array of hashes to the vhost to create either ScriptAlias or ScriptAliasMatch statements as per the [`mod_alias` documentation](http://httpd.apache.org/docs/current/mod/mod_alias.html). These hashes are formatted as follows:
 

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -768,7 +768,10 @@ describe 'apache::vhost define', :unless => UNSUPPORTED_PLATFORMS.include?(fact(
         host { 'test.server': ip => '127.0.0.1' }
         apache::vhost { 'test.server':
           docroot    => '/tmp',
-          aliases => [{ alias => '/image', path => '/ftp/pub/image' }],
+          aliases => [
+            { alias       => '/image'    , path => '/ftp/pub/image' }   ,
+            { scriptalias => '/myscript' , path => '/usr/share/myscript' }
+          ],
         }
       EOS
       apply_manifest(pp, :catch_failures => true)
@@ -777,6 +780,7 @@ describe 'apache::vhost define', :unless => UNSUPPORTED_PLATFORMS.include?(fact(
     describe file("#{$vhost_dir}/25-test.server.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain 'Alias /image "/ftp/pub/image"' }
+      it { is_expected.to contain 'ScriptAlias /myscript "/usr/share/myscript"' }
     end
   end
 

--- a/templates/vhost/_aliases.erb
+++ b/templates/vhost/_aliases.erb
@@ -6,6 +6,10 @@
   Alias <%= alias_statement["alias"] %> "<%= alias_statement["path"] %>"
       <%- elsif alias_statement["aliasmatch"] and alias_statement["aliasmatch"] != '' -%>
   AliasMatch <%= alias_statement["aliasmatch"] %> "<%= alias_statement["path"] %>"
+      <%- elsif alias_statement["scriptalias"] and alias_statement["scriptalias"] != '' -%>
+  ScriptAlias <%= alias_statement["scriptalias"] %> "<%= alias_statement["path"] %>"
+      <%- elsif alias_statement["scriptaliasmatch"] and alias_statement["scriptaliasmatch"] != '' -%>
+  ScriptAliasMatch <%= alias_statement["scriptaliasmatch"] %> "<%= alias_statement["path"] %>"
       <%- end -%>
     <%- end -%>
   <%- end -%>


### PR DESCRIPTION
Controlling the order of the Alias, ScriptAlias, AliasMatch and
ScriptAliasMatch directives is important to avoid directives shadowing
each other. Having an `aliases` parameter for Alias and AliasMatch
directives and a `scriptalias` parameter for ScriptAlias and
ScriptAliasMatch directives means all Aliases appear before all
ScriptAliases in the vhost configuration file, which means an Alias
directive can shadow a ScriptAlias directive. This breaks things like
the Nagios web interface.

Instead, extend `aliases` and its template to support hashes with
`scriptalias` and `scriptaliasmatch` keys so that all kinds of alias
directives can be specified in a single list, making it easy to control
their order.

Contains updated documentation and spec and acceptance tests.

The `scriptaliases` parameter still works as before but the
documentation now contains a deprecation notice informing users to use
`aliases` instead.
