### PR TITLE
MODULES-1446: mod_version is now builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
         * [Class: apache::mod::negotiation](#class-apachemodnegotiation)
         * [Class: apache::mod::deflate](#class-apachemoddeflate)
         * [Class: apache::mod::reqtimeout](#class-apachemodreqtimeout)
+        * [Class: apache::mod::version](#class-apachemodversion)
         * [Defined Type: apache::vhost](#defined-type-apachevhost)
         * [Parameter: `directories` for apache::vhost](#parameter-directories-for-apachevhost)
         * [SSL parameters for apache::vhost](#ssl-parameters-for-apachevhost)
@@ -821,6 +822,15 @@ mod_reqtimeout configuration.
   class { '::apache::mod::reqtimeout':
     timeouts => ['header=20-40,MinRate=500', 'body=20,MinRate=500'],
   }
+```
+
+####Class: `apache::mod::reqtimeout`
+
+This wrapper around mod_version warns on Debian and Ubuntu systems with Apache httpd 2.4
+about loading mod_version, as on these platforms it's already built-in.
+
+```puppet
+  include '::apache::mod::version'
 ```
 
 #####`timeouts`

--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -36,10 +36,11 @@ class apache::default_mods (
         include ::apache::mod::cache
         include ::apache::mod::mime
         include ::apache::mod::mime_magic
-        include ::apache::mod::vhost_alias
-        include ::apache::mod::suexec
         include ::apache::mod::rewrite
         include ::apache::mod::speling
+        include ::apache::mod::suexec
+        include ::apache::mod::version
+        include ::apache::mod::vhost_alias
         ::apache::mod { 'auth_digest': }
         ::apache::mod { 'authn_anon': }
         ::apache::mod { 'authn_dbm': }
@@ -51,7 +52,6 @@ class apache::default_mods (
         ::apache::mod { 'logio': }
         ::apache::mod { 'substitute': }
         ::apache::mod { 'usertrack': }
-        ::apache::mod { 'version': }
 
         if versioncmp($apache_version, '2.4') >= 0 {
           ::apache::mod { 'authn_core': }
@@ -71,6 +71,7 @@ class apache::default_mods (
         include ::apache::mod::reqtimeout
         include ::apache::mod::rewrite
         include ::apache::mod::userdir
+        include ::apache::mod::version
         include ::apache::mod::vhost_alias
         include ::apache::mod::speling
 
@@ -93,7 +94,6 @@ class apache::default_mods (
         ::apache::mod { 'logio': }
         ::apache::mod { 'unique_id': }
         ::apache::mod { 'usertrack': }
-        ::apache::mod { 'version': }
       }
       default: {}
     }

--- a/manifests/mod/version.pp
+++ b/manifests/mod/version.pp
@@ -1,0 +1,8 @@
+class apache::mod::version {
+
+  if ($::osfamily == 'debian' and versioncmp($apache_version, '2.4') >= 0) {
+    warning("${module_name}: module version_module is built-in and can't be loaded")
+  } else {
+    ::apache::mod { 'version': }
+  }
+}


### PR DESCRIPTION
while we are not loading it (by default), we should make it easier for
people transitioning their configuration from 2.2 to 2.4 to find issues:
thus adding a warning when someone tries to load mod_version.
