### PR TITLE
allow disabling default vhosts under 2.4

### DIFF
--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -70,7 +70,11 @@ IncludeOptional "<%= @confd_dir %>/*.conf"
 Include "<%= @confd_dir %>/*.conf"
 <%- end -%>
 <% if @vhost_load_dir != @confd_dir -%>
+<%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
+IncludeOptional "<%= @vhost_load_dir %>/*"
+<%- else -%>
 Include "<%= @vhost_load_dir %>/*"
+<%- end -%>
 <% end -%>
 
 <% if @error_documents -%>


### PR DESCRIPTION
when disabling the default vhost(s) under 2.4, there's nothing to
include in $sites-enabled/, which causes the following error:

```
The apache2 configtest failed.
Output of config test was:
apache2: Syntax error on line 46 of /etc/apache2/apache2.conf: No
matches for the wildcard '*' in '/etc/apache2/sites-enabled', failing
(use IncludeOptional if required)
Action 'configtest' failed.
The Apache error log may have more information.
```

by using IncludeOptional (as recommended), we allow the use of httpd as
simple web server, with single purpose configuration, without having to
define a (default) vhost.
