### PR TITLE
passenger concat needs to be wrapped in a check

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -795,10 +795,12 @@ define apache::vhost(
   # - $passenger_min_instances
   # - $passenger_start_timeout
   # - $passenger_pre_start
-  concat::fragment { "${name}-passenger":
-    target  => "${priority_real}-${filename}.conf",
-    order   => 290,
-    content => template('apache/vhost/_passenger.erb'),
+  if $passenger_app_root or $passenger_ruby or $passenger_min_instances or $passenger_start_timeout or $passenger_pre_start {
+    concat::fragment { "${name}-passenger":
+      target  => "${priority_real}-${filename}.conf",
+      order   => 290,
+      content => template('apache/vhost/_passenger.erb'),
+    }
   }
 
   # Template uses:


### PR DESCRIPTION
I was consistently getting the following error;
Critical: Scope(Concat::Fragment[default-passenger]): No content, source or symlink specified
Critical: Scope(Concat::Fragment[default-ssl-passenger]): No content, source or symlink specified
