### PR TITLE
(MODULES-1457) apache::vhost: SSLCACertificatePath can't be unset

### DIFF
--- a/templates/vhost/_ssl.erb
+++ b/templates/vhost/_ssl.erb
@@ -7,7 +7,7 @@
   <%- if @ssl_chain -%>
   SSLCertificateChainFile "<%= @ssl_chain %>"
   <%- end -%>
-  <%- if @ssl_certs_dir -%>
+  <%- if @ssl_certs_dir && @ssl_certs_dir != '' -%>
   SSLCACertificatePath    "<%= @ssl_certs_dir %>"
   <%- end -%>
   <%- if @ssl_ca -%>


### PR DESCRIPTION
The SSLCACertificatePath is always set. The check for @ssl_certs_dir only
covers "undef". As there is a default value in ::apache::params for
ssl_certs_dir it needs to be overriden with an empty string.

Right now the _ssl.erb template outputs 'SSLCACertificatePath ""' for an empty
string, which triggers a failing reload of httpd.

This patch just adds a "&& @ssl_certs_dir != ''" to the condition.

On a Puppet master passenger vhost it's probably  security relevant setting,
as it enables all system CA signed certificates access.

Related patch: https://github.com/puppetlabs/puppetlabs-apache/pull/787
