### PR TITLE
Satisfy doesn't work with apache 2.4

### DIFF
--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -298,7 +298,7 @@ describe 'apache::vhost define', :unless => UNSUPPORTED_PLATFORMS.include?(fact(
       end
     end
 
-    describe 'Satisfy and Auth directive' do
+    describe 'Satisfy and Auth directive', :unless => $apache_version == '2.4' do
       it 'should configure a vhost with Satisfy and Auth directive' do
         pp = <<-EOS
           class { 'apache': }


### PR DESCRIPTION
The ability to use the more complex Require\* syntax for apache 2.4
will be added eventually, but Satisfy shouldn't be tested as that is
deprecated in apache.
