### PR TITLE
Relying on missing fact

### DIFF
--- a/manifests/mod/dav_svn.pp
+++ b/manifests/mod/dav_svn.pp
@@ -5,7 +5,7 @@ class apache::mod::dav_svn (
   include ::apache::mod::dav
   ::apache::mod { 'dav_svn': }
 
-  if $::osfamily == 'Debian' and ($::operatingsystemmajrelease != '6' and $::operatingsystemmajrelease != '10.04') {
+  if $::osfamily == 'Debian' and ($::operatingsystemmajrelease != '6' and $::operatingsystemmajrelease != '10.04' and $::operatingsystemrelease != '10.04') {
     $loadfile_name = undef
   } else {
     $loadfile_name = 'dav_svn_authz_svn.load'


### PR DESCRIPTION
Ubuntu 10.04 with PE3.3 is missing the operatingsystemmajrelease fact,
so check either operatingsystemmajrelease or operatingsystemrelease.
