### PR TITLE
Add $status_path parameter to change mod_status url

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
         * [Class: apache::mod::pagespeed](#class-apachemodpagespeed)
         * [Class: apache::mod::php](#class-apachemodphp)
         * [Class: apache::mod::ssl](#class-apachemodssl)
+        * [Class: apache::mod::status](#class-apachemodstatus)
         * [Class: apache::mod::wsgi](#class-apachemodwsgi)
         * [Class: apache::mod::fcgid](#class-apachemodfcgid)
         * [Class: apache::mod::negotiation](#class-apachemodnegotiation)
@@ -556,7 +557,7 @@ There are many `apache::mod::[name]` classes within this module that can be decl
 * `shib`* (see [`apache::mod::shib`](#class-apachemodshib) below)
 * `speling`
 * `ssl`* (see [`apache::mod::ssl`](#class-apachemodssl) below)
-* `status`*
+* `status`* (see [`apache::mod::status`](#class-apachemodstatus) below)
 * `suphp`
 * `userdir`*
 * `vhost_alias`
@@ -720,6 +721,21 @@ Installs Apache SSL capabilities and uses the ssl.conf.erb template. These are t
 ```
 
 To *use* SSL with a virtual host, you must either set the`default_ssl_vhost` parameter in `::apache` to 'true' or set the `ssl` parameter in `apache::vhost` to 'true'.
+
+####Class: `apache::mod::status`
+
+Installs Apache mod_status and uses the status.conf.erb template. These are the defaults:
+
+```puppet
+    class { 'apache::mod::status':
+      allow_from      = ['127.0.0.1','::1'],
+      extended_status = 'On',
+      status_path     = '/server-status',
+){
+      
+      
+  }
+```
 
 ####Class: `apache::mod::wsgi`
 

--- a/manifests/mod/status.pp
+++ b/manifests/mod/status.pp
@@ -9,7 +9,9 @@
 #   /server-status URL.  Defaults to ['127.0.0.1', '::1'].
 # - $extended_status track and display extended status information. Valid
 #   values are 'On' or 'Off'.  Defaults to 'On'.
-#
+# - $status_path is the path assigned to the Location directive which
+#   defines the URL to access the server status. Defaults to '/server-status'.
+# 
 # Actions:
 # - Enable and configure Apache mod_status
 #
@@ -27,11 +29,12 @@ class apache::mod::status (
   $allow_from      = ['127.0.0.1','::1'],
   $extended_status = 'On',
   $apache_version = $::apache::apache_version,
+  $status_path     = '/server-status',
 ){
   validate_array($allow_from)
   validate_re(downcase($extended_status), '^(on|off)$', "${extended_status} is not supported for extended_status.  Allowed values are 'On' and 'Off'.")
   ::apache::mod { 'status': }
-  # Template uses $allow_from, $extended_status, $apache_version
+  # Template uses $allow_from, $extended_status, $apache_version, $status_path
   file { 'status.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/status.conf",

--- a/spec/classes/mod/status_spec.rb
+++ b/spec/classes/mod/status_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 # Helper function for testing the contents of `status.conf`
-def status_conf_spec(allow_from, extended_status)
+def status_conf_spec(allow_from, extended_status, status_path)
   it do
     is_expected.to contain_file("status.conf").with_content(
-      "<Location /server-status>\n"\
+      "<Location #{status_path}>\n"\
       "    SetHandler server-status\n"\
       "    Order deny,allow\n"\
       "    Deny from all\n"\
@@ -41,7 +41,7 @@ describe 'apache::mod::status', :type => :class do
 
     it { is_expected.to contain_apache__mod("status") }
 
-    status_conf_spec(["127.0.0.1", "::1"], "On")
+    status_conf_spec(["127.0.0.1", "::1"], "On", "/server-status")
 
     it { is_expected.to contain_file("status.conf").with({
       :ensure => 'file',
@@ -70,13 +70,13 @@ describe 'apache::mod::status', :type => :class do
 
     it { is_expected.to contain_apache__mod("status") }
 
-    status_conf_spec(["127.0.0.1", "::1"], "On")
+    status_conf_spec(["127.0.0.1", "::1"], "On", "/server-status")
 
     it { is_expected.to contain_file("status.conf").with_path("/etc/httpd/conf.d/status.conf") }
 
   end
 
-  context "with custom parameters $allow_from => ['10.10.10.10','11.11.11.11'], $extended_status => 'Off'" do
+  context "with custom parameters $allow_from => ['10.10.10.10','11.11.11.11'], $extended_status => 'Off', $status_path => '/custom-status'" do
     let :facts do
       {
         :osfamily               => 'Debian',
@@ -93,10 +93,11 @@ describe 'apache::mod::status', :type => :class do
       {
         :allow_from => ['10.10.10.10','11.11.11.11'],
         :extended_status => 'Off',
+        :status_path => '/custom-status',
       }
     end
 
-    status_conf_spec(["10.10.10.10", "11.11.11.11"], "Off")
+    status_conf_spec(["10.10.10.10", "11.11.11.11"], "Off", "/custom-status")
 
   end
 

--- a/templates/mod/status.conf.erb
+++ b/templates/mod/status.conf.erb
@@ -1,4 +1,4 @@
-<Location /server-status>
+<Location <%= @status_path %>>
     SetHandler server-status
     <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
     Require ip <%= Array(@allow_from).join(" ") %>


### PR DESCRIPTION
This change lets the user decide the url to use when accessing the status, instead of hardcoding it to '/server-status', which is the default.

This is #887 with 1 commit, and changes in the README and in https://github.com/puppetlabs/puppetlabs-apache/blob/master/spec/classes/mod/status_spec.rb
