### PR TITLE
Fix additional_includes on Apache 2.4

### DIFF
--- a/templates/vhost/_additional_includes.erb
+++ b/templates/vhost/_additional_includes.erb
@@ -1,5 +1,10 @@
 <% Array(@additional_includes).each do |include| -%>
   
   ## Load additional static includes
-  Include "<%= include %>"
+  <IfVersion < 2.4>
+    Include "<%= include %>"
+  </IfVersion>
+  <IfVersion >= 2.4>
+    IncludeOptional "<%= include %>"
+  </IfVersion>
 <% end -%>


### PR DESCRIPTION
Fix include on Apache 2.4 when no matching files exist