### PR TITLE
Modules 825 - apache2.4 - mod_itk dependency fix 

### DIFF
--- a/manifests/mod/itk.pp
+++ b/manifests/mod/itk.pp
@@ -13,8 +13,10 @@ class apache::mod::itk (
   if defined(Class['apache::mod::peruser']) {
     fail('May not include both apache::mod::itk and apache::mod::peruser on the same node')
   }
-  if defined(Class['apache::mod::prefork']) {
-    fail('May not include both apache::mod::itk and apache::mod::prefork on the same node')
+  if versioncmp($apache_version, '2.4') < 0 {
+    if defined(Class['apache::mod::prefork']) {
+      fail('May not include both apache::mod::itk and apache::mod::prefork on the same node')
+    }
   }
   if defined(Class['apache::mod::worker']) {
     fail('May not include both apache::mod::itk and apache::mod::worker on the same node')

--- a/manifests/mod/prefork.pp
+++ b/manifests/mod/prefork.pp
@@ -10,8 +10,10 @@ class apache::mod::prefork (
   if defined(Class['apache::mod::event']) {
     fail('May not include both apache::mod::prefork and apache::mod::event on the same node')
   }
-  if defined(Class['apache::mod::itk']) {
-    fail('May not include both apache::mod::prefork and apache::mod::itk on the same node')
+  if versioncmp($apache_version, '2.4') < 0 {
+    if defined(Class['apache::mod::itk']) {
+      fail('May not include both apache::mod::prefork and apache::mod::itk on the same node')
+    }
   }
   if defined(Class['apache::mod::peruser']) {
     fail('May not include both apache::mod::prefork and apache::mod::peruser on the same node')

--- a/manifests/mpm.pp
+++ b/manifests/mpm.pp
@@ -45,6 +45,13 @@ define apache::mpm (
           before  => File[$::apache::mod_enable_dir],
           notify  => Service['httpd'],
         }
+        
+        if $mpm == 'itk' {
+            file { "${lib_path}/mod_mpm_itk.so":
+              ensure  => link,
+              target  => "${lib_path}/mpm_itk.so"
+            }
+        }
       }
 
       if versioncmp($apache_version, '2.4') < 0 {


### PR DESCRIPTION
ref: https://tickets.puppetlabs.com/browse/MODULES-825
This commit fix the wrong behaviour of the apache module in case of mod_itk enabled on apache 2.4.
prior to apache 2.4 mod_itk and mod_prefork were mutually exclusive, now itk work along prefork so some fail test in itk.pp and prefork.pp are no more needed if version is >= 2.4
On mpm.pp an if statement has been added in order to fix an anomaly with mod_itk library name on ubuntu ( and possibly all debian) distros. the current manifest try to compose library name using "mod_mpm_" prefix. this behaviour is correct with many apache mods but not for mod_itk that installs "mpm_itk.so". this leads the generated itk.load  to load a nonexistant library file stopping apache service restart.
In order to preserve previous behaviour an if statement has been added to create a symlink to the real file in the debian case branch.
