### PR TITLE
(MODULES-1302) Add icons path for centos 7 / redhat

### DIFF
--- a/manifests/mod/alias.pp
+++ b/manifests/mod/alias.pp
@@ -3,7 +3,10 @@ class apache::mod::alias(
 ) {
   $icons_path = $::osfamily ? {
     'debian'  => '/usr/share/apache2/icons',
-    'redhat'  => '/var/www/icons',
+    'redhat'  => $::operatingsystemmajrelease ? {
+      '7'      => '/usr/share/httpd/icons',
+      default  => '/var/www/icons',
+     },
     'freebsd' => '/usr/local/www/apache22/icons',
   }
   apache::mod { 'alias': }


### PR DESCRIPTION
This change sets the default icons path for redhat and centos 7 as requested in https://tickets.puppetlabs.com/browse/MODULES-1302. 
