### PR TITLE
Fix linting errors

### DIFF
--- a/manifests/mpm.pp
+++ b/manifests/mpm.pp
@@ -45,11 +45,11 @@ define apache::mpm (
           before  => File[$::apache::mod_enable_dir],
           notify  => Service['httpd'],
         }
-        
+
         if $mpm == 'itk' {
             file { "${lib_path}/mod_mpm_itk.so":
-              ensure  => link,
-              target  => "${lib_path}/mpm_itk.so"
+              ensure => link,
+              target => "${lib_path}/mpm_itk.so"
             }
         }
       }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -104,7 +104,7 @@ class apache::params inherits ::apache::version {
     $mime_support_package = 'mailcap'
     $mime_types_config    = '/etc/mime.types'
     $docroot              = '/var/www/html'
-    if $::osfamily == "RedHat" {
+    if $::osfamily == 'RedHat' {
       $wsgi_socket_prefix = '/var/run/wsgi'
     } else {
       $wsgi_socket_prefix = undef


### PR DESCRIPTION
These escaped the iniial linting checks because fail_on_warning isn't enabled. I'm working with @cmurphy toget thatfixed in modulesync.
