### PR TITLE
Fixes version automatic detection for debian jessie;

### DIFF
--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -21,6 +21,8 @@ class apache::version {
     'Debian': {
       if $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease >= 13.10 {
         $default = '2.4'
+      } elsif $::operatingsystem == 'Debian' and $::operatingsystemrelease == 'jessie/sid' {
+        $default = '2.4'
       } else {
         $default = '2.2'
       }


### PR DESCRIPTION
Debian 8, Jessie uses Apache version 2.4
