### PR TITLE
update freebsd default version to 2.4

### DIFF
--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -28,7 +28,7 @@ class apache::version {
       }
     }
     'FreeBSD': {
-      $default = '2.2'
+      $default = '2.4'
     }
     default: {
       fail("Class['apache::version']: Unsupported osfamily: ${::osfamily}")


### PR DESCRIPTION
FreeBSD updated its default Apache version to 2.4 in July.

```
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                      H E A D S - U P
2014-07-13:
  The default version was changed from www/apache22 to www/apache24,
  pre-build apache modules will also reflect this!

  In case ports are build by yourself and apache22 is required
  use the following command to keep apache22 as default

  echo "DEFAULT_VERSIONS+=apache=2.2" >> /etc/make.conf

!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```
