### PR TITLE
Added code example for setenv class

### DIFF
--- a/README.md
+++ b/README.md
@@ -1429,9 +1429,9 @@ Used by HTTPD to set environment variables for vhosts. Defaults to '[]'.
 Example:
 
 ```puppet
-     apache::vhost {'setenv.example.com':
-         setenv  => ['SPECIAL_PATH /foo/bin'],
-      }
+    apache::vhost { 'setenv.example.com':
+      setenv => ['SPECIAL_PATH /foo/bin'],
+    }
 ```
 
 #####`setenvif`


### PR DESCRIPTION
Example usage is based on the Apache docs' own example for the SetEnv directive: 
http://httpd.apache.org/docs/2.2/mod/mod_env.html#setenv

Change requested here:
https://tickets.puppetlabs.com/browse/DOCUMENT-204
