### PR TITLE
Set keepalive to On by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ Changes the base location of the configuration directories used for the apache s
 
 #####`keepalive`
 
-Enables persistent connections.
+Enables persistent connections. Defaults to 'On'.
 
 #####`keepalive_timeout`
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -98,7 +98,7 @@ class apache::params inherits ::apache::version {
       'nss'  => 'libmodnss.so',
     }
     $conf_template        = 'apache/httpd.conf.erb'
-    $keepalive            = 'Off'
+    $keepalive            = 'On'
     $keepalive_timeout    = 15
     $max_keepalive_requests = 100
     $fastcgi_lib_path     = undef
@@ -186,7 +186,7 @@ class apache::params inherits ::apache::version {
       'php5' => 'libphp5.so',
     }
     $conf_template          = 'apache/httpd.conf.erb'
-    $keepalive              = 'Off'
+    $keepalive              = 'On'
     $keepalive_timeout      = 15
     $max_keepalive_requests = 100
     $fastcgi_lib_path       = '/var/lib/apache2/fastcgi'
@@ -322,7 +322,7 @@ class apache::params inherits ::apache::version {
       'php5' => 'libphp5.so',
     }
     $conf_template        = 'apache/httpd.conf.erb'
-    $keepalive            = 'Off'
+    $keepalive            = 'On'
     $keepalive_timeout    = 15
     $max_keepalive_requests = 100
     $fastcgi_lib_path     = undef # TODO: revisit


### PR DESCRIPTION
According to Apache documentation this is ```On``` by default since at least httpd 2.0.

Disclaimer: I want this change because I have a situation where "include apache" is there multiple times and so it's not possible to set that parameter by normal class parameter ways (no hiera involved).