### PR TITLE
Allow includes necessary for basic authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,6 +770,22 @@ For customized parameters, which tell Apache how Python is currently configured 
     }
 ```
 
+To specify an alternate mod\_wsgi package name to install and the name of the module .so it provides,
+(e.g. a "python27-mod\_wsgi" package that provides "python27-mod_wsgi.so" in the default module directory):
+
+```puppet
+    class { 'apache::mod::wsgi':
+      wsgi_socket_prefix => "\${APACHE_RUN_DIR}WSGI",
+      wsgi_python_home   => '/path/to/venv',
+      wsgi_python_path   => '/path/to/venv/site-packages',
+	  package_name       => 'python27-mod_wsgi',
+	  mod_path           => 'python27-mod_wsgi.so',
+    }
+```
+
+If ``mod_path`` does not contain "/", it will be prefixed by the default module path
+for your OS; otherwise, it will be used literally.
+
 More information about [WSGI](http://modwsgi.readthedocs.org/en/latest/).
 
 ####Class: `apache::mod::fcgid`

--- a/manifests/mod/authn_file.pp
+++ b/manifests/mod/authn_file.pp
@@ -1,0 +1,3 @@
+class apache::mod::authn_file {
+  ::apache::mod { 'authn_file': }
+}

--- a/manifests/mod/authz_default.pp
+++ b/manifests/mod/authz_default.pp
@@ -1,0 +1,3 @@
+class apache::mod::authz_default {
+  ::apache::mod { 'authz_default': }
+}

--- a/manifests/mod/authz_user.pp
+++ b/manifests/mod/authz_user.pp
@@ -1,0 +1,3 @@
+class apache::mod::authz_user {
+  ::apache::mod { 'authz_user': }
+}

--- a/manifests/mod/wsgi.pp
+++ b/manifests/mod/wsgi.pp
@@ -2,8 +2,28 @@ class apache::mod::wsgi (
   $wsgi_socket_prefix = $::apache::params::wsgi_socket_prefix,
   $wsgi_python_path   = undef,
   $wsgi_python_home   = undef,
+  $package_name       = undef,
+  $mod_path           = undef,
 ){
-  ::apache::mod { 'wsgi': }
+
+  if ($package_name != undef and $mod_path == undef) or ($package_name == undef and $mod_path != undef) {
+    fail('apache::mod::wsgi - both package_name and mod_path must be specified!')
+  }
+
+  if $package_name != undef {
+    if $mod_path =~ /\// {
+      $_mod_path = $mod_path
+    } else {
+      $_mod_path = "${::apache::params::lib_path}/${mod_path}"
+    }
+    ::apache::mod { 'wsgi':
+      package => $package_name,
+      path    => $_mod_path,
+    }
+  }
+  else {
+    ::apache::mod { 'wsgi': }
+  }
 
   # Template uses:
   # - $wsgi_socket_prefix

--- a/spec/classes/mod/wsgi_spec.rb
+++ b/spec/classes/mod/wsgi_spec.rb
@@ -55,6 +55,52 @@ describe 'apache::mod::wsgi', :type => :class do
       end
       it {is_expected.to contain_file('wsgi.conf').with_content(/^  WSGIPythonHome "\/path\/to\/virtenv"$/)}
     end
+    describe "with custom package_name and mod_path" do
+      let :params do
+        {
+          :package_name => 'mod_wsgi_package',
+          :mod_path     => '/foo/bar/baz',
+        }
+      end
+      it { is_expected.to contain_apache__mod('wsgi').with({
+          'package' => 'mod_wsgi_package',
+          'path'    => '/foo/bar/baz',
+        })
+      }
+      it { is_expected.to contain_package("mod_wsgi_package") }
+      it { is_expected.to contain_file('wsgi.load').with_content(%r"LoadModule wsgi_module /foo/bar/baz") }
+    end
+    describe "with custom mod_path not containing /" do
+      let :params do
+        {
+          :package_name => 'mod_wsgi_package',
+          :mod_path     => 'wsgi_mod_name.so',
+        }
+      end
+      it { is_expected.to contain_apache__mod('wsgi').with({
+          'path'     => 'modules/wsgi_mod_name.so',
+          'package'  => 'mod_wsgi_package',
+        })
+      }
+      it { is_expected.to contain_file('wsgi.load').with_content(%r"LoadModule wsgi_module modules/wsgi_mod_name.so") }
+
+    end
+    describe "with package_name but no mod_path" do
+      let :params do
+        {
+          :mod_path => '/foo/bar/baz',
+        }
+      end
+      it { expect { subject }.to raise_error Puppet::Error, /apache::mod::wsgi - both package_name and mod_path must be specified!/ }
+    end
+    describe "with mod_path but no package_name" do
+      let :params do
+        {
+          :package_name => '/foo/bar/baz',
+        }
+      end
+      it { expect { subject }.to raise_error Puppet::Error, /apache::mod::wsgi - both package_name and mod_path must be specified!/ }
+    end
   end
   context "on a FreeBSD OS" do
     let :facts do


### PR DESCRIPTION
allow some include apache::mod:: statements needed for basic_auth. The modules could not be inclued if you set default_mods => false. Includes were present in default_modules definition, though.
Tested on Debian wheezy 7.7