### PR TITLE
Documentation fix: ssl_protocol expects a string, not an array.

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,7 +735,7 @@ Installs Apache SSL capabilities and uses the ssl.conf.erb template. These are t
       ssl_compression        => false,
       ssl_options            => [ 'StdEnvVars' ],
       ssl_pass_phrase_dialog => 'builtin',
-      ssl_protocol           => [ 'all', '-SSLv2', '-SSLv3'],
+      ssl_protocol           => 'all -SSLv2 -SSLv3',
   }
 ```
 


### PR DESCRIPTION
The README.md sample uses an array where a string is expected.