### PR TITLE
add support for PassengerEnabled, avoid adding blank SSL values

### DIFF
--- a/manifests/mod/alias.pp
+++ b/manifests/mod/alias.pp
@@ -1,7 +1,7 @@
 class apache::mod::alias(
   $apache_version = $apache::apache_version
 ) {
-  $ver24 = versioncmp($apache_version, 2.4) >= 0
+  $ver24 = versioncmp($apache_version, '2.4') >= 0
 
   $icons_path = $::osfamily ? {
     'debian'  => '/usr/share/apache2/icons',

--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -7,6 +7,7 @@ class apache::mod::passenger (
   $passenger_stat_throttle_rate   = undef,
   $rack_autodetect                = undef,
   $rails_autodetect               = undef,
+  $passenger_enabled              = undef,
   $passenger_root                 = $::apache::params::passenger_root,
   $passenger_ruby                 = $::apache::params::passenger_ruby,
   $passenger_default_ruby         = $::apache::params::passenger_default_ruby,
@@ -73,6 +74,7 @@ class apache::mod::passenger (
   # - $passenger_max_requests
   # - $passenger_stat_throttle_rate
   # - $passenger_use_global_queue
+  # - $passenger_enabled
   # - $rack_autodetect
   # - $rails_autodetect
   file { 'passenger.conf':

--- a/templates/mod/passenger.conf.erb
+++ b/templates/mod/passenger.conf.erb
@@ -25,6 +25,9 @@
   <%- if @passenger_stat_throttle_rate -%>
   PassengerStatThrottleRate <%= @passenger_stat_throttle_rate %>
   <%- end -%>
+  <%- if @passenger_enabled -%>
+  PassengerEnabled <%= @passenger_enabled %>
+  <%- end -%>
   <%- if @rack_autodetect -%>
   RackAutoDetect <%= @rack_autodetect %>
   <%- end -%>

--- a/templates/vhost/_ssl.erb
+++ b/templates/vhost/_ssl.erb
@@ -4,22 +4,22 @@
   SSLEngine on
   SSLCertificateFile      "<%= @ssl_cert %>"
   SSLCertificateKeyFile   "<%= @ssl_key %>"
-  <%- if @ssl_chain -%>
+  <%- if @ssl_chain && @ssl_chain != '' -%>
   SSLCertificateChainFile "<%= @ssl_chain %>"
   <%- end -%>
   <%- if @ssl_certs_dir && @ssl_certs_dir != '' -%>
   SSLCACertificatePath    "<%= @ssl_certs_dir %>"
   <%- end -%>
-  <%- if @ssl_ca -%>
+  <%- if @ssl_ca && @ssl_ca != '' -%>
   SSLCACertificateFile    "<%= @ssl_ca %>"
   <%- end -%>
-  <%- if @ssl_crl_path -%>
+  <%- if @ssl_crl_path && @ssl_crl_path != '' -%>
   SSLCARevocationPath     "<%= @ssl_crl_path %>"
   <%- end -%>
-  <%- if @ssl_crl -%>
+  <%- if @ssl_crl && @ssl_crl != '' -%>
   SSLCARevocationFile     "<%= @ssl_crl %>"
   <%- end -%>
-  <%- if @ssl_crl_check && scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
+  <%- if @ssl_crl_check && @ssl_crl_check != '' && scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
   SSLCARevocationCheck    "<%= @ssl_crl_check %>"
   <%- end -%>
   <%- if @ssl_proxyengine -%>


### PR DESCRIPTION
PassengerEnabled option added b/c:
```
  RailsAutoDetect, RackAutoDetect and WsgiAutoDetect
  These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.
```

In the SSL module, changed template to avoid setting values if they are blank. Trying to use a module that passes in a value for these but I want to override it in hiera with a blank string so it doesn't get set in the config. Maybe I could have set the value to false in hiera but my change is consistent with what was in place for another optional SSL value in the template. 