### PR TITLE
MODULES-1622: Allow multiple Deny directives in a directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1697,7 +1697,7 @@ Pass a string of custom configuration directives to be placed at the end of the 
 
 ######`deny`
 
-Sets a [Deny](http://httpd.apache.org/docs/2.2/mod/mod_authz_host.html#deny) directive, specifying which hosts are denied access to the server. **Deprecated:** This parameter is being deprecated due to a change in Apache. It only works with Apache 2.2 and lower.
+Sets a [Deny](http://httpd.apache.org/docs/2.2/mod/mod_authz_host.html#deny) directive, specifying which hosts are denied access to the server. **Deprecated:** This parameter is being deprecated due to a change in Apache. It only works with Apache 2.2 and lower. You can use it as a single string for one rule or as an array for more than one.
 
 ```puppet
     apache::vhost { 'sample.example.net':

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -147,11 +147,20 @@ describe 'apache::vhost', :type => :define do
           'access_log_format'           => '%h %l %u %t \"%r\" %>s %b',
           'access_log_env_var'          => '',
           'aliases'                     => '/image',
-          'directories'                 => {
-            'path'     => '/var/www/files',
-            'provider' => 'files',
-            'deny'     => 'from all'
-          },
+          'directories'                 => [
+            {
+              'path'     => '/var/www/files',
+              'provider' => 'files',
+              'allow'    => [ 'from 127.0.0.1', 'from 127.0.0.2', ],
+              'deny'     => [ 'from 127.0.0.3', 'from 127.0.0.4', ],
+            },
+            {
+              'path'     => '/var/www/foo',
+              'provider' => 'files',
+              'allow'    => 'from 127.0.0.1',
+              'deny'     => 'from all',
+            },
+          ],
           'error_log'                   => false,
           'error_log_file'              => 'httpd_error_log',
           'error_log_pipe'              => '',

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -147,20 +147,10 @@ describe 'apache::vhost', :type => :define do
           'access_log_format'           => '%h %l %u %t \"%r\" %>s %b',
           'access_log_env_var'          => '',
           'aliases'                     => '/image',
-          'directories'                 => [
-            {
-              'path'     => '/var/www/files',
-              'provider' => 'files',
-              'allow'    => [ 'from 127.0.0.1', 'from 127.0.0.2', ],
-              'deny'     => [ 'from 127.0.0.3', 'from 127.0.0.4', ],
-            },
-            {
-              'path'     => '/var/www/foo',
-              'provider' => 'files',
-              'allow'    => 'from 127.0.0.1',
-              'deny'     => 'from all',
-            },
-          ],
+          'directories'                 => {
+            'path'     => '/var/www/files',
+            'provider' => 'files',
+          },
           'error_log'                   => false,
           'error_log_file'              => 'httpd_error_log',
           'error_log_pipe'              => '',
@@ -346,6 +336,21 @@ describe 'apache::vhost', :type => :define do
           'manage_docroot'  => true,
           'logroot'         => '/tmp/logroot',
           'logroot_ensure'  => 'absent',
+          'directories'     => [
+            {
+              'path'     => '/var/www/files',
+              'provider' => 'files',
+              'allow'    => [ 'from 127.0.0.1', 'from 127.0.0.2', ],
+              'deny'     => [ 'from 127.0.0.3', 'from 127.0.0.4', ],
+            },
+            {
+              'path'     => '/var/www/foo',
+              'provider' => 'files',
+              'allow'    => 'from 127.0.0.5',
+              'deny'     => 'from all',
+            },
+          ],
+
         }
       end
       let :facts do
@@ -389,6 +394,18 @@ describe 'apache::vhost', :type => :define do
       it { is_expected.to_not contain_concat__fragment('rspec.example.com-itk') }
       it { is_expected.to_not contain_concat__fragment('rspec.example.com-fallbackresource') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-directories') }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
+        :content => /^\s+Allow from 127\.0\.0\.1$/ ) }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
+        :content => /^\s+Allow from 127\.0\.0\.2$/ ) }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
+        :content => /^\s+Allow from 127\.0\.0\.5$/ ) }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
+        :content => /^\s+Deny from 127\.0\.0\.3$/ ) }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
+        :content => /^\s+Deny from 127\.0\.0\.4$/ ) }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
+        :content => /^\s+Deny from all$/ ) }
       it { is_expected.to_not contain_concat__fragment('rspec.example.com-additional_includes') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-logging') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-serversignature') }

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -55,8 +55,14 @@
       <%- else -%>
     Order allow,deny
       <%- end -%>
-      <%- if directory['deny'] and directory['deny'] != '' -%>
+      <%- if directory['deny'] and ! [ false, 'false', '' ].include?(directory['deny']) -%>
+        <%- if directory['deny'].kind_of?(Array) -%>
+          <%- Array(directory['deny']).each do |restrict| -%>
+    Deny <%=  restrict %>
+          <%- end -%>
+        <%- else -%>
     Deny <%= directory['deny'] %>
+        <%- end -%>
       <%- end -%>
       <%- if directory['allow'] and ! [ false, 'false', '' ].include?(directory['allow']) -%>
         <%- if directory['allow'].kind_of?(Array) -%>


### PR DESCRIPTION
Allow multiple `Deny` directives in the same way as `Allow` already works, example:  

    directories => [
      { 'path' => '/var/ww/first',
        'deny' => [ 'from 127.0.0.1', 'from 127.0.0.2', ],
      },