### PR TITLE
MODULES-1684: Specify mod_proxy_connect module for Apache >= 2.3.5

### DIFF
--- a/manifests/mod/proxy_connect.pp
+++ b/manifests/mod/proxy_connect.pp
@@ -1,0 +1,8 @@
+class apache::mod::proxy_connect (
+  $apache_version  = $::apache::apache_version,
+) {
+  if versioncmp($apache_version, '2.4') >= 0 {
+    Class['::apache::mod::proxy'] -> Class['::apache::mod::proxy_connect']
+    ::apache::mod { 'proxy_connect': }
+  }
+}

--- a/spec/classes/mod/proxy_connect_spec.rb
+++ b/spec/classes/mod/proxy_connect_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe 'apache::mod::proxy_connect', :type => :class do
+  let :pre_condition do
+    [
+      'include apache',
+      'include apache::mod::proxy',
+    ]
+  end
+  context 'on a Debian OS' do
+    let :facts do
+      {
+        :osfamily        => 'Debian',
+        :concat_basedir  => '/dne',
+        :operatingsystem => 'Debian',
+        :id              => 'root',
+        :kernel          => 'Linux',
+        :path            => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      }
+    end
+    context 'with Apache version < 2.4' do
+      let :facts do
+        super().merge({
+          :operatingsystemrelease => '7.0',
+          :lsbdistcodename        => 'wheezy',
+        })
+      end
+      let :params do
+        {
+          :apache_version => '2.2',
+        }
+      end
+      it { is_expected.not_to contain_apache__mod('proxy_connect') }
+    end
+    context 'with Apache version >= 2.4' do
+      let :facts do
+        super().merge({
+          :operatingsystemrelease => '8.0',
+          :lsbdistcodename        => 'jessie',
+        })
+      end
+      let :params do
+        {
+          :apache_version => '2.4',
+        }
+      end
+      it { is_expected.to contain_apache__mod('proxy_connect') }
+    end
+  end
+end


### PR DESCRIPTION
mod_proxy_connect was moved to own module since Apache >= 2.3.5.
AllowConnect directive won't work without this module on Ubuntu 14.04 or
Debian 8.