### PR TITLE
Quoted params to versioncmp in mod/alias.pp to avoid type error

### DIFF
--- a/manifests/mod/alias.pp
+++ b/manifests/mod/alias.pp
@@ -1,7 +1,7 @@
 class apache::mod::alias(
   $apache_version = $apache::apache_version
 ) {
-  $ver24 = versioncmp($apache_version, 2.4) >= 0
+  $ver24 = versioncmp($apache_version, '2.4') >= 0
 
   $icons_path = $::osfamily ? {
     'debian'  => '/usr/share/apache2/icons',


### PR DESCRIPTION
I've logged a JIRA ticket for this, please see 'MODULES-1692'.