### PR TITLE
add support for conf-enabled/*.conf in newer Debian/Ubuntu apache 2.4 setups

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,7 @@ class apache (
   $httpd_dir              = $::apache::params::httpd_dir,
   $server_root            = $::apache::params::server_root,
   $conf_dir               = $::apache::params::conf_dir,
+  $conf_enable_dir        = $::apache::params::conf_enable_dir,
   $confd_dir              = $::apache::params::confd_dir,
   $vhost_dir              = $::apache::params::vhost_dir,
   $vhost_enable_dir       = $::apache::params::vhost_enable_dir,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,6 +43,7 @@ class apache::params inherits ::apache::version {
     $server_root          = '/etc/httpd'
     $conf_dir             = "${httpd_dir}/conf"
     $confd_dir            = "${httpd_dir}/conf.d"
+    $conf_enable_dir      = undef
     $mod_dir              = "${httpd_dir}/conf.d"
     $mod_enable_dir       = undef
     $vhost_dir            = "${httpd_dir}/conf.d"
@@ -150,6 +151,7 @@ class apache::params inherits ::apache::version {
     $server_root         = '/etc/apache2'
     $conf_dir            = $httpd_dir
     $confd_dir           = "${httpd_dir}/conf.d"
+    $conf_enable_dir     = "${httpd_dir}/conf-enabled"
     $mod_dir             = "${httpd_dir}/mods-available"
     $mod_enable_dir      = "${httpd_dir}/mods-enabled"
     $vhost_dir           = "${httpd_dir}/sites-available"
@@ -286,6 +288,7 @@ class apache::params inherits ::apache::version {
     $httpd_dir        = '/usr/local/etc/apache22'
     $server_root      = '/usr/local'
     $conf_dir         = $httpd_dir
+    $conf_enable_dir  = undef
     $confd_dir        = "${httpd_dir}/Includes"
     $mod_dir          = "${httpd_dir}/Modules"
     $mod_enable_dir   = undef

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -76,6 +76,9 @@ IncludeOptional "<%= @vhost_load_dir %>/*"
 Include "<%= @vhost_load_dir %>/*"
 <%- end -%>
 <% end -%>
+<% if @conf_enable_dir %>
+IncludeOptional "<%= @conf_enable_dir %>/*.conf"
+<%- end -%>
 
 <% if @error_documents -%>
 # /usr/share/apache2/error on debian


### PR DESCRIPTION
Newer Debian/Ubuntu systems have a conf-available/conf-enabled system in which things like 
charset.conf, other-vhosts-access-log.conf,  serve-cgi-bin.conf, localized-error-pages.conf, security.conf and other such necessities reside that used to be in conf.d.

So puppetlabs::apache is broken on Ubuntu/Debian with apache 2.4 without this. 