### PR TITLE
ssl: Added HSTS settings option for Strict-Transport-Security enablement.

### DIFF
--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -4,6 +4,7 @@ class apache::mod::ssl (
   $ssl_cipher             = 'HIGH:MEDIUM:!aNULL:!MD5',
   $ssl_protocol           = [ 'all', '-SSLv2', '-SSLv3' ],
   $ssl_pass_phrase_dialog = 'builtin',
+  $hsts_options           = undef,
   $apache_version         = $::apache::apache_version,
   $package_name           = undef,
 ) {
@@ -46,9 +47,10 @@ class apache::mod::ssl (
   #
   # $ssl_compression
   # $ssl_options
-  # $session_cache,
+  # $session_cache
   # $ssl_mutex
   # $apache_version
+  # $hsts_options
   #
   file { 'ssl.conf':
     ensure  => file,

--- a/templates/mod/ssl.conf.erb
+++ b/templates/mod/ssl.conf.erb
@@ -25,4 +25,10 @@
 <% if @ssl_options -%>
   SSLOptions <%= @ssl_options.compact.join(' ') %>
 <% end -%>
+
+<% if @hsts_options %>
+  <IfModule mod_headers.c>
+    Header always set Strict-Transport-Security "<%= @hsts_options %>"
+  </IfModule>
+<% end -%>
 </IfModule>


### PR DESCRIPTION
Added HSTS settings option for Strict-Transport-Security enablement.

Can be tested doing: curl --insecure -si https://www.example.com/