### PR TITLE
Symlinks on all distros

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -440,7 +440,7 @@ define apache::vhost(
     require => Package['httpd'],
     notify  => Class['apache::service'],
   }
-  if $::osfamily == 'Debian' {
+  if $::apache::vhost_enable_dir {
     $vhost_enable_dir = $::apache::vhost_enable_dir
     $vhost_symlink_ensure = $ensure ? {
       present => link,


### PR DESCRIPTION
Create symlinks on all distros (not just Debian) when a separate $vhost_enable_dir is used. Without this a different $vhost_enable_dir as conf.d on centos does not create symlinks to enable vhosts.