### PR TITLE
ssl_protocol expects a string, not an array.

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,7 +739,7 @@ Installs Apache SSL capabilities and uses the ssl.conf.erb template. These are t
       ssl_compression        => false,
       ssl_options            => [ 'StdEnvVars' ],
       ssl_cipher             => 'HIGH:MEDIUM:!aNULL:!MD5',
-      ssl_protocol           => ['all','-SSLv2','-SSLv3'],
+      ssl_protocol           => 'all -SSLv2 -SSLv3',
       ssl_pass_phrase_dialog => 'builtin',
       ssl_random_seed_bytes  => '512',
     }


### PR DESCRIPTION
This was lost with #1007 (e8c565).