### PR TITLE
Fix for PR 845

### DIFF
--- a/README.md
+++ b/README.md
@@ -1005,7 +1005,7 @@ Setting `add_listen` to 'false' stops the vhost from creating a Listen statement
 
 #####`use_optional_includes`
 
-Specifies if for apache > 2.4 it should use IncludeOptional instead of Include.
+Specifies if for apache > 2.4 it should use IncludeOptional instead of Include for `additional_includes`. Defaults to 'false'.
 
 #####`additional_includes`
 

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -64,7 +64,7 @@ LogFormat "<%= format -%>" <%= nickname %>
   <%- end -%>
 <% end -%>
 
-<%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 && @use_optional_includes -%>
+<%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
 IncludeOptional "<%= @confd_dir %>/*.conf"
 <%- else -%>
 Include "<%= @confd_dir %>/*.conf"


### PR DESCRIPTION
`use_optional_includes` should only be used for `additional_includes`,
otherwise things don't work.