### PR TITLE
add ProxyErrorOverride directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1222,6 +1222,10 @@ Specifies URLs you do not want to proxy. This parameter is meant to be used in c
 
 Sets the [ProxyPreserveHost Directive](http://httpd.apache.org/docs/2.2/mod/mod_proxy.html#proxypreservehost).  true Enables the Host: line from an incoming request to be proxied to the host instead of hostname .  false sets this option to off (default).
 
+#####`proxy_error_override`
+
+Sets the [ProxyErrorOverride Directive](http://httpd.apache.org/docs/2.2/mod/mod_proxy.html#proxyerroroverride). This directive controls whether apache should override error pages for proxied content. This option is off by default.
+
 #####`options`
 
 Sets the [Options](http://httpd.apache.org/docs/current/mod/core.html#options) for the specified virtual host. Defaults to '['Indexes','FollowSymLinks','MultiViews']', as demonstrated below:

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -67,6 +67,7 @@ define apache::vhost(
   $php_admin_values            = {},
   $no_proxy_uris               = [],
   $proxy_preserve_host         = false,
+  $proxy_error_override        = false,
   $redirect_source             = '/',
   $redirect_dest               = undef,
   $redirect_status             = undef,

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -103,6 +103,7 @@ describe 'apache::vhost define', :unless => UNSUPPORTED_PLATFORMS.include?(fact(
             { 'path' => '/foo', 'url' => 'http://backend-foo/'},
           ],
         proxy_preserve_host   => true,
+        proxy_error_override  => true,
         }
       EOS
       apply_manifest(pp, :catch_failures => true)
@@ -113,6 +114,7 @@ describe 'apache::vhost define', :unless => UNSUPPORTED_PLATFORMS.include?(fact(
       it { is_expected.to contain "ServerName proxy.example.com" }
       it { is_expected.to contain "ProxyPass" }
       it { is_expected.to contain "ProxyPreserveHost On" }
+      it { is_expected.to contain "ProxyErrorOverride On" }
       it { is_expected.not_to contain "<Proxy \*>" }
     end
   end

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -192,6 +192,7 @@ describe 'apache::vhost', :type => :define do
           'php_admin_values'            => ['true', 'false'],
           'no_proxy_uris'               => '/foo',
           'proxy_preserve_host'         => true,
+          'proxy_error_override'        => true,
           'redirect_source'             => '/bar',
           'redirect_dest'               => '/',
           'redirect_status'             => 'temp',

--- a/templates/vhost/_proxy.erb
+++ b/templates/vhost/_proxy.erb
@@ -6,6 +6,9 @@
 <% if @proxy_preserve_host -%>
   ProxyPreserveHost On
 <%- end -%>
+<% if @proxy_error_override -%>
+  ProxyErrorOverride On
+<%- end -%>
 <%- [@proxy_pass].flatten.compact.each do |proxy| -%>
   ProxyPass <%= proxy['path'] %> <%= proxy['url'] -%>
   <%- if proxy['params'] -%>


### PR DESCRIPTION
This PR adds support for the ProxyErrorOverride directive. http://httpd.apache.org/docs/2.2/mod/mod_proxy.html#proxyerroroverride