### PR TITLE
adjust params and mpm to recent FreeBSD packages

### DIFF
--- a/manifests/mpm.pp
+++ b/manifests/mpm.pp
@@ -13,10 +13,7 @@ define apache::mpm (
   $_path = "${lib_path}/${_lib}"
   $_id   = "mpm_${mpm}_module"
 
-  if versioncmp($apache_version, '2.4') >= 0 and
-    (($::osfamily != 'FreeBSD') or
-    ($::osfamily == 'FreeBSD' and $mpm == 'itk')) {
-
+  if versioncmp($apache_version, '2.4') >= 0 {
     file { "${mod_dir}/${mpm}.load":
       ensure  => file,
       path    => "${mod_dir}/${mpm}.load",

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -309,8 +309,8 @@ class apache::params inherits ::apache::version {
     $ssl_certs_dir    = '/usr/local/etc/apache24'
     $passenger_conf_file = 'passenger.conf'
     $passenger_conf_package_file = undef
-    $passenger_root   = '/usr/local/lib/ruby/gems/1.9/gems/passenger-4.0.10'
-    $passenger_ruby   = '/usr/bin/ruby'
+    $passenger_root   = '/usr/local/lib/ruby/gems/2.0/gems/passenger-4.0.58'
+    $passenger_ruby   = '/usr/local/bin/ruby'
     $passenger_default_ruby = undef
     $suphp_addhandler = 'php5-script'
     $suphp_engine     = 'off'


### PR DESCRIPTION
With this change I can use theforeman/puppet to setup a Puppet master under Passenger on FreeBSD.