### PR TITLE
Add support for Passenger's PassengerAppEnv setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1252,6 +1252,10 @@ Sets the overrides for the specified virtual host. Accepts an array of [AllowOve
 
 Sets [PassengerRoot](https://www.phusionpassenger.com/documentation/Users%20guide%20Apache.html#PassengerAppRoot), the location of the Passenger application root if different from the DocumentRoot.
 
+#####`passenger_app_env`
+
+Sets [PassengerAppEnv](https://www.phusionpassenger.com/documentation/Users%20guide%20Apache.html#PassengerAppEnv), the environment for the Passenger application. If not specifies, defaults to the global setting or 'production'.
+
 #####`passenger_ruby`
 
 Sets [PassengerRuby](https://www.phusionpassenger.com/documentation/Users%20guide%20Apache.html#PassengerRuby) on this virtual host, the Ruby interpreter to use for the application.

--- a/README.passenger.md
+++ b/README.passenger.md
@@ -201,6 +201,14 @@ Allows toggling of PassengerUseGlobalQueue.  NOTE: PassengerUseGlobalQueue is
 the default in Passenger 4.x and the versions >= 4.x have disabled this
 configuration option altogether.  Use with caution.
 
+### passenger_app_env
+
+Sets the global default `PassengerAppEnv` for Passenger applications. Not set by
+default (`undef`) and thus defaults to Passenger's built-in value of 'production'.
+This directive can be overridden in an `apache::vhost` resource.
+
+https://www.phusionpassenger.com/documentation/Users%20guide%20Apache.html#PassengerAppEnv
+
 ## Parameters used to load the module
 
 Unlike the tuning parameters specified above, the following parameters are only

--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -12,6 +12,7 @@ class apache::mod::passenger (
   $passenger_default_ruby         = $::apache::params::passenger_default_ruby,
   $passenger_max_pool_size        = undef,
   $passenger_use_global_queue     = undef,
+  $passenger_app_env              = undef,
   $mod_package                    = undef,
   $mod_package_ensure             = undef,
   $mod_lib                        = undef,
@@ -73,6 +74,7 @@ class apache::mod::passenger (
   # - $passenger_max_requests
   # - $passenger_stat_throttle_rate
   # - $passenger_use_global_queue
+  # - $passenger_app_env
   # - $rack_autodetect
   # - $rails_autodetect
   file { 'passenger.conf':

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -105,6 +105,7 @@ define apache::vhost(
   $allow_encoded_slashes       = undef,
   $suexec_user_group           = undef,
   $passenger_app_root          = undef,
+  $passenger_app_env           = undef,
   $passenger_ruby              = undef,
   $passenger_min_instances     = undef,
   $passenger_start_timeout     = undef,
@@ -225,7 +226,7 @@ define apache::vhost(
     include ::apache::mod::suexec
   }
 
-  if $passenger_app_root or $passenger_ruby or $passenger_min_instances or $passenger_start_timeout or $passenger_pre_start {
+  if $passenger_app_root or $passenger_app_env or $passenger_ruby or $passenger_min_instances or $passenger_start_timeout or $passenger_pre_start {
     include ::apache::mod::passenger
   }
 
@@ -839,11 +840,12 @@ define apache::vhost(
 
   # Template uses:
   # - $passenger_app_root
+  # - $passenger_app_env
   # - $passenger_ruby
   # - $passenger_min_instances
   # - $passenger_start_timeout
   # - $passenger_pre_start
-  if $passenger_app_root or $passenger_ruby or $passenger_min_instances or $passenger_start_timeout or $passenger_pre_start {
+  if $passenger_app_root or $passenger_app_env or $passenger_ruby or $passenger_min_instances or $passenger_start_timeout or $passenger_pre_start {
     concat::fragment { "${name}-passenger":
       target  => "${priority_real}${filename}.conf",
       order   => 300,

--- a/spec/classes/mod/passenger_spec.rb
+++ b/spec/classes/mod/passenger_spec.rb
@@ -95,6 +95,12 @@ describe 'apache::mod::passenger', :type => :class do
       end
       it { is_expected.to contain_file('passenger.conf').with_content(/^  PassengerUseGlobalQueue on$/) }
     end
+    describe "with passenger_app_env => 'foo'" do
+      let :params do
+        { :passenger_app_env => 'foo' }
+      end
+      it { is_expected.to contain_file('passenger.conf').with_content(/^  PassengerAppEnv foo$/) }
+    end
     describe "with mod_path => '/usr/lib/foo/mod_foo.so'" do
       let :params do
         { :mod_path => '/usr/lib/foo/mod_foo.so' }

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -245,6 +245,7 @@ describe 'apache::vhost', :type => :define do
           'suexec_user_group'           => 'root root',
           'allow_encoded_slashes'       => 'nodecode',
           'passenger_app_root'          => '/usr/share/myapp',
+          'passenger_app_env'           => 'test',
           'passenger_ruby'              => '/usr/bin/ruby1.9.1',
           'passenger_min_instances'     => '1',
           'passenger_start_timeout'     => '600',

--- a/templates/mod/passenger.conf.erb
+++ b/templates/mod/passenger.conf.erb
@@ -34,4 +34,7 @@
   <%- if @passenger_use_global_queue -%>
   PassengerUseGlobalQueue <%= @passenger_use_global_queue %>
   <%- end -%>
+  <%- if @passenger_app_env -%>
+  PassengerAppEnv <%= @passenger_app_env %>
+  <%- end -%>
 </IfModule>

--- a/templates/vhost/_passenger.erb
+++ b/templates/vhost/_passenger.erb
@@ -1,6 +1,9 @@
 <% if @passenger_app_root -%>
   PassengerAppRoot <%= @passenger_app_root %>
 <% end -%>
+<% if @passenger_app_env -%>
+  PassengerAppEnv <%= @passenger_app_env %>
+<% end -%>
 <% if @passenger_ruby -%>
   PassengerRuby <%= @passenger_ruby %>
 <% end -%>


### PR DESCRIPTION
(#1776) Add support for specifying PassengerAppEnv
either as a global setting to `apache::mod::passenger` or
per `apache::vhost`.