### PR TITLE
fix bug in scriptalias code that keeps scriptalias from beeing included in default vhost

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -678,7 +678,7 @@ define apache::vhost(
   # Template uses:
   # - $scriptaliases
   # - $scriptalias
-  if $scriptaliases and ! empty($scriptaliases) {
+  if ( $scriptalias or $scriptaliases != [] ) {
     concat::fragment { "${name}-scriptalias":
       target  => "${priority_real}${filename}.conf",
       order   => 180,


### PR DESCRIPTION
The scriptalias parameter is used in manifest/init.pp to setup the default vhosts.

However due to this bug $scriptalias from init.pp will never be set in the default vhost.

 This propably need to be closely looked at, as this bugfix propably can have effects on other parts of the code.

This patch has been tested on Centos-7 and forge version of puppetlabs-apache 1.3.0


```puppet
class { '::apache': 
  "default_confd_files"    =>  false,
  "default_mods"            => false,
  "default_vhost"            => true
}

```