### PR TITLE
MODULES-1784 check for deprecated options and fail when they are unsupported

### DIFF
--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -2,6 +2,20 @@
 
   ## Directories, there should at least be a declaration for <%= @docroot %>
   <%- [@_directories].flatten.compact.each do |directory| -%>
+    <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
+      <%- if directory['allow'] and ! [ false, 'false', '' ].include?(directory['allow']) -%>
+        <%- scope.function_fail(["Apache::Vhost: Using allow is not supported in your Apache version"]) -%>
+      <%- end -%>
+      <%- if directory['deny'] and ! [ false, 'false', '' ].include?(directory['deny']) -%>
+        <%- scope.function_fail(["Apache::Vhost: Using deny is not supported in your Apache version"]) -%>
+      <%- end -%>
+      <%- if directory['order'] and ! [ false, 'false', '' ].include?(directory['order']) -%>
+        <%- scope.function_fail(["Apache::Vhost: Using order is not supported in your Apache version"]) -%>
+      <%- end -%>
+      <%- if directory['satisfy'] and ! [ false, 'false', '' ].include?(directory['satisfy']) -%>
+        <%- scope.function_fail(["Apache::Vhost: Using satisfy is not supported in your Apache version"]) -%>
+      <%- end -%>
+    <%- end -%>
     <%- if directory['path'] and directory['path'] != '' -%>
       <%- if directory['provider'] and directory['provider'].match('(directory|location|files)') -%>
         <%- if /^(.*)match$/ =~ directory['provider'] -%>


### PR DESCRIPTION
See https://tickets.puppetlabs.com/browse/MODULES-1784 for more information.
Basically if you specify allow, deny, order or satisfy on a system running Apache 2.4, those options get silently dropped. 

With this pull request those manifests would fail and alert the user that they are not using supported options.

Feedback very much welcome.
I tried to solve this in the manifest but failed since $directories can be an array of hashes and I found no way to check for the existence of a key in such a construct.
