### PR TITLE
Changes to address the changed cache_root and module name in Apache 2.4.

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ There are many `apache::mod::[name]` classes within this module that can be decl
 * `deflate`
 * `dev`
 * `dir`*
-* `disk_cache`
+* `disk_cache` (see [`apache::mod::disk_cache`](#class-apachemoddisk_cache) below)
 * `event`(see [`apache::mod::event`](#class-apachemodevent) below)
 * `expires`
 * `fastcgi`
@@ -642,6 +642,17 @@ It is not recommended to leave this set to false though it can be very useful fo
       '10.10.38',
       '127.0.0.1',
     ],
+  }
+```
+
+####Class: `apache::mod::disk_cache`
+
+Installs and configures mod_disk_cache. The cache root is determined based on apache version and OS. It can be specified directly as well.
+
+Specifying the cache root:
+```puppet
+  class {'::apache::mod::disk_cache':
+    cache_root => '/path/to/cache',
   }
 ```
 

--- a/manifests/mod/disk_cache.pp
+++ b/manifests/mod/disk_cache.pp
@@ -3,7 +3,7 @@ class apache::mod::disk_cache {
     $cache_root = $::osfamily ? {
       'debian'  => '/var/cache/apache2/mod_cache_disk',
       'redhat'  => '/var/cache/httpd/proxy',
-      'freebsd' => '/var/cache/mod_disk_cache', # TODO: Confirm
+      'freebsd' => '/var/cache/mod_cache_disk', # TODO: Confirm
     }
   }
   else {

--- a/manifests/mod/disk_cache.pp
+++ b/manifests/mod/disk_cache.pp
@@ -1,5 +1,5 @@
 class apache::mod::disk_cache {
-  if $::apache::apache_version >= 2.4 {
+  if versioncmp($::apache::apache_version, '2.4') >= 0 {
     $cache_root = $::osfamily ? {
       'debian'  => '/var/cache/apache2/mod_cache_disk',
       'redhat'  => '/var/cache/httpd/proxy',

--- a/manifests/mod/disk_cache.pp
+++ b/manifests/mod/disk_cache.pp
@@ -1,22 +1,29 @@
-class apache::mod::disk_cache {
-  if versioncmp($::apache::apache_version, '2.4') >= 0 {
-    $cache_root = $::osfamily ? {
+class apache::mod::disk_cache (
+  $cache_root = undef,
+) {
+  if $cache_root {
+    $_cache_root = $cache_root
+  }
+  elsif versioncmp($::apache::apache_version, '2.4') >= 0 {
+    $_cache_root = $::osfamily ? {
       'debian'  => '/var/cache/apache2/mod_cache_disk',
       'redhat'  => '/var/cache/httpd/proxy',
-      'freebsd' => '/var/cache/mod_cache_disk', # TODO: Confirm
+      'freebsd' => '/var/cache/mod_cache_disk',
     }
   }
   else {
-    $cache_root = $::osfamily ? {
+    $_cache_root = $::osfamily ? {
       'debian'  => '/var/cache/apache2/mod_disk_cache',
       'redhat'  => '/var/cache/mod_proxy',
       'freebsd' => '/var/cache/mod_disk_cache',
     }
   }
 
-  $mod_name = $::osfamily ? {
-    'FreeBSD' => 'cache_disk',
-    default   => 'disk_cache',
+  if versioncmp($::apache::apache_version, '2.4') >= 0 {
+    apache::mod { 'cache_disk': }
+  }
+  else {
+    apache::mod { 'disk_cache': }
   }
 
   if $::osfamily != 'FreeBSD' {
@@ -26,8 +33,7 @@ class apache::mod::disk_cache {
   }
   Class['::apache::mod::cache'] -> Class['::apache::mod::disk_cache']
 
-  apache::mod { $mod_name: }
-  # Template uses $cache_root
+  # Template uses $_cache_root
   file { 'disk_cache.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/disk_cache.conf",

--- a/manifests/mod/disk_cache.pp
+++ b/manifests/mod/disk_cache.pp
@@ -1,8 +1,17 @@
 class apache::mod::disk_cache {
-  $cache_root = $::osfamily ? {
-    'debian'  => '/var/cache/apache2/mod_disk_cache',
-    'redhat'  => '/var/cache/mod_proxy',
-    'freebsd' => '/var/cache/mod_disk_cache',
+  if $::apache::apache_version >= 2.4 {
+    $cache_root = $::osfamily ? {
+      'debian'  => '/var/cache/apache2/mod_cache_disk',
+      'redhat'  => '/var/cache/httpd/proxy',
+      'freebsd' => '/var/cache/mod_disk_cache', # TODO: Confirm
+    }
+  }
+  else {
+    $cache_root = $::osfamily ? {
+      'debian'  => '/var/cache/apache2/mod_disk_cache',
+      'redhat'  => '/var/cache/mod_proxy',
+      'freebsd' => '/var/cache/mod_disk_cache',
+    }
   }
 
   $mod_name = $::osfamily ? {

--- a/manifests/mod/disk_cache.pp
+++ b/manifests/mod/disk_cache.pp
@@ -18,7 +18,7 @@ class apache::mod::disk_cache {
   Class['::apache::mod::cache'] -> Class['::apache::mod::disk_cache']
 
   apache::mod { $mod_name: }
-  # Template uses $cache_proxy
+  # Template uses $cache_root
   file { 'disk_cache.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/disk_cache.conf",

--- a/templates/mod/disk_cache.conf.erb
+++ b/templates/mod/disk_cache.conf.erb
@@ -1,8 +1,4 @@
-<IfModule mod_proxy.c>
-  <IfModule mod_disk_cache.c>
-     CacheEnable disk /
-     CacheRoot "<%= @cache_root %>"
-     CacheDirLevels 2
-     CacheDirLength 1
-  </IfModule>
-</IfModule>
+CacheEnable disk /
+CacheRoot "<%= @cache_root %>"
+CacheDirLevels 2
+CacheDirLength 1

--- a/templates/mod/disk_cache.conf.erb
+++ b/templates/mod/disk_cache.conf.erb
@@ -1,4 +1,4 @@
 CacheEnable disk /
-CacheRoot "<%= @cache_root %>"
+CacheRoot "<%= @_cache_root %>"
 CacheDirLevels 2
 CacheDirLength 1


### PR DESCRIPTION
Load the correct disk cache module name based on the version of Apache (it changed in 2.4).

Also allow the user to specify the cache root for cases where the default location can't be used, e.g. if the disk cache needs to be located at an encrypted mount point to meet compliance regulations.