### PR TITLE
MODULES-1779 install package mod_ldap on CentOS 7

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -77,6 +77,10 @@ class apache::params inherits ::apache::version {
       },
       'fastcgi'     => 'mod_fastcgi',
       'fcgid'       => 'mod_fcgid',
+      'ldap'        => $::apache::version::distrelease ? {
+        '7'     => 'mod_ldap',
+        default => undef,
+      },
       'pagespeed'   => 'mod-pagespeed-stable',
       'passenger'   => 'mod_passenger',
       'perl'        => 'mod_perl',


### PR DESCRIPTION
On CentOS 7 `/usr/lib64/httpd/modules/mod_ldap.so` is part of the `mod_ldap` RPM.
In previous versions it is part of the `httpd` RPM.

This PR installs `mod_ldap` on CentOS 7 systems. 