### PR TITLE
Fixed default mpm_event config warning

### DIFF
--- a/manifests/mod/event.pp
+++ b/manifests/mod/event.pp
@@ -9,7 +9,7 @@ class apache::mod::event (
   $apache_version         = $::apache::apache_version,
   $threadlimit            = '64',
   $listenbacklog          = '511',
-  $maxrequestworkers      = '256',
+  $maxrequestworkers      = '250',
   $maxconnectionsperchild = '0',
 ) {
   if defined(Class['apache::mod::itk']) {


### PR DESCRIPTION
This should remove the warning and change the values to the defaults set by apache during the config check.
> AH00513: WARNING: MaxRequestWorkers of 256 is not an integer multiple of ThreadsPerChild of 25, decreasing to nearest multiple 250, for a maximum of 10 servers.