### PR TITLE
Fixes #880 - (MODULES-1391) Correct Ubuntu Trusty mod_prefork package name

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -168,7 +168,6 @@ class apache::params inherits ::apache::version {
     $logroot_mode        = undef
     $lib_path            = '/usr/lib/apache2/modules'
     $mpm_module          = 'worker'
-    $dev_packages        = ['libaprutil1-dev', 'libapr1-dev', 'apache2-prefork-dev']
     $default_ssl_cert    = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
     $default_ssl_key     = '/etc/ssl/private/ssl-cert-snakeoil.key'
     $ssl_certs_dir       = '/etc/ssl/certs'
@@ -234,6 +233,11 @@ class apache::params inherits ::apache::version {
       'base_rules/modsecurity_crs_60_correlation.conf'
     ]
     $error_documents_path = '/usr/share/apache2/error'
+    if ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '13.10') >= 0) {
+      $dev_packages        = ['libaprutil1-dev', 'libapr1-dev', 'apache2-dev']
+    } else {
+      $dev_packages        = ['libaprutil1-dev', 'libapr1-dev', 'apache2-prefork-dev']
+    }
 
     #
     # Passenger-specific settings

--- a/spec/classes/dev_spec.rb
+++ b/spec/classes/dev_spec.rb
@@ -16,6 +16,16 @@ describe 'apache::dev', :type => :class do
     it { is_expected.to contain_package("libapr1-dev") }
     it { is_expected.to contain_package("apache2-prefork-dev") }
   end
+  context "on an Ubuntu 14 OS" do
+    let :facts do
+      {
+        :osfamily               => 'Debian',
+        :operatingsystem        => 'Ubuntu',
+        :operatingsystemrelease => '14.04',
+      }
+    end
+    it { is_expected.to contain_package("apache2-dev") }
+  end
   context "on a RedHat OS" do
     let :facts do
       {

--- a/spec/classes/dev_spec.rb
+++ b/spec/classes/dev_spec.rb
@@ -19,9 +19,12 @@ describe 'apache::dev', :type => :class do
   context "on an Ubuntu 14 OS" do
     let :facts do
       {
+        :lsbdistrelease         => '14.04',
+        :lsbdistcodename        => 'trusty',
         :osfamily               => 'Debian',
         :operatingsystem        => 'Ubuntu',
         :operatingsystemrelease => '14.04',
+        :is_pe                  => false,
       }
     end
     it { is_expected.to contain_package("apache2-dev") }


### PR DESCRIPTION
    (MODULES-1391) Correct Ubuntu Trusty mod_prefork package name

    This module calls apache2-prefork-dev as the package
    name for the mod_prefork module for all Debian-flavored Linuxes. However
    Ubuntu 14.04 changes this to apache2-dev and makes apache2-prefork-dev
    an alias.

    The result is that calling this resource, even with the package
    installed, always results in a package changed purged to present
    message, as it's scanning dpkg for apache2-prefork-dev, finding the
    package missing, and then installing the alias via apt.