### PR TITLE
(#1391) Correct Debian jessie mod_prefork dev package name

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -233,7 +233,7 @@ class apache::params inherits ::apache::version {
       'base_rules/modsecurity_crs_60_correlation.conf'
     ]
     $error_documents_path = '/usr/share/apache2/error'
-    if ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '13.10') >= 0) {
+    if ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '13.10') >= 0) or ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '8') >= 0) {
       $dev_packages        = ['libaprutil1-dev', 'libapr1-dev', 'apache2-dev']
     } else {
       $dev_packages        = ['libaprutil1-dev', 'libapr1-dev', 'apache2-prefork-dev']


### PR DESCRIPTION
This module calls apache2-prefork-dev as the package
name for the mod_prefork module for all Debian-flavored Linuxes. However
Ubuntu 14.04 changes this to apache2-dev and makes apache2-prefork-dev
an alias.

The result is that calling this resource, even with the package
installed, always results in a package changed purged to present
message, as it's scanning dpkg for apache2-prefork-dev, finding the
package missing, and then installing the alias via apt.

Relates to 25be287baf for the Ubuntu part