### PR TITLE
include mod_filter when needed instead of instantiating it

### DIFF
--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -158,7 +158,7 @@ class apache::default_mods (
       }
 
       # filter is needed by mod_deflate
-      ::apache::mod { 'filter': }
+      include ::apache::mod::filter
     }
   } else {
     if versioncmp($apache_version, '2.4') >= 0 {
@@ -168,7 +168,7 @@ class apache::default_mods (
       }
 
       # filter is needed by mod_deflate
-      ::apache::mod { 'filter': }
+      include ::apache::mod::filter
     }
   }
 }


### PR DESCRIPTION
mod_filter gets included in a few places, and when some of them include and other instantiate, we end up with duplicate resources.