### PR TITLE
Don't manage docroot when default vhosts are disabled

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -355,6 +355,7 @@ class apache (
       priority        => '15',
       ip              => $ip,
       logroot_mode    => $logroot_mode,
+      manage_docroot  => $default_vhost,
     }
     $ssl_access_log_file = $::osfamily ? {
       'freebsd' => $access_log_file,
@@ -371,6 +372,7 @@ class apache (
       priority        => '15',
       ip              => $ip,
       logroot_mode    => $logroot_mode,
+      manage_docroot  => $default_ssl_vhost,
     }
   }
 }

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -690,6 +690,7 @@ describe 'apache', :type => :class do
       }
       end
       it { is_expected.to contain_apache__vhost('default').with_ensure('absent') }
+      it { is_expected.not_to contain_file('/var/www/html') }
     end
     context 'with default ssl vhost' do
       let :params do {
@@ -697,6 +698,7 @@ describe 'apache', :type => :class do
         }
       end
       it { is_expected.to contain_apache__vhost('default-ssl').with_ensure('present') }
+      it { is_expected.to contain_file('/var/www/html') }
     end
   end
   context 'with unsupported osfamily' do


### PR DESCRIPTION
As the code is now, if you set default_vhost or default_ssl_vhost to
false, the docroot directory will still be managed, but you will be
unable to set non-default ownership. Set manage_docroot to the value of
default*_vhost in the vhost resource declarations.