### PR TITLE
Documentation: fix Quickstart instructions for Ruby 1.8.7 (Red Hat)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2535,9 +2535,14 @@ Read the complete module [contribution guide](https://docs.puppetlabs.com/forge/
 This project contains tests for both [rspec-puppet](http://rspec-puppet.com/) and [beaker-rspec](https://github.com/puppetlabs/beaker-rspec) to verify functionality. For in-depth information please see their respective documentation.
 
 Quickstart:
-
+  Ruby > 1.8.7
     gem install bundler
     bundle install
     bundle exec rake spec
     bundle exec rspec spec/acceptance
     RS_DEBUG=yes bundle exec rspec spec/acceptance
+
+  Ruby = 1.8.7
+    gem install bundler
+    bundle install --without system_tests
+    bundle exec rake spec


### PR DESCRIPTION
Following the quickstart doesn't work in older Ruby version (like the default version on RHEL 6 systems)
```
$ bundle install
Fetching gem metadata from https://rubygems.org/........
Fetching version metadata from https://rubygems.org/..
Using rake 10.4.2
Using CFPropertyList 2.3.0

Gem::InstallError: i18n requires Ruby version >= 1.9.3.
An error occurred while installing i18n (0.7.0), and Bundler cannot continue.
Make sure that `gem install i18n -v '0.7.0'` succeeds before bundling.
```
You need this command instead:
```
$ bundle install --without system_tests
```