### PR TITLE
Ensure resources notify Apache::Service class

### DIFF
--- a/README.md
+++ b/README.md
@@ -2505,7 +2505,7 @@ Something along the lines of:
         exec { 'restorecon_apache':
           command => 'restorecon -Rv /apache_spec',
           path    => '/bin:/usr/bin/:/sbin:/usr/sbin',
-          before  => Service['httpd'],
+          before  => Class['Apache::Service'],
           require => Class['apache'],
         }
         class { 'apache': }

--- a/manifests/balancer.pp
+++ b/manifests/balancer.pp
@@ -50,7 +50,7 @@ define apache::balancer (
     owner  => '0',
     group  => '0',
     mode   => '0644',
-    notify => Service['httpd'],
+    notify => Class['Apache::Service'],
   }
 
   concat::fragment { "00-${name}-header":

--- a/manifests/custom_config.pp
+++ b/manifests/custom_config.pp
@@ -34,7 +34,7 @@ define apache::custom_config (
   $filename = "${priority_prefix}${filename_middle}.conf"
 
   if ! $verify_config or $ensure == 'absent' {
-    $notifies = Service['httpd']
+    $notifies = Class['Apache::Service']
   } else {
     $notifies = undef
   }
@@ -53,7 +53,7 @@ define apache::custom_config (
       command     => $verify_command,
       subscribe   => File["apache_${name}"],
       refreshonly => true,
-      notify      => Service['httpd'],
+      notify      => Class['Apache::Service'],
       before      => Exec["remove ${name} if invalid"],
     }
 

--- a/manifests/mod/auth_cas.pp
+++ b/manifests/mod/auth_cas.pp
@@ -42,7 +42,7 @@ class apache::mod::auth_cas (
     content => template('apache/mod/auth_cas.conf.erb'),
     require => [ Exec["mkdir ${::apache::mod_dir}"], ],
     before  => File[$::apache::mod_dir],
-    notify  => Service['httpd'],
+    notify  => Class['Apache::Service'],
   }
 
 }

--- a/spec/defines/custom_config_spec.rb
+++ b/spec/defines/custom_config_spec.rb
@@ -30,7 +30,7 @@ describe 'apache::custom_config', :type => :define do
       'refreshonly' => 'true',
       'subscribe'   => 'File[apache_rspec]',
       'command'     => '/usr/sbin/apachectl -t',
-      'notify'      => 'Service[httpd]',
+      'notify'      => 'Class[Apache::Service]',
       'before'      => 'Exec[remove rspec if invalid]',
     })
     }
@@ -83,7 +83,7 @@ describe 'apache::custom_config', :type => :define do
     it { is_expected.to_not contain_exec('service notify for rspec') }
     it { is_expected.to_not contain_exec('remove rspec if invalid') }
     it { is_expected.to contain_file('apache_rspec').with({
-      'notify' => 'Service[httpd]'
+      'notify' => 'Class[Apache::Service]'
     })
     }
   end


### PR DESCRIPTION
(#MODULES-1829) Fix resources that notify Service[httpd]

With the introduction of the service_manage bool, the Service[httpd]
class will not be part of the catalog if false. However there are still
some resources which notify Service[httpd] instead of the wrapper
Apache::Service class and these choke on undefined Service[httpd]
resource if service_manage is false.