### PR TITLE
no longer enforce the default value for $apache_name

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -44,10 +44,10 @@ class apache::package (
           before => Package['httpd'],
         }
       }
-      $apache_package = $::apache::params::apache_name
+      $apache_package = $::apache::apache_name
     }
     default: {
-      $apache_package = $::apache::params::apache_name
+      $apache_package = $::apache::apache_name
     }
   }
 

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -121,7 +121,7 @@ define apache::vhost(
     fail('You must include the apache base class before using any apache defined resources')
   }
 
-  $apache_name = $::apache::params::apache_name
+  $apache_name = $::apache::apache_name
 
   validate_re($ensure, '^(present|absent)$',
   "${ensure} is not supported for ensure.


### PR DESCRIPTION
The documentation states that the parameter `${apache::apache_name}` is available to install a different apache package. It is not working as expected, because the default values are still enforced in several places, ignoring the `apache_name` parameter.

This patch fixes this issue.