### PR TITLE
make $lib_path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,10 @@ Sets the amount of time the server waits for subsequent requests on a persistent
 
 Sets the limit of the number of requests allowed per connection when KeepAlive is on. Defaults to '100'.
 
+#####`lib_path`
+
+Specifies the location where apache module files are stored. It should not be configured manually without special reason.
+
 #####`loadfile_name`
 
 Sets the file name for the module loadfile. Should be in the format *.load.  This can be used to set the module load order.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,6 +48,7 @@ class apache (
   $mod_dir                = $::apache::params::mod_dir,
   $mod_enable_dir         = $::apache::params::mod_enable_dir,
   $mpm_module             = $::apache::params::mpm_module,
+  $lib_path               = $::apache::params::lib_path,
   $conf_template          = $::apache::params::conf_template,
   $servername             = $::apache::params::servername,
   $manage_user            = true,

--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -2,7 +2,7 @@ define apache::mod (
   $package        = undef,
   $package_ensure = 'present',
   $lib            = undef,
-  $lib_path       = $::apache::params::lib_path,
+  $lib_path       = $::apache::lib_path,
   $id             = undef,
   $path           = undef,
   $loadfile_name  = undef,

--- a/manifests/mod/wsgi.pp
+++ b/manifests/mod/wsgi.pp
@@ -14,7 +14,7 @@ class apache::mod::wsgi (
     if $mod_path =~ /\// {
       $_mod_path = $mod_path
     } else {
-      $_mod_path = "${::apache::params::lib_path}/${mod_path}"
+      $_mod_path = "${::apache::lib_path}/${mod_path}"
     }
     ::apache::mod { 'wsgi':
       package => $package_name,

--- a/manifests/mpm.pp
+++ b/manifests/mpm.pp
@@ -1,5 +1,5 @@
 define apache::mpm (
-  $lib_path       = $::apache::params::lib_path,
+  $lib_path       = $::apache::lib_path,
   $apache_version = $::apache::apache_version,
 ) {
   if ! defined(Class['apache']) {


### PR DESCRIPTION
In conjunction with `${apache::apache_version}` it is sometimes required to also change `$lib_path` to a non-default location. This patch introduces `lib_path` as a new parameter.