### PR TITLE
give a lower priority to mod_passenger

### DIFF
--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -15,9 +15,9 @@ class apache::mod::passenger (
   $passenger_app_env              = undef,
   $mod_package                    = undef,
   $mod_package_ensure             = undef,
-  $mod_lib                        = undef,
+  $mod_lib                        = 'mod_passenger.so',
   $mod_lib_path                   = undef,
-  $mod_id                         = undef,
+  $mod_id                         = 'passenger_module',
   $mod_path                       = undef,
 ) {
   # Managed by the package, but declare it to avoid purging
@@ -56,7 +56,7 @@ class apache::mod::passenger (
 
   $_id = $mod_id
   $_path = $mod_path
-  ::apache::mod { 'passenger':
+  ::apache::mod { 'zpassenger':
     package        => $_package,
     package_ensure => $_package_ensure,
     lib            => $_lib,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -82,7 +82,7 @@ class apache::params inherits ::apache::version {
         default => undef,
       },
       'pagespeed'   => 'mod-pagespeed-stable',
-      'passenger'   => 'mod_passenger',
+      'zpassenger'   => 'mod_passenger',
       'perl'        => 'mod_perl',
       'php5'        => $::apache::version::distrelease ? {
         '5'     => 'php53',
@@ -182,7 +182,7 @@ class apache::params inherits ::apache::version {
       'fcgid'       => 'libapache2-mod-fcgid',
       'nss'         => 'libapache2-mod-nss',
       'pagespeed'   => 'mod-pagespeed-stable',
-      'passenger'   => 'libapache2-mod-passenger',
+      'zpassenger'  => 'libapache2-mod-passenger',
       'perl'        => 'libapache2-mod-perl2',
       'php5'        => 'libapache2-mod-php5',
       'proxy_html'  => 'libapache2-mod-proxy-html',
@@ -331,7 +331,7 @@ class apache::params inherits ::apache::version {
       # NOTE: not sure where the shibboleth should come from
       'auth_kerb'  => 'www/mod_auth_kerb2',
       'fcgid'      => 'www/mod_fcgid',
-      'passenger'  => 'www/rubygem-passenger',
+      'zpassenger' => 'www/rubygem-passenger',
       'perl'       => 'www/mod_perl2',
       'php5'       => 'www/mod_php5',
       'proxy_html' => 'www/mod_proxy_html',
@@ -391,7 +391,7 @@ class apache::params inherits ::apache::version {
       # NOTE: I list here only modules that are not included in www-servers/apache
       'auth_kerb'  => 'www-apache/mod_auth_kerb',
       'fcgid'      => 'www-apache/mod_fcgid',
-      'passenger'  => 'www-apache/passenger',
+      'zpassenger' => 'www-apache/passenger',
       'perl'       => 'www-apache/mod_perl',
       'php5'       => 'dev-lang/php',
       'proxy_html' => 'www-apache/mod_proxy_html',

--- a/spec/classes/mod/passenger_spec.rb
+++ b/spec/classes/mod/passenger_spec.rb
@@ -20,10 +20,10 @@ describe 'apache::mod::passenger', :type => :class do
       }
     end
     it { is_expected.to contain_class("apache::params") }
-    it { is_expected.to contain_apache__mod('passenger') }
+    it { is_expected.to contain_apache__mod('zpassenger') }
     it { is_expected.to contain_package("libapache2-mod-passenger") }
-    it { is_expected.to contain_file('passenger.load').with({
-      'path' => '/etc/apache2/mods-available/passenger.load',
+    it { is_expected.to contain_file('zpassenger.load').with({
+      'path' => '/etc/apache2/mods-available/zpassenger.load',
     }) }
     it { is_expected.to contain_file('passenger.conf').with({
       'path' => '/etc/apache2/mods-available/passenger.conf',
@@ -105,25 +105,25 @@ describe 'apache::mod::passenger', :type => :class do
       let :params do
         { :mod_path => '/usr/lib/foo/mod_foo.so' }
       end
-      it { is_expected.to contain_file('passenger.load').with_content(/^LoadModule passenger_module \/usr\/lib\/foo\/mod_foo\.so$/) }
+      it { is_expected.to contain_file('zpassenger.load').with_content(/^LoadModule passenger_module \/usr\/lib\/foo\/mod_foo\.so$/) }
     end
     describe "with mod_lib_path => '/usr/lib/foo'" do
       let :params do
         { :mod_lib_path => '/usr/lib/foo' }
       end
-      it { is_expected.to contain_file('passenger.load').with_content(/^LoadModule passenger_module \/usr\/lib\/foo\/mod_passenger\.so$/) }
+      it { is_expected.to contain_file('zpassenger.load').with_content(/^LoadModule passenger_module \/usr\/lib\/foo\/mod_passenger\.so$/) }
     end
     describe "with mod_lib => 'mod_foo.so'" do
       let :params do
         { :mod_lib => 'mod_foo.so' }
       end
-      it { is_expected.to contain_file('passenger.load').with_content(/^LoadModule passenger_module \/usr\/lib\/apache2\/modules\/mod_foo\.so$/) }
+      it { is_expected.to contain_file('zpassenger.load').with_content(/^LoadModule passenger_module \/usr\/lib\/apache2\/modules\/mod_foo\.so$/) }
     end
     describe "with mod_id => 'mod_foo'" do
       let :params do
         { :mod_id => 'mod_foo' }
       end
-      it { is_expected.to contain_file('passenger.load').with_content(/^LoadModule mod_foo \/usr\/lib\/apache2\/modules\/mod_passenger\.so$/) }
+      it { is_expected.to contain_file('zpassenger.load').with_content(/^LoadModule mod_foo \/usr\/lib\/apache2\/modules\/mod_passenger\.so$/) }
     end
 
     context "with Ubuntu 12.04 defaults" do
@@ -221,15 +221,15 @@ describe 'apache::mod::passenger', :type => :class do
       }
     end
     it { is_expected.to contain_class("apache::params") }
-    it { is_expected.to contain_apache__mod('passenger') }
+    it { is_expected.to contain_apache__mod('zpassenger') }
     it { is_expected.to contain_package("mod_passenger") }
     it { is_expected.to contain_file('passenger_package.conf').with({
       'path' => '/etc/httpd/conf.d/passenger.conf',
     }) }
     it { is_expected.to contain_file('passenger_package.conf').without_content }
     it { is_expected.to contain_file('passenger_package.conf').without_source }
-    it { is_expected.to contain_file('passenger.load').with({
-      'path' => '/etc/httpd/conf.d/passenger.load',
+    it { is_expected.to contain_file('zpassenger.load').with({
+      'path' => '/etc/httpd/conf.d/zpassenger.load',
     }) }
     it { is_expected.to contain_file('passenger.conf').without_content(/PassengerRoot/) }
     it { is_expected.to contain_file('passenger.conf').without_content(/PassengerRuby/) }
@@ -260,7 +260,7 @@ describe 'apache::mod::passenger', :type => :class do
       }
     end
     it { is_expected.to contain_class("apache::params") }
-    it { is_expected.to contain_apache__mod('passenger') }
+    it { is_expected.to contain_apache__mod('zpassenger') }
     it { is_expected.to contain_package("www/rubygem-passenger") }
   end
   context "on a Gentoo OS" do
@@ -277,7 +277,7 @@ describe 'apache::mod::passenger', :type => :class do
       }
     end
     it { is_expected.to contain_class("apache::params") }
-    it { is_expected.to contain_apache__mod('passenger') }
+    it { is_expected.to contain_apache__mod('zpassenger') }
     it { is_expected.to contain_package("www-apache/passenger") }
   end
 end


### PR DESCRIPTION
By giving mod_passenger a lower priority, mod_proxy will be loaded before mod_passenger, allowing a single vhost to direct certain requests using mod_proxy and direct the others to mod_passenger.

Use case: puppetmaster where the CA requests are proxied to a single server (without the need to configure the agents for different servers).