### PR TITLE
Allow setting environment variables inside the proxy locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1335,12 +1335,15 @@ apache::vhost { 'site.name.fdqn':
       'params' => { 'retry' => '0', 'timeout' => '5' }, },
     { 'path' => '/e', 'url' => 'http://backend-a/e',
       'keywords' => ['nocanon', 'interpolate'] },
+    { 'path' => '/f', 'url' => 'http://backend-f/',
+      'setenv' => ['proxy-nokeepalive 1','force-proxy-request-1.0 1']},
   ],
 }
 ```
 
 `reverse_urls` is optional and can be an array or a string. It is useful when used with `mod_proxy_balancer`.
 `params` is an optional parameter. It allows to provide the ProxyPass key=value parameters (Connection settings).
+`setenv` is optional and is an array to set environment variables for the proxy directive, for details see http://httpd.apache.org/docs/current/mod/mod_proxy.html#envsettings
 
 #####`rack_base_uris`
 

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -211,7 +211,8 @@ describe 'apache::vhost', :type => :define do
               'params'   => {
                       'retry'   => '0',
                       'timeout' => '5'
-              }
+              },
+              'setenv'   => ['proxy-nokeepalive 1','force-proxy-request-1.0 1'],
             }
           ],
           'suphp_addhandler'            => 'foo',
@@ -353,6 +354,10 @@ describe 'apache::vhost', :type => :define do
               /retry=0/) }
       it { is_expected.to contain_concat__fragment('rspec.example.com-proxy').with_content(
               /timeout=5/) }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-proxy').with_content(
+              /SetEnv force-proxy-request-1.0 1/) }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-proxy').with_content(
+              /SetEnv proxy-nokeepalive 1/) }
       it { is_expected.to contain_concat__fragment('rspec.example.com-proxy').with_content(
               /noquery interpolate/) }
       it { is_expected.to contain_concat__fragment('rspec.example.com-rack') }

--- a/templates/vhost/_proxy.erb
+++ b/templates/vhost/_proxy.erb
@@ -25,6 +25,11 @@
     ProxyPassReverse <%= reverse_url %>
     <%- end -%>
   <%- end -%>
+  <%- if proxy['setenv'] -%>
+    <%- Array(proxy['setenv']).each do |setenv_var| -%>
+    SetEnv <%= setenv_var -%>
+    <%- end -%>
+  <%- end -%>
   </Location>
 <% end -%>
 <% if @proxy_dest -%>


### PR DESCRIPTION
This patch adds support to set variables using 'SetEnv' inside proxy
locations. This is needed to support some backends that don't properly
support HTTP/1.1, as it allows a fallback by the Apache httpd server.
For details see [1] (Apache httpd documentation) and [2] (use case).

[1] http://httpd.apache.org/docs/2.2/mod/mod_proxy.html#envsettings
[2] https://wiki.jenkins-ci.org/display/JENKINS/Running+Jenkins+behind+Apache