### PR TITLE
Remove Debian workaround as it broke Red Hat systems

### DIFF
--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -25,20 +25,6 @@ class apache::mod::passenger (
     file { 'passenger_package.conf':
       path => "${::apache::mod_dir}/${passenger_conf_package_file}",
     }
-  } else {
-    # Remove passenger_extra.conf left over from before Passenger support was
-    # reworked for Debian. This is a temporary fix for users running this
-    # module from master after release 1.0.1 It will be removed in two
-    # releases from now.
-    $passenger_package_conf_ensure = $::osfamily ? {
-      'Debian' => 'absent',
-      default  => undef,
-    }
-
-    file { 'passenger_package.conf':
-      ensure => $passenger_package_conf_ensure,
-      path   => "${::apache::mod_dir}/passenger_extra.conf",
-    }
   }
 
   $_package = $mod_package

--- a/spec/classes/mod/passenger_spec.rb
+++ b/spec/classes/mod/passenger_spec.rb
@@ -28,7 +28,6 @@ describe 'apache::mod::passenger', :type => :class do
     it { is_expected.to contain_file('passenger.conf').with({
       'path' => '/etc/apache2/mods-available/passenger.conf',
     }) }
-    it { is_expected.to contain_file('passenger_package.conf').with_ensure('absent') }
     describe "with passenger_root => '/usr/lib/example'" do
       let :params do
         { :passenger_root => '/usr/lib/example' }


### PR DESCRIPTION
On Red Hat systems it was entirely possible to have the path for 'passenger_package.conf' file equal to that of the 'passenger.conf' file, causing an error. This was only the case when the '$passenger_conf_package_file' variable was not set (the default behaviour).

It was due to be removed anyway.