### PR TITLE
Apache: allow setting the default type

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,10 @@ Sets up a default SSL virtual host. Defaults to 'false'. If set to 'true', sets 
 
 SSL vhosts only respond to HTTPS queries.
 
+#####`default_type`
+
+(Apache httpd 2.2 only) MIME content-type that will be sent if the server cannot determine a type in any other way. This directive has been deprecated in Apache httpd 2.4, and only exists there for backwards compatibility of configuration files.
+
 #####`default_vhost`
 
 Sets up a default virtual host. Defaults to 'true', set to 'false' to set up [customized virtual hosts](#configure-a-virtual-host).

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,7 @@ class apache (
   $default_ssl_crl_path   = undef,
   $default_ssl_crl        = undef,
   $default_ssl_crl_check  = undef,
+  $default_type           = 'none',
   $ip                     = undef,
   $service_enable         = true,
   $service_manage         = true,

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -149,6 +149,40 @@ describe 'apache', :type => :class do
       ) }
     end
 
+    describe "Check default type" do
+      context "with Apache version < 2.4" do
+        let :params do
+          {
+            :apache_version => '2.2',
+          }
+        end
+    
+       context "when default_type => 'none'" do
+          let :params do
+            { :default_type => 'none' }
+          end
+    
+          it { is_expected.to contain_file("/etc/apache2/apache2.conf").with_content %r{^DefaultType none$} }
+        end
+        context "when default_type => 'text/plain'" do
+          let :params do
+            { :default_type => 'text/plain' }
+          end
+    
+          it { is_expected.to contain_file("/etc/apache2/apache2.conf").with_content %r{^DefaultType text/plain$} }
+        end
+      end
+   
+      context "with Apache version >= 2.4" do
+        let :params do
+          {
+            :apache_version => '2.4',
+          }
+        end
+        it { is_expected.to contain_file("/etc/apache2/apache2.conf").without_content %r{^DefaultType [.]*$} }
+      end
+    end
+
     describe "Don't create user resource" do
       context "when parameter manage_user is false" do
         let :params do
@@ -351,6 +385,38 @@ describe 'apache', :type => :class do
         end
 
         it { is_expected.to contain_file("/etc/httpd/conf/httpd.conf").with_content %r{^AddDefaultCharset none$} }
+      end
+
+      context "with Apache version < 2.4" do
+        let :params do
+          {
+            :apache_version => '2.2',
+          }
+        end
+
+       context "when default_type => 'none'" do
+          let :params do
+            { :default_type => 'none' }
+          end
+
+          it { is_expected.to contain_file("/etc/httpd/conf/httpd.conf").with_content %r{^DefaultType none$} }
+        end
+        context "when default_type => 'text/plain'" do
+          let :params do
+            { :default_type => 'text/plain' }
+          end
+
+          it { is_expected.to contain_file("/etc/httpd/conf/httpd.conf").with_content %r{^DefaultType text/plain$} }
+        end
+      end
+
+      context "with Apache version >= 2.4" do
+        let :params do
+          {
+            :apache_version => '2.4',
+          }
+        end
+        it { is_expected.to contain_file("/etc/httpd/conf/httpd.conf").without_content %r{^DefaultType [.]*$} }
       end
 
       it { is_expected.to contain_file("/etc/httpd/conf/httpd.conf").with_content %r{^Include "/etc/httpd/site\.d/\*"$} }

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -34,7 +34,9 @@ AccessFileName .htaccess
 AddDefaultCharset <%= @default_charset %>
 <% end -%>
 
-DefaultType none
+<%- if scope.function_versioncmp([@apache_version, '2.4']) < 0 -%>
+DefaultType <%= @default_type %>
+<%- end -%>
 HostnameLookups Off
 ErrorLog "<%= @logroot %>/<%= @error_log %>"
 LogLevel <%= @log_level %>


### PR DESCRIPTION
This setting is only valid on Apache httpd 2.2 (and possibly lower)

Please make sure to review the test extensively, I may have done something wrong about the position I placed that test.