### PR TITLE
Apache: add module for mod_geoip

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
         * [Classes: apache::mod::*](#classes-apachemodname)
         * [Class: apache::mod::alias](#class-apachemodalias)
         * [Class: apache::mod::event](#class-apachemodevent)
+        * [Class: apache::mod::geoip](#class-apachemodgeoip)
         * [Class: apache::mod::info](#class-apachemodinfo)
         * [Class: apache::mod::pagespeed](#class-apachemodpagespeed)
         * [Class: apache::mod::php](#class-apachemodphp)
@@ -617,6 +618,12 @@ To configure the event thread limit:
     $threadlimit      => '128',
   }
 ```
+
+####Class:  `apache::mod::geoip`
+
+Installs and manages geoip module.
+
+Full Documentation for geoip is available from [maxmind](http://dev.maxmind.com/geoip/legacy/mod_geoip2/).
 
 ####Class: `apache::mod::auth_cas`
 

--- a/manifests/mod/geoip.pp
+++ b/manifests/mod/geoip.pp
@@ -1,0 +1,38 @@
+# Class: apache::mod::geoip
+#
+# This class enables and configures Apache mod_geoip
+#
+# Actions:
+# - Enable and configure Apache mod_geoip
+#
+# Requires:
+# - The apache class
+#
+# Sample Usage:
+#
+#  include apache::mod::geoip
+#
+class apache::mod::geoip (
+  $enabled        = true,
+  $db_file        = '/usr/share/GeoIP/GeoIP.dat',
+  $package_ensure = 'present',
+){
+
+  validate_re($db_file, '^[\'"]?(?:/[^/]+)*[\'"]?$', "${db_file} is not supported for db_file.  Allowed values are paths.")
+  validate_bool($enabled)
+
+  apache::mod { 'geoip':
+    package        => 'mod_geoip',
+    package_ensure => $package_ensure,
+  }
+
+  # Template uses all class parameters
+  file { 'geoip.conf':
+    ensure  => 'present',
+    path    => "${apache::mod_dir}/geoip.conf",
+    content => template('apache/mod/geoip.conf.erb'),
+    require => Exec["mkdir ${apache::mod_dir}"],
+    before  => File[$apache::mod_dir],
+    notify  => Class['::apache::service'],
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -77,6 +77,7 @@ class apache::params inherits ::apache::version {
       },
       'fastcgi'     => 'mod_fastcgi',
       'fcgid'       => 'mod_fcgid',
+      'geoip'       => 'mod_geoip',
       'ldap'        => $::apache::version::distrelease ? {
         '7'     => 'mod_ldap',
         default => undef,
@@ -180,6 +181,7 @@ class apache::params inherits ::apache::version {
       'dav_svn'     => 'libapache2-svn',
       'fastcgi'     => 'libapache2-mod-fastcgi',
       'fcgid'       => 'libapache2-mod-fcgid',
+      'geoip'       => 'libapache2-mod_geoip',
       'nss'         => 'libapache2-mod-nss',
       'pagespeed'   => 'mod-pagespeed-stable',
       'zpassenger'  => 'libapache2-mod-passenger',
@@ -331,6 +333,7 @@ class apache::params inherits ::apache::version {
       # NOTE: not sure where the shibboleth should come from
       'auth_kerb'  => 'www/mod_auth_kerb2',
       'fcgid'      => 'www/mod_fcgid',
+      'geoip'      => 'www/mod_geoip',
       'zpassenger' => 'www/rubygem-passenger',
       'perl'       => 'www/mod_perl2',
       'php5'       => 'www/mod_php5',
@@ -391,6 +394,7 @@ class apache::params inherits ::apache::version {
       # NOTE: I list here only modules that are not included in www-servers/apache
       'auth_kerb'  => 'www-apache/mod_auth_kerb',
       'fcgid'      => 'www-apache/mod_fcgid',
+      'geoip'      => 'www/mod_geoip',
       'zpassenger' => 'www-apache/passenger',
       'perl'       => 'www-apache/mod_perl',
       'php5'       => 'dev-lang/php',

--- a/spec/classes/mod/geoip_spec.rb
+++ b/spec/classes/mod/geoip_spec.rb
@@ -1,0 +1,165 @@
+require 'spec_helper'
+
+describe 'apache::mod::geoip', :type => :class do
+  let :pre_condition do
+    [
+      'include apache',
+    ]
+  end
+  context "on a Debian OS" do
+    let :facts do
+      {
+        :osfamily               => 'Debian',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
+        :lsbdistcodename        => 'squeeze',
+        :operatingsystem        => 'Debian',
+        :id                     => 'root',
+        :kernel                 => 'Linux',
+        :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :is_pe                  => false,
+      }
+    end
+    it { is_expected.to contain_class("apache::params") }
+    it { is_expected.to contain_apache__mod('geoip') }
+    it { is_expected.to contain_file("geoip.conf").with_ensure('present') }
+    it { is_expected.to contain_file("geoip.conf").with({
+      'path' => '/etc/apache2/mods-available/geoip.conf',
+    } )}
+    it { is_expected.to contain_file("geoip.conf symlink").with_ensure('link') }
+    describe "enable geoip" do
+      let :params do
+        { :enabled => true }
+      end
+      it { is_expected.to contain_file("geoip.conf").with_content(/^GeoIPEnable On$/) }
+    end
+    describe "disable geoip" do
+      let :params do
+        { :enabled => false }
+      end
+      it { is_expected.to contain_file("geoip.conf").with_content(/^GeoIPEnable Off$/) }
+    end
+    describe "with db_file => /usr/share/GeoIP/GeoIP.dat" do
+      let :params do
+        { :db_file => "/usr/share/GeoIP/GeoIP.dat" }
+      end
+     it { is_expected.to contain_file("geoip.conf").with_content(/^GeoIPDBFile \/usr\/share\/GeoIP\/GeoIP.dat$/) }
+    end
+  end
+
+  context "on a RedHat OS" do
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
+        :operatingsystem        => 'RedHat',
+        :id                     => 'root',
+        :kernel                 => 'Linux',
+        :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :is_pe                  => false,
+      }
+    end
+    it { is_expected.to contain_class("apache::params") }
+    it { is_expected.to contain_apache__mod('geoip') }
+    it { is_expected.to contain_file("geoip.conf").with_ensure('present') }
+    it { is_expected.to contain_file("geoip.conf").with({
+      'path' => '/etc/httpd/conf.d/geoip.conf',
+    } )}
+    describe "enable geoip" do
+      let :params do
+        { :enabled => true }
+      end
+      it { is_expected.to contain_file("geoip.conf").with_content(/^GeoIPEnable On$/) }
+    end
+    describe "disable geoip" do
+      let :params do
+        { :enabled => false }
+      end
+      it { is_expected.to contain_file("geoip.conf").without_content(/^GeoIPEnable [.]+$/) }
+    end
+    describe "with db_file => /usr/share/GeoIP/GeoIP.dat" do
+      let :params do
+        { :db_file => "/usr/share/GeoIP/GeoIP.dat" }
+      end
+     it { is_expected.to contain_file("geoip.conf").with_content(/^GeoIPDBFile \/usr\/share\/GeoIP\/GeoIP.dat$/) }
+    end
+  end
+
+  context "on a FreeBSD OS" do
+    let :facts do
+      {
+        :osfamily               => 'FreeBSD',
+        :operatingsystemrelease => '9',
+        :concat_basedir         => '/dne',
+        :operatingsystem        => 'FreeBSD',
+        :id                     => 'root',
+        :kernel                 => 'FreeBSD',
+        :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :is_pe                  => false,
+      }
+    end
+    it { is_expected.to contain_class("apache::params") }
+    it { is_expected.to contain_apache__mod('geoip') }
+    it { is_expected.to contain_file("geoip.conf").with_ensure('present') }
+    it { is_expected.to contain_file("geoip.conf").with({
+      'path' => '/usr/local/etc/apache24/Modules/geoip.conf',
+    } )}
+    describe "enable geoip" do
+      let :params do
+        { :enabled => true }
+      end
+      it { is_expected.to contain_file("geoip.conf").with_content(/^GeoIPEnable On$/) }
+    end
+    describe "disable geoip" do
+      let :params do
+        { :enabled => false }
+      end
+      it { is_expected.to contain_file("geoip.conf").without_content(/^GeoIPEnable [.]+$/) }
+    end
+    describe "with db_file => /usr/share/GeoIP/GeoIP.dat" do
+      let :params do
+        { :db_file => "/usr/share/GeoIP/GeoIP.dat" }
+      end
+     it { is_expected.to contain_file("geoip.conf").with_content(/^GeoIPDBFile \/usr\/share\/GeoIP\/GeoIP.dat$/) }
+    end
+  end
+  context "on a Gentoo OS" do
+    let :facts do
+      {
+        :osfamily               => 'Gentoo',
+        :operatingsystem        => 'Gentoo',
+        :operatingsystemrelease => '3.16.1-gentoo',
+        :concat_basedir         => '/dne',
+        :id                     => 'root',
+        :kernel                 => 'Linux',
+        :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
+        :is_pe                  => false,
+      }
+    end
+    it { is_expected.to contain_class("apache::params") }
+    it { is_expected.to contain_apache__mod('geoip') }
+    it { is_expected.to contain_file("geoip.conf").with_ensure('present') }
+    it { is_expected.to contain_file("geoip.conf").with({
+      'path' => '/etc/apache2/modules.d/geoip.conf',
+    } )}
+    describe "enable geoip" do
+      let :params do
+        { :enabled => true }
+      end
+      it { is_expected.to contain_file("geoip.conf").with_content(/^GeoIPEnable On$/) }
+    end
+    describe "disable geoip" do
+      let :params do
+        { :enabled => false }
+      end
+      it { is_expected.to contain_file("geoip.conf").without_content(/^GeoIPEnable [.]+$/) }
+    end
+    describe "with db_file => /usr/share/GeoIP/GeoIP.dat" do
+      let :params do
+        { :db_file => "/usr/share/GeoIP/GeoIP.dat" }
+      end
+     it { is_expected.to contain_file("geoip.conf").with_content(/^GeoIPDBFile \/usr\/share\/GeoIP\/GeoIP.dat$/) }
+    end
+  end
+end

--- a/templates/mod/geoip.conf.erb
+++ b/templates/mod/geoip.conf.erb
@@ -1,0 +1,3 @@
+GeoIPEnable <%= scope.function_bool2httpd([@enabled]) %>
+
+GeoIPDBFile <%= @db_file %>


### PR DESCRIPTION
Only actually tested on RHEL 6.

Debian *should* be ok according to https://packages.debian.org/wheezy/all/geoip-database/filelist (this package is recommended by a direct dependency of the Apache module, so most systems install it automatically with the Apache module)

Edit: typo