### PR TITLE
Apache: add support for the ProxyPassMatch directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1247,6 +1247,10 @@ Array of IPs to exclude from mod_security rule matching
 
 Specifies URLs you do not want to proxy. This parameter is meant to be used in combination with [`proxy_dest`](#proxy_dest).
 
+#####`no_proxy_uris_match`
+
+This directive is equivalent to `no_proxy_uris`, but takes regular expressions.
+
 #####`proxy_preserve_host`
 
 Sets the [ProxyPreserveHost Directive](http://httpd.apache.org/docs/2.2/mod/mod_proxy.html#proxypreservehost).  true Enables the Host: line from an incoming request to be proxied to the host instead of hostname .  false sets this option to off (default).
@@ -1348,6 +1352,10 @@ apache::vhost { 'site.name.fdqn':
 `reverse_urls` is optional and can be an array or a string. It is useful when used with `mod_proxy_balancer`.
 `params` is an optional parameter. It allows to provide the ProxyPass key=value parameters (Connection settings).
 `setenv` is optional and is an array to set environment variables for the proxy directive, for details see http://httpd.apache.org/docs/current/mod/mod_proxy.html#envsettings
+
+#####`proxy_pass_match`
+
+This directive is equivalent to proxy_pass, but takes regular expressions, see [ProxyPassMatch](http://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassmatch) for details.
 
 #####`rack_base_uris`
 

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -57,7 +57,10 @@ define apache::vhost(
   $scriptalias                 = undef,
   $scriptaliases               = [],
   $proxy_dest                  = undef,
+  $proxy_dest_match            = undef,
+  $proxy_dest_reverse_match    = undef,
   $proxy_pass                  = undef,
+  $proxy_pass_match            = undef,
   $suphp_addhandler            = $::apache::params::suphp_addhandler,
   $suphp_engine                = $::apache::params::suphp_engine,
   $suphp_configpath            = $::apache::params::suphp_configpath,
@@ -66,6 +69,7 @@ define apache::vhost(
   $php_admin_flags             = {},
   $php_admin_values            = {},
   $no_proxy_uris               = [],
+  $no_proxy_uris_match         = [],
   $proxy_preserve_host         = false,
   $proxy_error_override        = false,
   $redirect_source             = '/',
@@ -364,7 +368,7 @@ define apache::vhost(
   }
 
   # Load mod_proxy if needed and not yet loaded
-  if ($proxy_dest or $proxy_pass) {
+  if ($proxy_dest or $proxy_pass or $proxy_pass_match or $proxy_dest_match) {
     if ! defined(Class['apache::mod::proxy']) {
       include ::apache::mod::proxy
     }

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -215,12 +215,25 @@ describe 'apache::vhost', :type => :define do
               'setenv'   => ['proxy-nokeepalive 1','force-proxy-request-1.0 1'],
             }
           ],
+          'proxy_pass_match'            => [
+            {
+              'path'     => '/a',
+              'url'      => 'http://backend-a/',
+              'keywords' => ['noquery', 'interpolate'],
+              'params'   => {
+                      'retry'   => '0',
+                      'timeout' => '5'
+              },
+              'setenv'   => ['proxy-nokeepalive 1','force-proxy-request-1.0 1'],
+            }
+          ],
           'suphp_addhandler'            => 'foo',
           'suphp_engine'                => 'on',
           'suphp_configpath'            => '/var/www/html',
           'php_admin_flags'             => ['foo', 'bar'],
           'php_admin_values'            => ['true', 'false'],
           'no_proxy_uris'               => '/foo',
+          'no_proxy_uris_match'         => '/foomatch',
           'proxy_preserve_host'         => true,
           'proxy_error_override'        => true,
           'redirect_source'             => '/bar',

--- a/templates/vhost/_proxy.erb
+++ b/templates/vhost/_proxy.erb
@@ -32,6 +32,29 @@
   <%- end -%>
   </Location>
 <% end -%>
+<% [@proxy_pass_match].flatten.compact.each do |proxy| %>
+  ProxyPassMatch <%= proxy['path'] %> <%= proxy['url'] %>
+  <%- if proxy['params'] -%>
+    <%- proxy['params'].each_pair do |key, value| -%> <%= key %>=<%= value -%>
+    <%- end -%>
+  <%- end -%>
+  <%- if proxy['keywords'] %> <%= proxy['keywords'].join(' ') -%>
+  <%- end %>
+  <Location <%= proxy['path']%>>
+  <%- if proxy['reverse_urls'].nil? -%>
+    ProxyPassReverse <%= proxy['url'] %>
+  <%- else -%>
+    <%- Array(proxy['reverse_urls']).each do |reverse_url| -%>
+    ProxyPassReverse <%= reverse_url %>
+    <%- end -%>
+  <%- end -%>
+  <%- if proxy['setenv'] -%>
+    <%- Array(proxy['setenv']).each do |setenv_var| -%>
+    SetEnv <%= setenv_var -%>
+    <%- end -%>
+  <%- end -%>
+  </Location>
+<% end -%>
 <% if @proxy_dest -%>
 <%- Array(@no_proxy_uris).each do |uri| -%>
   ProxyPass        <%= uri %> !
@@ -39,5 +62,14 @@
   ProxyPass          / <%= @proxy_dest %>/
   <Location          />
     ProxyPassReverse <%= @proxy_dest %>/
+  </Location>
+<% end -%>
+<% if @proxy_dest_match -%>
+<%- Array(@no_proxy_uris_match).each do |uri| -%>
+  ProxyPassMatch        <%= uri %> !
+<% end -%>
+  ProxyPassMatch          / <%= @proxy_dest_match %>/
+  <Location          />
+    ProxyPassReverse <%= @proxy_dest_reverse_match %>/
   </Location>
 <% end -%>


### PR DESCRIPTION
This would require more tests, although due to how the tests for the normal ProxyPass directive are written, they match ProxyPassMatch as well, making it a bit more difficult.