### PR TITLE
Fixes/apache name

### DIFF
--- a/manifests/dev.pp
+++ b/manifests/dev.pp
@@ -1,7 +1,4 @@
 class apache::dev {
-  if $::osfamily == 'FreeBSD' and !defined(Class['apache::package']) {
-    fail('apache::dev requires apache::package; please include apache or apache::package class first')
-  }
   include ::apache::params
   $packages = $::apache::params::dev_packages
   if $packages { # FreeBSD doesn't have dev packages to install

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -44,10 +44,10 @@ class apache::package (
           before => Package['httpd'],
         }
       }
-      $apache_package = $::apache::params::apache_name
+      $apache_package = $::apache::apache_name
     }
     default: {
-      $apache_package = $::apache::params::apache_name
+      $apache_package = $::apache::apache_name
     }
   }
 

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -2,6 +2,12 @@ class apache::package (
   $ensure     = 'present',
   $mpm_module = $::apache::params::mpm_module,
 ) inherits ::apache::params {
+
+  # The base class must be included first because it is used by parameter defaults
+  if ! defined(Class['apache']) {
+    fail('You must include the apache base class before using any apache defined resources')
+  }
+
   case $::osfamily {
     'FreeBSD': {
       case $mpm_module {

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -125,7 +125,7 @@ define apache::vhost(
     fail('You must include the apache base class before using any apache defined resources')
   }
 
-  $apache_name = $::apache::params::apache_name
+  $apache_name = $::apache::apache_name
 
   validate_re($ensure, '^(present|absent)$',
   "${ensure} is not supported for ensure.

--- a/spec/classes/dev_spec.rb
+++ b/spec/classes/dev_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
 describe 'apache::dev', :type => :class do
+  let(:pre_condition) {[
+    'include apache'
+  ]}
   context "on a Debian OS" do
     let :facts do
       {
@@ -9,6 +12,10 @@ describe 'apache::dev', :type => :class do
         :operatingsystem        => 'Debian',
         :operatingsystemrelease => '6',
         :is_pe                  => false,
+        :concat_basedir         => '/foo',
+        :id                     => 'root',
+        :path                   => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
+        :kernel                 => 'Linux'
       }
     end
     it { is_expected.to contain_class("apache::params") }
@@ -25,6 +32,10 @@ describe 'apache::dev', :type => :class do
         :operatingsystem        => 'Ubuntu',
         :operatingsystemrelease => '14.04',
         :is_pe                  => false,
+        :concat_basedir         => '/foo',
+        :id                     => 'root',
+        :path                   => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
+        :kernel                 => 'Linux'
       }
     end
     it { is_expected.to contain_package("apache2-dev") }
@@ -36,29 +47,31 @@ describe 'apache::dev', :type => :class do
         :operatingsystem        => 'RedHat',
         :operatingsystemrelease => '6',
         :is_pe                  => false,
+        :concat_basedir         => '/foo',
+        :id                     => 'root',
+        :path                   => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
+        :kernel                 => 'Linux'
       }
     end
     it { is_expected.to contain_class("apache::params") }
     it { is_expected.to contain_package("httpd-devel") }
   end
   context "on a FreeBSD OS" do
-    let :pre_condition do
-      'include apache::package'
-    end
     let :facts do
       {
         :osfamily               => 'FreeBSD',
         :operatingsystem        => 'FreeBSD',
         :operatingsystemrelease => '9',
         :is_pe                  => false,
+        :concat_basedir         => '/foo',
+        :id                     => 'root',
+        :path                   => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
+        :kernel                 => 'FreeBSD'
       }
     end
     it { is_expected.to contain_class("apache::params") }
   end
   context "on a Gentoo OS" do
-    let :pre_condition do
-      'include apache::package'
-    end
     let :facts do
       {
         :osfamily               => 'Gentoo',
@@ -66,6 +79,10 @@ describe 'apache::dev', :type => :class do
         :operatingsystemrelease => '3.16.1-gentoo',
         :concat_basedir         => '/dne',
         :is_pe                  => false,
+        :concat_basedir         => '/foo',
+        :id                     => 'root',
+        :path                   => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
+        :kernel                 => 'Linux'
       }
     end
     it { is_expected.to contain_class("apache::params") }

--- a/spec/classes/mod/dev_spec.rb
+++ b/spec/classes/mod/dev_spec.rb
@@ -1,16 +1,14 @@
 require 'spec_helper'
 
 describe 'apache::mod::dev', :type => :class do
+  let(:pre_condition) {[
+    'include apache'
+  ]}
   [
-    ['RedHat',  '6', 'Santiago'],
-    ['Debian',  '6', 'squeeze'],
-    ['FreeBSD', '9', 'FreeBSD'],
-  ].each do |osfamily, operatingsystemrelease, lsbdistcodename|
-    if osfamily == 'FreeBSD'
-      let :pre_condition do
-        'include apache::package'
-      end
-    end
+    ['RedHat',  '6', 'Santiago', 'Linux'],
+    ['Debian',  '6', 'squeeze', 'Linux'],
+    ['FreeBSD', '9', 'FreeBSD', 'FreeBSD'],
+  ].each do |osfamily, operatingsystemrelease, lsbdistcodename, kernel|
     context "on a #{osfamily} OS" do
       let :facts do
         {
@@ -19,6 +17,10 @@ describe 'apache::mod::dev', :type => :class do
           :operatingsystem        => osfamily,
           :operatingsystemrelease => operatingsystemrelease,
           :is_pe                  => false,
+          :concat_basedir         => '/foo',
+          :id                     => 'root',
+          :path                   => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
+          :kernel                 => kernel
         }
       end
       it { is_expected.to contain_class('apache::dev') }


### PR DESCRIPTION
Based on the work of @fraenki in https://github.com/puppetlabs/puppetlabs-apache/pull/1056
His patch is rebased against a more recent master, and I added 2 patches.
- fail if the apache base class is not defined
- ensure the base class is loaded during the tests

This was not the case during the previous versions, which caused some tests to fail after changing the parameter references used.