### PR TITLE
allow acess to userdirs again

### DIFF
--- a/templates/mod/userdir.conf.erb
+++ b/templates/mod/userdir.conf.erb
@@ -9,7 +9,7 @@
     Options MultiViews Indexes SymLinksIfOwnerMatch IncludesNoExec
     <Limit GET POST OPTIONS>
       <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
-      Require all denied
+      Require all granted
       <%- else -%>
       Order allow,deny
       Allow from all
@@ -17,7 +17,7 @@
     </Limit>
     <LimitExcept GET POST OPTIONS>
       <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
-      Require all denied
+      Require all granted
       <%- else -%>
       Order allow,deny
       Allow from all


### PR DESCRIPTION
After fixing the permission directives for Apache 2.4 in 460775670a, the userdirs were not accessible anymore because of `Require all denied`.