### PR TITLE
Revert "Supersede ssl_random_seed_bytes with ssl_random_seeds option to ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -774,12 +774,7 @@ Installs Apache SSL capabilities and uses the ssl.conf.erb template. These are t
       ssl_cipher             => 'HIGH:MEDIUM:!aNULL:!MD5',
       ssl_protocol           => [ 'all', '-SSLv2', '-SSLv3' ],
       ssl_pass_phrase_dialog => 'builtin',
-      ssl_random_seeds       => [
-        'startup builtin',
-        'startup file:/dev/urandom 512',
-        'connect builtin',
-        'connect file:/dev/urandom 512',
-      ],
+      ssl_random_seed_bytes  => '512',
     }
 ```
 

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -4,12 +4,7 @@ class apache::mod::ssl (
   $ssl_cipher             = 'HIGH:MEDIUM:!aNULL:!MD5',
   $ssl_protocol           = [ 'all', '-SSLv2', '-SSLv3' ],
   $ssl_pass_phrase_dialog = 'builtin',
-  $ssl_random_seeds       = [
-    'startup builtin',
-    'startup file:/dev/urandom 512',
-    'connect builtin',
-    'connect file:/dev/urandom 512',
-  ],
+  $ssl_random_seed_bytes  = '512',
   $apache_version         = $::apache::apache_version,
   $package_name           = undef,
 ) {
@@ -58,7 +53,6 @@ class apache::mod::ssl (
   # $ssl_options
   # $session_cache,
   # $ssl_mutex
-  # $ssl_random_seeds
   # $apache_version
   #
   file { 'ssl.conf':

--- a/spec/classes/mod/ssl_spec.rb
+++ b/spec/classes/mod/ssl_spec.rb
@@ -128,17 +128,13 @@ describe 'apache::mod::ssl', :type => :class do
       it { is_expected.to contain_file('ssl.conf').with_content(/^  SSLPassPhraseDialog exec:\/path\/to\/program$/)}
     end
 
-    context 'setting ssl_random_seeds' do
+    context 'setting ssl_random_seed_bytes' do
       let :params do
         {
-          :ssl_random_seeds => ['startup builtin',
-                                'startup file:/dev/random 256',
-                                'connect file:/dev/urandom 1024' ],
-         }
+          :ssl_random_seed_bytes => '1024',
+        }
       end
-      it { is_expected.to contain_file('ssl.conf').with_content(/^  SSLRandomSeed startup builtin$/)}
-      it { is_expected.to contain_file('ssl.conf').with_content(/^  SSLRandomSeed startup file:\/dev\/random 256$/)}
-      it { is_expected.to contain_file('ssl.conf').with_content(/^  SSLRandomSeed connect file:\/dev\/urandom 1024$/)}
+      it { is_expected.to contain_file('ssl.conf').with_content(%r{^  SSLRandomSeed startup file:/dev/urandom 1024$})}
     end
   end
 end

--- a/templates/mod/ssl.conf.erb
+++ b/templates/mod/ssl.conf.erb
@@ -1,9 +1,8 @@
 <IfModule mod_ssl.c>
-  <%- Array(@ssl_random_seeds).each do |ssl_random_seed| -%>
-    <%- if ssl_random_seed != '' -%>
-  SSLRandomSeed <%= ssl_random_seed %>
-    <%- end -%>
-  <%- end -%>
+  SSLRandomSeed startup builtin
+  SSLRandomSeed startup file:/dev/urandom <%= @ssl_random_seed_bytes %>
+  SSLRandomSeed connect builtin
+  SSLRandomSeed connect file:/dev/urandom <%= @ssl_random_seed_bytes %>
 
   AddType application/x-x509-ca-cert .crt
   AddType application/x-pkcs7-crl    .crl


### PR DESCRIPTION
...allow setting of both random source and bytes."

This reverts commit d431fce700f357a6330544490788bd124b2982dd.

Conflicts:
	manifests/mod/ssl.pp