### PR TITLE
Debian 7 is very inconsistent with mod_suphp

### DIFF
--- a/spec/acceptance/mod_suphp_spec.rb
+++ b/spec/acceptance/mod_suphp_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper_acceptance'
 
 describe 'apache::mod::suphp class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
-  case fact('osfamily')
-    when 'Debian'
+  case fact('operatingsystem')
+    when 'Ubuntu'
       context "default suphp config" do
         it 'succeeds in puppeting suphp' do
           pp = <<-EOS


### PR DESCRIPTION
It works fine on all the ubuntus. It's clearly ok. I don't know why
debian 7 does this.