### PR TITLE
Make Options directive configurable for mod userdir

### DIFF
--- a/manifests/mod/userdir.pp
+++ b/manifests/mod/userdir.pp
@@ -3,6 +3,7 @@ class apache::mod::userdir (
   $dir = 'public_html',
   $disable_root = true,
   $apache_version = $::apache::apache_version,
+  $options = [ 'MultiViews', 'Indexes', 'SymLinksIfOwnerMatch', 'IncludesNoExec' ],
 ) {
   ::apache::mod { 'userdir': }
 

--- a/templates/mod/userdir.conf.erb
+++ b/templates/mod/userdir.conf.erb
@@ -6,7 +6,7 @@
 
   <Directory "<%= @home %>/*/<%= @dir %>">
     AllowOverride FileInfo AuthConfig Limit Indexes
-    Options MultiViews Indexes SymLinksIfOwnerMatch IncludesNoExec
+    Options <%= @options.join(' ') %>
     <Limit GET POST OPTIONS>
       <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
       Require all denied


### PR DESCRIPTION
Always have `Indexes` enabled for `mod_userdir` seems wrong, so this pull request makes it configurable.