### PR TITLE
Allow settings to be overridden as parameters to apache::mod::ssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,12 +769,15 @@ Installs Apache SSL capabilities and uses the ssl.conf.erb template. These are t
 
 ```puppet
     class { 'apache::mod::ssl':
-      ssl_compression        => false,
-      ssl_options            => [ 'StdEnvVars' ],
-      ssl_cipher             => 'HIGH:MEDIUM:!aNULL:!MD5',
-      ssl_protocol           => [ 'all', '-SSLv2', '-SSLv3' ],
-      ssl_pass_phrase_dialog => 'builtin',
-      ssl_random_seed_bytes  => '512',
+      ssl_compression         => false,
+      ssl_cryptodevice        => 'builtin',
+      ssl_options             => [ 'StdEnvVars' ],
+      ssl_cipher              => 'HIGH:MEDIUM:!aNULL:!MD5',
+      ssl_honorcipherorder    => 'On',
+      ssl_protocol            => [ 'all', '-SSLv2', '-SSLv3' ],
+      ssl_pass_phrase_dialog  => 'builtin',
+      ssl_random_seed_bytes   => '512',
+      ssl_sessioncachetimeout => '300',
     }
 ```
 

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -1,12 +1,15 @@
 class apache::mod::ssl (
-  $ssl_compression        = false,
-  $ssl_options            = [ 'StdEnvVars' ],
-  $ssl_cipher             = 'HIGH:MEDIUM:!aNULL:!MD5',
-  $ssl_protocol           = [ 'all', '-SSLv2', '-SSLv3' ],
-  $ssl_pass_phrase_dialog = 'builtin',
-  $ssl_random_seed_bytes  = '512',
-  $apache_version         = $::apache::apache_version,
-  $package_name           = undef,
+  $ssl_compression         = false,
+  $ssl_cryptodevice        = 'builtin',
+  $ssl_options             = [ 'StdEnvVars' ],
+  $ssl_cipher              = 'HIGH:MEDIUM:!aNULL:!MD5',
+  $ssl_honorcipherorder    = 'On',
+  $ssl_protocol            = [ 'all', '-SSLv2', '-SSLv3' ],
+  $ssl_pass_phrase_dialog  = 'builtin',
+  $ssl_random_seed_bytes   = '512',
+  $ssl_sessioncachetimeout = '300',
+  $apache_version          = $::apache::apache_version,
+  $package_name            = undef,
 ) {
   $session_cache = $::osfamily ? {
     'debian'  => "\${APACHE_RUN_DIR}/ssl_scache(512000)",
@@ -50,9 +53,14 @@ class apache::mod::ssl (
   # Template uses
   #
   # $ssl_compression
+  # $ssl_cryptodevice
+  # $ssl_cipher
+  # $ssl_honorcipherorder
   # $ssl_options
-  # $session_cache,
+  # $session_cache
   # $ssl_mutex
+  # $ssl_random_seed_bytes
+  # $ssl_sessioncachetimeout
   # $apache_version
   #
   file { 'ssl.conf':

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -313,6 +313,12 @@ describe 'apache::vhost', :type => :define do
       it { is_expected.to compile }
       it { is_expected.to_not contain_file('/var/www/foo') }
       it { is_expected.to contain_class('apache::mod::ssl') }
+      it { is_expected.to contain_file('ssl.conf').with(
+        :content => /^\s+SSLHonorCipherOrder On$/ ) }
+      it { is_expected.to contain_file('ssl.conf').with(
+        :content => /^\s+SSLPassPhraseDialog builtin$/ ) }
+      it { is_expected.to contain_file('ssl.conf').with(
+        :content => /^\s+SSLSessionCacheTimeout 300$/ ) }
       it { is_expected.to contain_class('apache::mod::mime') }
       it { is_expected.to contain_class('apache::mod::vhost_alias') }
       it { is_expected.to contain_class('apache::mod::wsgi') }

--- a/templates/mod/ssl.conf.erb
+++ b/templates/mod/ssl.conf.erb
@@ -9,17 +9,17 @@
 
   SSLPassPhraseDialog <%= @ssl_pass_phrase_dialog %>
   SSLSessionCache "shmcb:<%= @session_cache %>"
-  SSLSessionCacheTimeout 300
+  SSLSessionCacheTimeout <%= @ssl_sessioncachetimeout %>
 <% if @ssl_compression -%>
   SSLCompression On
 <% end -%>
-  <% if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
+  <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
   Mutex <%= @ssl_mutex %>
-  <% else -%>
+  <%- else -%>
   SSLMutex <%= @ssl_mutex %>
-  <% end -%>
-  SSLCryptoDevice builtin
-  SSLHonorCipherOrder On
+  <%- end -%>
+  SSLCryptoDevice <%= @ssl_cryptodevice %>
+  SSLHonorCipherOrder <%= @ssl_honorcipherorder %>
   SSLCipherSuite <%= @ssl_cipher %>
   SSLProtocol <%= @ssl_protocol.compact.join(' ') %>
 <% if @ssl_options -%>


### PR DESCRIPTION
SSLSessionCacheTimeout, SSLCryptoDevice and SSLHonorCipherOrder are currently hardcoded in ssl.conf.erb.
This PR allows those to be overridden via parameters to apache::mod::ssl.
This will also fix https://tickets.puppetlabs.com/browse/MODULES-1851.