### PR TITLE
Earsdown fixes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,6 +61,7 @@ class apache (
   $logroot_mode           = $::apache::params::logroot_mode,
   $log_level              = $::apache::params::log_level,
   $log_formats            = {},
+  $error_log              = $::apache::params::error_log,
   $ports_file             = $::apache::params::ports_file,
   $docroot                = $::apache::params::docroot,
   $apache_version         = $::apache::version::default,
@@ -248,24 +249,25 @@ class apache (
     case $::osfamily {
       'debian': {
         $pidfile              = "\${APACHE_PID_FILE}"
-        $error_log            = 'error.log'
         $scriptalias          = '/usr/lib/cgi-bin'
         $access_log_file      = 'access.log'
       }
       'redhat': {
         $pidfile              = 'run/httpd.pid'
-        $error_log            = 'error_log'
         $scriptalias          = '/var/www/cgi-bin'
         $access_log_file      = 'access_log'
+        if $::operatingsystem == 'CentOS' and $::operatingsystemmajrelease == '7' {
+          $error_documents_path = '/usr/share/httpd/error'
+        } else {
+          $error_documents_path = '/var/www/error'
+        }
       }
       'freebsd': {
         $pidfile              = '/var/run/httpd.pid'
-        $error_log            = 'httpd-error.log'
         $scriptalias          = '/usr/local/www/apache24/cgi-bin'
         $access_log_file      = 'httpd-access.log'
       } 'gentoo': {
         $pidfile              = '/run/apache2.pid'
-        $error_log            = 'error.log'
         $error_documents_path = '/usr/share/apache2/error'
         $scriptalias          = '/var/www/localhost/cgi-bin'
         $access_log_file      = 'access.log'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -52,6 +52,7 @@ class apache::params inherits ::apache::version {
     $ports_file           = "${conf_dir}/ports.conf"
     $logroot              = '/var/log/httpd'
     $logroot_mode         = undef
+    $error_log            = 'error_log'
     $lib_path             = 'modules'
     $mpm_module           = 'prefork'
     $dev_packages         = 'httpd-devel'
@@ -166,6 +167,7 @@ class apache::params inherits ::apache::version {
     $ports_file          = "${conf_dir}/ports.conf"
     $logroot             = '/var/log/apache2'
     $logroot_mode        = undef
+    $error_log           = 'error.log'
     $lib_path            = '/usr/lib/apache2/modules'
     $mpm_module          = 'worker'
     $default_ssl_cert    = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
@@ -309,6 +311,7 @@ class apache::params inherits ::apache::version {
     $ports_file       = "${conf_dir}/ports.conf"
     $logroot          = '/var/log/apache24'
     $logroot_mode     = undef
+    $error_log        = 'httpd-error.log'
     $lib_path         = '/usr/local/libexec/apache24'
     $mpm_module       = 'prefork'
     $dev_packages     = undef
@@ -373,6 +376,7 @@ class apache::params inherits ::apache::version {
     $ports_file       = "${conf_dir}/ports.conf"
     $logroot          = '/var/log/apache2'
     $logroot_mode     = undef
+    $error_log        = 'error.log'
     $lib_path         = '/usr/lib/apache2/modules'
     $mpm_module       = 'prefork'
     $dev_packages     = undef

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -119,6 +119,18 @@ define apache::vhost(
   $modsec_disable_ids          = undef,
   $modsec_disable_ips          = undef,
   $modsec_body_limit           = undef,
+  $perl                        = undef,
+  $perl_postconfigrequire      = [],
+  $perl_status                 = false,
+  $perl_status_path            = "/perl-status",
+  $perl_status_allow_from      = ["127.0.0.1"],
+  $perl_options                = [],
+  $perl_interpstart            = '20',
+  $perl_interpmax              = '30',
+  $perl_interpminspare         = '3',
+  $perl_interpmaxspare         = '3',
+  $perl_interpmaxrequests      = '500',
+  $perl_interpscope            = 'request',
 ) {
   # The base class must be included first because it is used by parameter defaults
   if ! defined(Class['apache']) {
@@ -232,6 +244,10 @@ define apache::vhost(
 
   if $passenger_app_root or $passenger_app_env or $passenger_ruby or $passenger_min_instances or $passenger_start_timeout or $passenger_pre_start {
     include ::apache::mod::passenger
+  }
+  
+  if $perl {
+    include ::apache::mod::perl
   }
 
   # Configure the defaultness of a vhost
@@ -854,6 +870,26 @@ define apache::vhost(
       target  => "${priority_real}${filename}.conf",
       order   => 300,
       content => template('apache/vhost/_passenger.erb'),
+    }
+  }
+
+  # Template uses:
+  # - $perl_postconfigrequire
+  # - $perl_status
+  # - $perl_status_path
+  # - $perl_status_allow_from
+  # - $perl_options
+  # - $perl_interpstart
+  # - $perl_interpmax
+  # - $perl_interpminspare
+  # - $perl_interpmaxspare
+  # - $perl_interpmaxrequests
+  # - $perl_interpscope
+  if $perl {
+    concat::fragment { "${name}-perl":
+      target  => "${priority_real}-${filename}.conf",
+      order   => 305,
+      content => template('apache/vhost/_perl.erb'),
     }
   }
 

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -38,7 +38,11 @@ AddDefaultCharset <%= @default_charset %>
 DefaultType <%= @default_type %>
 <%- end -%>
 HostnameLookups Off
+<%- if /^[|\/]/.match(@error_log) || /^syslog:/.match(@error_log) -%>
+ErrorLog "<%= @error_log %>"
+<%- else -%>
 ErrorLog "<%= @logroot %>/<%= @error_log %>"
+<%- end -%>
 LogLevel <%= @log_level %>
 EnableSendfile <%= @sendfile %>
 <%- if @allow_encoded_slashes -%>

--- a/templates/vhost/_perl.erb
+++ b/templates/vhost/_perl.erb
@@ -1,0 +1,40 @@
+# mod_perl configuration
+<% if @perl_postconfigrequire and ! @perl_postconfigrequire.empty? -%>
+<% Array(@perl_postconfigrequire).each do |script| -%>
+  PerlPostConfigRequire <%= script %>
+<% end -%>
+<% end -%>
+<% if @perl_status -%>
+  <Location <%= @perl_status_path %>>
+    SetHandler perl-script
+    PerlResponseHandler Apache2::Status
+    <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
+    Require ip <%= Array(@perl_status_allow_from).join(" ") %>
+    <%- else -%>
+    Order deny,allow
+    Deny from all
+    Allow from <%= Array(@perl_status_allow_from).join(" ") %>
+    <%- end -%>
+  </Location>
+<% end -%>
+<% if @perl_options and ! @perl_options.empty? -%>
+  PerlOptions <%= Array(@perl_options).join(" ") %>
+<% end -%>
+<% if @perl_interpstart -%>
+  PerlInterpStart <%= @perl_interpstart %>
+<% end -%>
+<% if @perl_interpmax -%>
+  PerlInterpMax <%= @perl_interpmax %>
+<% end -%>
+<% if @perl_interpminspare -%>
+  PerlInterpMinSpare <%= @perl_interpminspare %>
+<% end -%>
+<% if @perl_interpmaxspare -%>
+  PerlInterpMaxSpare <%= @perl_interpmaxspare %>
+<% end -%>
+<% if @perl_interpmaxrequests -%>
+  PerlInterpMaxRequests <%= @perl_interpmaxrequests %>
+<% end -%>
+<% if @perl_interpscope -%>
+  PerlInterpScope <%= @perl_interpscope %>
+<% end -%>


### PR DESCRIPTION
1. Apache system-wide error_log directive is now configurable
2. Fixed broken default error_documents_path on CentOS 7
3. Apache system-wide error_log now supports commands and syslog
4. Preliminary support for mod_perl