### PR TITLE
MODULES-1789 add initial mod_geoip support

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,14 +635,14 @@ These are the default settings:
 
 ```puppet
   class {'apache::mod::geoip':
-    $enable => 'Off',
-    $dbfile => '/usr/share/GeoIP/GeoIP.dat',
-    $flag   => 'Standard',
-    $output => 'All',
+    $enable  => false,
+    $db_file => '/usr/share/GeoIP/GeoIP.dat',
+    $flag    => 'Standard',
+    $output  => 'All',
   }
 ```
 
-The parameter `dbfile` can be a single directory or a hash of directories.
+The parameter `db_file` can be a single directory or a hash of directories.
 
 ####Class: `apache::mod::info`
 
@@ -1859,7 +1859,7 @@ Note that you must declare `class {'apache::mod::geoip': }` before using this di
       docroot     => '/var/www/first',
       directories => [
         { path         => '/var/www/first',
-          geoip_enable => 'On',
+          geoip_enable => true,
         },
       ],
     }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
         * [Classes: apache::mod::*](#classes-apachemodname)
         * [Class: apache::mod::alias](#class-apachemodalias)
         * [Class: apache::mod::event](#class-apachemodevent)
+        * [Class: apache::mod::geoip](#class-apachemodgeoip)
         * [Class: apache::mod::info](#class-apachemodinfo)
         * [Class: apache::mod::pagespeed](#class-apachemodpagespeed)
         * [Class: apache::mod::php](#class-apachemodphp)
@@ -623,6 +624,25 @@ To configure the event thread limit:
 Installs and manages mod_auth_cas. The parameters `cas_login_url` and `cas_validate_url` are required.
 
 Full documentation on mod_auth_cas is available from [JASIG](https://github.com/Jasig/mod_auth_cas).
+
+####Class: `apache::mod::geoip`
+
+Installs and manages mod_geoip.
+
+Full documentation on mod_geoip is available from [MaxMind](http://dev.maxmind.com/geoip/legacy/mod_geoip2/).
+
+These are the default settings:
+
+```puppet
+  class {'apache::mod::geoip':
+    $enable => 'Off',
+    $dbfile => '/usr/share/GeoIP/GeoIP.dat',
+    $flag   => 'Standard',
+    $output => 'All',
+  }
+```
+
+The parameter `dbfile` can be a single directory or a hash of directories.
 
 ####Class: `apache::mod::info`
 
@@ -1824,6 +1844,22 @@ An array of hashes used to override the [ErrorDocument](https://httpd.apache.org
               'document'   => '/service-unavail',
             },
           ],
+        },
+      ],
+    }
+```
+
+######`geoip_enable`
+
+Sets the [GeoIPEnable](http://dev.maxmind.com/geoip/legacy/mod_geoip2/#Configuration) directive.
+Note that you must declare `class {'apache::mod::geoip': }` before using this directive.
+
+```puppet
+    apache::vhost { 'first.example.com':
+      docroot     => '/var/www/first',
+      directories => [
+        { path         => '/var/www/first',
+          geoip_enable => 'On',
         },
       ],
     }

--- a/manifests/mod/geoip.pp
+++ b/manifests/mod/geoip.pp
@@ -1,22 +1,22 @@
 class apache::mod::geoip (
-  $enable                  = 'Off',
-  $dbfile                  = '/usr/share/GeoIP/GeoIP.dat',
-  $flag                    = 'Standard',
-  $output                  = 'All',
-  $enableutf8              = undef,
-  $scanproxyheaders        = undef,
-  $uselastxforwarededforip = undef,
+  $enable                     = false,
+  $db_file                    = '/usr/share/GeoIP/GeoIP.dat',
+  $flag                       = 'Standard',
+  $output                     = 'All',
+  $enable_utf8                = undef,
+  $scan_proxy_headers         = undef,
+  $use_last_xforwarededfor_ip = undef,
 ) {
   ::apache::mod { 'geoip': }
 
   # Template uses:
   # - enable
-  # - dbfile
+  # - db_file
   # - flag
   # - output
-  # - enableutf8
-  # - scanproxyheaders
-  # - uselastxforwarededforip
+  # - enable_utf8
+  # - scan_proxy_headers
+  # - use_last_xforwarededfor_ip
   file { 'geoip.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/geoip.conf",

--- a/manifests/mod/geoip.pp
+++ b/manifests/mod/geoip.pp
@@ -1,0 +1,29 @@
+class apache::mod::geoip (
+  $enable                  = 'Off',
+  $dbfile                  = '/usr/share/GeoIP/GeoIP.dat',
+  $flag                    = 'Standard',
+  $output                  = 'All',
+  $enableutf8              = undef,
+  $scanproxyheaders        = undef,
+  $uselastxforwarededforip = undef,
+) {
+  ::apache::mod { 'geoip': }
+
+  # Template uses:
+  # - enable
+  # - dbfile
+  # - flag
+  # - output
+  # - enableutf8
+  # - scanproxyheaders
+  # - uselastxforwarededforip
+  file { 'geoip.conf':
+    ensure  => file,
+    path    => "${::apache::mod_dir}/geoip.conf",
+    content => template('apache/mod/geoip.conf.erb'),
+    require => Exec["mkdir ${::apache::mod_dir}"],
+    before  => File[$::apache::mod_dir],
+    notify  => Class['apache::service'],
+  }
+
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -77,6 +77,7 @@ class apache::params inherits ::apache::version {
       },
       'fastcgi'     => 'mod_fastcgi',
       'fcgid'       => 'mod_fcgid',
+      'geoip'       => 'mod_geoip',
       'ldap'        => $::apache::version::distrelease ? {
         '7'     => 'mod_ldap',
         default => undef,

--- a/templates/mod/geoip.conf.erb
+++ b/templates/mod/geoip.conf.erb
@@ -1,0 +1,22 @@
+GeoIPEnable <%= @enable %>
+
+<%- if @dbfile and ! [ false, 'false', '' ].include?(@dbfile) -%>
+    <%- if @dbfile.kind_of?(Array) -%>
+      <%- Array(@dbfile).each do |file| -%>
+GeoIPDBFile <%= file %> <%= @flag %>
+      <%- end -%>
+    <%- else -%>
+GeoIPDBFile <%= @dbfile %> <%= @flag %>
+    <%- end -%>
+<%- end -%>
+GeoIPOutput <%= @output %>
+<% if @enableutf8 -%>
+GeoIPEnableUTF8 <%= @enableutf8 %>
+<% end -%>
+<% if @scanproxyheaders -%>
+GeoIPScanProxyHeaders <%= @scanproxyheaders %>
+<% end -%>
+<% if @uselastxforwarededforip -%>
+GeoIPUseLastXForwardedForIP <%= @uselastxforwarededforip %>
+<% end -%>
+

--- a/templates/mod/geoip.conf.erb
+++ b/templates/mod/geoip.conf.erb
@@ -1,22 +1,22 @@
-GeoIPEnable <%= @enable %>
+GeoIPEnable <%= scope.function_bool2httpd([@enable]) %>
 
-<%- if @dbfile and ! [ false, 'false', '' ].include?(@dbfile) -%>
-    <%- if @dbfile.kind_of?(Array) -%>
-      <%- Array(@dbfile).each do |file| -%>
+<%- if @db_file and ! [ false, 'false', '' ].include?(@db_file) -%>
+    <%- if @db_file.kind_of?(Array) -%>
+      <%- Array(@db_file).each do |file| -%>
 GeoIPDBFile <%= file %> <%= @flag %>
       <%- end -%>
     <%- else -%>
-GeoIPDBFile <%= @dbfile %> <%= @flag %>
+GeoIPDBFile <%= @db_file %> <%= @flag %>
     <%- end -%>
 <%- end -%>
 GeoIPOutput <%= @output %>
-<% if @enableutf8 -%>
-GeoIPEnableUTF8 <%= @enableutf8 %>
+<% if ! @enable_utf8.nil? -%>
+GeoIPEnableUTF8 <%= scope.function_bool2httpd([@enable_utf8]) %>
 <% end -%>
-<% if @scanproxyheaders -%>
-GeoIPScanProxyHeaders <%= @scanproxyheaders %>
+<% if ! @scan_proxy_headers.nil? -%>
+GeoIPScanProxyHeaders <%= scope.function_bool2httpd([@scan_proxy_headers]) %>
 <% end -%>
-<% if @uselastxforwarededforip -%>
-GeoIPUseLastXForwardedForIP <%= @uselastxforwarededforip %>
+<% if ! @use_last_xforwarededfor_ip.nil? -%>
+GeoIPUseLastXForwardedForIP <%= scope.function_bool2httpd([@use_last_xforwarededfor_ip]) %>
 <% end -%>
 

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -34,6 +34,9 @@
     Header <%= header %>
       <%- end -%>
     <%- end -%>
+    <%- if directory['geoip_enable'] and directory['geoip_enable'] != '' -%>
+    GeoIPEnable <%= directory['geoip_enable'] %>
+    <%- end -%>
     <%- if directory['options'] -%>
     Options <%= Array(directory['options']).join(' ') %>
     <%- end -%>

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -34,8 +34,8 @@
     Header <%= header %>
       <%- end -%>
     <%- end -%>
-    <%- if directory['geoip_enable'] and directory['geoip_enable'] != '' -%>
-    GeoIPEnable <%= directory['geoip_enable'] %>
+    <%- if ! directory['geoip_enable'].nil? -%>
+    GeoIPEnable <%= scope.function_bool2httpd([directory['geoip_enable']]) %>
     <%- end -%>
     <%- if directory['options'] -%>
     Options <%= Array(directory['options']).join(' ') %>


### PR DESCRIPTION
This adds support for mod_geoip.
I've tested it on CentOS 6 and 7.

There is one problem with this: if you want to set `GeoIPEnable` in a `directories` parameter you must declare the class `apache::mod::geoip` yourself.  
As the `directories` parameter can be an array of hashes I cannot check for the value of `geoip_enable` here:  
```puppet
    apache::vhost { 'first.example.com':
      docroot     => '/var/www/first',
      directories => [
        { path         => '/var/www/first',
          geoip_enable => 'On',
        },
      ],
    }
```

And because of this, I cannot automatically include it.