### PR TITLE
Fixed setting multiple env_var in a location block for proxy pass.

### DIFF
--- a/templates/vhost/_proxy.erb
+++ b/templates/vhost/_proxy.erb
@@ -27,7 +27,7 @@
   <%- end -%>
   <%- if proxy['setenv'] -%>
     <%- Array(proxy['setenv']).each do |setenv_var| -%>
-    SetEnv <%= setenv_var -%>
+    SetEnv <%= setenv_var %>
     <%- end -%>
   <%- end -%>
   </Location>


### PR DESCRIPTION
This fix should allow people using multiple env_var because each var being set needs to be on it's own line. 