### PR TITLE
Updated the default docroot value for Ubuntu 14.04, as the the default Ubuntu apache document root is /var/www/html

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -259,6 +259,7 @@ class apache::params inherits ::apache::version {
             $passenger_root         = '/usr/lib/ruby/vendor_ruby/phusion_passenger/locations.ini'
             $passenger_ruby         = undef
             $passenger_default_ruby = '/usr/bin/ruby'
+            $docroot                = '/var/www/html'
           }
           default: {
             # The following settings may or may not work on Ubuntu releases not


### PR DESCRIPTION
When I go to AWS, go to EC2 launch the ubuntu 14.04 AMI, install puppet and install this puppet module, and I put the apache parametrized class with no parameters. I get apache installed and running but it has the docroot as /var/www , not as /var/www/html which is the default docroot on ubuntu 14.04. I do not know about the other versions of ubuntu. I have not tested them.