### PR TITLE
log_level ^ and $ removed so that log_levels like info ssl:debug are allowed

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -186,7 +186,8 @@ define apache::vhost(
   Allowed values are 'directory' and 'absent'.")
 
   if $log_level {
-    validate_re($log_level, '^(emerg|alert|crit|error|warn|notice|info|debug)$',
+    $valid_log_level_re = '(emerg|alert|crit|error|warn|notice|info|debug)'
+    validate_re($log_level, $valid_log_level_re,
     "Log level '${log_level}' is not one of the supported Apache HTTP Server log levels.")
   }
 


### PR DESCRIPTION
I had the need to debug ssl in apache for just one vhost

So I copy and pasted from init.pp

I was not able to run the test suite, I'll try harder but please consider nevertheless
