### PR TITLE
README: clarify that keepalive is a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Changes the base location of the configuration directories used for the apache s
 
 #####`keepalive`
 
-Enables persistent connections.
+Enables persistent connections. This should be a string 'on' or 'off'.
 
 #####`keepalive_timeout`
 


### PR DESCRIPTION
Using `keepalive => true` inserts `KeepAlive true`, which actually works with Apache 2.2.

Apache 2.4 is more strict, and requires `on` or `off` instead. We should clarify in the README that this is actually a string option, not a boolean. Otherwise, Apache will fail to start and confuse people.

----

On a different note, I think it would actually be better to use `bool2httpd` here. Since this *is* a boolean option, it makes more sense to use it (over a string), and it will be compatible with people specifying strings anyway. It also protects people upgrading from Apache 2.2 to 2.4 from the unexpected error.

I'd be happy to prepare a PR for that (and drop this one), but wanted to ask first (and issues are disabled in this repository, so I made this PR instead).