### PR TITLE
Fix remoteip unit test for rspec-puppet 2

### DIFF
--- a/spec/classes/mod/remoteip_spec.rb
+++ b/spec/classes/mod/remoteip_spec.rb
@@ -46,7 +46,7 @@ describe 'apache::mod::remoteip', :type => :class do
         { :apache_version => '2.2' }
       end
       it 'should fail' do
-        expect { subject }.to raise_error(Puppet::Error, /mod_remoteip is only available in Apache 2.4/)
+        expect { catalogue }.to raise_error(Puppet::Error, /mod_remoteip is only available in Apache 2.4/)
       end
     end
   end


### PR DESCRIPTION
We updated the rspec-puppet tests, then merged e0255bd,which assumed
rspec-puppet 1. This patch updates the newly merged tests for the
remoteip mod.