### PR TITLE
(MODULES-1874) Fix proxy_connect module on apache >= 2.2

### DIFF
--- a/manifests/mod/proxy_connect.pp
+++ b/manifests/mod/proxy_connect.pp
@@ -1,7 +1,7 @@
 class apache::mod::proxy_connect (
   $apache_version  = $::apache::apache_version,
 ) {
-  if versioncmp($apache_version, '2.4') >= 0 {
+  if versioncmp($apache_version, '2.2') >= 0 {
     Class['::apache::mod::proxy'] -> Class['::apache::mod::proxy_connect']
     ::apache::mod { 'proxy_connect': }
   }

--- a/spec/classes/mod/proxy_connect_spec.rb
+++ b/spec/classes/mod/proxy_connect_spec.rb
@@ -19,7 +19,21 @@ describe 'apache::mod::proxy_connect', :type => :class do
         :is_pe                  => false,
       }
     end
-    context 'with Apache version < 2.4' do
+    context 'with Apache version < 2.2' do
+      let :facts do
+        super().merge({
+          :operatingsystemrelease => '7.0',
+          :lsbdistcodename        => 'wheezy',
+        })
+      end
+      let :params do
+        {
+          :apache_version => '2.1',
+        }
+      end
+      it { is_expected.not_to contain_apache__mod('proxy_connect') }
+    end
+    context 'with Apache version = 2.2' do
       let :facts do
         super().merge({
           :operatingsystemrelease => '7.0',
@@ -31,7 +45,7 @@ describe 'apache::mod::proxy_connect', :type => :class do
           :apache_version => '2.2',
         }
       end
-      it { is_expected.not_to contain_apache__mod('proxy_connect') }
+      it { is_expected.to contain_apache__mod('proxy_connect') }
     end
     context 'with Apache version >= 2.4' do
       let :facts do


### PR DESCRIPTION
As discussed in MODULES-1874, the proxy_connect module exists since Apache 2.2, so there is no reason to restrict it to Apache >= 2.4.

[MODULES-1874](https://tickets.puppetlabs.com/browse/MODULES-1874) was closed as Fixed a week ago, but the problem is still present in master and I couldn't find a PR that fixes this.