### PR TITLE
Allow to fully remove a vhost with special configurations

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -251,8 +251,12 @@ define apache::vhost(
   # This ensures that the docroot exists
   # But enables it to be specified across multiple vhost resources
   if ! defined(File[$docroot]) and $manage_docroot {
+    $docroot_ensure = $ensure? {
+      present => 'directory',
+      default => 'absent',
+    }
     file { $docroot:
-      ensure  => directory,
+      ensure  => $docroot_ensure,
       owner   => $docroot_owner,
       group   => $docroot_group,
       mode    => $docroot_mode,
@@ -263,8 +267,12 @@ define apache::vhost(
 
   # Same as above, but for logroot
   if ! defined(File[$logroot]) {
+    $logroot_ensure_real = $ensure? {
+      present => $logroot_ensure,
+      default => 'absent',
+    }
     file { $logroot:
-      ensure  => $logroot_ensure,
+      ensure  => $logroot_ensure_real,
       mode    => $logroot_mode,
       require => Package['httpd'],
       before  => Concat["${priority_real}${filename}.conf"],

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -453,7 +453,10 @@ describe 'apache::vhost', :type => :define do
       it { is_expected.to_not contain_class('apache::mod::proxy_http') }
       it { is_expected.to_not contain_class('apache::mod::passenger') }
       it { is_expected.to_not contain_class('apache::mod::headers') }
-      it { is_expected.to contain_file('/var/www/foo') }
+      it { is_expected.to contain_file('/var/www/foo').with({
+        'ensure' => 'absent',
+      })
+      }
       it { is_expected.to contain_file('/tmp/logroot').with({
         'ensure' => 'absent',
       })


### PR DESCRIPTION
This commit allows apache::vhost to fully take knowledge of the vhost
status.
There were two places where the "ensure => absent" caused some failure,
puppet wanting to create some subdirectory in the vhost when it was
removed.