### PR TITLE
Do not offload overriding LogFormats to httpd

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ Specifies the location where apache module files are stored. It should not be co
 
 #####`loadfile_name`
 
-Sets the file name for the module loadfile. Should be in the format *.load.  This can be used to set the module load order.
+Sets the file name for the module loadfile. Should be in the format \*.load.  This can be used to set the module load order.
 
 #####`log_level`
 
@@ -370,6 +370,17 @@ Define additional [LogFormats](https://httpd.apache.org/docs/current/mod/mod_log
 ```puppet
   $log_formats = { vhost_common => '%v %h %l %u %t \"%r\" %>s %b' }
 ```
+
+There are a number of predefined LogFormats in the httpd.conf that Puppet writes out:
+
+```httpd
+LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+LogFormat "%h %l %u %t \"%r\" %>s %b" common
+LogFormat "%{Referer}i -> %U" referer
+LogFormat "%{User-agent}i" agent
+```
+
+If your `$log_formats` contains one of those, they will be overwritten with **your** definition.
 
 #####`logroot`
 

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -218,6 +218,23 @@ describe 'apache', :type => :class do
       end
     end
 
+    describe "Override existing LogFormats" do
+      context "When parameter log_formats is a hash" do
+        let :params do
+          { :log_formats => {
+            'common'   => "%v %h %l %u %t \"%r\" %>s %b",
+            'combined' => "%v %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\""
+          } }
+        end
+
+        it { is_expected.to contain_file("/etc/apache2/apache2.conf").with_content %r{^LogFormat "%v %h %l %u %t \"%r\" %>s %b" common\n} }
+        it { is_expected.to contain_file("/etc/apache2/apache2.conf").without_content %r{^LogFormat "%h %l %u %t \"%r\" %>s %b \"%\{Referer\}i\" \"%\{User-agent\}i\"" combined\n} }
+        it { is_expected.to contain_file("/etc/apache2/apache2.conf").with_content %r{^LogFormat "%v %h %l %u %t \"%r\" %>s %b" common\n} }
+        it { is_expected.to contain_file("/etc/apache2/apache2.conf").with_content %r{^LogFormat "%v %h %l %u %t \"%r\" %>s %b \"%\{Referer\}i\" \"%\{User-agent\}i\"" combined\n} }
+        it { is_expected.to contain_file("/etc/apache2/apache2.conf").without_content %r{^LogFormat "%h %l %u %t \"%r\" %>s %b \"%\{Referer\}i\" \"%\{User-agent\}i\"" combined\n} }
+      end
+    end
+
     context "on Ubuntu" do
       let :facts do
         super().merge({

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -60,10 +60,18 @@ Include "<%= @mod_load_dir %>/*.conf"
 <% end -%>
 Include "<%= @ports_file %>"
 
+<% unless @log_formats.has_key?('combined') -%>
 LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+<% end -%>
+<% unless @log_formats.has_key?('common') -%>
 LogFormat "%h %l %u %t \"%r\" %>s %b" common
+<% end -%>
+<% unless @log_formats.has_key?('referer') -%>
 LogFormat "%{Referer}i -> %U" referer
+<% end -%>
+<% unless @log_formats.has_key?('agent') -%>
 LogFormat "%{User-agent}i" agent
+<% end -%>
 <% if @log_formats and !@log_formats.empty? -%>
   <%- @log_formats.sort.each do |nickname,format| -%>
 LogFormat "<%= format -%>" <%= nickname %>


### PR DESCRIPTION
if an admin overrides one of the pre-existing formats, do not offload
that to httpd: check for it, and replace it at configuration
generation time.