### PR TITLE
unify log_level checking and allow trace1-8 levels

### DIFF
--- a/lib/puppet/parser/functions/validate_apache_log_level.rb
+++ b/lib/puppet/parser/functions/validate_apache_log_level.rb
@@ -1,0 +1,27 @@
+module Puppet::Parser::Functions
+  newfunction(:validate_apache_log_level, :doc => <<-'ENDHEREDOC') do |args|
+    Perform simple validation of a string against the list of known log
+    levels as per http://httpd.apache.org/docs/current/mod/core.html#loglevel
+        validate_apache_loglevel('info')
+
+    Modules maybe specified with their own levels like these:
+        validate_apache_loglevel('warn ssl:info')
+        validate_apache_loglevel('warn mod_ssl.c:info')
+        validate_apache_loglevel('warn ssl_module:info')
+
+    Expected to be used from the main or vhost.
+    
+    Might be used from directory too later as apaceh supports that
+
+    ENDHEREDOC
+    if (args.size != 1) then
+      raise Puppet::ParseError, ("validate_apache_loglevel(): wrong number of arguments (#{args.length}; must be 1)")
+    end
+
+    log_level = args[0]
+    msg = "Log level '${log_level}' is not one of the supported Apache HTTP Server log levels."
+
+    raise Puppet::ParseError, (msg) unless log_level =~ Regexp.compile('(emerg|alert|crit|error|warn|notice|info|debug|trace[1-8])')
+
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -124,10 +124,7 @@ class apache (
     }
   }
 
-  $valid_log_level_re = '(emerg|alert|crit|error|warn|notice|info|debug)'
-
-  validate_re($log_level, $valid_log_level_re,
-  "Log level '${log_level}' is not one of the supported Apache HTTP Server log levels.")
+  validate_apache_log_level($log_level)
 
   class { '::apache::service':
     service_name   => $service_name,

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -186,8 +186,7 @@ define apache::vhost(
   Allowed values are 'directory' and 'absent'.")
 
   if $log_level {
-    validate_re($log_level, '^(emerg|alert|crit|error|warn|notice|info|debug)$',
-    "Log level '${log_level}' is not one of the supported Apache HTTP Server log levels.")
+    validate_apache_log_level($log_level)
   }
 
   if $access_log_file and $access_log_pipe {

--- a/spec/unit/puppet/parser/functions/validate_apache_log_level.rb
+++ b/spec/unit/puppet/parser/functions/validate_apache_log_level.rb
@@ -1,0 +1,39 @@
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper'
+
+describe "the validate_apache_log_level function" do
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+  it "should exist" do
+    expect(Puppet::Parser::Functions.function("validate_apache_log_level")).to eq("function_validate_apache_log_level")
+  end
+
+  it "should raise a ParseError if there is less than 1 arguments" do
+    expect { scope.function_validate_apache_log_level([]) }.to( raise_error(Puppet::ParseError) )
+  end
+
+  it "should raise a ParseError when given garbage" do
+    expect { scope.function_validate_apache_log_level(['garbage']) }.to( raise_error(Puppet::ParseError) )
+  end
+
+  it "should not raise a ParseError when given a plain log level" do
+    expect { scope.function_validate_apache_log_level(['info']) }.to_not raise_error 
+  end
+
+  it "should not raise a ParseError when given a log level and module log level" do
+    expect { scope.function_validate_apache_log_level(['warn ssl:info']) }.to_not raise_error 
+  end
+
+  it "should not raise a ParseError when given a log level and module log level" do
+    expect { scope.function_validate_apache_log_level(['warn mod_ssl.c:info']) }.to_not raise_error 
+  end
+
+  it "should not raise a ParseError when given a log level and module log level" do
+    expect { scope.function_validate_apache_log_level(['warn ssl_module:info']) }.to_not raise_error 
+  end
+
+  it "should not raise a ParseError when given a trace level" do
+    expect { scope.function_validate_apache_log_level(['trace4']) }.to_not raise_error 
+  end
+
+end


### PR DESCRIPTION
this request came out of discussion on "log_level ^ and $ removed so that log_levels like info ssl:debug are allowed #1089"

added validate_apache_log_level function to apply same test to both apache class and vhost - trace levels also supported

still todo is think about supporting log_level checking in directories