### PR TITLE
Fix test condition for proxy directives.

### DIFF
--- a/templates/vhost/_proxy.erb
+++ b/templates/vhost/_proxy.erb
@@ -1,4 +1,4 @@
-<% if @proxy_dest or @proxy_pass -%>
+<% if @proxy_dest or @proxy_pass or @proxy_pass_match or @proxy_dest_match -%>
 
   ## Proxy rules
   ProxyRequests Off


### PR DESCRIPTION
Hi,

The _proxy.erb partial template must also be inserted when only **proxy_dest_match**
or **proxy_dest_match** are set. 

Otherwise, **proxy_pass_match** are for example ignored if there is not at least one **proxy_pass** directive.

Here is a fix.