### PR TITLE
Change proxy_pass_match to use the proxy template

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -624,9 +624,10 @@ define apache::vhost(
   # Template uses:
   # - $proxy_dest
   # - $proxy_pass
+  # - $proxy_pass_match
   # - $proxy_preserve_host
   # - $no_proxy_uris
-  if $proxy_dest or $proxy_pass {
+  if $proxy_dest or $proxy_pass or $proxy_pass_match {
     concat::fragment { "${name}-proxy":
       target  => "${priority_real}${filename}.conf",
       order   => 140,

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -139,7 +139,7 @@ describe 'apache::vhost define', :unless => UNSUPPORTED_PLATFORMS.include?(fact(
     describe file("#{$vhost_dir}/25-proxy.example.com.conf") do
       it { is_expected.to contain '<VirtualHost \*:80>' }
       it { is_expected.to contain "ServerName proxy.example.com" }
-      it { is_expected.to contain "ProxyPassMatch" }
+      it { is_expected.to contain "ProxyPassMatch\s+/foo http://backend-foo/" }
       it { is_expected.to contain "ProxyPreserveHost On" }
       it { is_expected.to contain "ProxyErrorOverride On" }
       it { is_expected.not_to contain "<Proxy \*>" }


### PR DESCRIPTION
Hi,
version 1.4 started to support proxy_pass_match. The featrue seems not to be fully implemented. The variable is now known by the module but does not change anything except loading of the mod_proxy httpd module. I changed the vhost.pp so that proxy_pass_match will make use of the proxy template.

Kind regards,
Matthias