### PR TITLE
Use string instead, not regex, for file test

### DIFF
--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -139,7 +139,7 @@ describe 'apache::vhost define', :unless => UNSUPPORTED_PLATFORMS.include?(fact(
     describe file("#{$vhost_dir}/25-proxy.example.com.conf") do
       it { is_expected.to contain '<VirtualHost \*:80>' }
       it { is_expected.to contain "ServerName proxy.example.com" }
-      it { is_expected.to contain "ProxyPassMatch\s+/foo http://backend-foo/" }
+      it { is_expected.to contain "ProxyPassMatch /foo http://backend-foo/" }
       it { is_expected.to contain "ProxyPreserveHost On" }
       it { is_expected.to contain "ProxyErrorOverride On" }
       it { is_expected.not_to contain "<Proxy \*>" }


### PR DESCRIPTION
The beaker-rspec contains matcher does not understand "+" in the
context of checking whether a string is contained in a file resource
(though it does seem to understand "\s" just fine), which was causing
acceptance test failures. Since we know the exact string to expect we
just remove the regular expression bits.