### PR TITLE
Update PE dependency in 1.4.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -58,7 +58,7 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": "3.x"
+      "version_requirement": ">= 3.7.0 < 4.0.0"
     },
     {
       "name": "puppet",


### PR DESCRIPTION
PE < 3.7.0 binds to puppetlabs-concat 1.0.x, which is incompatible with
the vhost rewrite that was added in puppetlabs-apache 1.2.0.