### PR TITLE
(#1971) new $service_restart parameter to influence httpd.

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,11 @@ Name of the Apache service to run. Defaults to: 'httpd' on RedHat, 'apache2' on 
 
 Determines whether the HTTPD service state is managed by Puppet . Defaults to 'true'.
 
+#####`service_restart`
+
+Determines whether the HTTPD service restart command should be anything other than the default managed by Puppet.  Defaults to undef.
+
+
 #####`trace_enable`
 
 Controls how TRACE requests per RFC 2616 are handled. More information about [TraceEnable](http://httpd.apache.org/docs/current/mod/core.html#traceenable). Defaults to 'On'.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,7 @@ class apache (
   $service_enable         = true,
   $service_manage         = true,
   $service_ensure         = 'running',
+  $service_restart        = undef,
   $purge_configs          = true,
   $purge_vhost_dir        = undef,
   $purge_vdir             = false,
@@ -128,10 +129,11 @@ class apache (
   validate_apache_log_level($log_level)
 
   class { '::apache::service':
-    service_name   => $service_name,
-    service_enable => $service_enable,
-    service_manage => $service_manage,
-    service_ensure => $service_ensure,
+    service_name    => $service_name,
+    service_enable  => $service_enable,
+    service_manage  => $service_manage,
+    service_ensure  => $service_ensure,
+    service_restart => $service_restart,
   }
 
   # Deprecated backwards-compatibility

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -21,6 +21,7 @@ class apache::service (
   $service_enable = true,
   $service_ensure = 'running',
   $service_manage = true,
+  $service_restart = undef
 ) {
   # The base class must be included first because parameter defaults depend on it
   if ! defined(Class['apache::params']) {
@@ -39,9 +40,10 @@ class apache::service (
   }
   if $service_manage {
     service { 'httpd':
-      ensure => $_service_ensure,
-      name   => $service_name,
-      enable => $service_enable,
+      ensure  => $_service_ensure,
+      name    => $service_name,
+      enable  => $service_enable,
+      restart => $service_restart
     }
   }
 }

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -91,6 +91,18 @@ describe 'apache::service', :type => :class do
       let (:params) {{ :service_ensure => 'UNDEF' }}
       it { is_expected.to contain_service("httpd").without_ensure }
     end
+
+    context "with $service_restart unset" do
+      it { is_expected.to contain_service("httpd").without_restart }
+    end
+
+    context "with $service_restart => '/usr/sbin/apachectl graceful'" do
+     let (:params) {{ :service_restart => '/usr/sbin/apachectl graceful' }}
+     it { is_expected.to contain_service("httpd").with(
+        'restart' => '/usr/sbin/apachectl graceful'
+      )
+     }
+    end
   end
 
 


### PR DESCRIPTION
Adds a new parameter to apache and apache::service to
permit restart paramter to the httpd service to be set.

For instance this allows to a restart to be configured
as apachectl graceful for instance.

Fixes https://tickets.puppetlabs.com/browse/MODULES-1971

the change is fully backwards compatible.