### PR TITLE
Fix additional includes in vhost

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -105,6 +105,7 @@ define apache::vhost(
   $fastcgi_socket              = undef,
   $fastcgi_dir                 = undef,
   $additional_includes         = [],
+  $use_optional_includes       = $::apache::use_optional_includes,
   $apache_version              = $::apache::apache_version,
   $allow_encoded_slashes       = undef,
   $suexec_user_group           = undef,

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -510,6 +510,21 @@ describe 'apache::vhost', :type => :define do
       it { is_expected.to_not contain_concat__fragment('rspec.example.com-charsets') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-file_footer') }
     end
+    context 'with use_optional_includes' do
+      let :pre_condition do
+        'class { "apache": default_vhost => false, default_mods => false, vhost_enable_dir => "/etc/apache2/sites-enabled", apache_version => "2.4", use_optional_includes => true }'
+      end
+      let(:params) do
+        {
+          :docroot             => '/rspec/docroot',
+          :port                => '80',
+          :additional_includes => '/my_optional_include_dir',
+        }
+      end
+      it { is_expected.to compile }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-additional_includes').with(
+        :content => /^\s+IncludeOptional "\/my_optional_include_dir"$/ ) }
+    end
   end
   describe 'access logs' do
     let :facts do

--- a/templates/vhost/_additional_includes.erb
+++ b/templates/vhost/_additional_includes.erb
@@ -2,9 +2,9 @@
 
   ## Load additional static includes
 <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 && @use_optional_includes -%>
-IncludeOptional "<%= include %>"
+  IncludeOptional "<%= include %>"
 <%- else -%>
-Include "<%= include %>"
+  Include "<%= include %>"
 <%- end -%>
 
 <% end -%>


### PR DESCRIPTION
The parameter `use_optional_includes` was recently added to the module, but it was not working in configuration generated by `apache::vhost`. This PR means to fix that.

Should both commits be squashed or does it make sense to keep them separate?