### PR TITLE
SecRuleEngine parameter for modsecurity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1010,6 +1010,10 @@ Name of package to install containing crs rules
 
 Directory to install the modsec configuration and activated rules links into
 
+#####`modsec_secruleengine`
+
+Configures the rules engine. Valid vaules are On, Off, and DetectionOnly
+
 #####`activated_rules`
 
 Array of rules from the modsec_crs_path to activate by symlinking to

--- a/manifests/mod/security.pp
+++ b/manifests/mod/security.pp
@@ -2,6 +2,7 @@ class apache::mod::security (
   $crs_package           = $::apache::params::modsec_crs_package,
   $activated_rules       = $::apache::params::modsec_default_rules,
   $modsec_dir            = $::apache::params::modsec_dir,
+  $modsec_secruleengine  = $::apache::params::modsec_secruleengine,
   $allowed_methods       = 'GET HEAD POST OPTIONS',
   $content_types         = 'application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/x-amf',
   $restricted_extensions = '.asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -211,6 +211,7 @@ class apache::params inherits ::apache::version {
     $modsec_crs_package   = 'modsecurity-crs'
     $modsec_crs_path      = '/usr/share/modsecurity-crs'
     $modsec_dir           = '/etc/modsecurity'
+    $modsec_secruleengine = 'On'
     $modsec_default_rules = [
       'base_rules/modsecurity_35_bad_robots.data',
       'base_rules/modsecurity_35_scanners.data',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -126,6 +126,7 @@ class apache::params inherits ::apache::version {
     $modsec_crs_package   = 'mod_security_crs'
     $modsec_crs_path      = '/usr/lib/modsecurity.d'
     $modsec_dir           = '/etc/httpd/modsecurity.d'
+    $modsec_secruleengine = 'On'
     $modsec_default_rules = [
       'base_rules/modsecurity_35_bad_robots.data',
       'base_rules/modsecurity_35_scanners.data',

--- a/templates/mod/security.conf.erb
+++ b/templates/mod/security.conf.erb
@@ -9,7 +9,7 @@
 <%- end -%>
 
     # Default recommended configuration
-    SecRuleEngine On
+    SecRuleEngine <%= @modsec_secruleengine %>
     SecRequestBodyAccess On
     SecRule REQUEST_HEADERS:Content-Type "text/xml" \
       "id:'200000',phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=XML"


### PR DESCRIPTION
Added a parameter that sets mod security SecRuleEngine. Allowing for DetectionOnly or off.