### PR TITLE
removing the default declaration to allow override.

### DIFF
--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -54,7 +54,6 @@ class apache::default_mods (
         ::apache::mod { 'authn_dbm': }
         ::apache::mod { 'authz_dbm': }
         ::apache::mod { 'authz_owner': }
-        ::apache::mod { 'expires': }
         ::apache::mod { 'ext_filter': }
         ::apache::mod { 'include': }
         ::apache::mod { 'logio': }
@@ -95,7 +94,6 @@ class apache::default_mods (
         ::apache::mod { 'authz_dbm': }
         ::apache::mod { 'authz_owner': }
         ::apache::mod { 'dumpio': }
-        ::apache::mod { 'expires': }
         ::apache::mod { 'file_cache': }
         ::apache::mod { 'imagemap':}
         ::apache::mod { 'include': }


### PR DESCRIPTION
Having these entries did not allow for a calling module to override this declaration.  The agent would throw the following error: 

Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Duplicate declaration: Apache::Mod[expires] is already declared in file /etc/puppetlabs/puppet/environments/production/modules/apache/manifests/default_mods.pp:57; cannot redeclare at....