### PR TITLE
Add user and group directives to Class: apache documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,10 @@ Changes the location of the default [Documentroot](https://httpd.apache.org/docs
 
 Enables custom error documents. Defaults to 'false'.
 
+#####`group`
+
+Changes the group that Apache will answer requests as. The parent process will continue to be run as root, but resource accesses by child processes will be done under this group. By default, puppet will attempt to manage this group as a resource under `::apache`. If this is not what you want, set [`manage_group`](#manage_group) to 'false'. Defaults to the OS-specific default user for apache, as detected in `::apache::params`.
+
 #####`httpd_dir`
 
 Changes the base location of the configuration directories used for the apache service. This is useful for specially repackaged HTTPD builds, but might have unintended consequences when used in combination with the default distribution packages. Defaults to '/etc/httpd' on RedHat, '/etc/apache2' on Debian, '/usr/local/etc/apache22' on FreeBSD, and '/etc/apache2' on Gentoo.
@@ -468,6 +472,10 @@ Controls how TRACE requests per RFC 2616 are handled. More information about [Tr
 #####`vhost_dir`
 
 Changes the location of the configuration directory your virtual host configuration files are placed in. Defaults to 'etc/httpd/conf.d' on RedHat, '/etc/apache2/sites-available' on Debian, '/usr/local/etc/apache22/Vhosts' on FreeBSD, and '/etc/apache2/vhosts.d' on Gentoo.
+
+#####`user`
+
+Changes the user that Apache will answer requests as. The parent process will continue to be run as root, but resource accesses by child processes will be done under this user. By default, puppet will attept to manage this user as a resource under `::apache`. If this is not what you want, set [`manage_user`](#manage_user) to 'false'. Defaults to the OS-specific default user for apache, as detected in `::apache::params`.
 
 #####`apache_name`
 


### PR DESCRIPTION
The `README` doesn't document the presence of the `user` and `group` parameters for `::apache`, though they are referenced by `manage_user` and `manage_group`. This change provides that documentation, and includes a pointer to `manage_user` and `manage_group` respectively.