### PR TITLE
Support puppetlabs-concat 2.x

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,9 +1,7 @@
 fixtures:
   repositories:
     stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    concat:
-      repo: "git://github.com/puppetlabs/puppetlabs-concat.git"
-      branch: "1.2.x"
+    concat: "git://github.com/puppetlabs/puppetlabs-concat.git"
     portage: "git://github.com/gentoo/puppet-portage.git"
   symlinks:
     apache: "#{source_dir}"

--- a/manifests/balancer.pp
+++ b/manifests/balancer.pp
@@ -47,6 +47,7 @@ define apache::balancer (
   $target = "${::apache::params::confd_dir}/balancer_${name}.conf"
 
   concat { $target:
+    ensure => present,
     owner  => '0',
     group  => '0',
     mode   => '0644',
@@ -54,7 +55,6 @@ define apache::balancer (
   }
 
   concat::fragment { "00-${name}-header":
-    ensure  => present,
     target  => $target,
     order   => '01',
     content => "<Proxy balancer://${name}>\n",
@@ -67,14 +67,12 @@ define apache::balancer (
   # concat fragments. We don't have to do anything about them.
 
   concat::fragment { "01-${name}-proxyset":
-    ensure  => present,
     target  => $target,
     order   => '19',
     content => inline_template("<% @proxy_set.keys.sort.each do |key| %> Proxyset <%= key %>=<%= @proxy_set[key] %>\n<% end %>"),
   }
 
   concat::fragment { "01-${name}-footer":
-    ensure  => present,
     target  => $target,
     order   => '20',
     content => "</Proxy>\n",

--- a/manifests/balancermember.pp
+++ b/manifests/balancermember.pp
@@ -46,7 +46,6 @@ define apache::balancermember(
 ) {
 
   concat::fragment { "BalancerMember ${name}":
-    ensure  => present,
     target  => "${::apache::params::confd_dir}/balancer_${balancer_cluster}.conf",
     content => inline_template(" BalancerMember ${url} <%= @options.join ' ' %>\n"),
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -232,6 +232,7 @@ class apache (
   }
 
   concat { $ports_file:
+    ensure  => present,
     owner   => 'root',
     group   => $::apache::params::root_group,
     mode    => '0644',
@@ -239,7 +240,6 @@ class apache (
     require => Package['httpd'],
   }
   concat::fragment { 'Apache ports header':
-    ensure  => present,
     target  => $ports_file,
     content => template('apache/ports_header.erb')
   }

--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -3,7 +3,6 @@ define apache::listen {
 
   # Template uses: $listen_addr_port
   concat::fragment { "Listen ${listen_addr_port}":
-    ensure  => present,
     target  => $::apache::ports_file,
     content => template('apache/listen.erb'),
   }

--- a/manifests/namevirtualhost.pp
+++ b/manifests/namevirtualhost.pp
@@ -3,7 +3,6 @@ define apache::namevirtualhost {
 
   # Template uses: $addr_port
   concat::fragment { "NameVirtualHost ${addr_port}":
-    ensure  => present,
     target  => $::apache::ports_file,
     content => template('apache/namevirtualhost.erb'),
   }

--- a/metadata.json
+++ b/metadata.json
@@ -68,6 +68,6 @@
   "description": "Module for Apache configuration",
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 2.4.0 < 5.0.0"},
-    {"name":"puppetlabs/concat","version_requirement":">= 1.1.1 < 2.0.0"}
+    {"name":"puppetlabs/concat","version_requirement":">= 1.1.1 < 3.0.0"}
   ]
 }

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -50,7 +50,7 @@ describe 'apache::vhost', :type => :define do
       let :facts do default_facts end
       it { is_expected.to contain_class("apache") }
       it { is_expected.to contain_class("apache::params") }
-      it { is_expected.to contain_file("25-rspec.example.com.conf").with(
+      it { is_expected.to contain_concat("25-rspec.example.com.conf").with(
         :ensure => 'present',
         :path   => '/etc/apache2/sites-available/25-rspec.example.com.conf'
       ) }
@@ -77,7 +77,7 @@ describe 'apache::vhost', :type => :define do
       let :facts do default_facts end
       it { is_expected.to contain_class("apache") }
       it { is_expected.to contain_class("apache::params") }
-      it { is_expected.to contain_file("25-rspec.example.com.conf").with(
+      it { is_expected.to contain_concat("25-rspec.example.com.conf").with(
         :ensure => 'present',
         :path   => '/usr/local/etc/apache24/Vhosts/25-rspec.example.com.conf'
       ) }
@@ -99,7 +99,7 @@ describe 'apache::vhost', :type => :define do
       let :facts do default_facts end
       it { is_expected.to contain_class("apache") }
       it { is_expected.to contain_class("apache::params") }
-      it { is_expected.to contain_file("25-rspec.example.com.conf").with(
+      it { is_expected.to contain_concat("25-rspec.example.com.conf").with(
         :ensure => 'present',
         :path   => '/etc/apache2/vhosts.d/25-rspec.example.com.conf'
       ) }


### PR DESCRIPTION
2.0.0 is compatible with current 1.x usage, so permit either 1.x or 2.x
to satisfy the concat dependency.  Move all ensure parameters from
concat::fragment to concat itself.