### PR TITLE
Add ssl_openssl_conf_cmd param (apache::mod::ssl and apache::vhost)

### DIFF
--- a/README.md
+++ b/README.md
@@ -823,6 +823,7 @@ Installs Apache SSL capabilities and uses the ssl.conf.erb template. These are t
       ssl_compression         => false,
       ssl_cryptodevice        => 'builtin',
       ssl_options             => [ 'StdEnvVars' ],
+      ssl_openssl_conf_cmd    => undef,
       ssl_cipher              => 'HIGH:MEDIUM:!aNULL:!MD5',
       ssl_honorcipherorder    => 'On',
       ssl_protocol            => [ 'all', '-SSLv2', '-SSLv3' ],
@@ -2250,6 +2251,10 @@ An array:
       ssl_options => [ '+StrictRequire', '+ExportCertData' ],
     }
 ```
+
+#####`ssl_openssl_conf_cmd`
+
+Sets the [SSLOpenSSLConfCmd](http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslopensslconfcmd) directive, which provides direct configuration of OpenSSL parameters. Defaults to 'undef'.
 
 #####`ssl_proxyengine`
 

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -2,6 +2,7 @@ class apache::mod::ssl (
   $ssl_compression         = false,
   $ssl_cryptodevice        = 'builtin',
   $ssl_options             = [ 'StdEnvVars' ],
+  $ssl_openssl_conf_cmd    = undef,
   $ssl_cipher              = 'HIGH:MEDIUM:!aNULL:!MD5',
   $ssl_honorcipherorder    = 'On',
   $ssl_protocol            = [ 'all', '-SSLv2', '-SSLv3' ],
@@ -57,6 +58,7 @@ class apache::mod::ssl (
   # $ssl_cipher
   # $ssl_honorcipherorder
   # $ssl_options
+  # $ssl_openssl_conf_cmd
   # $session_cache
   # $ssl_mutex
   # $ssl_random_seed_bytes

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -26,6 +26,7 @@ define apache::vhost(
   $ssl_verify_client           = undef,
   $ssl_verify_depth            = undef,
   $ssl_options                 = undef,
+  $ssl_openssl_conf_cmd        = undef,
   $ssl_proxyengine             = false,
   $priority                    = undef,
   $default_vhost               = false,
@@ -729,6 +730,7 @@ define apache::vhost(
   # - $ssl_verify_client
   # - $ssl_verify_depth
   # - $ssl_options
+  # - $ssl_openssl_conf_cmd
   # - $apache_version
   if $ssl {
     concat::fragment { "${name}-ssl":

--- a/spec/classes/mod/ssl_spec.rb
+++ b/spec/classes/mod/ssl_spec.rb
@@ -136,5 +136,14 @@ describe 'apache::mod::ssl', :type => :class do
       end
       it { is_expected.to contain_file('ssl.conf').with_content(%r{^  SSLRandomSeed startup file:/dev/urandom 1024$})}
     end
+
+    context 'setting ssl_openssl_conf_cmd' do
+      let :params do
+        {
+          :ssl_openssl_conf_cmd => 'DHParameters "foo.pem"',
+        }
+      end
+      it { is_expected.to contain_file('ssl.conf').with_content(/^\s+SSLOpenSSLConfCmd DHParameters "foo.pem"$/)}
+    end
   end
 end

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -153,6 +153,7 @@ describe 'apache::vhost', :type => :define do
           'ssl_verify_client'           => 'optional',
           'ssl_verify_depth'            => '3',
           'ssl_options'                 => '+ExportCertData',
+          'ssl_openssl_conf_cmd'        => 'DHParameters "foo.pem"',
           'ssl_proxyengine'             => true,
           'priority'                    => '30',
           'default_vhost'               => true,
@@ -398,6 +399,8 @@ describe 'apache::vhost', :type => :define do
       it { is_expected.to contain_concat__fragment('rspec.example.com-serveralias') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-setenv') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-ssl') }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-ssl').with(
+        :content => /^\s+SSLOpenSSLConfCmd\s+DHParameters "foo.pem"$/ ) }
       it { is_expected.to contain_concat__fragment('rspec.example.com-suphp') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-php_admin') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-header') }

--- a/templates/mod/ssl.conf.erb
+++ b/templates/mod/ssl.conf.erb
@@ -25,4 +25,7 @@
 <% if @ssl_options -%>
   SSLOptions <%= @ssl_options.compact.join(' ') %>
 <% end -%>
+<%- if @ssl_openssl_conf_cmd -%>
+  SSLOpenSSLConfCmd <%= @ssl_openssl_conf_cmd %>
+<%- end -%>
 </IfModule>

--- a/templates/vhost/_ssl.erb
+++ b/templates/vhost/_ssl.erb
@@ -43,4 +43,7 @@
   <%- if @ssl_options -%>
   SSLOptions <%= Array(@ssl_options).join(' ') %>
   <%- end -%>
+  <%- if @ssl_openssl_conf_cmd -%>
+  SSLOpenSSLConfCmd       <%= @ssl_openssl_conf_cmd %>
+  <%- end -%>
 <% end -%>


### PR DESCRIPTION
Being able to set SSLOpenSSLConfCmd e. g. allows for setting DHParameters in order to protect against [Logjam attack](https://weakdh.org).