### PR TITLE
create resources with hiera

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,6 +72,15 @@ class apache (
   $allow_encoded_slashes  = undef,
   $package_ensure         = 'installed',
   $use_optional_includes  = $::apache::params::use_optional_includes,
+
+  ### START Hiera Lookups ###
+  $vhosts                 = {},
+  $balancers              = {},
+  $mods                   = {},
+  $npms                   = {},
+  $custom_configs         = {},
+  ### END Hiera Lookups ###
+
 ) inherits ::apache::params {
   validate_bool($default_vhost)
   validate_bool($default_ssl_vhost)
@@ -382,5 +391,13 @@ class apache (
       logroot_mode    => $logroot_mode,
       manage_docroot  => $default_ssl_vhost,
     }
+  
+    # Create resources from hiera lookups
+    create_resources('::apache::vhost', $vhosts)
+    create_resources('::apache::balancer', $balancers)
+    create_resources('::apache::mod', $mods)
+    create_resources('::apache::npms', $npms)
+    create_resources('::apache::custom_config', $custom_configs)
+
   }
 }


### PR DESCRIPTION
With this PR we can create vhosts, balancers, mods, npms, and custom_configs directly with hiera. here an example:

   ---
     apache::vhosts:
      'supervision.example.net':                                                          
        port: 80                                                                    
        docroot: '/usr/share/graphite-web/static/'                                  
        wsgi_daemon_process: '_graphite'                                            
        wsgi_daemon_process_options:                                                
          processes: 5                                                              
          threads: 5                                                                
          display-name: "%{literal('%')}{GROUP}"                                    
          inactivity-timeout: 120                                                   
          user: '_graphite'                                                         
          group: '_graphite'                 
    classes:                                                                        
      - apache                                                                      
