### PR TITLE
Amazon Linux does not support systemd. Having the versioncmp makes th…

### DIFF
--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -12,7 +12,7 @@ class apache::default_mods (
       if versioncmp($apache_version, '2.4') >= 0 {
         # Lets fork it
         # Do not try to load mod_systemd on RHEL/CentOS 6 SCL.
-        if ( !($::osfamily == 'redhat' and versioncmp($::operatingsystemrelease, '7.0') == -1) and !($::operatingsystem == 'Amazon' and versioncmp($::operatingsystemrelease, '2014.09') <= 0  ) ) {
+        if ( !($::osfamily == 'redhat' and versioncmp($::operatingsystemrelease, '7.0') == -1) and !$::operatingsystem == 'Amazon' ) {
           ::apache::mod { 'systemd': }
         }
         ::apache::mod { 'unixd': }


### PR DESCRIPTION
…is fail on newer versions (which do not yet support systemd). Run this on 2015.03 and you end up with an apache server that will not start.