### PR TITLE
Fix test condition for proxy directives.

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -628,7 +628,7 @@ define apache::vhost(
   # - $proxy_pass_match
   # - $proxy_preserve_host
   # - $no_proxy_uris
-  if $proxy_dest or $proxy_pass or $proxy_pass_match {
+  if $proxy_dest or $proxy_pass or $proxy_pass_match or $proxy_dest_match {
     concat::fragment { "${name}-proxy":
       target  => "${priority_real}${filename}.conf",
       order   => 140,

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -414,6 +414,30 @@ describe 'apache::vhost', :type => :define do
       it { is_expected.to contain_concat__fragment('rspec.example.com-charsets') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-file_footer') }
     end
+    context 'proxy_pass_match' do
+      let :params do
+        {
+          'docroot'          => '/rspec/docroot',
+          'proxy_pass_match'            => [
+            {
+              'path'     => '.*',
+              'url'      => 'http://backend-a/',
+            }
+          ],
+        }
+      end
+      it { is_expected.to contain_concat__fragment('rspec.example.com-proxy').with_content(
+              /ProxyPassMatch .* http:\/\/backend-a\//).with_content(/## Proxy rules/) }
+    end
+    context 'proxy_dest_match' do
+      let :params do
+        {
+          'docroot'          => '/rspec/docroot',
+          'proxy_dest_match' => '/'
+        }
+      end
+      it { is_expected.to contain_concat__fragment('rspec.example.com-proxy').with_content(/## Proxy rules/) }
+    end
     context 'not everything can be set together...' do
       let :params do
         {

--- a/templates/vhost/_proxy.erb
+++ b/templates/vhost/_proxy.erb
@@ -1,4 +1,4 @@
-<% if @proxy_dest or @proxy_pass -%>
+<% if @proxy_dest or @proxy_pass or @proxy_pass_match or @proxy_dest_match -%>
 
   ## Proxy rules
   ProxyRequests Off


### PR DESCRIPTION
The _proxy.erb partial template must also be inserted when only @proxy_dest_match
or @proxy_dest_match are set.