### PR TITLE
(maint) Drop testing of ruby 1.8 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake 
 matrix:
   fast_finish: true
   include:
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 1.9.3
     env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 2.1.5


### PR DESCRIPTION
This module is very time-consuming in travis ci, and over half
of that test time is on the 1 cell (of 5) that tests ruby 1.8.
Also, ruby 1.8 has been retired for two years (June 2013).

This PR drops ruby 1.8 testing in travis.