### PR TITLE
Include full path for UserDir directive

### DIFF
--- a/templates/mod/userdir.conf.erb
+++ b/templates/mod/userdir.conf.erb
@@ -2,7 +2,7 @@
 <% if @disable_root -%>
   UserDir disabled root
 <% end -%>
-  UserDir <%= @dir %>
+  UserDir <%= @home %>/*/<%= @dir %>
 
   <Directory "<%= @home %>/*/<%= @dir %>">
     AllowOverride FileInfo AuthConfig Limit Indexes


### PR DESCRIPTION
The UserDir directive in templates/mod/userdir.conf.erb should probably match the [directory stanza](https://github.com/puppetlabs/puppetlabs-apache/blob/master/templates/mod/userdir.conf.erb#L7) directly below it.

We were setting `home` as /var/home and getting inconsistent results since it wasn't actually being passed to UserDir. Changing this seemed to fix our issue.