### PR TITLE
mod::alias should be included when the aliases parameter is used

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -363,7 +363,7 @@ define apache::vhost(
   }
 
   # Load mod_alias if needed and not yet loaded
-  if ($scriptalias or $scriptaliases != []) or ($redirect_source and $redirect_dest) {
+  if ($scriptalias and $scriptaliases != []) or ($aliases and $aliases != []) or ($redirect_source and $redirect_dest) {
     if ! defined(Class['apache::mod::alias'])  and ($ensure == 'present') {
       include ::apache::mod::alias
     }

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -427,6 +427,20 @@ describe 'apache::vhost', :type => :define do
       it { is_expected.to contain_concat__fragment('rspec.example.com-charsets') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-file_footer') }
     end
+    context 'set only aliases' do
+      let :params do
+        {
+          'docroot' => '/rspec/docroot',
+          'aliases' => [
+            {
+              'alias' => '/alias',
+              'path'  => '/rspec/docroot',
+            },
+          ]
+        }
+      end
+      it { is_expected.to contain_class('apache::mod::alias')}
+    end
     context 'proxy_pass_match' do
       let :params do
         {


### PR DESCRIPTION
`mod::alias` should be included when `aliases` is set, otherwise Apache fails to start.

I've added a simple rspec test around this as well, though it seems to stand out from the other tests around vhosts. Ideally acceptance tests would catch things like this as well, but a separate test for each parameter seems like a rather large undertaking (though I'm happy too look at adding one for this case if desired).