### PR TITLE
Fix _proxy.erb for SetEnv within ProxyMatch.

### DIFF
--- a/templates/vhost/_proxy.erb
+++ b/templates/vhost/_proxy.erb
@@ -50,7 +50,7 @@
   <%- end -%>
   <%- if proxy['setenv'] -%>
     <%- Array(proxy['setenv']).each do |setenv_var| -%>
-    SetEnv <%= setenv_var -%>
+    SetEnv <%= setenv_var %>
     <%- end -%>
   <%- end -%>
   </Location>


### PR DESCRIPTION
Fix _proxy.erb to put multiple SetEnv directives on separate lines for ProxyMatch blocks.  This was already fixed for plain ProxyPass blocks.