### PR TITLE
add possibility to set icons_path to false so no alias will be set for it

### DIFF
--- a/manifests/mod/alias.pp
+++ b/manifests/mod/alias.pp
@@ -1,27 +1,20 @@
 class apache::mod::alias(
   $apache_version = $apache::apache_version,
   $icons_options  = 'Indexes MultiViews',
-) {
-  $ver24 = versioncmp($apache_version, '2.4') >= 0
+  # set icons_path to false to disable the alias
+  $icons_path     = $::apache::params::alias_icons_path,
 
-  $icons_path = $::osfamily ? {
-    'debian'  => '/usr/share/apache2/icons',
-    'Suse'    => '/usr/share/apache2/icons',
-    'redhat'  => $ver24 ? {
-      true    => '/usr/share/httpd/icons',
-      default => '/var/www/icons',
-    },
-    'freebsd' => '/usr/local/www/apache24/icons',
-    'gentoo'  => '/usr/share/apache2/icons',
-  }
+) {
   apache::mod { 'alias': }
   # Template uses $icons_path
-  file { 'alias.conf':
-    ensure  => file,
-    path    => "${::apache::mod_dir}/alias.conf",
-    content => template('apache/mod/alias.conf.erb'),
-    require => Exec["mkdir ${::apache::mod_dir}"],
-    before  => File[$::apache::mod_dir],
-    notify  => Class['apache::service'],
+  if $icons_path {
+    file { 'alias.conf':
+      ensure  => file,
+      path    => "${::apache::mod_dir}/alias.conf",
+      content => template('apache/mod/alias.conf.erb'),
+      require => Exec["mkdir ${::apache::mod_dir}"],
+      before  => File[$::apache::mod_dir],
+      notify  => Class['apache::service'],
+    }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -113,6 +113,10 @@ class apache::params inherits ::apache::version {
     $mime_support_package = 'mailcap'
     $mime_types_config    = '/etc/mime.types'
     $docroot              = '/var/www/html'
+    $alias_icons_path     = $::apache::version::distrelease ? {
+      '7'     => '/usr/share/httpd/icons',
+      default => '/var/www/icons',
+    }
     $error_documents_path = $::apache::version::distrelease ? {
       '7'     => '/usr/share/httpd/error',
       default => '/var/www/error'
@@ -233,6 +237,7 @@ class apache::params inherits ::apache::version {
       'base_rules/modsecurity_crs_59_outbound_blocking.conf',
       'base_rules/modsecurity_crs_60_correlation.conf'
     ]
+    $alias_icons_path     = '/usr/share/apache2/icons'
     $error_documents_path = '/usr/share/apache2/error'
     if ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '13.10') >= 0) or ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '8') >= 0) {
       $dev_packages        = ['libaprutil1-dev', 'libapr1-dev', 'apache2-dev']
@@ -355,6 +360,7 @@ class apache::params inherits ::apache::version {
     $mime_types_config    = '/usr/local/etc/mime.types'
     $wsgi_socket_prefix   = undef
     $docroot              = '/usr/local/www/apache24/data'
+    $alias_icons_path     = '/usr/local/www/apache24/icons'
     $error_documents_path = '/usr/local/www/apache24/error'
   } elsif $::osfamily == 'Gentoo' {
     $user             = 'apache'
@@ -416,6 +422,7 @@ class apache::params inherits ::apache::version {
     $mime_types_config    = '/etc/mime.types'
     $wsgi_socket_prefix   = undef
     $docroot              = '/var/www/localhost/htdocs'
+    $alias_icons_path     = '/usr/share/apache2/icons'
     $error_documents_path = '/usr/share/apache2/error'
   } elsif $::osfamily == 'Suse' {
     $user                = 'wwwrun'
@@ -462,6 +469,7 @@ class apache::params inherits ::apache::version {
     $mime_types_config    = '/etc/mime.types'
     $docroot              = '/srv/www'
     $cas_cookie_path      = '/var/cache/apache2/mod_auth_cas/'
+    $alias_icons_path     = '/usr/share/apache2/icons'
     $error_documents_path = '/usr/share/apache2/error'
     $dev_packages        = ['libapr-util1-devel', 'libapr1-devel']
 


### PR DESCRIPTION
It is not always that we want Alias /icons in our config, but right now if the alias mod gets pulled in there is no way around that. This commit fixes that.