### PR TITLE
Adding use_optional_includes parameter to vhost define.

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -107,6 +107,7 @@ define apache::vhost(
   $fastcgi_socket              = undef,
   $fastcgi_dir                 = undef,
   $additional_includes         = [],
+  $use_optional_includes       = $::apache::use_optional_includes,
   $apache_version              = $::apache::apache_version,
   $allow_encoded_slashes       = undef,
   $suexec_user_group           = undef,

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -299,6 +299,7 @@ describe 'apache::vhost', :type => :define do
           'fastcgi_dir'                 => '/tmp',
           'additional_includes'         => '/custom/path/includes',
           'apache_version'              => '2.4',
+          'use_optional_includes'       => true,
           'suexec_user_group'           => 'root root',
           'allow_encoded_slashes'       => 'nodecode',
           'passenger_app_root'          => '/usr/share/myapp',


### PR DESCRIPTION
I was testing with debian jessie connecting to a puppetmaster 3.7.3-1 + hiera and apache/templates/vhost/_additional_includes.erb was reporting @use_optional_includes as undef. 