### PR TITLE
we also want to have groups with '-' like vhost-users

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -149,7 +149,7 @@ define apache::vhost(
   # Input validation begins
 
   if $suexec_user_group {
-    validate_re($suexec_user_group, '^\w+ \w+$',
+    validate_re($suexec_user_group, '^[\w-]+ [\w-]+$',
     "${suexec_user_group} is not supported for suexec_user_group.  Must be 'user group'.")
   }
 


### PR DESCRIPTION
extended regex for suexec users/groups to accept '-' additionally to word characters