### PR TITLE
Move the description of the timeout parameter to the correct module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1047,6 +1047,11 @@ mod_reqtimeout configuration.
   }
 ```
 
+#####`timeouts`
+
+A string or an array that sets the `RequestReadTimeout` option. Defaults to
+`['header=20-40,MinRate=500', 'body=20,MinRate=500']`.
+
 ####Class: `apache::mod::version`
 
 This wrapper around mod_version warns on Debian and Ubuntu systems with Apache httpd 2.4
@@ -1055,12 +1060,6 @@ about loading mod_version, as on these platforms it's already built-in.
 ```puppet
   include '::apache::mod::version'
 ```
-
-#####`timeouts`
-
-A string or an array that sets the `RequestReadTimeout` option. Defaults to
-`['header=20-40,MinRate=500', 'body=20,MinRate=500']`.
-
 
 ####Class: `apache::mod::security`
 


### PR DESCRIPTION
The timeouts parameter was under the wrong module in README.md.  The change moves it from the description of apache::mod::version to apache::mod::reqtimeout