### PR TITLE
RedHat derived systems >= 7 use mod_dir of conf.modules.d, not conf.d

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ Setting this to 'false' stops the user resource from being created. This is for 
 
 #####`mod_dir`
 
-Changes the location of the configuration directory your Apache modules configuration files are placed in. Defaults to '/etc/httpd/conf.d' for RedHat, '/etc/apache2/mods-available' for Debian, '/usr/local/etc/apache22/Modules' for FreeBSD, and '/etc/apache2/modules.d' on Gentoo.
+Changes the location of the configuration directory your Apache modules configuration files are placed in. Defaults to '/etc/httpd/conf.d' for RedHat 6 and earlier, '/etc/httpd/conf.modules.d' for RedHat 7, '/etc/apache2/mods-available' for Debian, '/usr/local/etc/apache22/Modules' for FreeBSD, and '/etc/apache2/modules.d' on Gentoo.
 
 #####`mpm_module`
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,7 +44,10 @@ class apache::params inherits ::apache::version {
     $server_root          = '/etc/httpd'
     $conf_dir             = "${httpd_dir}/conf"
     $confd_dir            = "${httpd_dir}/conf.d"
-    $mod_dir              = "${httpd_dir}/conf.d"
+    $mod_dir              = $::apache::version::distrelease ? {
+      '7'     => "${httpd_dir}/conf.modules.d",
+      default => "${httpd_dir}/conf.d",
+    },
     $mod_enable_dir       = undef
     $vhost_dir            = "${httpd_dir}/conf.d"
     $vhost_enable_dir     = undef


### PR DESCRIPTION
I'm not crazy about using $::apache::version::distrelease as the selector to determine the default for mod_dir, but that's what was done for other RHEL7 vs. earlier decisions.

I kind of feel like using the $::apache::version itself would be better, since then we don't need to update all of the code when RHEL8 comes out.  Then again, that will be years, so maybe it's not worth worrying about right now.