### PR TITLE
Fix apache::mod::cgid so it can be used with the event MPM

### DIFF
--- a/manifests/mod/cgid.pp
+++ b/manifests/mod/cgid.pp
@@ -2,7 +2,12 @@ class apache::mod::cgid {
   case $::osfamily {
     'FreeBSD': {}
     default: {
-      Class['::apache::mod::worker'] -> Class['::apache::mod::cgid']
+      if defined(Class['::apache::mod::worker']) {
+        Class['::apache::mod::worker'] -> Class['::apache::mod::cgid']
+      }
+      elsif defined(Class['::apache::mod::event']) {
+        Class['::apache::mod::event'] -> Class['::apache::mod::cgid']
+      }
     }
   }
 


### PR DESCRIPTION
Before this, attempting to include `apache::mod::cgid` when using the event MPM
raised the following error:
`Could not find resource 'Class[Apache::Mod::Worker]' for relationship on 'Class[Apache::Mod::Cgid]'`