### PR TITLE
Apache readme reorganization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,582 +1,1164 @@
-#apache
+# apache
 
-####Table of Contents
+[Module description]: #module-description
 
-1. [Overview - What is the apache module?](#overview)
-2. [Module Description - What does the module do?](#module-description)
-3. [Setup - The basics of getting started with apache](#setup)
-    * [Beginning with apache - Installation](#beginning-with-apache)
-    * [Configure a virtual host - Basic options for getting started](#configure-a-virtual-host)
-4. [Usage - The classes and defined types available for configuration](#usage)
-    * [Classes and Defined Types](#classes-and-defined-types)
-        * [Class: apache](#class-apache)
-        * [Defined Type: apache::custom_config](#defined-type-apachecustom_config)
-        * [Class: apache::default_mods](#class-apachedefault_mods)
-        * [Defined Type: apache::mod](#defined-type-apachemod)
-        * [Classes: apache::mod::*](#classes-apachemodname)
-        * [Class: apache::mod::alias](#class-apachemodalias)
-        * [Class: apache::mod::event](#class-apachemodevent)
-        * [Class: apache::mod::geoip](#class-apachemodgeoip)
-        * [Class: apache::mod::info](#class-apachemodinfo)
-        * [Class: apache::mod::pagespeed](#class-apachemodpagespeed)
-        * [Class: apache::mod::php](#class-apachemodphp)
-        * [Class: apache::mod::ssl](#class-apachemodssl)
-        * [Class: apache::mod::status](#class-apachemodstatus)
-        * [Class: apache::mod::expires](#class-apachemodexpires)
-        * [Class: apache::mod::wsgi](#class-apachemodwsgi)
-        * [Class: apache::mod::fcgid](#class-apachemodfcgid)
-        * [Class: apache::mod::negotiation](#class-apachemodnegotiation)
-        * [Class: apache::mod::deflate](#class-apachemoddeflate)
-        * [Class: apache::mod::reqtimeout](#class-apachemodreqtimeout)
-        * [Class: apache::mod::security](#class-modsecurity)
-        * [Class: apache::mod::version](#class-apachemodversion)
-        * [Defined Type: apache::vhost](#defined-type-apachevhost)
-        * [Parameter: `directories` for apache::vhost](#parameter-directories-for-apachevhost)
-        * [SSL parameters for apache::vhost](#ssl-parameters-for-apachevhost)
-        * [Defined Type: apache::fastcgi::server](#defined-type-fastcgi-server)
-    * [Virtual Host Examples - Demonstrations of some configuration options](#virtual-host-examples)
-    * [Load Balancing](#load-balancing)
-        * [Defined Type: apache::balancer](#defined-type-apachebalancer)
-        * [Defined Type: apache::balancermember](#defined-type-apachebalancermember)
-        * [Examples - Load balancing with exported and non-exported resources](#examples)
-5. [Reference - An under-the-hood peek at what the module is doing and how](#reference)
-    * [Classes](#classes)
-        * [Public Classes](#public-classes)
-        * [Private Classes](#private-classes)
-    * [Defined Types](#defined-types)
-        * [Public Defined Types](#public-defined-types)
-        * [Private Defined Types](#private-defined-types)
-    * [Templates](#templates)
-6. [Limitations - OS compatibility, etc.](#limitations)
-7. [Development - Guide for contributing to the module](#development)
-    * [Contributing to the apache module](#contributing)
-    * [Running tests - A quick guide](#running-tests)
+[Setup]: #setup
+[Beginning with Apache]: #beginning-with-apache
 
-##Overview
+[Usage]: #usage
+[Configuring virtual hosts]: #configuring-virtual-hosts
+[Configuring virtual hosts with SSL]: #configuring-virtual-hosts-with-ssl
+[Configuring virtual host port and address bindings]: #configuring-virtual-host-port-and-address-bindings
+[Configuring virtual hosts for apps and processors]: #configuring-virtual-hosts-for-apps-and-processors
+[Configuring IP-based virtual hosts]: #configuring-ip-based-virtual-hosts
+[Installing Apache modules]: #installing-apache-modules
+[Installing arbitrary modules]: #installing-arbitrary-modules
+[Installing specific modules]: #installing-specific-modules
+[Configuring FastCGI servers]: #configuring-fastcgi-servers-to-handle-php-files
+[Load balancing examples]: #load-balancing-examples
 
-The apache module allows you to set up virtual hosts and manage web services with minimal effort.
+[Reference]: #reference
+[Public classes]: #public-classes
+[Private classes]: #private-classes
+[Public defines]: #public-defines
+[Private defines]: #private-defines
+[Templates]: #templates
 
-##Module Description
+[Limitations]: #limitations
 
-Apache is a widely-used web server, and this module provides a simplified way of creating configurations to manage your infrastructure. This includes the ability to configure and manage a range of different virtual host setups, as well as a streamlined way to install and configure Apache modules.
+[Development]: #development
+[Contributing]: #contributing
+[Running tests]: #running-tests
 
-##Setup
+[`AddDefaultCharset`]: http://httpd.apache.org/docs/current/mod/core.html#adddefaultcharset
+[`add_listen`]: #add_listen
+[`Alias`]: https://httpd.apache.org/docs/current/mod/mod_alias.html#alias
+[`AliasMatch`]: https://httpd.apache.org/docs/current/mod/mod_alias.html#aliasmatch
+[aliased servers]: https://httpd.apache.org/docs/current/urlmapping.html
+[`AllowEncodedSlashes`]: http://httpd.apache.org/docs/current/mod/core.html#allowencodedslashes
+[`apache`]: #class-apache
+[`apache_version`]: #apache_version
+[`apache::balancer`]: #define-apachebalancer
+[`apache::balancermember`]: #define-apachebalancermember
+[`apache::fastcgi::server`]: #define-apachefastcgiserver
+[`apache::mod`]: #define-apachemod
+[`apache::mod::<MODULE NAME>`]: #classes-apachemodmodule-name
+[`apache::mod::event`]: #class-apachemodevent
+[`apache::mod::itk`]: #class-apachemoditk
+[`apache::mod::passenger`]: #class-apachemodpassenger
+[`apache::mod::peruser`]: #class-apachemodperuser
+[`apache::mod::prefork`]: #class-apachemodprefork
+[`apache::mod::proxy_html`]: #class-apachemodproxy_html
+[`apache::mod::security`]: #class-apachemodsecurity
+[`apache::mod::ssl`]: #class-apachemodssl
+[`apache::mod::worker`]: #class-apachemodworker
+[`apache::params`]: #class-apacheparams
+[`apache::version`]: #class-apacheversion
+[`apache::vhost`]: #define-apachevhost
+[`apache::vhost::WSGIImportScript`]: #wsgiimportscript
+[Apache HTTP Server]: http://httpd.apache.org
+[Apache modules]: http://httpd.apache.org/docs/current/mod/
+[array]: https://docs.puppetlabs.com/puppet/latest/reference/lang_data_array.html
 
-**What apache affects:**
+[beaker-rspec]: https://github.com/puppetlabs/beaker-rspec
 
-* configuration files and directories (created and written to)
-    * **WARNING**: Configurations that are *not* managed by Puppet will be purged.
-* package/service/configuration files for Apache
-* Apache modules
-* virtual hosts
-* listened-to ports
-* `/etc/make.conf` on FreeBSD and Gentoo
-* depends on module 'gentoo/puppet-portage' for Gentoo
+[certificate revocation list]: http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcarevocationfile
+[certificate revocation list path]: http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcarevocationpath
+[common gateway interface]: http://httpd.apache.org/docs/current/howto/cgi.html
+[`confd_dir`]: #confd_dir
+[`content`]: #content
+[custom error documents]: http://httpd.apache.org/docs/current/custom-error.html
+[`custom_fragment`]: #custom_fragment
 
-###Beginning with Apache
+[`default_mods`]: #default_mods
+[`default_ssl_crl`]: #default_ssl_crl
+[`default_ssl_crl_path`]: #default_ssl_crl_path
+[`default_ssl_vhost`]: #default_ssl_vhost
+[`directory`]: #directory
+[`DirectoryIndex`]: http://httpd.apache.org/docs/current/mod/mod_dir.html#directoryindex
+[`docroot`]: #docroot
+[`docroot_owner`]: #docroot_owner
+[`docroot_group`]: #docroot_group
+[`DocumentRoot`]: https://httpd.apache.org/docs/current/mod/core.html#documentroot
 
-To install Apache with the default parameters
+[`EnableSendfile`]: http://httpd.apache.org/docs/current/mod/core.html#enablesendfile
+[`ExpiresByType`]: http://httpd.apache.org/docs/current/mod/mod_expires.html#expiresbytype
+[enforcing mode]: http://selinuxproject.org/page/Guide/Mode
+[`ensure`]: https://docs.puppetlabs.com/references/latest/type.html#package-attribute-ensure
+[exported resources]: http://docs.puppetlabs.com/latest/reference/lang_exported.md
+[`ExtendedStatus`]: http://httpd.apache.org/docs/current/mod/core.html#extendedstatus
 
-```puppet
-    class { 'apache':  }
-```
+[Facter]: http://docs.puppetlabs.com/facter/
+[FastCGI]: http://www.fastcgi.com/
+[FallbackResource]: https://httpd.apache.org/docs/current/mod/mod_dir.html#fallbackresource
+[`fallbackresource`]: #fallbackresource
+[filter rules]: http://httpd.apache.org/docs/current/filter.html
+[`filters`]: #filters
+[`ForceType`]: http://httpd.apache.org/docs/current/mod/core.html#forcetype
 
-The defaults are determined by your operating system (e.g. Debian systems have one set of defaults, and RedHat systems have another, as do FreeBSD and Gentoo systems). These defaults work well in a testing environment, but are not suggested for production. To establish customized parameters
+[GeoIPScanProxyHeaders]: http://dev.maxmind.com/geoip/legacy/mod_geoip2/#Proxy-Related_Directives
+[`gentoo/puppet-portage`]: https://github.com/gentoo/puppet-portage
 
-```puppet
-    class { 'apache':
-      default_mods        => false,
-      default_confd_files => false,
-    }
-```
+[Hash]: https://docs.puppetlabs.com/puppet/latest/reference/lang_data_hash.html
 
-###Configure a virtual host
+[`IncludeOptional`]: http://httpd.apache.org/docs/current/mod/core.html#includeoptional
+[`Include`]: http://httpd.apache.org/docs/current/mod/core.html#include
+[interval syntax]: http://httpd.apache.org/docs/current/mod/mod_expires.html#AltSyn
+[`ip`]: #ip
+[`ip_based`]: #ip_based
+[IP-based virtual hosts]: http://httpd.apache.org/docs/current/vhosts/ip-based.html
 
-Declaring the `apache` class creates a default virtual host by setting up a vhost on port 80, listening on all interfaces and serving `$apache::docroot`.
+[`KeepAlive`]: http://httpd.apache.org/docs/current/mod/core.html#keepalive
+[`KeepAliveTimeout`]: http://httpd.apache.org/docs/current/mod/core.html#keepalivetimeout
+[`keepalive` parameter]: #keepalive
+[`keepalive_timeout`]: #keepalive_timeout
 
-```puppet
-    class { 'apache': }
-```
+[`lib`]: #lib
+[`lib_path`]: #lib_path
+[`Listen`]: http://httpd.apache.org/docs/current/bind.html
+[`ListenBackLog`]: https://httpd.apache.org/docs/current/mod/mpm_common.html#listenbacklog
+[`LoadFile`]: https://httpd.apache.org/docs/current/mod/mod_so.html#loadfile
+[`LogFormat`]: https://httpd.apache.org/docs/current/mod/mod_log_config.html#logformat
+[`logroot`]: #logroot
+[Log security]: http://httpd.apache.org/docs/current/logs.html#security
 
-To configure a very basic, name-based virtual host
+[`manage_user`]: #manage_user
+[`manage_group`]: #manage_group
+[`MaxConnectionsPerChild`]: https://httpd.apache.org/docs/current/mod/mpm_common.html#maxconnectionsperchild
+[`max_keepalive_requests`]: #max_keepalive_requests
+[`MaxRequestWorkers`]: https://httpd.apache.org/docs/current/mod/mpm_common.html#maxrequestworkers
+[`MaxSpareThreads`]: https://httpd.apache.org/docs/current/mod/mpm_common.html#maxsparethreads
+[MIME `content-type`]: https://www.iana.org/assignments/media-types/media-types.xhtml
+[`MinSpareThreads`]: https://httpd.apache.org/docs/current/mod/mpm_common.html#minsparethreads
+[`mod_alias`]: https://httpd.apache.org/docs/current/mod/mod_alias.html
+[`mod_auth_cas`]: https://github.com/Jasig/mod_auth_cas
+[`mod_authnz_external`]: https://code.google.com/p/mod-auth-external/
+[`mod_expires`]: http://httpd.apache.org/docs/current/mod/mod_expires.html
+[`mod_fcgid`]: https://httpd.apache.org/mod_fcgid/mod/mod_fcgid.html
+[`mod_geoip`]: http://dev.maxmind.com/geoip/legacy/mod_geoip2/
+[`mod_info`]: https://httpd.apache.org/docs/current/mod/mod_info.html
+[`mod_mpm_event`]: https://httpd.apache.org/docs/current/mod/event.html
+[`mod_negotiation`]: http://httpd.apache.org/docs/current/mod/mod_negotiation.html
+[`mod_pagespeed`]: https://developers.google.com/speed/pagespeed/module/?hl=en
+[`mod_php`]: http://php.net/manual/en/book.apache.php
+[`mod_proxy`]: https://httpd.apache.org/docs/current/mod/mod_proxy.html
+[`mod_proxy_balancer`]: http://httpd.apache.org/docs/current/mod/mod_proxy_balancer.html
+[`mod_reqtimeout`]: http://httpd.apache.org/docs/current/mod/mod_reqtimeout.html
+[`mod_security`]: https://www.modsecurity.org/
+[`mod_ssl`]: http://httpd.apache.org/docs/current/mod/mod_ssl.html
+[`mod_status`]: http://httpd.apache.org/docs/current/mod/mod_status.html
+[`mod_version`]: http://httpd.apache.org/docs/current/mod/mod_version.html
+[`mod_wsgi`]: http://modwsgi.readthedocs.org/en/latest/
+[module contribution guide]: http://docs.puppetlabs.com/forge/contributing.html
+[`mpm_module`]: #mpm_module
+[multi-processing module]: http://httpd.apache.org/docs/current/mpm.html
 
-```puppet
-    apache::vhost { 'first.example.com':
-      port    => '80',
-      docroot => '/var/www/first',
-    }
-```
+[name-based virtual hosts]: https://httpd.apache.org/docs/current/vhosts/name-based.html
 
-*Note:* The default priority is 15. If nothing matches this priority, the alphabetically first name-based vhost is used. This is also true if you pass a higher priority and no names match anything else.
+[open source Puppet]: http://docs.puppetlabs.com/puppet/
+[`Options`]: https://httpd.apache.org/docs/current/mod/core.html#options
 
-A slightly more complicated example, changes the docroot owner/group from the default 'root'
+[`path`]: #path
+[`Peruser`]: http://www.freebsd.org/cgi/url.cgi?ports/www/apache22-peruser-mpm/pkg-descr
+[`port`]: #port
+[`priority`]: #defines-apachevhost
+[`ProxyPass`]: http://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypass
+[`ProxySet`]: http://httpd.apache.org/docs/current/mod/mod_proxy.html#proxyset
+[Puppet Enterprise]: http://docs.puppetlabs.com/pe/
+[Puppet Forge]: http://forge.puppetlabs.com
+[Puppet Labs]: http://puppetlabs.com
+[Puppet module]: http://docs.puppetlabs.com/puppet/latest/reference/modules_fundamentals.html
+[Puppet module's code]: https://github.com/puppetlabs/puppetlabs-apache/blob/master/manifests/default_mods.pp
+[`purge_configs`]: #purge_configs
+[`purge_vhost_configs`]: #purge_vhost_configs
+[Python]: https://www.python.org/
 
-```puppet
-    apache::vhost { 'second.example.com':
-      port          => '80',
-      docroot       => '/var/www/second',
-      docroot_owner => 'third',
-      docroot_group => 'third',
-    }
-```
+[Rack]: http://rack.github.io/
+[`rack_base_uris`]: #rack_base_uris
+[RFC 2616]: https://www.ietf.org/rfc/rfc2616.txt
+[`RequestReadTimeout`]: http://httpd.apache.org/docs/current/mod/mod_reqtimeout.html#requestreadtimeout
+[rspec-puppet]: http://rspec-puppet.com/
 
-To set up a virtual host with SSL and default SSL certificates
+[`ScriptAlias`]: https://httpd.apache.org/docs/current/mod/mod_alias.html#scriptalias
+[`ScriptAliasMatch`]: https://httpd.apache.org/docs/current/mod/mod_alias.html#scriptaliasmatch
+[`scriptalias`]: #scriptalias
+[SELinux]: http://selinuxproject.org/
+[`ServerAdmin`]: http://httpd.apache.org/docs/current/mod/core.html#serveradmin
+[`serveraliases`]: #serveraliases
+[`ServerLimit`]: https://httpd.apache.org/docs/current/mod/mpm_common.html#serverlimit
+[`ServerName`]: http://httpd.apache.org/docs/current/mod/core.html#servername
+[`ServerRoot`]: http://httpd.apache.org/docs/current/mod/core.html#serverroot
+[`ServerTokens`]: http://httpd.apache.org/docs/current/mod/core.html#servertokens
+[`ServerSignature`]: http://httpd.apache.org/docs/current/mod/core.html#serversignature
+[Service attribute restart]: http://docs.puppetlabs.com/references/latest/type.html#service-attribute-restart
+[`source`]: #source
+[SSLCARevocationCheck]: http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcarevocationcheck
+[SSL certificate key file]: http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcertificatekeyfile
+[SSL chain]: https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcertificatechainfile
+[SSL encryption]: https://httpd.apache.org/docs/current/ssl/index.html
+[`ssl`]: #ssl
+[`ssl_cert`]: #ssl_cert
+[`ssl_compression`]: #ssl_compression
+[`ssl_key`]: #ssl_key
+[`StartServers`]: https://httpd.apache.org/docs/current/mod/mpm_common.html#startservers
+[suPHP]: http://www.suphp.org/Home.html
+[`suphp_addhandler`]: #suphp_addhandler
+[`suphp_configpath`]: #suphp_configpath
+[`suphp_engine`]: #suphp_engine
+[supported operating system]: https://forge.puppetlabs.com/supported#puppet-supported-modules-compatibility-matrix
 
-```puppet
-    apache::vhost { 'ssl.example.com':
-      port    => '443',
-      docroot => '/var/www/ssl',
-      ssl     => true,
-    }
-```
+[`ThreadLimit`]: http://httpd.apache.org/docs/current/mod/mpm_common.html#threadlimit
+[`ThreadsPerChild`]: https://httpd.apache.org/docs/current/mod/mpm_common.html#threadsperchild
+[`TimeOut`]: http://httpd.apache.org/docs/current/mod/core.html#timeout
+[template]: http://docs.puppetlabs.com/puppet/latest/reference/lang_template.html
+[`TraceEnable`]: http://httpd.apache.org/docs/current/mod/core.html#traceenable
 
-To set up a virtual host with SSL and specific SSL certificates
+[`verify_config`]: #verify_config
+[`vhost`]: #define-apachevhost
+[`vhost_dir`]: #vhost_dir
+[`virtual_docroot`]: #virtual_docroot
 
-```puppet
-    apache::vhost { 'fourth.example.com':
-      port     => '443',
-      docroot  => '/var/www/fourth',
-      ssl      => true,
-      ssl_cert => '/etc/ssl/fourth.example.com.cert',
-      ssl_key  => '/etc/ssl/fourth.example.com.key',
-    }
-```
+[Web Server Gateway Interface]: https://www.python.org/dev/peps/pep-3333/#abstract
+[`WSGIPythonPath`]: https://code.google.com/p/modwsgi/wiki/ConfigurationDirectives#WSGIPythonPath
+[`WSGIPythonHome`]: https://code.google.com/p/modwsgi/wiki/ConfigurationDirectives#WSGIPythonHome
 
-Virtual hosts listen on '*' by default. To listen on a specific IP address
+#### Table of Contents
 
-```puppet
-    apache::vhost { 'subdomain.example.com':
-      ip      => '127.0.0.1',
-      port    => '80',
-      docroot => '/var/www/subdomain',
-    }
-```
+1. [Module description - What is the apache module, and what does it do?][Module description]
+2. [Setup - The basics of getting started with apache][Setup]
+    - [Beginning with Apache - Installation][Beginning with Apache]
+3. [Usage - The classes and defined types available for configuration][Usage]
+    - [Configuring virtual hosts - Examples to help get started][Configuring virtual hosts]
+    - [Configuring FastCGI servers to handle PHP files][Configuring FastCGI servers]
+    - [Load balancing with exported and non-exported resources][Load balancing examples]
+4. [Reference - An under-the-hood peek at what the module is doing and how][Reference]
+    - [Public classes][]
+    - [Private classes][]
+    - [Public defines][]
+    - [Private defines][]
+    - [Templates][]
+5. [Limitations - OS compatibility, etc.][Limitations]
+6. [Development - Guide for contributing to the module][Development]
+    - [Contributing to the apache module][Contributing]
+    - [Running tests - A quick guide][Running tests]
 
-To set up a virtual host with a wildcard alias for the subdomain mapped to a same-named directory, for example: `http://example.com.loc` to `/var/www/example.com`
+## Module description
 
-```puppet
-    apache::vhost { 'subdomain.loc':
-      vhost_name       => '*',
-      port             => '80',
-      virtual_docroot  => '/var/www/%-2+',
-      docroot          => '/var/www',
-      serveraliases    => ['*.loc',],
-    }
-```
+[Apache HTTP Server][] (also called Apache HTTPD, or simply Apache) is a widely used web server. This [Puppet module][] simplifies the task of creating configurations to manage Apache servers in your infrastructure. It can configure and manage a range of virtual host setups and provides a streamlined way to install and configure [Apache modules][].
 
-To set up a virtual host with suPHP
+## Setup
 
-```puppet
-    apache::vhost { 'suphp.example.com':
-      port                => '80',
-      docroot             => '/home/appuser/myphpapp',
-      suphp_addhandler    => 'x-httpd-php',
-      suphp_engine        => 'on',
-      suphp_configpath    => '/etc/php5/apache2',
-      directories         => { path => '/home/appuser/myphpapp',
-        'suphp'           => { user => 'myappuser', group => 'myappgroup' },
-      }
-    }
-```
+**What the apache Puppet module affects:**
 
-To set up a virtual host with WSGI
+- Configuration files and directories (created and written to)
+  - **WARNING**: Configurations *not* managed by Puppet will be purged.
+- Package/service/configuration files for Apache
+- Apache modules
+- Virtual hosts
+- Listened-to ports
+- `/etc/make.conf` on FreeBSD and Gentoo
 
-```puppet
-    apache::vhost { 'wsgi.example.com':
-      port                        => '80',
-      docroot                     => '/var/www/pythonapp',
-      wsgi_application_group      => '%{GLOBAL}',
-      wsgi_daemon_process         => 'wsgi',
-      wsgi_daemon_process_options => {
-        processes    => '2',
-        threads      => '15',
-        display-name => '%{GROUP}',
-       },
-      wsgi_import_script          => '/var/www/demo.wsgi',
-      wsgi_import_script_options  =>
-        { process-group => 'wsgi', application-group => '%{GLOBAL}' },
-      wsgi_process_group          => 'wsgi',
-      wsgi_script_aliases         => { '/' => '/var/www/demo.wsgi' },
-    }
-```
+On Gentoo, this module depends on the [`gentoo/puppet-portage`][] Puppet module. Note that while several options apply or enable certain features and settings for Gentoo, it is not a [supported operating system][] for this module.
 
-Starting in Apache 2.2.16, HTTPD supports [FallbackResource](https://httpd.apache.org/docs/current/mod/mod_dir.html#fallbackresource), a simple replacement for common RewriteRules.
+**Note**: This module modifies Apache configuration files and directories and purges any configuration not managed by Puppet. Apache configuration should be managed by Puppet, as unmanaged configuration files can cause unexpected failures.
 
-```puppet
-    apache::vhost { 'wordpress.example.com':
-      port                => '80',
-      docroot             => '/var/www/wordpress',
-      fallbackresource    => '/index.php',
-    }
-```
+To temporarily disable full Puppet management, set the [`purge_configs`][] parameter in the [`apache`][] class declaration to 'false'. We recommend using this only as a temporary means of saving and relocating customized configurations.
 
-To set up a virtual host with filter rules
+### Beginning with Apache
 
-```puppet
-    apache::vhost { 'subdomain.loc':
-      port             => '80',
-      filters          => [
-        'FilterDeclare  COMPRESS',
-        'FilterProvider COMPRESS DEFLATE resp=Content-Type $text/html',
-        'FilterChain    COMPRESS',
-        'FilterProtocol COMPRESS DEFLATE change=yes;byteranges=no',
-      ],
-      docroot          => '/var/www/html',
-    }
-```
+To have Puppet install Apache with the default parameters, declare the [`apache`][] class:
 
-Please note that the 'disabled' argument to FallbackResource is only supported since Apache 2.2.24.
+~~~ puppet
+class { 'apache': }
+~~~
 
-See a list of all [virtual host parameters](#defined-type-apachevhost). See an extensive list of [virtual host examples](#virtual-host-examples).
+The Puppet module applies a default configuration based on your operating system; Debian, Red Hat, FreeBSD, and Gentoo systems each have unique default configurations. These defaults work in testing environments but are not suggested for production, and Puppet recommends customizing the class's parameters to suit your site. Use the [Reference](#reference) section to find information about the class's parameters and their default values.
 
-##Usage
+You can customize parameters when declaring the `apache` class. For instance, this declaration installs Apache without the apache module's [default virtual host configuration][Configuring virtual hosts], allowing you to customize all Apache virtual hosts:
 
-###Classes and Defined Types
+~~~ puppet
+class { 'apache':
+  default_vhosts => false,
+}
+~~~
 
-This module modifies Apache configuration files and directories and purges any configuration not managed by Puppet. Configuration of Apache should be managed by Puppet, as non-Puppet configuration files can cause unexpected failures.
+## Usage
 
-It is possible to temporarily disable full Puppet management by setting the [`purge_configs`](#purge_configs) parameter within the base `apache` class to 'false'. This option should only be used as a temporary means of saving and relocating customized configurations. See the [`purge_configs` parameter](#purge_configs) for more information.
+### Configuring a virtual host
 
-####Class: `apache`
+The default [`apache`][] class sets up a virtual host on port 80, listening on all interfaces and serving the [`docroot`][] parameter's default directory of `/var/www`.
 
-The apache module's primary class, `apache`, guides the basic setup of Apache on your system.
+**Note**: See the [`apache::vhost`][] define's reference for a list of all virtual host parameters.
 
-You can establish a default vhost in this class, the `vhost` class, or both. You can add additional vhost configurations for specific virtual hosts using a declaration of the `vhost` type.
+To configure basic [name-based virtual hosts][], specify the [`port`][] and [`docroot`][] parameters in the [`apache::vhost`][] define:
+
+~~~ puppet
+apache::vhost { 'vhost.example.com':
+  port    => '80',
+  docroot => '/var/www/vhost',
+}
+~~~
+
+**Note**: Apache processes virtual hosts in alphabetical order, and server administrators can prioritize Apache's virtual host processing by prefixing a virtual host's configuration file name with a number. The [`apache::vhost`][] define applies a default [`priority`][] of 15, which Puppet interprets by prefixing the virtual host's file name with `15-`. This all means that if multiple sites have the same priority, or if you disable priority numbers by setting the `priority` parameter's value to 'false', Apache still processes virtual hosts in alphabetical order.
+
+To configure user and group ownership for `docroot`, use the [`docroot_owner`][] and [`docroot_group`][] parameters:
+
+~~~ puppet
+apache::vhost { 'user.example.com':
+  port          => '80',
+  docroot       => '/var/www/user',
+  docroot_owner => 'www-data',
+  docroot_group => 'www-data',
+}
+~~~
+
+#### Configuring virtual hosts with SSL
+
+To configure a virtual host to use [SSL encryption][] and default SSL certificates, set the [`ssl`][] parameter. You must also specify the [`port`][] parameter, typically with a value of '443', to accomodate HTTPS requests:
+
+~~~ puppet
+apache::vhost { 'ssl.example.com':
+  port    => '443',
+  docroot => '/var/www/ssl',
+  ssl     => true,
+}
+~~~
+
+To configure a virtual host to use SSL and specific SSL certificates, use the paths to the certificate and key in the [`ssl_cert`][] and [`ssl_key`][] parameters, respectively:
+
+~~~ puppet
+apache::vhost { 'cert.example.com':
+  port     => '443',
+  docroot  => '/var/www/cert',
+  ssl      => true,
+  ssl_cert => '/etc/ssl/fourth.example.com.cert',
+  ssl_key  => '/etc/ssl/fourth.example.com.key',
+}
+~~~
+
+To configure a mix of SSL and unencrypted virtual hosts at the same domain, declare them with separate [`apache::vhost`] defines:
+
+~~~ puppet
+# The non-ssl virtual host
+apache::vhost { 'mix.example.com non-ssl':
+  servername => 'mix.example.com',
+  port       => '80',
+  docroot    => '/var/www/mix',
+}
+
+# The SSL virtual host at the same domain
+apache::vhost { 'mix.example.com ssl':
+  servername => 'mix.example.com',
+  port       => '443',
+  docroot    => '/var/www/mix',
+  ssl        => true,
+}
+~~~
+
+To configure a virtual host to redirect unencrypted connections to SSL, declare them with separate [`apache::vhost`] defines and redirect unencrypted requests to the virtual host with SSL enabled:
+
+~~~ puppet
+apache::vhost { 'redirect.example.com non-ssl':
+  servername      => 'redirect.example.com',
+  port            => '80',
+  docroot         => '/var/www/redirect',
+  redirect_status => 'permanent',
+  redirect_dest   => 'https://redirect.example.com/'
+}
+
+apache::vhost { 'redirect.example.com ssl':
+  servername => 'redirect.example.com',
+  port       => '443',
+  docroot    => '/var/www/redirect',
+  ssl        => true,
+}
+~~~
+
+#### Configuring virtual host port and address bindings
+
+Virtual hosts listen on all IP addresses ('*') by default. To configure the virtual host to listen on a specific IP address, use the [`ip`][] parameter:
+
+~~~ puppet
+apache::vhost { 'ip.example.com':
+  ip      => '127.0.0.1',
+  port    => '80',
+  docroot => '/var/www/ip',
+}
+~~~
+
+To configure a virtual host with [aliased servers][], refer to the aliases using the [`serveraliases`][] parameter:
+
+~~~ puppet
+apache::vhost { 'aliases.example.com':
+  serveraliases => [
+    'aliases.example.org',
+    'aliases.example.net',
+  ],
+  port          => '80',
+  docroot       => '/var/www/aliases',
+}
+~~~
+
+To set up a virtual host with a wildcard alias for the subdomain mapped to a same-named directory, such as 'http://example.com.loc' mapped to `/var/www/example.com`, define the wildcard alias using the [`serveraliases`][] parameter and the document root with the [`virtual_docroot`][] parameter:
+
+~~~ puppet
+apache::vhost { 'subdomain.loc':
+  vhost_name      => '*',
+  port            => '80',
+  virtual_docroot => '/var/www/%-2+',
+  docroot         => '/var/www',
+  serveraliases   => ['*.loc',],
+}
+~~~
+
+To configure a virtual host with [filter rules][], pass the filter directives as an [array][] using the [`filters`][] parameter:
+
+~~~ puppet
+apache::vhost { 'subdomain.loc':
+  port    => '80',
+  filters => [
+    'FilterDeclare  COMPRESS',
+    'FilterProvider COMPRESS DEFLATE resp=Content-Type $text/html',
+    'FilterChain    COMPRESS',
+    'FilterProtocol COMPRESS DEFLATE change=yes;byteranges=no',
+  ],
+  docroot => '/var/www/html',
+}
+~~~
+
+#### Configuring virtual hosts for apps and processors
+
+To set up a virtual host with [suPHP][], use the [`suphp_engine`][] parameter to enable the suPHP engine, [`suphp_addhandler`][] parameter to define a MIME type, [`suphp_configpath`][] to set which path suPHP passes to the PHP interpreter, and the [`directory`][] parameter to configure Directory, File, and Location directive blocks:
+
+~~~ puppet
+apache::vhost { 'suphp.example.com':
+  port             => '80',
+  docroot          => '/home/appuser/myphpapp',
+  suphp_addhandler => 'x-httpd-php',
+  suphp_engine     => 'on',
+  suphp_configpath => '/etc/php5/apache2',
+  directories      => [
+    { 'path'  => '/home/appuser/myphpapp',
+      'suphp' => { 
+        user  => 'myappuser',
+        group => 'myappgroup',
+      },
+    },
+  ],
+}
+~~~
+
+You can use a set of parameters to configure a virtual host to use the [Web Server Gateway Interface][] (WSGI) for [Python][] applications:
+
+~~~ puppet
+apache::vhost { 'wsgi.example.com':
+  port                        => '80',
+  docroot                     => '/var/www/pythonapp',
+  wsgi_application_group      => '%{GLOBAL}',
+  wsgi_daemon_process         => 'wsgi',
+  wsgi_daemon_process_options => {
+    processes    => '2',
+    threads      => '15',
+    display-name => '%{GROUP}',
+  },
+  wsgi_import_script          => '/var/www/demo.wsgi',
+  wsgi_import_script_options  => {
+    process-group     => 'wsgi',
+    application-group => '%{GLOBAL}',
+  },
+  wsgi_process_group          => 'wsgi',
+  wsgi_script_aliases         => { '/' => '/var/www/demo.wsgi' },
+}
+~~~
+
+Starting in Apache 2.2.16, Apache supports [FallbackResource][], a simple replacement for common RewriteRules. You can set a FallbackResource using the [`fallbackresource`][] parameter:
+
+~~~ puppet
+apache::vhost { 'wordpress.example.com':
+  port             => '80',
+  docroot          => '/var/www/wordpress',
+  fallbackresource => '/index.php',
+}
+~~~
+
+**Note**: The `fallbackresource` parameter only supports the 'disabled' value since Apache 2.2.24.
+
+To configure a virtual host with a designated directory for [Common Gateway Interface][] (CGI) files, use the [`scriptalias`][] parameter to define the `cgi-bin` path:
+
+~~~ puppet
+apache::vhost { 'cgi.example.com':
+  port        => '80',
+  docroot     => '/var/www/cgi',
+  scriptalias => '/usr/lib/cgi-bin',
+}
+~~~
+
+To configure a virtual host for [Rack][], use the [`rack_base_uris`][] parameter:
+
+~~~ puppet
+apache::vhost { 'rack.example.com':
+  port           => '80',
+  docroot        => '/var/www/rack',
+  rack_base_uris => ['/rackapp1', '/rackapp2'],
+}
+~~~
+
+#### Configuring IP-based virtual hosts
+
+You can configure [IP-based virtual hosts][] to listen on any port and have them respond to requests on specific IP addresses. In this example, we set the server to listen on ports 80 and 81 because the example virtual hosts are _not_ declared with a [`port`][] parameter:
+
+~~~ puppet
+apache::listen { '80': }
+
+apache::listen { '81': }
+~~~
+
+Then we configure the IP-based virtual hosts with the [`ip_based`][] parameter:
+
+~~~ puppet
+apache::vhost { 'first.example.com':
+  ip       => '10.0.0.10',
+  docroot  => '/var/www/first',
+  ip_based => true,
+}
+
+apache::vhost { 'second.example.com':
+  ip       => '10.0.0.11',
+  docroot  => '/var/www/second',
+  ip_based => true,
+}
+~~~
+
+You can also configure a mix of IP- and [name-based virtual hosts][], and in any combination of [SSL][SSL encryption] and unencrypted configurations. First, we add two IP-based virtual hosts on an IP address (in this example, 10.0.0.10). One uses SSL and the other is unencrypted:
+
+~~~ puppet
+apache::vhost { 'The first IP-based virtual host, non-ssl':
+  servername => 'first.example.com',
+  ip         => '10.0.0.10',
+  port       => '80',
+  ip_based   => true,
+  docroot    => '/var/www/first',
+}
+
+apache::vhost { 'The first IP-based vhost, ssl':
+  servername => 'first.example.com',
+  ip         => '10.0.0.10',
+  port       => '443',
+  ip_based   => true,
+  docroot    => '/var/www/first-ssl',
+  ssl        => true,
+}
+~~~
+
+Next, we add two name-based virtual hosts listening on a second IP address (10.0.0.20):
+
+~~~ puppet
+apache::vhost { 'second.example.com':
+  ip      => '10.0.0.20',
+  port    => '80',
+  docroot => '/var/www/second',
+}
+
+apache::vhost { 'third.example.com':
+  ip      => '10.0.0.20',
+  port    => '80',
+  docroot => '/var/www/third',
+}
+~~~
+
+To add name-based virtual hosts that answer on either 10.0.0.10 or 10.0.0.20, you **must** set the [`add_listen`][] parameter to 'false' to disable the default Apache setting of `Listen 80`, as it conflicts with the preceding IP-based virtual hosts.
+
+~~~ puppet
+apache::vhost { 'fourth.example.com':
+  port       => '80',
+  docroot    => '/var/www/fourth',
+  add_listen => false,
+}
+
+apache::vhost { 'fifth.example.com':
+  port       => '80',
+  docroot    => '/var/www/fifth',
+  add_listen => false,
+}
+~~~
+
+### Installing Apache modules
+
+There's two ways to install [Apache modules][] using the Puppet apache module:
+
+- Use the [`apache::mod::<MODULE NAME>`][] classes to [install specific Apache modules with parameters][Installing specific modules].
+- Use the [`apache::mod`][] define to [install arbitrary Apache modules][Installing arbitrary modules].
+
+#### Installing specific modules
+
+The Puppet apache module supports installing many common [Apache modules][], often with parameterized configuration options. For a list of supported Apache modules, see the [`apache::mod::<MODULE NAME>`][] class references.
+
+For example, you can install the `mod_ssl` Apache module with default settings by declaring the [`apache::mod::ssl`][] class:
+
+~~~ puppet
+class { 'apache::mod::ssl': }
+~~~
+
+[`apache::mod::ssl`][] has several parameterized options that you can set when declaring it. For instance, to enable `mod_ssl` with compression enabled, set the [`ssl_compression`][] parameter to 'true':
+
+~~~ puppet
+class { 'apache::mod::ssl':
+  ssl_compression => true,
+}
+~~~
+
+Note that some modules have prerequisites, which are documented in their references under [`apache::mod::<MODULE NAME>`][].
+
+#### Installing arbitrary modules
+
+You can pass the name of any module that your operating system's package manager can install to the [`apache::mod`][] define to install it. Unlike the specific-module classes, the [`apache::mod`][] define doesn't tailor the installation based on other installed modules or with specific parameters---Puppet only grabs and installs the module's package, leaving detailed configuration up to you. 
+
+For example, to install the [`mod_authnz_external`][] Apache module, declare the define with the 'mod_authnz_external' name:
+
+~~~ puppet
+apache::mod { 'mod_authnz_external': }
+~~~
+
+There's several optional parameters you can specify when defining Apache modules this way. See the [define's reference][`apache::mod`] for details.
+
+### Configuring FastCGI servers to handle PHP files
+
+Add the [`apache::fastcgi::server`][] define to allow [FastCGI][] servers to handle requests for specific files. For example, the following defines a FastCGI server at 127.0.0.1 (localhost) on port 9000 to handle PHP requests:
+
+~~~ puppet
+apache::fastcgi::server { 'php':
+  host       => '127.0.0.1:9000',
+  timeout    => 15,
+  flush      => false,
+  faux_path  => '/var/www/php.fcgi',
+  fcgi_alias => '/php.fcgi',
+  file_type  => 'application/x-httpd-php'
+}
+~~~
+
+You can then use the [`custom_fragment`] parameter to configure the virtual host to have the FastCGI server handle the specified file type:
+
+~~~ puppet
+apache::vhost { 'www':
+  ...
+  custom_fragment => 'AddType application/x-httpd-php .php'
+  ...
+}
+~~~
+
+### Load balancing examples
+
+Apache supports load balancing across groups of servers through the [`mod_proxy`][] Apache module. Puppet supports configuring Apache load balancing groups (also known as balancer clusters) through the [`apache::balancer`][] and [`apache::balancermember`][] defines.
+
+To enable load balancing with [exported resources][], export the [`apache::balancermember`][] define from the load balancer member server:
+
+~~~ puppet
+@@apache::balancermember { "${::fqdn}-puppet00":
+  balancer_cluster => 'puppet00',
+  url              => "ajp://${::fqdn}:8009",
+  options          => ['ping=5', 'disablereuse=on', 'retry=5', 'ttl=120'],
+}
+~~~
+
+Then, on the proxy server, create the load balancing group:
+
+~~~ puppet
+apache::balancer { 'puppet00': }
+~~~
+
+To enable load balancing without exporting resources, declare the following on the proxy server:
+
+~~~ puppet
+apache::balancer { 'puppet00': }
+
+apache::balancermember { "${::fqdn}-puppet00":
+    balancer_cluster => 'puppet00',
+    url              => "ajp://${::fqdn}:8009",
+    options          => ['ping=5', 'disablereuse=on', 'retry=5', 'ttl=120'],
+  }
+~~~
+
+Then declare the `apache::balancer` and `apache::balancermember` defines on the proxy server.
+
+If you need to use the [ProxySet](http://httpd.apache.org/docs/current/mod/mod_proxy.html#proxyset) directive on the balancer, use the [`proxy_set`](#proxy_set) parameter of `apache::balancer`:
+
+~~~ puppet
+apache::balancer { 'puppet01':
+  proxy_set => {
+    'stickysession' => 'JSESSIONID',
+  },
+}
+~~~
+
+## Reference
+
+- [**Public Classes**](#public-classes)
+    - [Class: apache](#class-apache)
+    - [Class: apache::dev](#class-apachedev)
+    - [Classes: apache::mod::*](#classes-apachemodname)
+- [**Private Classes**](#private-classes)
+    - [Class: apache::confd::no_accf](#class-apacheconfdno_accf)
+    - [Class: apache::default_confd_files](#class-apachedefault_confd_files)
+    - [Class: apache::default_mods](#class-apachedefault_mods)
+    - [Class: apache::package](#class-apachepackage)
+    - [Class: apache::params](#class-apacheparams)
+    - [Class: apache::service](#class-apacheservice)
+    - [Class: apache::version](#class-apacheversion)
+- [**Public Defines**](#public-defines)
+    - [Define: apache::balancer](#define-apachebalancer)
+    - [Define: apache::balancermember](#define-apachebalancermember)
+    - [Define: apache::custom_config](#define-apachecustom_config)
+    - [Define: apache::fastcgi::server](#define-fastcgi-server)
+    - [Define: apache::listen](#define-apachelisten)
+    - [Define: apache::mod](#define-apachemod)
+    - [Define: apache::namevirtualhost](#define-apachenamevirtualhost)
+    - [Define: apache::vhost](#define-apachevhost)
+- [**Private Defines**](#private-defines)
+    - [Define: apache::default_mods::load](#define-default_mods-load)
+    - [Define: apache::peruser::multiplexer](#define-apacheperusermultiplexer)
+    - [Define: apache::peruser::processor](#define-apacheperuserprocessor)
+    - [Define: apache::security::file_link](#define-apachesecurityfile_link)
+- [**Templates**](#templates)
+
+### Public Classes
+
+#### Class: `apache`
+
+Guides the basic setup and installation of Apache on your system.
+
+When this class is declared with the default options, Puppet:
+
+- Installs the appropriate Apache software package and [required Apache modules](#default_mods) for your operating system.
+- Places the required configuration files in a directory, with the [default location](#conf_dir) determined by your operating system.
+- Configures the server with a default virtual host and standard port ('80') and address ('*') bindings.
+- Creates a document root directory determined by your operating system, typically `/var/www`.
+- Starts the Apache service.
+
+You can simply declare the default `apache` class:
+
+~~~ puppet
+class { 'apache': }
+~~~
+
+You can establish a default virtual host in this class, by using the [`apache::vhost`][] define, or both. You can also configure additional specific virtual hosts with the [`apache::vhost`][] define. Puppet recommends customizing the `apache` class's declaration with the following parameters, as its default settings are not optimized for production.
 
 **Parameters within `apache`:**
 
-#####`allow_encoded_slashes`
+##### `allow_encoded_slashes`
 
-This sets the server default for the [`AllowEncodedSlashes` declaration](http://httpd.apache.org/docs/current/mod/core.html#allowencodedslashes) which modifies the responses to URLs with `\` and `/` characters. The default is undefined, which omits the declaration from the server configuration and select the Apache default setting of `Off`. Allowed values are: `on`, `off` or `nodecode`.
+Sets the server default for the [`AllowEncodedSlashes`][] declaration, which modifies the responses to URLs containing '\' and '/' characters. Valid options: 'on', 'off', 'nodecode'. Default: 'undef', which omits the declaration from the server's configuration and uses Apache's default setting of 'off'.
 
-#####`apache_version`
+##### `apache_version`
 
-Configures the behavior of the module templates, package names, and default mods by setting the Apache version. Default is determined by the class `apache::version` using the OS family and release. It should not be configured manually without special reason.
+Configures module template behavior, package names, and default Apache modules by defining the version of Apache to use. Default: Determined by your operating system family and release via the [`apache::version`][] class. Puppet recommends against manually configuring this parameter without reason.
 
-#####`conf_dir`
+##### `conf_dir`
 
-Changes the location of the configuration directory the main configuration file is placed in. Defaults to '/etc/httpd/conf' on RedHat, '/etc/apache2' on Debian, '/usr/local/etc/apache22' on FreeBSD, and '/etc/apache2' on Gentoo.
+Sets the directory where the Apache server's main configuration file is located. Default: Depends on your operating system.
 
-#####`confd_dir`
+- **Debian**: `/etc/apache2`
+- **FreeBSD**: `/usr/local/etc/apache22`
+- **Gentoo**: `/etc/apache2`
+- **Red Hat**: `/etc/httpd/conf`
 
-Changes the location of the configuration directory your custom configuration files are placed in. Defaults to '/etc/httpd/conf' on RedHat, '/etc/apache2/conf.d' on Debian, '/usr/local/etc/apache22' on FreeBSD, and '/etc/apache2/conf.d' on Gentoo.
+##### `conf_template`
 
-#####`conf_template`
+Defines the [template][] used for the main Apache configuration file. Default: `apache/httpd.conf.erb`. Modifying this parameter is potentially risky, as the apache Puppet module is designed to use a minimal configuration file customized by `conf.d` entries.
 
-Overrides the template used for the main apache configuration file. Defaults to 'apache/httpd.conf.erb'.
+##### `confd_dir`
 
-*Note:* Using this parameter is potentially risky, as the module has been built for a minimal configuration file with the configuration primarily coming from conf.d/ entries.
+Sets the location of the Apache server's custom configuration directory. Default: Depends on your operating system.
 
-#####`default_charset`
+- **Debian**: `/etc/apache2/conf.d`
+- **FreeBSD**: `/usr/local/etc/apache22`
+- **Gentoo**: `/etc/apache2/conf.d`
+- **Red Hat**: `/etc/httpd/conf`
 
-If defined, the value will be set as `AddDefaultCharset` in the main configuration file. It is undefined by default.
+##### `default_charset`
 
-#####`default_confd_files`
+Used as the [`AddDefaultCharset`][] directive in the main configuration file. Default: 'undef'.
 
-Generates default set of include-able Apache configuration files under  `${apache::confd_dir}` directory. These configuration files correspond to what is usually installed with the Apache package on a given platform.
+##### `default_confd_files`
 
-#####`default_mods`
+Determines whether Puppet generates a default set of includable Apache configuration files in the directory defined by the [`confd_dir`][] parameter. These configuration files correspond to what is typically installed with the Apache package on the server's operating system. Valid options: Boolean. Default: 'true'.
 
-Sets up Apache with default settings based on your OS. Valid values are 'true', 'false', or an array of mod names.
+##### `default_mods`
 
-Defaults to 'true', which includes the default [HTTPD mods](https://github.com/puppetlabs/puppetlabs-apache/blob/master/manifests/default_mods.pp).
+Determines whether to configure and enable a set of default [Apache modules][] depending on your operating system. Valid options: 'true', 'false', or an array of Apache module names. Default: 'true'.
 
-If false, it only includes the mods required to make HTTPD work, and any other mods can be declared on their own.
+If this parameter's value is 'false', Puppet only includes the Apache modules required to make the HTTP daemon work on your operating system, and you can declare any other modules separately using the [`apache::mod::<MODULE NAME>`][] class or [`apache::mod`][] define. 
 
-If an array, the apache module includes the array of mods listed.
+If 'true', Puppet installs additional modules, the list of which depends on the operating system as well as the [`apache_version`][] and [`mpm_module`][] parameters' values. As these lists of modules can change frequently, consult the [Puppet module's code][] for up-to-date lists.
 
-#####`default_ssl_ca`
+If this parameter contains an array, Puppet instead enables all passed Apache modules.
 
-The default certificate authority, which is automatically set to 'undef'. This default works out of the box but must be updated with your specific certificate information before being used in production.
+##### `default_ssl_ca`
 
-#####`default_ssl_cert`
+Sets the default certificate authority for the Apache server. Default: 'undef'. 
 
-The default SSL certification, which is automatically set based on your operating system  ('/etc/pki/tls/certs/localhost.crt' for RedHat, '/etc/ssl/certs/ssl-cert-snakeoil.pem' for Debian, '/usr/local/etc/apache22/server.crt' for FreeBSD, and '/etc/ssl/apache2/server.crt' for Gentoo). This default works out of the box but must be updated with your specific certificate information before being used in production.
+While this default value results in a functioning Apache server, you **must** update this parameter with your certificate authority information before deploying this server in a production environment.
 
-#####`default_ssl_chain`
+##### `default_ssl_cert`
 
-The default SSL chain, which is automatically set to 'undef'. This default works out of the box but must be updated with your specific certificate information before being used in production.
+Sets the [SSL encryption][] certificate location. Default: Determined by your operating system.
 
-#####`default_ssl_crl`
+- **Debian**: `/etc/ssl/certs/ssl-cert-snakeoil.pem`
+- **FreeBSD**: `/usr/local/etc/apache22/server.crt`
+- **Gentoo**: `/etc/ssl/apache2/server.crt`
+- **Red Hat**: `/etc/pki/tls/certs/localhost.crt`
 
-The default certificate revocation list to use, which is automatically set to 'undef'. This default works out of the box but must be updated with your specific certificate information before being used in production.
+While the default value results in a functioning Apache server, you **must** update this parameter with your certificate location before deploying this server in a production environment.
 
-#####`default_ssl_crl_path`
+##### `default_ssl_chain`
 
-The default certificate revocation list path, which is automatically set to 'undef'. This default works out of the box but must be updated with your specific certificate information before being used in production.
+Sets the default [SSL chain][] location. Default: 'undef'. 
 
-#####`default_ssl_crl_check`
+While this default value results in a functioning Apache server, you **must** update this parameter with your SSL chain before deploying this server in a production environment.
 
-Sets the default certificate revocation check level via the [SSLCARevocationCheck directive](http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcarevocationcheck), which is automatically set to 'undef'. This default works out of the box but must be specified when using CRLs in production. Only applicable to Apache 2.4 or higher, the value is ignored on older versions.
+##### `default_ssl_crl`
 
-#####`default_ssl_key`
+Sets the path of the default [certificate revocation list][] (CRL) file to use. Default: 'undef'.
 
-The default SSL key, which is automatically set based on your operating system ('/etc/pki/tls/private/localhost.key' for RedHat, '/etc/ssl/private/ssl-cert-snakeoil.key' for Debian, '/usr/local/etc/apache22/server.key' for FreeBSD, and '/etc/ssl/apache2/server.key' for Gentoo). This default works out of the box but must be updated with your specific certificate information before being used in production.
+While this default value results in a functioning Apache server, you **must** update this parameter with your CRL file's path before deploying this server in a production environment. You can use this parameter with or in place of the [`default_ssl_crl_path`][].
 
-#####`default_ssl_vhost`
+##### `default_ssl_crl_path`
 
-Sets up a default SSL virtual host. Defaults to 'false'. If set to 'true', sets up the following vhost:
+Sets the server's [certificate revocation list path][], which contains your CRLs. Default: 'undef'. 
 
-```puppet
-    apache::vhost { 'default-ssl':
-      port            => 443,
-      ssl             => true,
-      docroot         => $docroot,
-      scriptalias     => $scriptalias,
-      serveradmin     => $serveradmin,
-      access_log_file => "ssl_${access_log_file}",
-      }
-```
+While this default value results in a functioning Apache server, you **must** update this parameter with the CRL path before deploying this server in a production environment.
 
-SSL vhosts only respond to HTTPS queries.
+##### `default_ssl_crl_check`
 
-#####`default_type`
+Sets the default certificate revocation check level via the [`SSLCARevocationCheck`] directive. Default: 'undef'.
 
-(Apache httpd 2.2 only) MIME content-type that will be sent if the server cannot determine a type in any other way. This directive has been deprecated in Apache httpd 2.4, and only exists there for backwards compatibility of configuration files.
+While this default value results in a functioning Apache server, you **must** specify this parameter when using certificate revocation lists in a production environment.
 
-#####`default_vhost`
+This parameter only applies to Apache 2.4 or higher and is ignored on older versions.
 
-Sets up a default virtual host. Defaults to 'true', set to 'false' to set up [customized virtual hosts](#configure-a-virtual-host).
+##### `default_ssl_key`
 
-#####`docroot`
+Sets the [SSL certificate key file][] location. Default: Determined by your operating system.
 
-Changes the location of the default [Documentroot](https://httpd.apache.org/docs/current/mod/core.html#documentroot). Defaults to '/var/www/html' on RedHat, '/var/www' on Debian, '/usr/local/www/apache22/data' on FreeBSD, and '/var/www/localhost/htdocs' on Gentoo.
+- **Debian**: `/etc/ssl/private/ssl-cert-snakeoil.key`
+- **FreeBSD**: `/usr/local/etc/apache22/server.key`
+- **Gentoo**: `/etc/ssl/apache2/server.key`
+- **Red Hat**: `/etc/pki/tls/private/localhost.key`
 
-#####`error_documents`
+While these default values result in a functioning Apache server, you **must** update this parameter with your SSL key's location before deploying this server in a production environment.
 
-Enables custom error documents. Defaults to 'false'.
+##### `default_ssl_vhost`
 
-#####`group`
+Configures a default [SSL][SSL encryption] virtual host. Valid options: Boolean. Default: 'false'. 
 
-Changes the group that Apache will answer requests as. The parent process will continue to be run as root, but resource accesses by child processes will be done under this group. By default, puppet will attempt to manage this group as a resource under `::apache`. If this is not what you want, set [`manage_group`](#manage_group) to 'false'. Defaults to the OS-specific default user for apache, as detected in `::apache::params`.
+If 'true', Puppet automatically configures the following virtual host using the [`apache::vhost`][] define:
 
-#####`httpd_dir`
+~~~ puppet
+apache::vhost { 'default-ssl':
+  port            => 443,
+  ssl             => true,
+  docroot         => $docroot,
+  scriptalias     => $scriptalias,
+  serveradmin     => $serveradmin,
+  access_log_file => "ssl_${access_log_file}",
+  }
+~~~
 
-Changes the base location of the configuration directories used for the apache service. This is useful for specially repackaged HTTPD builds, but might have unintended consequences when used in combination with the default distribution packages. Defaults to '/etc/httpd' on RedHat, '/etc/apache2' on Debian, '/usr/local/etc/apache22' on FreeBSD, and '/etc/apache2' on Gentoo.
+**Note**: SSL virtual hosts only respond to HTTPS queries.
 
-#####`keepalive`
+##### `default_type`
 
-Enables persistent connections.
+_Apache 2.2 only_. Sets the [MIME `content-type`][] sent if the server cannot otherwise determine an appropriate `content-type`. This directive is deprecated in Apache 2.4 and newer and only exists for backwards compatibility in configuration files. Default: 'undef'.
 
-#####`keepalive_timeout`
+##### `default_vhost`
 
-Sets the amount of time the server waits for subsequent requests on a persistent connection. Defaults to '15'.
+Configures a default virtual host when the class is declared. Valid options: Boolean. Default: 'true'. 
 
-#####`max_keepalive_requests`
+To configure [customized virtual hosts][Configuring virtual hosts], set this parameter's value to 'false'.
 
-Sets the limit of the number of requests allowed per connection when KeepAlive is on. Defaults to '100'.
+##### `docroot`
 
-#####`lib_path`
+Sets the default [`DocumentRoot`][] location. Default: Determined by your operating system.
 
-Specifies the location where apache module files are stored. It should not be configured manually without special reason.
+- **Debian**: `/var/www`
+- **FreeBSD**: `/usr/local/www/apache22/data`
+- **Gentoo**: `/var/www/localhost/htdocs`
+- **Red Hat**: `/var/www/html`
 
-#####`loadfile_name`
+##### `error_documents`
 
-Sets the file name for the module loadfile. Should be in the format \*.load.  This can be used to set the module load order.
+Determines whether to enable [custom error documents][] on the Apache server. Valid options: Boolean. Default: 'false'.
 
-#####`log_level`
+##### `group`
 
-Changes the verbosity level of the error log. Defaults to 'warn'. Valid values are 'emerg', 'alert', 'crit', 'error', 'warn', 'notice', 'info', or 'debug'.
+Sets the group ID that owns any Apache processes spawned to answer requests. 
 
-#####`log_formats`
+By default, Puppet attempts to manage this group as a resource under the `apache` class, determining the group based on the operating system as detected by the [`apache::params`][] class. To to prevent the group resource from being created and use a group created by another Puppet module, set the [`manage_group`][] parameter's value to 'false'.
 
-Define additional [LogFormats](https://httpd.apache.org/docs/current/mod/mod_log_config.html#logformat). This is done in a Hash:
+**Note**: Modifying this parameter only changes the group ID that Apache uses to spawn child processes to access resources. It does not change the user that owns the parent server process.
 
-```puppet
-  $log_formats = { vhost_common => '%v %h %l %u %t \"%r\" %>s %b' }
-```
+##### `httpd_dir`
 
-There are a number of predefined LogFormats in the httpd.conf that Puppet writes out:
+Sets the Apache server's base configuration directory. This is useful for specially repackaged Apache server builds but might have unintended consequences when combined with the default distribution packages. Default: Determined by your operating system.
 
-```httpd
+- **Debian**: `/etc/apache2`
+- **FreeBSD**: `/usr/local/etc/apache22`
+- **Gentoo**: `/etc/apache2`
+- **Red Hat**: `/etc/httpd`
+
+##### `keepalive`
+
+Determines whether to enable persistent HTTP connections with the [`KeepAlive`][] directive. Valid options: 'Off', 'On'. Default: 'Off'.
+
+If 'On', use the [`keepalive_timeout`][] and [`max_keepalive_requests`][] parameters to set relevant options.
+
+##### `keepalive_timeout`
+
+Sets the [`KeepAliveTimeout`] directive, which determines the amount of time the Apache server waits for subsequent requests on a persistent HTTP connection. Default: '15'. 
+
+This parameter is only relevant if the [`keepalive` parameter][] is enabled.
+
+##### `max_keepalive_requests`
+
+Limits the number of requests allowed per connection when the [`keepalive` parameter][] is enabled. Default: '100'.
+
+##### `lib_path`
+
+Specifies the location where [Apache module][] files are stored. Default: Depends on the operating system.
+
+- **Debian** and **Gentoo**: `/usr/lib/apache2/modules`
+- **FreeBSD**: `/usr/local/libexec/apache24`
+- **Red Hat**: `modules`
+
+**Note**: Do not configure this parameter manually without special reason.
+
+##### `loadfile_name`
+
+Sets the [`LoadFile`] directive's filename. Valid options: Filenames in the format `\*.load`. 
+
+This can be used to set the module load order.
+
+##### `log_level`
+
+Changes the error log's verbosity. Valid options: 'alert', 'crit', 'debug', 'emerg', 'error', 'info', 'notice', 'warn'. Default: 'warn'.
+
+##### `log_formats`
+
+Define additional [`LogFormat`][] directives. Valid options: A [Hash][], such as:
+
+~~~ puppet
+$log_formats = { vhost_common => '%v %h %l %u %t \"%r\" %>s %b' }
+~~~
+
+There are a number of predefined `LogFormats` in the `httpd.conf` that Puppet creates:
+
+~~~ httpd
 LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
 LogFormat "%h %l %u %t \"%r\" %>s %b" common
 LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
-```
+~~~
 
-If your `$log_formats` contains one of those, they will be overwritten with **your** definition.
+If your `log_formats` parameter contains one of those, it will be overwritten with **your** definition.
 
-#####`logroot`
+##### `logroot`
 
-Changes the directory where Apache log files for the virtual host are placed. Defaults to '/var/log/httpd' on RedHat, '/var/log/apache2' on Debian, '/var/log/apache22' on FreeBSD, and '/var/log/apache2' on Gentoo.
+Changes the directory of Apache log files for the virtual host. Default: Determined by your operating system.
 
-#####`logroot_mode`
+- **Debian**: `/var/log/apache2`
+- **FreeBSD**: `/var/log/apache22`
+- **Gentoo**: `/var/log/apache2`
+- **Red Hat**: `/var/log/httpd`
 
-Overrides the mode the default logroot directory is set to ($::apache::logroot). Defaults to undef. Do NOT give people write access to the directory the logs are stored
-in without being aware of the consequences; see http://httpd.apache.org/docs/2.4/logs.html#security for details.
+##### `logroot_mode`
 
-#####`manage_group`
+Overrides the default [`logroot`][] directory's mode. Default: 'undef'. 
 
-Setting this to 'false' stops the group resource from being created. This is for when you have a group, created from another Puppet module, you want to use to run Apache. Without this parameter, attempting to use a previously established group would result in a duplicate resource error.
+**Note**: Do _not_ grant write access to the directory where the logs are stored without being aware of the consequences. See the [Apache documentation][Log security] for details.
 
-#####`manage_user`
+##### `manage_group`
 
-Setting this to 'false' stops the user resource from being created. This is for instances when you have a user, created from another Puppet module, you want to use to run Apache. Without this parameter, attempting to use a previously established user would result in a duplicate resource error.
+When 'false', stops Puppet from creating the group resource. Valid options: Boolean. Default: 'true'. 
 
-#####`mod_dir`
+If you have a group created from another Puppet module that you want to use to run Apache, set this to 'false'. Without this parameter, attempting to use a previously established group results in a duplicate resource error.
 
-Changes the location of the configuration directory your Apache modules configuration files are placed in. Defaults to '/etc/httpd/conf.d' for RedHat, '/etc/apache2/mods-available' for Debian, '/usr/local/etc/apache22/Modules' for FreeBSD, and '/etc/apache2/modules.d' on Gentoo.
+##### `manage_user`
 
-#####`mpm_module`
+When 'false', stops Puppet from creating the user resource. Valid options: Boolean. Default: 'true'.
 
-Determines which MPM is loaded and configured for the HTTPD process. Valid values are 'event', 'itk', 'peruser', 'prefork', 'worker', or 'false'. Defaults to 'prefork' on RedHat, FreeBSD and Gentoo, and 'worker' on Debian. Must be set to 'false' to explicitly declare the following classes with custom parameters:
+This is for instances when you have a user, created from another Puppet module, you want to use to run Apache. Without this parameter, attempting to use a previously established user would result in a duplicate resource error.
 
-* `apache::mod::event`
-* `apache::mod::itk`
-* `apache::mod::peruser`
-* `apache::mod::prefork`
-* `apache::mod::worker`
+##### `mod_dir`
 
-*Note:* Switching between different MPMs on FreeBSD is possible but quite difficult. Before changing `$mpm_module` you must uninstall all packages that depend on your currently-installed Apache.
+Sets where Puppet places configuration files for your [Apache modules][]. Default: Determined by your operating system.
 
-#####`package_ensure`
+- **Debian**: `/etc/apache2/mods-available`
+- **FreeBSD**: `/usr/local/etc/apache22/Modules`
+- **Gentoo**: `/etc/apache2/modules.d`
+- **Red Hat**: `/etc/httpd/conf.d`
 
-Allows control over the package ensure attribute. Can be 'present','absent', or a version string.
+##### `mpm_module`
 
-#####`ports_file`
+Determines which [multi-processing module][] (MPM) is loaded and configured for the HTTPD process. Valid options: 'event', 'itk', 'peruser', 'prefork', 'worker', or 'false'. Default: Determined by your operating system.
 
-Changes the name of the file containing Apache ports configuration. Default is `${conf_dir}/ports.conf`.
+- **Debian**: `worker`
+- **FreeBSD, Gentoo, and Red Hat**: `prefork`
 
-#####`purge_configs`
+You must set this to 'false' to explicitly declare the following classes with custom parameters:
 
-Removes all other Apache configs and vhosts, defaults to 'true'. Setting this to 'false' is a stopgap measure to allow the apache module to coexist with existing or otherwise-managed configuration. It is recommended that you move your configuration entirely to resources within this module.
+- [`apache::mod::event`][]
+- [`apache::mod::itk`][]
+- [`apache::mod::peruser`][]
+- [`apache::mod::prefork`][]
+- [`apache::mod::worker`][]
 
-#####`purge_vhost_configs`
+**Note**: Switching between different MPMs on FreeBSD is possible but quite difficult. Before changing `mpm_module`, you must uninstall all packages that depend on your installed Apache server.
 
-If `vhost_dir` != `confd_dir`, this controls the removal of any configurations that are not managed by Puppet within `vhost_dir`. It defaults to the value of `purge_configs`. Setting this to false is a stopgap measure to allow the apache module to coexist with existing or otherwise unmanaged configurations within `vhost_dir`
+##### `package_ensure`
 
-#####`sendfile`
+Controls the `package` resource's [`ensure`][] attribute. Valid options: 'absent', 'installed' (or the equivalent 'present'), or a version string. Default: 'installed'.
 
-Makes Apache use the Linux kernel sendfile to serve static files. Defaults to 'On'.
+##### `ports_file`
 
-#####`serveradmin`
+Sets the path to the file containing Apache ports configuration. Default: `{$conf_dir}/ports.conf`.
 
-Sets the server administrator. Defaults to 'root@localhost'.
+##### `purge_configs`
 
-#####`servername`
+Removes all other Apache configs and virtual hosts. Valid options: Boolean. Default: 'true'. 
 
-Sets the server name. Defaults to `fqdn` provided by Facter.
+Setting this to 'false' is a stopgap measure to allow the apache Puppet module to coexist with existing or unmanaged configurations. We recommend moving your configuration to resources within this module. For virtual host configurations, see [`purge_vhost_configs`][].
 
-#####`server_root`
+##### `purge_vhost_configs`
 
-Sets the root directory in which the server resides. Defaults to '/etc/httpd' on RedHat, '/etc/apache2' on Debian, '/usr/local' on FreeBSD, and '/var/www' on Gentoo.
+If the [`vhost_dir`][] parameter's value differs from the [`confd_dir`][] parameter's, the Boolean parameter `purge_vhost_configs` determines whether Puppet removes any configurations inside `vhost_dir` _not_ managed by Puppet. Default: same as [`purge_configs`][].
 
-#####`server_signature`
+Setting `purge_vhost_configs` to 'false' is a stopgap measure to allow the apache Puppet module to coexist with existing or otherwise unmanaged configurations within `vhost_dir`.
 
-Configures a trailing footer line under server-generated documents. More information about [ServerSignature](http://httpd.apache.org/docs/current/mod/core.html#serversignature). Defaults to 'On'.
+##### `sendfile`
 
-#####`server_tokens`
+Forces Apache to use the Linux kernel's `sendfile` support to serve static files, via the [`EnableSendfile`][] directive. Valid options: 'On', 'Off'. Default: 'On'.
 
-Controls how much information Apache sends to the browser about itself and the operating system. More information about [ServerTokens](http://httpd.apache.org/docs/current/mod/core.html#servertokens). Defaults to 'OS'.
+##### `serveradmin`
 
-#####`service_enable`
+Sets the Apache server administrator's contact information via Apache's [`ServerAdmin`][] directive. Default: 'root@localhost'.
 
-Determines whether the HTTPD service is enabled when the machine is booted. Defaults to 'true'.
+##### `servername`
 
-#####`service_ensure`
+Sets the Apache server name via Apache's [`ServerName`][] directive. Default: the 'fqdn' fact reported by [Facter][].
 
-Determines whether the service should be running. Valid values are 'true', 'false', 'running', or 'stopped' when Puppet should manage the service. Any other value sets ensure to 'false' for the Apache service, which is useful when you want to let the service be managed by some other application like Pacemaker. Defaults to 'running'.
+##### `server_root`
 
-#####`service_name`
+Sets the Apache server's root directory via Apache's [`ServerRoot`][] directive. Default: determined by your operating system.
 
-Name of the Apache service to run. Defaults to: 'httpd' on RedHat, 'apache2' on Debian and Gentoo, and 'apache22' on FreeBSD.
+- **Debian**: `/etc/apache2`
+- **FreeBSD**: `/usr/local`
+- **Gentoo**: `/var/www`
+- **Red Hat**: `/etc/httpd`
 
-#####`service_manage`
+##### `server_signature`
 
-Determines whether the HTTPD service state is managed by Puppet . Defaults to 'true'.
+Configures a trailing footer line to display at the bottom of server-generated documents, such as error documents and output of certain [Apache modules][], via Apache's [`ServerSignature`][] directive. Valid options: 'Off', 'On'. Default: 'On'.
 
-#####`service_restart`
+##### `server_tokens`
 
-Determines whether the HTTPD service restart command should be anything other than the default managed by Puppet.  Defaults to undef.
+Controls how much information Apache sends to the browser about itself and the operating system, via Apache's [`ServerTokens`][] directive. Defaults to 'OS'.
 
-#####`timeout`
+##### `service_enable`
 
-Sets the amount of seconds the server will wait for certain events before failing a request. Defaults to 120.
+Determines whether Puppet enables the Apache HTTPD service when the system is booted. Valid options: Boolean. Default: 'true'.
 
-#####`trace_enable`
+##### `service_ensure`
 
-Controls how TRACE requests per RFC 2616 are handled. More information about [TraceEnable](http://httpd.apache.org/docs/current/mod/core.html#traceenable). Defaults to 'On'.
+Determines whether Puppet should make sure the service is running. Valid options: 'true' (equivalent to 'running'), 'false' (equivalent to 'stopped'). Default: 'running'.
 
-#####`vhost_dir`
+The 'false' or 'stopped' values set the 'httpd' service resource's `ensure` parameter to 'false', which is useful when you want to let the service be managed by another application, such as Pacemaker. 
 
-Changes the location of the configuration directory your virtual host configuration files are placed in. Defaults to 'etc/httpd/conf.d' on RedHat, '/etc/apache2/sites-available' on Debian, '/usr/local/etc/apache22/Vhosts' on FreeBSD, and '/etc/apache2/vhosts.d' on Gentoo.
+##### `service_name`
 
-#####`user`
+Sets the name of the Apache service. Default: determined by your operating system.
 
-Changes the user that Apache will answer requests as. The parent process will continue to be run as root, but resource accesses by child processes will be done under this user. By default, puppet will attept to manage this user as a resource under `::apache`. If this is not what you want, set [`manage_user`](#manage_user) to 'false'. Defaults to the OS-specific default user for apache, as detected in `::apache::params`.
+- **Debian and Gentoo**: `apache2`
+- **FreeBSD**: `apache22`
+- **Red Hat**: `httpd`
 
-#####`apache_name`
+##### `service_manage`
 
-The name of the Apache package to install. This is automatically detected in `::apache::params`. You might need to override this if you are using a non-standard Apache package, such as those from Red Hat's software collections.
+Determines whether Puppet manages the HTTPD service's state. Default: 'true'.
 
-####Defined Type: `apache::custom_config`
+##### `service_restart`
 
-Allows you to create custom configs for Apache. The configuration files are only added to the Apache confd dir if the file is valid. An error is raised during the Puppet run if the file is invalid and `$verify_config` is `true`.
+Determines whether Puppet should use a specific command to restart the HTTPD service. Valid options: a command to restart the Apache service. Default: 'undef', which uses the [default Puppet behavior][Service attribute restart].
 
-```puppet
-    apache::custom_config { 'test':
-        content => '# Test',
-    }
-```
+##### `timeout`
 
-**Parameters within `apache::custom_config`:**
+Sets Apache's [`TimeOut`][] directive, which defines the number of seconds Apache waits for certain events before failing a request. Defaults to 120.
 
-#####`ensure`
+##### `trace_enable`
 
-Specify whether the configuration file is present or absent. Defaults to 'present'. Valid values are 'present' and 'absent'.
+Controls how Apache handles `TRACE` requests (per [RFC 2616][]) via the [`TraceEnable`][] directive. Valid options: 'Off', 'On'. Default: 'On'.
 
-#####`confdir`
+##### `vhost_dir`
 
-The directory to place the configuration file in. Defaults to `$::apache::confd_dir`.
+Changes your virtual host configuration files' location. Default: determined by your operating system.
 
-#####`content`
+- **Debian**: `/etc/apache2/sites-available`
+- **FreeBSD**: `/usr/local/etc/apache22/Vhosts`
+- **Gentoo**: `/etc/apache2/vhosts.d`
+- **Red Hat**: `etc/httpd/conf.d`
 
-The content of the configuration file. Only one of `$content` and `$source` can be specified.
+##### `user`
 
-#####`priority`
+Changes the user Apache uses to answer requests. Apache's parent process will continue to be run as root, but child processes will access resources as the user defined by this parameter. 
 
-The priority of the configuration file, used for ordering. Defaults to '25'.
+Default: Puppet sets the default value via the [`apache::params`][] class, which manages the user based on your operating system:
 
-Pass priority `false` to omit the priority prefix in file names.
+- **Debian**: 'www-data'
+- **FreeBSD**: 'www'
+- **Gentoo** and **Red Hat**: 'apache'
 
-#####`source`
+To prevent Puppet from managing the user, set the [`manage_user`][] parameter to 'false'.
 
-The source of the configuration file. Only one of `$content` and `$source` can be specified.
+##### `apache_name`
 
-#####`verify_command`
+The name of the Apache package to install. Default: Puppet sets the default value via the [`apache::params`][] class, which manages the user based on your operating system:
 
-The command to use to verify the configuration file. It should use a fully qualified command. Defaults to '/usr/sbin/apachectl -t'. The `$verify_command` is only used if `$verify_config` is `true`. If the `$verify_command` fails, the configuration file is deleted, the Apache service is not notified, and an error is raised during the Puppet run.
+The default value is determined by your operating system:
 
-#####`verify_config`
+- **Debian**: 'apache2'
+- **FreeBSD**: 'apache24'
+- **Gentoo**: 'www-servers/apache'
+- **Red Hat**: 'httpd'
 
-Boolean to specify whether the configuration file should be validated before the Apache service is notified. Defaults to `true`.
+You might need to override this if you are using a non-standard Apache package, such as those from Red Hat's software collections.
 
-####Class: `apache::default_mods`
+#### Class: `apache::dev`
 
-Installs default Apache modules based on what OS you are running.
+Installs Apache development libraries. By default, the package name is defined by the [`dev_packages`] parameter of the [`apache::params`] class based on your operating system:
 
-```puppet
-    class { 'apache::default_mods': }
-```
+The default value is determined by your operating system:
 
-####Defined Type: `apache::mod`
+- **Debian** : 'libaprutil1-dev', 'libapr1-dev'; 'apache2-dev' on Ubuntu 13.10 and Debian 8; 'apache2-prefork-dev' on other versions
+- **FreeBSD**: 'undef'; see note below 
+- **Gentoo**: 'undef'
+- **Red Hat**: 'httpd-devel'
 
-Used to enable arbitrary Apache HTTPD modules for which there is no specific `apache::mod::[name]` class. The `apache::mod` defined type also installs the required packages to enable the module, if any.
+**Note**: On FreeBSD, you must declare the `apache::package` or `apache` classes before declaring `apache::dev`.
 
-```puppet
-    apache::mod { 'rewrite': }
-    apache::mod { 'ldap': }
-```
+#### Classes: `apache::mod::<MODULE NAME>`
 
-####Classes: `apache::mod::[name]`
+Enables specific [Apache modules][]. You can enable and configure an Apache module by declaring its class. For example, to install and enable [`mod_alias`][] with no icons, you can declare the [`apache::mod::alias`][] class with the `icons_options` parameter set to 'None':
 
-There are many `apache::mod::[name]` classes within this module that can be declared using `include`:
+~~~ puppet
+class { 'apache::mod::alias':
+  icons_options => 'None',
+}
+~~~
+
+The following Apache modules have supported classes, many of which allow for parameterized configuration. You can install other Apache modules with the [`apache::mod`][] define.
 
 * `actions`
-* `alias`(see [`apache::mod::alias`](#class-apachemodalias) below)
+* `alias` (see [`apache::mod::alias`](#class-apachemodalias))
 * `auth_basic`
-* `auth_cas`* (see [`apache::mod::auth_cas`](#class-apachemodauthcas) below)
+* `auth_cas`* (see [`apache::mod::auth_cas`](#class-apachemodauthcas))
 * `auth_kerb`
 * `authn_core`
 * `authn_file`
@@ -594,11 +1176,12 @@ There are many `apache::mod::[name]` classes within this module that can be decl
 * `dev`
 * `dir`*
 * `disk_cache`
-* `event`(see [`apache::mod::event`](#class-apachemodevent) below)
+* `event` (see [`apache::mod::event`](#class-apachemodevent))
 * `expires`
 * `fastcgi`
 * `fcgid`
 * `filter`
+* `geoip` (see [`apache::mod::geoip`][])
 * `headers`
 * `include`
 * `info`*
@@ -608,7 +1191,7 @@ There are many `apache::mod::[name]` classes within this module that can be decl
 * `mime_magic`*
 * `negotiation`
 * `nss`*
-* `pagespeed` (see [`apache::mod::pagespeed`](#class-apachemodpagespeed) below)
+* `pagespeed` (see [`apache::mod::pagespeed`](#class-apachemodpagespeed))
 * `passenger`*
 * `perl`
 * `peruser`
@@ -626,562 +1209,549 @@ There are many `apache::mod::[name]` classes within this module that can be decl
 * `rpaf`*
 * `setenvif`
 * `security`
-* `shib`* (see [`apache::mod::shib`](#class-apachemodshib) below)
+* `shib`* (see [`apache::mod::shib`](#class-apachemodshib))
 * `speling`
-* `ssl`* (see [`apache::mod::ssl`](#class-apachemodssl) below)
-* `status`* (see [`apache::mod::status`](#class-apachemodstatus) below)
+* `ssl`* (see [`apache::mod::ssl`](#class-apachemodssl))
+* `status`* (see [`apache::mod::status`](#class-apachemodstatus))
 * `suphp`
 * `userdir`*
+* `version`
 * `vhost_alias`
 * `worker`*
-* `wsgi` (see [`apache::mod::wsgi`](#class-apachemodwsgi) below)
+* `wsgi` (see [`apache::mod::wsgi`](#class-apachemodwsgi))
 * `xsendfile`
 
-Modules noted with a * indicate that the module has settings and, thus, a template that includes parameters. These parameters control the module's configuration. Most of the time, these parameters do not require any configuration or attention.
+Modules noted with a * indicate that the module has settings and a template that includes parameters to configure the module. Most Apache module class parameters have default values and don't require configuration. For modules with templates, Puppet installs template files with the module; these template files are required for the module to work.
 
-The modules mentioned above, and other Apache modules that have templates, cause template files to be dropped along with the mod install. The module will not work without the template. Any module without a template installs the package but drops no files.
+##### Class: `apache::mod::alias`
 
-###Class: `apache::mod::alias`
+Installs and manages [`mod_alias`][].
 
-Installs and manages the alias module.
+**Parameters within `apache::mod::alias`**:
 
-Full Documentation for alias is available from [Apache](https://httpd.apache.org/docs/current/mod/mod_alias.html).
+* `icons_options`: Disables directory listings for the icons directory, via Apache [`Options`] directive. Default: 'Indexes MultiViews'.
+* `icons_path`: Sets the local path for an `/icons/` Alias. Default: depends on your operating system.
 
-To disable directory listing for the icons directory:
-```puppet
-  class { 'apache::mod::alias':
-    icons_options => 'None',
-  }
-```
+- **Debian**: `/usr/share/apache2/icons`
+- **FreeBSD**: `/usr/local/www/apache24/icons`
+- **Gentoo**: `/var/www/icons`
+- **Red Hat**: `/var/www/icons`, except on Apache 2.4, where it's `/usr/share/httpd/icons`
 
-####Class:  `apache::mod::event`
+##### Class: `apache::mod::event`
 
-Installs and manages mpm_event module.
+Installs and manages [`mod_mpm_event`][]. You can't include both `apache::mod::event` and [`apache::mod::itk`][], [`apache::mod::peruser`][], [`apache::mod::prefork`][], or [`apache::mod::worker`][] on the same server.
 
-Full Documentation for mpm_event is available from [Apache](https://httpd.apache.org/docs/current/mod/event.html).
+**Parameters within `apache::mod::event`**:
 
-To configure the event thread limit:
+- `listenbacklog`: Sets the maximum length of the pending connections queue via the module's [`ListenBackLog`][] directive. Default: '511'.
+- `maxclients` (_Apache 2.3.12 or older_: `maxrequestworkers`): Sets the maximum number of connections Apache can simultaneously process, via the module's [`MaxRequestWorkers`][] directive. Default: '150'.
+- `maxconnectionsperchild` (_Apache 2.3.8 or older_: `maxrequestsperchild`): Limits the number of connections a child server handles during its life, via the module's [`MaxConnectionsPerChild`][] directive. Default: '0'.
+- `maxsparethreads` and `minsparethreads`: Sets the maximum and minimum number of idle threads, via the [`MaxSpareThreads`][] and [`MinSpareThreads`][] directives. Default: '75' and '25', respectively.
+- `serverlimit`: Limits the configurable number of processes via the [`ServerLimit`][] directive. Default: '25'.
+- `startservers`: Sets the number of child server processes created at startup, via the module's [`StartServers`][] directive. Default: '2'.
+- `threadlimit`: Limits the number of event threads via the module's [`ThreadLimit`][] directive. Default: '64'.
+- `threadsperchild`: Sets the number of threads created by each child process, via the [`ThreadsPerChild`][] directive. Default: '25'.
 
-```puppet
-  class {'apache::mod::event':
-    $threadlimit      => '128',
-  }
-```
+##### Class: `apache::mod::auth_cas`
 
-####Class: `apache::mod::auth_cas`
+Installs and manages [`mod_auth_cas`][]. Its parameters share names with the Apache module's directives.
 
-Installs and manages mod_auth_cas. The parameters `cas_login_url` and `cas_validate_url` are required.
+The `cas_login_url` and `cas_validate_url` parameters are required; several other parameters have 'undef' default values.
 
-Full documentation on mod_auth_cas is available from [JASIG](https://github.com/Jasig/mod_auth_cas).
+**Parameters within `apache::mod::auth_cas`**:
 
-####Class: `apache::mod::geoip`
+- `cas_authoritative`: Determines whether an optional authorization directive is authoritative and binding. Default: 'undef'.
+- `cas_certificate_path`: Sets the path to the X509 certificate of the Certificate Authority for the server in `cas_login_url` and `cas_validate_url`. Default: 'undef'.
+- `cas_cache_clean_interval`: Sets the minimum number of seconds that must pass between cache cleanings. Default: 'undef'.
+- `cas_cookie_domain`: Sets the value of the `Domain=` parameter in the `Set-Cookie` HTTP header. Default: 'undef'.
+- `cas_cookie_entropy`: Sets the number of bytes to use when creating session identifiers. Default: 'undef'.
+- `cas_cookie_http_only`: Sets the optional `HttpOnly` flag when `mod_auth_cas` issues cookies. Default: 'undef'.
+- `cas_debug`: Determines whether to enable the module's debugging mode. Default: 'Off'.
+- `cas_idle_timeout`: Default: 'undef'.
+- `cas_login_url`: **Required**. Sets the URL to which the module redirects users when they attempt to access a CAS-protected resource and don't have an active session.
+- `cas_root_proxied_as`: Sets the URL end users see when access to this Apache server is proxied. Default: 'undef'.
+- `cas_timeout`: Limits the number of seconds a `mod_auth_cas` session can remain active. Default: 'undef'.
+- `cas_validate_depth`: Limits the depth for chained certificate validation. Default: 'undef'.
+- `cas_validate_url`: **Required**. Sets the URL to use when validating a client-presented ticket in an HTTP query string.
+- `cas_version`: The CAS protocol version to adhere to. Valid options: '1', '2'. Default: '2'.
 
-Installs and manages mod_geoip.
+##### Class: `apache::mod::deflate`
 
-Full documentation on mod_geoip is available from [MaxMind](http://dev.maxmind.com/geoip/legacy/mod_geoip2/).
+Installs and configures [`mod_deflate`][].
 
-These are the default settings:
+**Parameters within `apache::mod::deflate`:**
 
-```puppet
-  class {'apache::mod::geoip':
-    enable  => false,
-    db_file => '/usr/share/GeoIP/GeoIP.dat',
-    flag    => 'Standard',
-    output  => 'All',
-  }
-```
+- `types`: An [array][] of [MIME types][MIME `content-type`] to be deflated. Default: [ 'text/html text/plain text/xml', 'text/css', 'application/x-javascript application/javascript application/ecmascript', 'application/rss+xml' ].
+- `notes`: A [Hash][] where the key represents the type and the value represents the note name. Default: { 'Input'  => 'instream', 'Output' => 'outstream', 'Ratio'  => 'ratio' }
 
-#####`enable`
+##### Class: `apache::mod::expires`
 
-Boolean. Enable or Disable mod_geoip globally. Defaults to false.
+Installs [`mod_expires`][] and uses the `expires.conf.erb` template to generate its configuration.
 
-#####`db_file`
+**Parameters within `apache::mod::expires`**:
 
-The full path to your GeoIP database file. Defaults to `/usr/share/GeoIP/GeoIP.dat`. This parameter optionally takes an array of paths for multiple GeoIP database files.
+- `expires_active`: Enables generation of `Expires` headers for a document realm. Default: 'true'.
+- `expires_default`: Default algorithm for calculating expiration time using [`ExpiresByType`][] syntax or [interval syntax][]. Default: undef.
+- `expires_by_type`: Describes a set of [MIME `content-type`][] and their expiration times. Valid options: An [array][] of [Hashes][Hash], with each Hash's key a valid MIME `content-type` (i.e. 'text/json') and its value following valid [interval syntax][]. Default: undef.
 
-#####`flag`
+##### Class: `apache::mod::fcgid`
 
-GeoIP Flag. Defaults to 'Standard'.
+Installs and configures [`mod_fcgid`][].
 
-#####`output`
+The class makes no effort to individually parameterize all available options. Instead, configure `mod_fcgid` using the `options` [Hash][]. For example:
 
-Defines which output variables to use. Defaults to 'All'.
+~~~ puppet
+class { 'apache::mod::fcgid':
+  options => {
+    'FcgidIPCDir'  => '/var/run/fcgidsock',
+    'SharememPath' => '/var/run/fcgid_shm',
+    'AddHandler'   => 'fcgid-script .fcgi',
+  },
+}
+~~~
 
-#####`enable_utf8`
+For a full list of options, see the [official `mod_fcgid` documentation][`mod_fcgid`].
 
-Boolean. Changes the output from ISO-8859-1 (Latin-1) to UTF-8.
+If you include `apache::mod::fcgid`, you can set the [`FcgidWrapper`][] per directory, per virtual host. The module must be loaded first; Puppet will not automatically enable it if you set the `fcgiwrapper` parameter in `apache::vhost`.
 
-#####`scan_proxy_headers`
+~~~ puppet
+include apache::mod::fcgid
 
-Boolean. Enables the GeoIPScanProxyHeaders option. More information can be found [here](http://dev.maxmind.com/geoip/legacy/mod_geoip2/#Proxy-Related_Directives).
-
-#####`scan_proxy_header_field`
-
-Specifies which header that mod_geoip should look at to determine the client's IP address.
-
-#####`use_last_xforwarededfor_ip`
-
-Boolean. If a comma-separated list of IP addresses is found, use the last IP address for the client's IP.
-
-####Class: `apache::mod::info`
-
-Installs and manages mod_info which provides a comprehensive overview of the server configuration.
-
-Full documentation for mod_info is available from [Apache](https://httpd.apache.org/docs/current/mod/mod_info.html).
-
-These are the default settings:
-
-```puppet
-  $allow_from      = ['127.0.0.1','::1'],
-  $apache_version  = $::apache::apache_version,
-  $restrict_access = true,
-```
-
-To set the addresses that are allowed to access /server-info add the following:
-
-```puppet
-  class {'apache::mod::info':
-    allow_from      => [
-      '10.10.36',
-      '10.10.38',
-      '127.0.0.1',
-    ],
-  }
-```
-
-To disable the access restrictions add the following:
-
-```puppet
-  class {'apache::mod::info':
-    restrict_access => false,
-  }
-```
-
-It is not recommended to leave this set to false though it can be very useful for testing. For this reason, you can insert this setting in your normal code to temporarily disable the restrictions like so:
-
-```puppet
-  class {'apache::mod::info':
-    restrict_access => false, # false disables the block below
-    allow_from      => [
-      '10.10.36',
-      '10.10.38',
-      '127.0.0.1',
-    ],
-  }
-```
-
-####Class: `apache::mod::pagespeed`
-
-Installs and manages mod_pagespeed, which is a Google module that rewrites web pages to reduce latency and bandwidth.
-
-This module does *not* manage the software repositories needed to automatically install the
-mod-pagespeed-stable package. The module does however require that the package be installed,
-or be installable using the system's default package provider.  You should ensure that this
-pre-requisite is met or declaring `apache::mod::pagespeed` causes the Puppet run to fail.
-
-These are the defaults:
-
-```puppet
-    class { 'apache::mod::pagespeed':
-      inherit_vhost_config          => 'on',
-      filter_xhtml                  => false,
-      cache_path                    => '/var/cache/mod_pagespeed/',
-      log_dir                       => '/var/log/pagespeed',
-      memcache_servers              => [],
-      rewrite_level                 => 'CoreFilters',
-      disable_filters               => [],
-      enable_filters                => [],
-      forbid_filters                => [],
-      rewrite_deadline_per_flush_ms => 10,
-      additional_domains            => undef,
-      file_cache_size_kb            => 102400,
-      file_cache_clean_interval_ms  => 3600000,
-      lru_cache_per_process         => 1024,
-      lru_cache_byte_limit          => 16384,
-      css_flatten_max_bytes         => 2048,
-      css_inline_max_bytes          => 2048,
-      css_image_inline_max_bytes    => 2048,
-      image_inline_max_bytes        => 2048,
-      js_inline_max_bytes           => 2048,
-      css_outline_min_bytes         => 3000,
-      js_outline_min_bytes          => 3000,
-      inode_limit                   => 500000,
-      image_max_rewrites_at_once    => 8,
-      num_rewrite_threads           => 4,
-      num_expensive_rewrite_threads => 4,
-      collect_statistics            => 'on',
-      statistics_logging            => 'on',
-      allow_view_stats              => [],
-      allow_pagespeed_console       => [],
-      allow_pagespeed_message       => [],
-      message_buffer_size           => 100000,
-      additional_configuration      => { }
+apache::vhost { 'example.org':
+  docroot     => '/var/www/html',
+  directories => {
+    path        => '/var/www/html',
+    fcgiwrapper => {
+      command => '/usr/local/bin/fcgiwrapper',
     }
-```
+  },
+}
+~~~
 
-Full documentation for mod_pagespeed is available from [Google](http://modpagespeed.com).
+##### Class: `apache::mod::geoip`
 
-####Class: `apache::mod::php`
+Installs and manages [`mod_geoip`][].
 
-Installs and configures mod_php. The defaults are OS-dependant.
+**Parameters within `apache::mod::geoip`**:
 
-Overriding the package name:
-```puppet
-  class {'::apache::mod::php':
-    package_name => "php54-php",
-    path         => "${::apache::params::lib_path}/libphp54-php5.so",
-  }
-```
+- `db_file`: Sets the path to your GeoIP database file. Valid options: a path, or an [array][] paths for multiple GeoIP database files. Default: `/usr/share/GeoIP/GeoIP.dat`.
+- `enable`: Determines whether to globally enable [`mod_geoip`][]. Valid options: Boolean. Default: 'false'.
+- `flag`: Sets the GeoIP flag. Valid options: 'CheckCache', 'IndexCache', 'MemoryCache', 'Standard'. Default: 'Standard'.
+- `output`: Defines which output variables to use. Valid options: 'All', 'Env', 'Request', 'Notes'. Default: 'All'.
+- `enable_utf8`: Changes the output from ISO-8859-1 (Latin-1) to UTF-8. Valid options: Boolean. Default: 'undef'.
+- `scan_proxy_headers`: Enables the [GeoIPScanProxyHeaders][] option. Valid options: Boolean. Default: 'undef'.
+- `scan_proxy_header_field`: Specifies which header [`mod_geoip`][] should look at to determine the client's IP address. Default: 'undef'.
+- `use_last_xforwarededfor_ip` (sic): Determines whether to use the first or last IP address for the client's IP if a comma-separated list of IP addresses is found. Valid options: Boolean. Default: 'undef'.
 
-Overriding the default configuartion:
-```puppet
-  class {'::apache::mod::php':
-    source => 'puppet:///modules/apache/my_php.conf',
-  }
-```
+##### Class: `apache::mod::info`
 
-or
-```puppet
-  class {'::apache::mod::php':
-    template => 'apache/php.conf.erb',
-  }
-```
+Installs and manages [`mod_info`][], which provides a comprehensive overview of the server configuration.
 
-or
+**Parameters within `apache::mod::info`**:
 
-```puppet
-  class {'::apache::mod::php':
-    content => '
-AddHandler php5-script .php
-AddType text/html .php',
-  }
-```
-####Class: `apache::mod::shib`
+- `allow_from`: Whitelist of IPv4 or IPv6 addresses or ranges that can access `/server-info`. Valid options: One or more octets of an IPv4 address, an IPv6 address or range, or an array of either. Default: ['127.0.0.1','::1']
+- `apache_version`: Default: `$::apache::apache_version`,
+- `restrict_access`: Determines whether to enable access restrictions. If 'false', the `allow_from` whitelist is ignored and any IP address can access `/server-info`. Valid options: Boolean. Default: 'true'.
 
-Installs the [Shibboleth](http://shibboleth.net/) module for Apache which allows the use of SAML2 Single-Sign-On (SSO) authentication by Shibboleth Identity Providers and Shibboleth Federations. This class only installs and configures the Apache components of a Shibboleth Service Provider (a web application that consumes Shibboleth SSO identities). The Shibboleth configuration can be managed manually, with Puppet, or using a [Shibboleth Puppet Module](https://github.com/aethylred/puppet-shibboleth).
+##### Class: `apache::mod::negotiation`
 
-Defining this class enables the Shibboleth specific parameters in `apache::vhost` instances.
-
-####Class: `apache::mod::ssl`
-
-Installs Apache SSL capabilities and uses the ssl.conf.erb template. These are the defaults:
-
-```puppet
-    class { 'apache::mod::ssl':
-      ssl_compression         => false,
-      ssl_cryptodevice        => 'builtin',
-      ssl_options             => [ 'StdEnvVars' ],
-      ssl_openssl_conf_cmd    => undef,
-      ssl_cipher              => 'HIGH:MEDIUM:!aNULL:!MD5',
-      ssl_honorcipherorder    => 'On',
-      ssl_protocol            => [ 'all', '-SSLv2', '-SSLv3' ],
-      ssl_pass_phrase_dialog  => 'builtin',
-      ssl_random_seed_bytes   => '512',
-      ssl_sessioncachetimeout => '300',
-    }
-```
-
-To *use* SSL with a virtual host, you must either set the`default_ssl_vhost` parameter in `::apache` to 'true' or set the `ssl` parameter in `apache::vhost` to 'true'.
-
-####Class: `apache::mod::status`
-
-Installs Apache mod_status and uses the status.conf.erb template. These are the defaults:
-
-```puppet
-    class { 'apache::mod::status':
-      allow_from      => ['127.0.0.1','::1'],
-      extended_status => 'On',
-      status_path     => '/server-status',
-){
-
-
-  }
-```
-
-####Class: `apache::mod::expires`
-
-Installs Apache mod_expires and uses the expires.conf.erb template. These are the defaults:
-
-```puppet
-    class { 'apache::mod::expires':
-      expires_active  => true,
-      expires_default => undef,
-      expires_by_type => undef,
-){
-
-
-  }
-```
-
-`expires_by_type` is an array of Hashes, describing a set of types and their expire times:
-
-```puppet
-  class { 'apache::mod::expires':
-    expires_by_type => [
-      { 'text/json' => 'access plus 1 month' },
-      { 'text/html' => 'access plus 1 year' },
-    ]
-  }
-```
-
-####Class: `apache::mod::wsgi`
-
-Enables Python support in the WSGI module. To use, simply `include 'apache::mod::wsgi'`.
-
-For customized parameters, which tell Apache how Python is currently configured on the operating system,
-
-```puppet
-    class { 'apache::mod::wsgi':
-      wsgi_socket_prefix => "\${APACHE_RUN_DIR}WSGI",
-      wsgi_python_home   => '/path/to/venv',
-      wsgi_python_path   => '/path/to/venv/site-packages',
-    }
-```
-
-To specify an alternate mod\_wsgi package name to install and the name of the module .so it provides,
-(e.g. a "python27-mod\_wsgi" package that provides "python27-mod_wsgi.so" in the default module directory):
-
-```puppet
-    class { 'apache::mod::wsgi':
-      wsgi_socket_prefix => "\${APACHE_RUN_DIR}WSGI",
-      wsgi_python_home   => '/path/to/venv',
-      wsgi_python_path   => '/path/to/venv/site-packages',
-      package_name       => 'python27-mod_wsgi',
-      mod_path           => 'python27-mod_wsgi.so',
-    }
-```
-
-If ``mod_path`` does not contain "/", it will be prefixed by the default module path
-for your OS; otherwise, it will be used literally.
-
-More information about [WSGI](http://modwsgi.readthedocs.org/en/latest/).
-
-####Class: `apache::mod::fcgid`
-
-Installs and configures mod_fcgid.
-
-The class makes no effort to list all available options, but rather uses an options hash to allow for ultimate flexibility:
-
-```puppet
-    class { 'apache::mod::fcgid':
-      options => {
-        'FcgidIPCDir'  => '/var/run/fcgidsock',
-        'SharememPath' => '/var/run/fcgid_shm',
-        'AddHandler'   => 'fcgid-script .fcgi',
-      },
-    }
-```
-
-For a full list op options, see the [official mod_fcgid documentation](https://httpd.apache.org/mod_fcgid/mod/mod_fcgid.html).
-
-It is also possible to set the FcgidWrapper per directory per vhost. You must ensure the fcgid module is loaded because there is no auto loading.
-
-```puppet
-    include apache::mod::fcgid
-    apache::vhost { 'example.org':
-      docroot     => '/var/www/html',
-      directories => {
-        path        => '/var/www/html',
-        fcgiwrapper => {
-          command => '/usr/local/bin/fcgiwrapper',
-        }
-      },
-    }
-```
-
-See [FcgidWrapper documentation](https://httpd.apache.org/mod_fcgid/mod/mod_fcgid.html#fcgidwrapper) for more information.
-
-####Class: `apache::mod::negotiation`
-
-Installs and configures mod_negotiation. If there are not provided any
-parameter, default apache mod_negotiation configuration is done.
-
-```puppet
-  class { '::apache::mod::negotiation':
-    force_language_priority => 'Prefer',
-    language_priority       => [ 'es', 'en', 'ca', 'cs', 'da', 'de', 'el', 'eo' ],
-  }
-```
+Installs and configures [`mod_negotiation`][].
 
 **Parameters within `apache::mod::negotiation`:**
 
-#####`force_language_priority`
+- `force_language_priority`: Sets the `ForceLanguagePriority` option. Valid option: String. Default: `Prefer Fallback`.
+- `language_priority`: An [array][] of languages to set the `LanguagePriority` option of the module. Default: [ 'en', 'ca', 'cs', 'da', 'de', 'el', 'eo', 'es', 'et', 'fr', 'he', 'hr', 'it', 'ja', 'ko', 'ltz', 'nl', 'nn', 'no', 'pl', 'pt', 'pt-BR', 'ru', 'sv', 'zh-CN', 'zh-TW' ]
 
-A string that sets the `ForceLanguagePriority` option. Defaults to `Prefer Fallback`.
+##### Class: `apache::mod::pagespeed`
 
-#####`language_priority`
+Installs and manages [`mod_pagespeed`], a Google module that rewrites web pages to reduce latency and bandwidth.
 
-An array of languages to set the `LanguagePriority` option of the module.
+While this Apache module requires the `mod-pagespeed-stable` package, Puppet **doesn't** manage the software repositories required to automatically install the package. If you declare this class when the package is either not installed or not available to your package manager, your Puppet run will fail.
 
-####Class: `apache::mod::deflate`
+**Parameters within `apache::mod::info`**:
 
-Installs and configures mod_deflate. If no parameters are provided, a default configuration is applied.
+- `inherit_vhost_config`: Default: 'on'.
+- `filter_xhtml`: Default: false.
+- `cache_path`: Default: '/var/cache/mod_pagespeed/'.
+- `log_dir`: Default: '/var/log/pagespeed'.
+- `memcache_servers`: Default: [].
+- `rewrite_level`: Default: 'CoreFilters'.
+- `disable_filters`: Default: [].
+- `enable_filters`: Default: [].
+- `forbid_filters`: Default: [].
+- `rewrite_deadline_per_flush_ms`: Default: 10.
+- `additional_domains`: Default: undef.
+- `file_cache_size_kb`: Default: 102400.
+- `file_cache_clean_interval_ms`: Default: 3600000.
+- `lru_cache_per_process`: Default: 1024.
+- `lru_cache_byte_limit`: Default: 16384.
+- `css_flatten_max_bytes`: Default: 2048.
+- `css_inline_max_bytes`: Default: 2048.
+- `css_image_inline_max_bytes`: Default: 2048.
+- `image_inline_max_bytes`: Default: 2048.
+- `js_inline_max_bytes`: Default: 2048.
+- `css_outline_min_bytes`: Default: 3000.
+- `js_outline_min_bytes`: Default: 3000.
+- `inode_limit`: Default: 500000.
+- `image_max_rewrites_at_once`: Default: 8.
+- `num_rewrite_threads`: Default: 4.
+- `num_expensive_rewrite_threads`: Default: 4.
+- `collect_statistics`: Default: 'on'.
+- `statistics_logging`: Default: 'on'.
+- `allow_view_stats`: Default: [].
+- `allow_pagespeed_console`: Default: [].
+- `allow_pagespeed_message`: Default: [].
+- `message_buffer_size`: Default: 100000.
+- `additional_configuration`: Default: { }.
 
-```puppet
-  class { '::apache::mod::deflate':
-    types => [ 'text/html', 'text/css' ],
-    notes => {
-      'Input' => 'instream',
-      'Ratio' => 'ratio',
-    },
-  }
-```
+The class's parameters correspond to the module's directives. See the [module's documentation][`mod_pagespeed`] for details.
 
-#####`types`
+##### Class: `apache::mod::php`
 
-An array of mime types to be deflated.
+Installs and configures [`mod_php`][]. 
 
-#####`notes`
+**Parameters within `apache::mod::php`**:
 
-A hash where the key represents the type and the value represents the note name.
+Default values depend on your operating system.
 
+> **Note**: This list is incomplete. Most of this class's parameters correspond to `mod_php` directives; see the [module's documentation][`mod_php`] for details.
 
-####Class: `apache::mod::reqtimeout`
+- `package_name`: Names the package that installs `php_mod`.
+- `path`: Defines the path to the `mod_php` shared object (`.so`) file.
+- `source`: Defines the path to the default configuration. Valid options include a `puppet:///` paths. 
+- `template`: Defines the path to the `php.conf` template Puppet uses to generate the configuration file.
+- `content`: Adds arbitrary content to `php.conf`.
 
-Installs and configures mod_reqtimeout. Defaults to recommended apache
-mod_reqtimeout configuration.
+##### Class: `apache::mod::reqtimeout`
 
-```puppet
-  class { '::apache::mod::reqtimeout':
-    timeouts => ['header=20-40,MinRate=500', 'body=20,MinRate=500'],
-  }
-```
+Installs and configures [`mod_reqtimeout`][].
 
-####Class: `apache::mod::version`
+**Parameters within `apache::mod::reqtimeout`**:
 
-This wrapper around mod_version warns on Debian and Ubuntu systems with Apache httpd 2.4
-about loading mod_version, as on these platforms it's already built-in.
+- `timeouts`: A string or [array][] that sets the [`RequestReadTimeout`][] option. Default: ['header=20-40,MinRate=500', 'body=20,MinRate=500'].
 
-```puppet
-  include '::apache::mod::version'
-```
+##### Class: `apache::mod::shib`
 
-#####`timeouts`
+Installs the [Shibboleth](http://shibboleth.net/) Apache module `mod_shib`, which enables SAML2 single sign-on (SSO) authentication by Shibboleth Identity Providers and Shibboleth Federations. This class only installs and configures the Apache components of a web application that consumes Shibboleth SSO identities, also known as a Shibboleth Service Provider. You can manage the Shibboleth configuration manually, with Puppet, or using a [Shibboleth Puppet Module](https://github.com/aethylred/puppet-shibboleth).
 
-A string or an array that sets the `RequestReadTimeout` option. Defaults to
-`['header=20-40,MinRate=500', 'body=20,MinRate=500']`.
+Defining this class enables Shibboleth-specific parameters in `apache::vhost` instances.
 
+##### Class: `apache::mod::ssl`
 
-####Class: `apache::mod::security`
+Installs [Apache SSL features][`mod_ssl`] and uses the `ssl.conf.erb` template to generate its configuration. 
 
-Installs and configures mod_security.  Defaults to enabled and running on all
-vhosts.
+**Parameters within `apache::mod::ssl`**:
 
-```puppet
-  include '::apache::mod::security'
-```
+- `ssl_cipher`: Default: 'HIGH:MEDIUM:!aNULL:!MD5'.
+- `ssl_compression`: Default: 'false'.
+- `ssl_cryptodevice`: Default: 'builtin'.
+- `ssl_honorcipherorder`: Default: 'On'.
+- `ssl_openssl_conf_cmd`: Default: 'undef'.
+- `ssl_options`: Default: [ 'StdEnvVars' ]
+- `ssl_pass_phrase_dialog`: Default: 'builtin'.
+- `ssl_protocol`: Default: [ 'all', '-SSLv2', '-SSLv3' ].
+- `ssl_random_seed_bytes`: Default: '512'.
+- `ssl_sessioncachetimeout`: Default: '300'.
 
-#####`crs_package`
+To use SSL with a virtual host, you must either set the [`default_ssl_vhost`][] parameter in `::apache` to 'true' **o**r the [`ssl`][] parameter in [`apache::vhost`][] to 'true'.
 
-Name of package to install containing crs rules
+##### Class: `apache::mod::status`
 
-#####`modsec_dir`
+Installs [`mod_status`][] and uses the `status.conf.erb` template to generate its configuration.
 
-Directory to install the modsec configuration and activated rules links into
+**Parameters within `apache::mod::status`**:
 
-#####`modsec_secruleengine`
+- `allow_from`: An [array][] of IPv4 or IPv6 addresses that can access `/server-status`. Default: ['127.0.0.1','::1'].
+- `extended_status`: Determines whether to track extended status information for each request, via the [`ExtendedStatus`][] directive. Valid options: 'Off', 'On'. Default: 'On'.
+- `status_path`: The server location of the status page. Default: '/server-status'.
 
-Configures the rules engine. Valid vaules are On, Off, and DetectionOnly
+##### Class: `apache::mod::version`
 
-#####`activated_rules`
+Installs [`mod_version`][] on many operating systems and Apache configurations.
 
-Array of rules from the modsec_crs_path to activate by symlinking to
+If Debian and Ubuntu systems with Apache 2.4 are classified with `apache::mod::version`, Puppet warns that `mod_version` is built-in and can't be loaded.
+
+##### Class: `apache::mod::security`
+
+Installs and configures Trustwave's [`mod_security`][]. It is enabled and runs by default on all virtual hosts.
+
+**Parameters within `apache::mod::security`**:
+
+- `activated_rules`: An [array][] of rules from the `modsec_crs_path` to activate via symlinks. Default: `modsec_default_rules` in [`apache::params`][].
+- `allowed_methods`: A space-separated list of allowed HTTP methods. Default: 'GET HEAD POST OPTIONS'.
+- `content_types`: A list of one or more allowed [MIME types][MIME `content-type`]. Default: 'application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/x-amf'
+- `crs_package`: Names the package that installs CRS rules. Default: `modsec_crs_package` in [`apache::params`][].
+- `modsec_dir`: Defines the path where Puppet installs the modsec configuration and activated rules links. Default: 'On', set by `modsec_dir` in [`apache::params`][].
 ${modsec_dir}/activated_rules.
+- `modsec_secruleengine`: Configures the modsec rules engine. Valid options: 'On', 'Off', and 'DetectionOnly'. Default: `modsec_secruleengine` in [`apache::params`][].
+- `restricted_extensions`: A space-separated list of prohibited file extensions. Default: '.asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/'.
+- `restricted_headers`: A list of restricted headers separated by slashes and spaces. Default: 'Proxy-Connection/ /Lock-Token/ /Content-Range/ /Translate/ /via/ /if/'.
 
-#####`allowed_methods`
+##### Class: `apache::mod::wsgi`
 
-HTTP methods allowed by mod_security
+Enables Python support via [`mod_wsgi`][].
 
-#####`content_types`
+**Parameters within `apache::mod::wsgi`**:
 
-Content-types allowed by mod_security
+- `mod_path`: Defines the path to the `mod_wsgi` shared object (`.so`) file. Default: undef.
+  - If the `mod_path` parameter doesn't contain `/`, Puppet prefixes it with your operating system's default module path.
+Otherwise, Puppet follows it literally.
+- `package_name`: Names the package that installs `mod_wsgi`. Default: undef.
+- `wsgi_python_home`: Defines the [`WSGIPythonHome`][] directive, such as '/path/to/venv'. Valid options: path. Default: undef.
+- `wsgi_python_path`: Defines the [`WSGIPythonPath`][] directive, such as '/path/to/venv/site-packages'. Valid options: path. Default: undef.
+- `wsgi_socket_prefix`: Defines the [`WSGISocketPrefix`][] directive, such as "\${APACHE_RUN_DIR}WSGI". Default: `wsgi_socket_prefix` in [`apache::params`][].
 
-#####`restricted_extensions`
+The class's parameters correspond to the module's directives. See the [module's documentation][`mod_wsgi`] for details.
 
-Extensions prohibited by mod_security
+### Private Classes
 
-#####`restricted_headers`
+#### Class: `apache::confd::no_accf`
 
-Headers restricted by mod_security
+Creates the `no-accf.conf` configuration file in `conf.d`, required by FreeBSD's Apache 2.4.
 
+#### Class: `apache::default_confd_files`
 
-####Defined Type: `apache::vhost`
+Includes `conf.d` files for FreeBSD.
 
-The Apache module allows a lot of flexibility in the setup and configuration of virtual hosts. This flexibility is due, in part, to `vhost` being a defined resource type, which allows it to be evaluated multiple times with different parameters.
+#### Class: `apache::default_mods`
 
-The `vhost` defined type allows you to have specialized configurations for virtual hosts that have requirements outside the defaults. You can set up a default vhost within the base `::apache` class, as well as set a customized vhost as default. Your customized vhost (priority 10) will be privileged over the base class vhost (15).
+Installs the Apache modules required to run the default configuration. See the `apache` class's [`default_mods`][] parameter for details.
 
-The `vhost` defined type uses `concat::fragment` to build the configuration file, so if you want to inject custom fragments for pieces of the configuration not supported by default by the defined type, you can add a custom fragment.  For the `order` parameter for the custom fragment, the `vhost` defined type uses multiples of 10, so any order that isn't a multiple of 10 should work.
+#### Class: `apache::package`
 
-```puppet
-    apache::vhost { "example.com":
-      docroot  => '/var/www/html',
-      priority => '25',
-    }
-    concat::fragment { "example.com-my_custom_fragment":
-      target  => '25-example.com.conf',
-      order   => 11,
-      content => '# my custom comment',
-    }
-```
+Installs and configures basic Apache packages.
 
-If you have a series of specific configurations and do not want a base `::apache` class default vhost, make sure to set the base class `default_vhost` to 'false'.
+#### Class: `apache::params`
 
-```puppet
-    class { 'apache':
-      default_vhost => false,
-    }
-```
+Manages Apache parameters for different operating systems.
 
-**Parameters within `apache::vhost`:**
+#### Class: `apache::service`
 
-#####`access_log`
+Manages the Apache daemon.
 
-Specifies whether `*_access.log` directives (`*_file`,`*_pipe`, or `*_syslog`) should be configured. Setting the value to 'false' chooses none. Defaults to 'true'.
+#### Class: `apache::version`
 
-#####`access_log_file`
+Attempts to automatically detect the Apache version based on the operating system.
 
-Sets the `*_access.log` filename that is placed in `$logroot`. Given a vhost, example.com, it defaults to 'example.com_ssl.log' for SSL vhosts and 'example.com_access.log' for non-SSL vhosts.
+### Public Defines
 
-#####`access_log_pipe`
+#### Define: `apache::balancer`
 
-Specifies a pipe to send access log messages to. Defaults to 'undef'.
+Creates an Apache load balancing group, also known as a balancer cluster, using [`mod_proxy`][]. Each load balancing group needs one or more balancer members, which you can declare in Puppet with the  [`apache::balancermember`][] define.
 
-#####`access_log_syslog`
+Declare one `apache::balancer` define for each Apache load balancing group. You can export `apache::balancermember` defines for all balancer members and collect them on a single Apache load balancer server using [exported resources][].
 
-Sends all access log messages to syslog. Defaults to 'undef'.
+**Parameters within `apache::balancer`**:
 
-#####`access_log_format`
+##### `name`
 
-Specifies the use of either a LogFormat nickname or a custom format string for the access log. Defaults to 'combined'. See [these examples](http://httpd.apache.org/docs/current/mod/mod_log_config.html).
+Sets the title of the balancer cluster and name of the `conf.d` file containing its configuration.
 
-#####`access_log_env_var`
+##### `proxy_set`
+
+Configures key-value pairs as [`ProxySet`][] lines. Valid options: [Hash][]. Default: '{}'.
+
+##### `collect_exported`
+
+Determines whether to use [exported resources][]. Valid options: Boolean. Default: 'true'.
+
+If you statically declare all of your backend servers, set this parameter to 'false' to rely on existing, declared balancer member resources. Also, use `apache::balancermember` with [array][] arguments.
+
+To dynamically declare backend servers via exported resources collected on a central node, set this parameter to 'true' to collect the balancer member resources exported by the balancer member nodes.
+
+If you don't use exported resources, a single Puppet run configures all balancer members. If you use exported resources, Puppet has to run on the balanced nodes first, then run on the balancer.
+
+#### Define: `apache::balancermember`
+
+Defines members of [`mod_proxy_balancer`][], which sets up a balancer member inside a listening service configuration block in the load balancer's `apache.cfg`.
+
+**Parameters within `apache::balancermember`**:
+
+##### `balancer_cluster`
+
+**Required**. Sets the Apache service's instance name, and must match the name of a declared [`apache::balancer`][] resource.
+
+##### `url`
+
+Specifies the URL used to contact the balancer member server. Default:  'http://${::fqdn}/'.
+
+##### `options`
+
+Specifies an [array][] of [options](http://httpd.apache.org/docs/current/mod/mod_proxy.html#balancermember) after the URL, and accepts any key-value pairs available to [`ProxyPass`][]. Default: an empty array.
+
+#### Define: `apache::custom_config`
+
+Adds a custom configuration file to the Apache server's `conf.d` directory. If the file is invalid and this define's `$verify_config` parameter is 'true', Puppet throws an error during a Puppet run.
+
+**Parameters within `apache::custom_config`**:
+
+##### `ensure`
+
+Specifies whether the configuration file should be present. Valid options: 'absent', 'present'. Default: 'present'.
+
+##### `confdir`
+
+Sets the directory in which Puppet places configuration files. Default: '$::apache::confd_dir'.
+
+##### `content`
+
+Sets the configuration file's content. The `content` and [`source`][] parameters are exclusive of each other.
+
+##### `priority`
+
+Sets the configuration file's priority by prefixing its filename with this parameter's numeric value, as Apache processes configuration files in alphanumeric order. The default value is `25`. 
+
+To omit the priority prefix in the configuration file's name, set this parameter to `false`.
+
+##### `source`
+
+Points to the configuration file's source. The [`content`][] and `source` parameters are exclusive of each other.
+
+##### `verify_command`
+
+Specifies the command Puppet uses to verify the configuration file. Use a fully qualified command. Default: `/usr/sbin/apachectl -t`.
+
+This parameter is only used if the [`verify_config`][] parameter's value is 'true'. If the `verify_command` fails, the Puppet run deletes the configuration file, does not notify the Apache service, and raises an error.
+
+##### `verify_config`
+
+Specifies whether to validate the configuration file before notifying the Apache service. Valid options: Boolean. Default: `true`.
+
+#### Define: `apache::fastcgi::server`
+
+Defines one or more external FastCGI servers to handle specific file types. Use this define with [`mod_fastcgi`][FastCGI].
+
+**Parameters within `apache::fastcgi::server`:**
+
+##### `host`
+
+Determines the FastCGI's hostname or IP address and TCP port number (1-65535).
+
+##### `timeout`
+
+Sets the number of seconds a [FastCGI][] application can be inactive before aborting the request and logging the event at the error LogLevel. The inactivity timer applies only as long as a connection is pending with the FastCGI application. If a request is queued to an application, but the application doesn't respond by writing and flushing within this period, the request is aborted. If communication is complete with the application but incomplete with the client (the response is buffered), the timeout does not apply.
+
+##### `flush`
+
+Forces [`mod_fastcgi`][FastCGI] to write to the client as data is received from the application. By default, `mod_fastcgi` buffers data in order to free the application as quickly as possible.
+
+##### `faux_path`
+
+Apache has [FastCGI][] handle URIs that resolve to this filename. The path set in this parameter does not have to exist in the local filesystem.
+
+##### `alias`
+
+Internally links actions with the FastCGI server. This alias must be unique.
+
+##### `file_type`
+
+Sets the [MIME `content-type`][] of the file to be processed by the FastCGI server.
+
+#### Define: `apache::listen`
+
+Adds [`Listen`][] directives to `ports.conf` in the Apache configuration directory that define the Apache server's or a virtual host's listening address and port. The [`apache::vhost`][] class uses this define, and titles take the form '<PORT>', '<IPV4>:<PORT>', or '<IPV6>:<PORT>'.
+
+#### Define: `apache::mod`
+
+Installs packages for an Apache module that doesn't have a corresponding [`apache::mod::<MODULE NAME>`][] class, and checks for or places the module's default configuration files in the Apache server's `module` and `enable` directories. The default locations depend on your operating system.
+
+**Parameters within `apache::mod`**: 
+
+##### `package`
+
+**Required**. Names the package Puppet uses to install the Apache module.
+
+##### `package_ensure`
+
+Determines whether Puppet ensures the Apache module should be installed. Valid options: 'absent', 'present'. Default: 'present'.
+
+##### `lib`
+
+Defines the module's shared object name. Its default value is `mod_$name.so`, and it should not be configured manually without special reason.
+
+##### `lib_path`
+
+Specifies a path to the module's libraries. Default: the `apache` class's [`lib_path`][] parameter. 
+
+Don't manually set this parameter without special reason. The [`path`][] parameter overrides this value.
+
+##### `loadfile_name`
+
+Sets the filename for the module's [`LoadFile`][] directive, which can also set the module load order as Apache processes them in alphanumeric order. Valid options: filenames formatted `\*.load`. Default: `$name.load`.
+
+##### `loadfiles`
+
+Specifies an [array][] of [`LoadFile`][] directives.
+
+##### `path`
+
+Specifies a path to the module. Default: [`lib_path`][]/[`lib`][]. Don't manually set this parameter without special reason.
+
+#### Define: `apache::namevirtualhost`
+
+Enables [name-based virtual hosts][] and adds all related directives to the `ports.conf` file in the Apache HTTPD configuration directory. Titles can take the forms '\*', '*:<PORT>', '\_default_:<PORT>, '<IP>', or '<IP>:<PORT>'.
+
+#### Define: `apache::vhost`
+
+The Apache module allows a lot of flexibility in the setup and configuration of virtual hosts. This flexibility is due, in part, to `vhost` being a defined resource type, which allows Apache to evaluate it multiple times with different parameters.
+
+The `apache::vhost` define allows you to have specialized configurations for virtual hosts that have requirements outside the defaults. You can set up a default virtual host within the base `::apache` class, as well as set a customized virtual host as the default. Customized virtual hosts have a lower numeric [`priority`][] than the base class's, causing Apache to process the customized virtual host first.
+
+The `apache::vhost` define uses `concat::fragment` to build the configuration file. To inject custom fragments for pieces of the configuration that the define doesn't inherently support, add a custom fragment. 
+
+For the custom fragment's `order` parameter, the `apache::vhost` define uses multiples of 10, so any `order` that isn't a multiple of 10 should work.
+
+**Parameters within `apache::vhost`**:
+
+##### `access_log`
+
+Determines whether to configure `*_access.log` directives (`*_file`,`*_pipe`, or `*_syslog`). Valid options: Boolean. Default: 'true'.
+
+##### `access_log_env_var`
 
 Specifies that only requests with particular environment variables be logged. Defaults to 'undef'.
 
-#####`add_default_charset`
+##### `access_log_file`
 
-Sets [AddDefaultCharset](http://httpd.apache.org/docs/current/mod/core.html#adddefaultcharset), a default value for the media charset, which is added to text/plain and text/html responses.
+Sets the filename of the `*_access.log` placed in [`logroot`][]. Given a virtual host---for instance, example.com---it defaults to 'example.com_ssl.log' for [SSL-encrypted][SSL encryption] virtual hosts and 'example.com_access.log' for unencrypted virtual hosts.
 
-#####`add_listen`
+##### `access_log_format`
 
-Determines whether the vhost creates a Listen statement. The default value is 'true'.
+Specifies the use of either a [`LogFormat`][] nickname or a custom-formatted string for the access log. Default: 'combined'.
 
-Setting `add_listen` to 'false' stops the vhost from creating a Listen statement, and this is important when you combine vhosts that are not passed an `ip` parameter with vhosts that *are* passed the `ip` parameter.
+##### `access_log_pipe`
 
-#####`use_optional_includes`
+Specifies a pipe where Apache sends access log messages. Default: 'undef'.
 
-Specifies if for apache > 2.4 it should use IncludeOptional instead of Include for `additional_includes`. Defaults to 'false'.
+##### `access_log_syslog`
 
-#####`additional_includes`
+Sends all access log messages to syslog. Default: 'undef'.
 
-Specifies paths to additional static, vhost-specific Apache configuration files. Useful for implementing a unique, custom configuration not supported by this module. Can be an array. Defaults to '[]'.
+##### `add_default_charset`
 
-#####`aliases`
+Sets a default media charset value for the [`AddDefaultCharset`][] directive, which is added to `text/plain` and `text/html` responses.
 
-Passes a list of hashes to the vhost to create Alias, AliasMatch, ScriptAlias or ScriptAliasMatch directives as per the [mod_alias documentation](http://httpd.apache.org/docs/current/mod/mod_alias.html). These hashes are formatted as follows:
+##### `add_listen`
 
-```puppet
+Determines whether the virtual host creates a [`Listen`][] statement. Valid options: Boolean. Default: 'true'.
+
+Setting `add_listen` to 'false' prevents the virtual host from creating a `Listen` statement. This is important when combining virtual hosts that aren't passed an `ip` parameter with those that are.
+
+##### `use_optional_includes`
+
+Specifies whether Apache uses the [`IncludeOptional`][] directive instead of [`Include`][] for `additional_includes` in Apache 2.4 or newer. Valid options: Boolean. Default: 'false'.
+
+##### `additional_includes`
+
+Specifies paths to additional static, virtual host-specific Apache configuration files. You can use this parameter to implement a unique, custom configuration not supported by this module. Valid options: a string path or [array][] of them. Default: an empty array.
+
+##### `aliases`
+
+Passes a list of [Hashes][Hash] to the virtual host to create [`Alias`][], [`AliasMatch`][], [`ScriptAlias`][] or [`ScriptAliasMatch`][] directives as per the [`mod_alias`][] documentation.
+
+For example:
+
+~~~ puppet
 aliases => [
   { aliasmatch       => '^/image/(.*)\.jpg$',
     path             => '/files/jpg.images/$1.jpg',
@@ -1199,102 +1769,100 @@ aliases => [
     path             => '/usr/share/nagios/html',
   },
 ],
-```
+~~~
 
-For `alias`, `aliasmatch`, `scriptalias` and `scriptaliasmatch` to work, each needs a corresponding context, such as `<Directory /path/to/directory>` or `<Location /some/location/here>`. The directives are created in the order specified in the `aliases` parameter. As described in the [`mod_alias` documentation](http://httpd.apache.org/docs/current/mod/mod_alias.html), more specific `alias`, `aliasmatch`, `scriptalias` or `scriptaliasmatch` parameters should come before the more general ones to avoid shadowing.
+For the `alias`, `aliasmatch`, `scriptalias` and `scriptaliasmatch` keys to work, each needs a corresponding context, such as `<Directory /path/to/directory>` or `<Location /some/location/here>`. Puppet creates the directives in the order specified in the `aliases` parameter. As described in the [`mod_alias`][] documentation, add more specific `alias`, `aliasmatch`, `scriptalias` or `scriptaliasmatch` parameters before the more general ones to avoid shadowing.
 
-*Note*: Using the `aliases` parameter is preferred over the `scriptaliases` parameter since here the order of the various alias directives among each other can be controlled precisely. Defining ScriptAliases using the `scriptaliases` parameter means *all* ScriptAlias directives will come after *all* Alias directives, which can lead to Alias directives shadowing ScriptAlias directives. This is often problematic, for example in case of Nagios.
+**Note**: Use the `aliases` parameter instead of the `scriptaliases` parameter because you can precisely control the various alias directives' order. Defining `ScriptAliases` using the `scriptaliases` parameter means *all* `ScriptAlias` directives will come after *all* `Alias` directives, which can lead to `Alias` directives shadowing `ScriptAlias` directives. This often causes problems, for example with Nagios.
 
-*Note:* If `apache::mod::passenger` is loaded and `PassengerHighPerformance => true` is set, then Alias might have issues honoring the `PassengerEnabled => off` statement. See [this article](http://www.conandalton.net/2010/06/passengerenabled-off-not-working.html) for details.
+If [`apache::mod::passenger`][] is loaded and `PassengerHighPerformance` is 'true', the `Alias` directive might not be able to honor the `PassengerEnabled => off` statement. See [this article](http://www.conandalton.net/2010/06/passengerenabled-off-not-working.html) for details.
 
-#####`allow_encoded_slashes`
+##### `allow_encoded_slashes`
 
-This sets the [`AllowEncodedSlashes` declaration](http://httpd.apache.org/docs/current/mod/core.html#allowencodedslashes) for the vhost, overriding the server default. This modifies the vhost responses to URLs with `\` and `/` characters. The default is undefined, which omits the declaration from the server configuration and select the Apache default setting of `Off`. Allowed values are: `on`, `off` or `nodecode`.
+Sets the [`AllowEncodedSlashes`][] declaration for the virtual host, overriding the server default. This modifies the virtual host responses to URLs with `\` and `/` characters. Valid options: 'nodecode', 'off', 'on'. Default: undef, which omits the declaration from the server configuration and selects the Apache default setting of `Off`. 
 
-#####`block`
+##### `block`
 
-Specifies the list of things Apache blocks access to. The default is an empty set, '[]'. Currently, the only option is 'scm', which blocks web access to .svn, .git and .bzr directories.
+Specifies the list of things to which Apache blocks access. Valid option: 'scm', which blocks web access to `.svn`, `.git`, and `.bzr` directories. Default: an empty [array][].
 
-#####`custom_fragment`
+##### `custom_fragment`
 
-Passes a string of custom configuration directives to be placed at the end of the vhost configuration. Defaults to 'undef'.
+Passes a string of custom configuration directives to place at the end of the virtual host configuration. Default: 'undef'.
 
-#####`default_vhost`
+##### `default_vhost`
 
-Sets a given `apache::vhost` as the default to serve requests that do not match any other `apache::vhost` definitions. The default value is 'false'.
+Sets a given `apache::vhost` define as the default to serve requests that do not match any other `apache::vhost` defines. Default: 'false'.
 
-#####`directories`
+##### `directories`
 
-See the [`directories` section](#parameter-directories-for-apachevhost).
+See the [`directories`](#parameter-directories-for-apachevhost) section.
 
-#####`directoryindex`
+##### `directoryindex`
 
-Sets the list of resources to look for when a client requests an index of the directory by specifying a '/' at the end of the directory name. [DirectoryIndex](http://httpd.apache.org/docs/current/mod/mod_dir.html#directoryindex) has more information. Defaults to 'undef'.
+Sets the list of resources to look for when a client requests an index of the directory by specifying a '/' at the end of the directory name. See the [`DirectoryIndex`][] directive documentation for details. Default: 'undef'.
 
-#####`docroot`
+##### `docroot`
 
-Provides the
-[DocumentRoot](http://httpd.apache.org/docs/current/mod/core.html#documentroot)
-directive, which identifies the directory Apache serves files from. Required.
+**Required**. Sets the [`DocumentRoot`][] location, from which Apache serves files.
 
-#####`docroot_group`
+##### `docroot_group`
 
-Sets group access to the docroot directory. Defaults to 'root'.
+Sets group access to the [`docroot`][] directory. Defaults to 'root'.
 
-#####`docroot_owner`
+##### `docroot_owner`
 
 Sets individual user access to the docroot directory. Defaults to 'root'.
 
-#####`docroot_mode`
+##### `docroot_mode`
 
 Sets access permissions of the docroot directory. Defaults to 'undef'.
 
-#####`manage_docroot`
+##### `manage_docroot`
 
 Whether to manage to docroot directory at all. Defaults to 'true'.
 
-#####`error_log`
+##### `error_log`
 
 Specifies whether `*_error.log` directives should be configured. Defaults to 'true'.
 
-#####`error_log_file`
+##### `error_log_file`
 
 Points to the `*_error.log` file. Given a vhost, example.com, it defaults to 'example.com_ssl_error.log' for SSL vhosts and 'example.com_access_error.log' for non-SSL vhosts.
 
-#####`error_log_pipe`
+##### `error_log_pipe`
 
 Specifies a pipe to send error log messages to. Defaults to 'undef'.
 
-#####`error_log_syslog`
+##### `error_log_syslog`
 
 Sends all error log messages to syslog. Defaults to 'undef'.
 
-#####`error_documents`
+##### `error_documents`
 
 A list of hashes which can be used to override the [ErrorDocument](https://httpd.apache.org/docs/current/mod/core.html#errordocument) settings for this vhost. Defaults to '[]'. Example:
 
-```puppet
+~~~ puppet
     apache::vhost { 'sample.example.net':
       error_documents => [
         { 'error_code' => '503', 'document' => '/service-unavail' },
         { 'error_code' => '407', 'document' => 'https://example.com/proxy/login' },
       ],
     }
-```
+~~~
 
-#####`ensure`
+##### `ensure`
 
 Specifies if the vhost file is present or absent. Defaults to 'present'.
 
-#####`fallbackresource`
+##### `fallbackresource`
 
 Sets the [FallbackResource](http://httpd.apache.org/docs/current/mod/mod_dir.html#fallbackresource) directive, which specifies an action to take for any URL that doesn't map to anything in your filesystem and would otherwise return 'HTTP 404 (Not Found)'. Valid values must either begin with a / or be 'disabled'. Defaults to 'undef'.
 
-#####`filters`
+##### `filters`
 
 [Filters](http://httpd.apache.org/docs/2.2/mod/mod_filter.html) enable smart, context-sensitive configuration of output content filters.
 
-```puppet
+~~~ puppet
     apache::vhost { "$::fqdn":
       filters => [
         'FilterDeclare   COMPRESS',
@@ -1303,25 +1871,25 @@ Sets the [FallbackResource](http://httpd.apache.org/docs/current/mod/mod_dir.htm
         'FilterProtocol  COMPRESS DEFLATE change=yes;byteranges=no',
       ],
     }
-```
+~~~
 
-#####`force_type`
+##### `force_type`
 
-Sets the [ForceType](http://httpd.apache.org/docs/2.2/mod/core.html#forcetype) directive, to force all matching files to be served with the specified MIME content-type.
+Sets the [`ForceType`][] directive, which forces Apache to serve all matching files with the specified [MIME `content-type`][].
 
-#####`headers`
+##### `headers`
 
 Adds lines to replace, merge, or remove response headers. See [Header](http://httpd.apache.org/docs/current/mod/mod_headers.html#header) for more information. Can be an array. Defaults to 'undef'.
 
-#####`ip`
+##### `ip`
 
 Sets the IP address the vhost listens on. Defaults to listen on all IPs.
 
-#####`ip_based`
+##### `ip_based`
 
 Enables an [IP-based](http://httpd.apache.org/docs/current/vhosts/ip-based.html) vhost. This parameter inhibits the creation of a NameVirtualHost directive, since those are used to funnel requests to name-based vhosts. Defaults to 'false'.
 
-#####`itk`
+##### `itk`
 
 Configures [ITK](http://mpm-itk.sesse.net/) in a hash. Keys can be:
 
@@ -1335,7 +1903,7 @@ Configures [ITK](http://mpm-itk.sesse.net/) in a hash. Keys can be:
 
 Usage typically looks like:
 
-```puppet
+~~~ puppet
     apache::vhost { 'sample.example.net':
       docroot => '/path/to/directory',
       itk     => {
@@ -1343,123 +1911,123 @@ Usage typically looks like:
         group => 'somegroup',
       },
     }
-```
+~~~
 
-#####`logroot`
+##### `logroot`
 
 Specifies the location of the virtual host's logfiles. Defaults to '/var/log/<apache log location>/'.
 
-#####`$logroot_ensure`
+##### `$logroot_ensure`
 
 Determines whether or not to remove the logroot directory for a virtual host. Valid values are 'directory', or 'absent'.
 
-#####`logroot_mode`
+##### `logroot_mode`
 
 Overrides the mode the logroot directory is set to. Defaults to undef. Do NOT give people write access to the directory the logs are stored
 in without being aware of the consequences; see http://httpd.apache.org/docs/2.4/logs.html#security for details.
 
-#####`log_level`
+##### `log_level`
 
 Specifies the verbosity of the error log. Defaults to 'warn' for the global server configuration and can be overridden on a per-vhost basis. Valid values are 'emerg', 'alert', 'crit', 'error', 'warn', 'notice', 'info' or 'debug'.
 
-######`modsec_body_limit`
+###### `modsec_body_limit`
 
 Configures the maximum request body size (in bytes) ModSecurity will accept for buffering
 
-######`modsec_disable_vhost`
+###### `modsec_disable_vhost`
 
 Boolean.  Only valid if apache::mod::security is included.  Used to disable mod_security on an individual vhost.  Only relevant if apache::mod::security is included.
 
-######`modsec_disable_ids`
+###### `modsec_disable_ids`
 
 Array of mod_security IDs to remove from the vhost.  Also takes a hash allowing removal of an ID from a specific location.
 
-```puppet
+~~~ puppet
     apache::vhost { 'sample.example.net':
       modsec_disable_ids => [ 90015, 90016 ],
     }
-```
+~~~
 
-```puppet
+~~~ puppet
     apache::vhost { 'sample.example.net':
       modsec_disable_ids => { '/location1' => [ 90015, 90016 ] },
     }
-```
+~~~
 
-######`modsec_disable_ips`
+###### `modsec_disable_ips`
 
 Array of IPs to exclude from mod_security rule matching
 
-#####`no_proxy_uris`
+##### `no_proxy_uris`
 
 Specifies URLs you do not want to proxy. This parameter is meant to be used in combination with [`proxy_dest`](#proxy_dest).
 
-#####`no_proxy_uris_match`
+##### `no_proxy_uris_match`
 
 This directive is equivalent to `no_proxy_uris`, but takes regular expressions.
 
-#####`proxy_preserve_host`
+##### `proxy_preserve_host`
 
 Sets the [ProxyPreserveHost Directive](http://httpd.apache.org/docs/2.2/mod/mod_proxy.html#proxypreservehost).  true Enables the Host: line from an incoming request to be proxied to the host instead of hostname .  false sets this option to off (default).
 
-#####`proxy_error_override`
+##### `proxy_error_override`
 
 Sets the [ProxyErrorOverride Directive](http://httpd.apache.org/docs/2.2/mod/mod_proxy.html#proxyerroroverride). This directive controls whether apache should override error pages for proxied content. This option is off by default.
 
-#####`options`
+##### `options`
 
 Sets the [Options](http://httpd.apache.org/docs/current/mod/core.html#options) for the specified virtual host. Defaults to '['Indexes','FollowSymLinks','MultiViews']', as demonstrated below:
 
-```puppet
+~~~ puppet
     apache::vhost { 'site.name.fdqn':
       …
       options => ['Indexes','FollowSymLinks','MultiViews'],
     }
-```
+~~~
 
 *Note:* If you use [`directories`](#parameter-directories-for-apachevhost), 'Options', 'Override', and 'DirectoryIndex' are ignored because they are parameters within `directories`.
 
-#####`override`
+##### `override`
 
 Sets the overrides for the specified virtual host. Accepts an array of [AllowOverride](http://httpd.apache.org/docs/current/mod/core.html#allowoverride) arguments. Defaults to '[none]'.
 
-#####`passenger_app_root`
+##### `passenger_app_root`
 
 Sets [PassengerRoot](https://www.phusionpassenger.com/documentation/Users%20guide%20Apache.html#PassengerAppRoot), the location of the Passenger application root if different from the DocumentRoot.
 
-#####`passenger_app_env`
+##### `passenger_app_env`
 
 Sets [PassengerAppEnv](https://www.phusionpassenger.com/documentation/Users%20guide%20Apache.html#PassengerAppEnv), the environment for the Passenger application. If not specifies, defaults to the global setting or 'production'.
 
-#####`passenger_ruby`
+##### `passenger_ruby`
 
 Sets [PassengerRuby](https://www.phusionpassenger.com/documentation/Users%20guide%20Apache.html#PassengerRuby) on this virtual host, the Ruby interpreter to use for the application.
 
-#####`passenger_min_instances`
+##### `passenger_min_instances`
 
 Sets [PassengerMinInstances](https://www.phusionpassenger.com/documentation/Users%20guide%20Apache.html#PassengerMinInstances), the minimum number of application processes to run.
 
-#####`passenger_start_timeout`
+##### `passenger_start_timeout`
 
 Sets [PassengerStartTimeout](https://www.phusionpassenger.com/documentation/Users%20guide%20Apache.html#_passengerstarttimeout_lt_seconds_gt), the timeout for the application startup.
 
-#####`passenger_pre_start`
+##### `passenger_pre_start`
 
 Sets [PassengerPreStart](https://www.phusionpassenger.com/documentation/Users%20guide%20Apache.html#PassengerPreStart), the URL of the application if pre-starting is required.
 
-#####`php_flags & values`
+##### `php_flags & values`
 
 Allows per-vhost setting [`php_value`s or `php_flag`s](http://php.net/manual/en/configuration.changes.php). These flags or values can be overwritten by a user or an application. Defaults to '{}'.
 
-#####`php_admin_flags & values`
+##### `php_admin_flags & values`
 
 Allows per-vhost setting [`php_admin_value`s or `php_admin_flag`s](http://php.net/manual/en/configuration.changes.php). These flags or values cannot be overwritten by a user or an application. Defaults to '{}'.
 
-#####`port`
+##### `port`
 
 Sets the port the host is configured on. The module's defaults ensure the host listens on port 80 for non-SSL vhosts and port 443 for SSL vhosts. The host only listens on the port set in this parameter.
 
-#####`priority`
+##### `priority`
 
 Sets the relative load-order for Apache HTTPD VirtualHost configuration files. Defaults to '25'.
 
@@ -1469,15 +2037,15 @@ If nothing matches the priority, the first name-based vhost is used. Likewise, p
 
 Pass priority `false` to omit the priority prefix in file names.
 
-#####`proxy_dest`
+##### `proxy_dest`
 
 Specifies the destination address of a [ProxyPass](http://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypass) configuration. Defaults to 'undef'.
 
-#####`proxy_pass`
+##### `proxy_pass`
 
 Specifies an array of `path => URI` for a [ProxyPass](http://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypass) configuration. Defaults to 'undef'. Optionally parameters can be added as an array.
 
-```puppet
+~~~ puppet
 apache::vhost { 'site.name.fdqn':
   …
   proxy_pass => [
@@ -1494,73 +2062,73 @@ apache::vhost { 'site.name.fdqn':
       'setenv' => ['proxy-nokeepalive 1','force-proxy-request-1.0 1']},
   ],
 }
-```
+~~~
 
 `reverse_urls` is optional and can be an array or a string. It is useful when used with `mod_proxy_balancer`.
 `params` is an optional parameter. It allows to provide the ProxyPass key=value parameters (Connection settings).
 `setenv` is optional and is an array to set environment variables for the proxy directive, for details see http://httpd.apache.org/docs/current/mod/mod_proxy.html#envsettings
 
-#####`proxy_dest_match`
+##### `proxy_dest_match`
 
 This directive is equivalent to proxy_dest, but takes regular expressions, see [ProxyPassMatch](http://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassmatch) for details.
 
-#####`proxy_dest_reverse_match`
+##### `proxy_dest_reverse_match`
 
 Allows you to pass a ProxyPassReverse if `proxy_dest_match` is specified. See [ProxyPassReverse](http://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassreverse) for details.
 
-#####`proxy_pass_match`
+##### `proxy_pass_match`
 
 This directive is equivalent to proxy_pass, but takes regular expressions, see [ProxyPassMatch](http://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassmatch) for details.
 
-#####`rack_base_uris`
+##### `rack_base_uris`
 
 Specifies the resource identifiers for a rack configuration. The file paths specified are listed as rack application roots for [Phusion Passenger](http://www.modrails.com/documentation/Users%20guide%20Apache.html#_railsbaseuri_and_rackbaseuri) in the _rack.erb template. Defaults to 'undef'.
 
-#####`redirect_dest`
+##### `redirect_dest`
 
 Specifies the address to redirect to. Defaults to 'undef'.
 
-#####`redirect_source`
+##### `redirect_source`
 
 Specifies the source URIs that redirect to the destination specified in `redirect_dest`. If more than one item for redirect is supplied, the source and destination must be the same length, and the items are order-dependent.
 
-```puppet
+~~~ puppet
     apache::vhost { 'site.name.fdqn':
       …
       redirect_source => ['/images','/downloads'],
       redirect_dest   => ['http://img.example.com/','http://downloads.example.com/'],
     }
-```
+~~~
 
-#####`redirect_status`
+##### `redirect_status`
 
 Specifies the status to append to the redirect. Defaults to 'undef'.
 
-```puppet
+~~~ puppet
     apache::vhost { 'site.name.fdqn':
       …
       redirect_status => ['temp','permanent'],
     }
-```
+~~~
 
-#####`redirectmatch_regexp` & `redirectmatch_status` & `redirectmatch_dest`
+##### `redirectmatch_regexp` & `redirectmatch_status` & `redirectmatch_dest`
 
 Determines which server status should be raised for a given regular expression and where to forward the user to. Entered as arrays. Defaults to 'undef'.
 
-```puppet
+~~~ puppet
     apache::vhost { 'site.name.fdqn':
       …
       redirectmatch_status => ['404','404'],
       redirectmatch_regexp => ['\.git(/.*|$)/','\.svn(/.*|$)'],
       redirectmatch_dest => ['http://www.example.com/1','http://www.example.com/2'],
     }
-```
+~~~
 
-#####`request_headers`
+##### `request_headers`
 
 Modifies collected [request headers](http://httpd.apache.org/docs/current/mod/mod_headers.html#requestheader) in various ways, including adding additional request headers, removing request headers, etc. Defaults to 'undef'.
 
-```puppet
+~~~ puppet
     apache::vhost { 'site.name.fdqn':
       …
       request_headers => [
@@ -1568,23 +2136,23 @@ Modifies collected [request headers](http://httpd.apache.org/docs/current/mod/mo
         'unset MirrorID',
       ],
     }
-```
-#####`rewrites`
+~~~
+##### `rewrites`
 
 Creates URL rewrite rules. Expects an array of hashes, and the hash keys can be any of 'comment', 'rewrite_base', 'rewrite_cond', 'rewrite_rule' or 'rewrite_map'. Defaults to 'undef'.
 
 For example, you can specify that anyone trying to access index.html is served welcome.html
 
-```puppet
+~~~ puppet
     apache::vhost { 'site.name.fdqn':
       …
       rewrites => [ { rewrite_rule => ['^index\.html$ welcome.html'] } ]
     }
-```
+~~~
 
 The parameter allows rewrite conditions that, when true, execute the associated rule. For instance, if you wanted to rewrite URLs only if the visitor is using IE
 
-```puppet
+~~~ puppet
     apache::vhost { 'site.name.fdqn':
       …
       rewrites => [
@@ -1595,11 +2163,11 @@ The parameter allows rewrite conditions that, when true, execute the associated 
         },
       ],
     }
-```
+~~~
 
 You can also apply multiple conditions. For instance, rewrite index.html to welcome.html only when the browser is Lynx or Mozilla (version 1 or 2)
 
-```puppet
+~~~ puppet
     apache::vhost { 'site.name.fdqn':
       …
       rewrites => [
@@ -1610,11 +2178,11 @@ You can also apply multiple conditions. For instance, rewrite index.html to welc
         },
       ],
     }
-```
+~~~
 
 Multiple rewrites and conditions are also possible
 
-```puppet
+~~~ puppet
     apache::vhost { 'site.name.fdqn':
       …
       rewrites => [
@@ -1639,21 +2207,21 @@ Multiple rewrites and conditions are also possible
         },
      ],
     }
-```
+~~~
 
 Refer to the [`mod_rewrite` documentation](http://httpd.apache.org/docs/current/mod/mod_rewrite.html) for more details on what is possible with rewrite rules and conditions.
 
-#####`scriptalias`
+##### `scriptalias`
 
 Defines a directory of CGI scripts to be aliased to the path '/cgi-bin', for example: '/usr/scripts'. Defaults to 'undef'.
 
-#####`scriptaliases`
+##### `scriptaliases`
 
 *Note*: This parameter is deprecated in favour of the `aliases` parameter.
 
 Passes an array of hashes to the vhost to create either ScriptAlias or ScriptAliasMatch statements as per the [`mod_alias` documentation](http://httpd.apache.org/docs/current/mod/mod_alias.html). These hashes are formatted as follows:
 
-```puppet
+~~~ puppet
     scriptaliases => [
       {
         alias => '/myscript',
@@ -1672,39 +2240,39 @@ Passes an array of hashes to the vhost to create either ScriptAlias or ScriptAli
         path  => '/usr/share/neatscript',
       },
     ]
-```
+~~~
 
 The ScriptAlias and ScriptAliasMatch directives are created in the order specified. As with [Alias and AliasMatch](#aliases) directives, more specific aliases should come before more general ones to avoid shadowing.
 
-#####`serveradmin`
+##### `serveradmin`
 
 Specifies the email address Apache displays when it renders one of its error pages. Defaults to 'undef'.
 
-#####`serveraliases`
+##### `serveraliases`
 
 Sets the [ServerAliases](http://httpd.apache.org/docs/current/mod/core.html#serveralias) of the site. Defaults to '[]'.
 
-#####`servername`
+##### `servername`
 
 Sets the servername corresponding to the hostname you connect to the virtual host at. Defaults to the title of the resource.
 
-#####`setenv`
+##### `setenv`
 
 Used by HTTPD to set environment variables for vhosts. Defaults to '[]'.
 
 Example:
 
-```puppet
+~~~ puppet
     apache::vhost { 'setenv.example.com':
       setenv => ['SPECIAL_PATH /foo/bin'],
     }
-```
+~~~
 
-#####`setenvif`
+##### `setenvif`
 
 Used by HTTPD to conditionally set environment variables for vhosts. Defaults to '[]'.
 
-#####`suphp_addhandler`, `suphp_configpath`, & `suphp_engine`
+##### `suphp_addhandler`, `suphp_configpath`, & `suphp_engine`
 
 Set up a virtual host with [suPHP](http://suphp.org/DocumentationView.html?file=apache/CONFIG).
 
@@ -1716,7 +2284,7 @@ Set up a virtual host with [suPHP](http://suphp.org/DocumentationView.html?file=
 
 To set up a virtual host with suPHP
 
-```puppet
+~~~ puppet
     apache::vhost { 'suphp.example.com':
       port                => '80',
       docroot             => '/home/appuser/myphpapp',
@@ -1727,17 +2295,17 @@ To set up a virtual host with suPHP
         'suphp'           => { user => 'myappuser', group => 'myappgroup' },
       }
     }
-```
+~~~
 
-#####`vhost_name`
+##### `vhost_name`
 
 Enables name-based virtual hosting. If no IP is passed to the virtual host, but the vhost is assigned a port, then the vhost name is 'vhost_name:port'. If the virtual host has no assigned IP or port, the vhost name is set to the title of the resource. Defaults to '*'.
 
-#####`virtual_docroot`
+##### `virtual_docroot`
 
 Sets up a virtual host with a wildcard alias subdomain mapped to a directory with the same name. For example, 'http://example.com' would map to '/var/www/example.com'. Defaults to 'false'.
 
-```puppet
+~~~ puppet
     apache::vhost { 'subdomain.loc':
       vhost_name       => '*',
       port             => '80',
@@ -1745,9 +2313,9 @@ Sets up a virtual host with a wildcard alias subdomain mapped to a directory wit
       docroot          => '/var/www',
       serveraliases    => ['*.loc',],
     }
-```
+~~~
 
-#####`wsgi_daemon_process`, `wsgi_daemon_process_options`, `wsgi_process_group`, `wsgi_script_aliases`, & `wsgi_pass_authorization`
+##### `wsgi_daemon_process`, `wsgi_daemon_process_options`, `wsgi_process_group`, `wsgi_script_aliases`, & `wsgi_pass_authorization`
 
 Set up a virtual host with [WSGI](https://code.google.com/p/modwsgi/).
 
@@ -1765,7 +2333,7 @@ Set up a virtual host with [WSGI](https://code.google.com/p/modwsgi/).
 
 To set up a virtual host with WSGI
 
-```puppet
+~~~ puppet
     apache::vhost { 'wsgi.example.com':
       port                        => '80',
       docroot                     => '/var/www/pythonapp',
@@ -1779,7 +2347,7 @@ To set up a virtual host with WSGI
       wsgi_script_aliases         => { '/' => '/var/www/demo.wsgi' },
       wsgi_chunked_request        => 'On',
     }
-```
+~~~
 
 ####Parameter `directories` for `apache::vhost`
 
@@ -1791,7 +2359,7 @@ The `provider` key is optional. If missing, this key defaults to 'directory'. Va
 
 General `directories` usage looks something like
 
-```puppet
+~~~ puppet
     apache::vhost { 'files.example.net':
       docroot     => '/var/www/files',
       directories => [
@@ -1801,26 +2369,26 @@ General `directories` usage looks something like
          },
       ],
     }
-```
+~~~
 
 *Note:* At least one directory should match the `docroot` parameter. After you start declaring directories, `apache::vhost` assumes that all required Directory blocks will be declared. If not defined, a single default Directory block is created that matches the `docroot` parameter.
 
 Available handlers, represented as keys, should be placed within the `directory`, `files`, or `location` hashes.  This looks like
 
-```puppet
+~~~ puppet
     apache::vhost { 'sample.example.net':
       docroot     => '/path/to/directory',
       directories => [ { path => '/path/to/directory', handler => value } ],
 }
-```
+~~~
 
 Any handlers you do not set in these hashes are considered 'undefined' within Puppet and are not added to the virtual host, resulting in the module using their default values. Supported handlers are:
 
-######`addhandlers`
+###### `addhandlers`
 
 Sets [AddHandler](http://httpd.apache.org/docs/current/mod/mod_mime.html#addhandler) directives, which map filename extensions to the specified handler. Accepts a list of hashes, with `extensions` serving to list the extensions being managed by the handler, and takes the form: `{ handler => 'handler-name', extensions => ['extension']}`.
 
-```puppet
+~~~ puppet
     apache::vhost { 'sample.example.net':
       docroot     => '/path/to/directory',
       directories => [
@@ -1829,13 +2397,13 @@ Sets [AddHandler](http://httpd.apache.org/docs/current/mod/mod_mime.html#addhand
         },
       ],
     }
-```
+~~~
 
-######`allow`
+###### `allow`
 
 Sets an [Allow](http://httpd.apache.org/docs/2.2/mod/mod_authz_host.html#allow) directive, which groups authorizations based on hostnames or IPs. **Deprecated:** This parameter is being deprecated due to a change in Apache. It only works with Apache 2.2 and lower. You can use it as a single string for one rule or as an array for more than one.
 
-```puppet
+~~~ puppet
     apache::vhost { 'sample.example.net':
       docroot     => '/path/to/directory',
       directories => [
@@ -1844,13 +2412,13 @@ Sets an [Allow](http://httpd.apache.org/docs/2.2/mod/mod_authz_host.html#allow) 
         },
       ],
     }
-```
+~~~
 
-######`allow_override`
+###### `allow_override`
 
 Sets the types of directives allowed in [.htaccess](http://httpd.apache.org/docs/current/mod/core.html#allowoverride) files. Accepts an array.
 
-```puppet
+~~~ puppet
     apache::vhost { 'sample.example.net':
       docroot      => '/path/to/directory',
       directories  => [
@@ -1859,69 +2427,69 @@ Sets the types of directives allowed in [.htaccess](http://httpd.apache.org/docs
         },
       ],
     }
-```
+~~~
 
-######`auth_basic_authoritative`
+###### `auth_basic_authoritative`
 
 Sets the value for [AuthBasicAuthoritative](https://httpd.apache.org/docs/current/mod/mod_auth_basic.html#authbasicauthoritative), which determines whether authorization and authentication are passed to lower level Apache modules.
 
-######`auth_basic_fake`
+###### `auth_basic_fake`
 
 Sets the value for [AuthBasicFake](http://httpd.apache.org/docs/current/mod/mod_auth_basic.html#authbasicfake), which statically configures authorization credentials for a given directive block.
 
-######`auth_basic_provider`
+###### `auth_basic_provider`
 
 Sets the value for [AuthBasicProvider] (http://httpd.apache.org/docs/current/mod/mod_auth_basic.html#authbasicprovider), which sets the authentication provider for a given location.
 
-######`auth_digest_algorithm`
+###### `auth_digest_algorithm`
 
 Sets the value for [AuthDigestAlgorithm](http://httpd.apache.org/docs/current/mod/mod_auth_digest.html#authdigestalgorithm), which selects the algorithm used to calculate the challenge and response hashes.
 
-######`auth_digest_domain`
+###### `auth_digest_domain`
 
 Sets the value for [AuthDigestDomain](http://httpd.apache.org/docs/current/mod/mod_auth_digest.html#authdigestdomain), which allows you to specify one or more URIs in the same protection space for digest authentication.
 
-######`auth_digest_nonce_lifetime`
+###### `auth_digest_nonce_lifetime`
 
 Sets the value for [AuthDigestNonceLifetime](http://httpd.apache.org/docs/current/mod/mod_auth_digest.html#authdigestnoncelifetime), which controls how long the server nonce is valid.
 
-######`auth_digest_provider`
+###### `auth_digest_provider`
 
 Sets the value for [AuthDigestProvider](http://httpd.apache.org/docs/current/mod/mod_auth_digest.html#authdigestprovider), which sets the authentication provider for a given location.
 
-######`auth_digest_qop`
+###### `auth_digest_qop`
 
 Sets the value for [AuthDigestQop](http://httpd.apache.org/docs/current/mod/mod_auth_digest.html#authdigestqop), which determines the quality-of-protection to use in digest authentication.
 
-######`auth_digest_shmem_size`
+###### `auth_digest_shmem_size`
 
 Sets the value for [AuthAuthDigestShmemSize](http://httpd.apache.org/docs/current/mod/mod_auth_digest.html#authdigestshmemsize), which defines the amount of shared memory allocated to the server for keeping track of clients.
 
-######`auth_group_file`
+###### `auth_group_file`
 
 Sets the value for [AuthGroupFile](https://httpd.apache.org/docs/current/mod/mod_authz_groupfile.html#authgroupfile), which sets the name of the text file containing the list of user groups for authorization.
 
-######`auth_name`
+###### `auth_name`
 
 Sets the value for [AuthName](http://httpd.apache.org/docs/current/mod/mod_authn_core.html#authname), which sets the name of the authorization realm.
 
-######`auth_require`
+###### `auth_require`
 
 Sets the entity name you're requiring to allow access. Read more about [Require](http://httpd.apache.org/docs/current/mod/mod_authz_host.html#requiredirectives).
 
-######`auth_type`
+###### `auth_type`
 
 Sets the value for [AuthType](http://httpd.apache.org/docs/current/mod/mod_authn_core.html#authtype), which guides the type of user authentication.
 
-######`auth_user_file`
+###### `auth_user_file`
 
 Sets the value for [AuthUserFile](http://httpd.apache.org/docs/current/mod/mod_authn_file.html#authuserfile), which sets the name of the text file containing the users/passwords for authentication.
 
-######`custom_fragment`
+###### `custom_fragment`
 
 Pass a string of custom configuration directives to be placed at the end of the directory configuration.
 
-```puppet
+~~~ puppet
   apache::vhost { 'monitor':
     …
     directories => [
@@ -1942,13 +2510,13 @@ Pass a string of custom configuration directives to be placed at the end of the 
       },
     ]
   }
-```
+~~~
 
-######`deny`
+###### `deny`
 
 Sets a [Deny](http://httpd.apache.org/docs/2.2/mod/mod_authz_host.html#deny) directive, specifying which hosts are denied access to the server. **Deprecated:** This parameter is being deprecated due to a change in Apache. It only works with Apache 2.2 and lower. You can use it as a single string for one rule or as an array for more than one.
 
-```puppet
+~~~ puppet
     apache::vhost { 'sample.example.net':
       docroot     => '/path/to/directory',
       directories => [
@@ -1957,13 +2525,13 @@ Sets a [Deny](http://httpd.apache.org/docs/2.2/mod/mod_authz_host.html#deny) dir
         },
       ],
     }
-```
+~~~
 
-######`error_documents`
+###### `error_documents`
 
 An array of hashes used to override the [ErrorDocument](https://httpd.apache.org/docs/current/mod/core.html#errordocument) settings for the directory.
 
-```puppet
+~~~ puppet
     apache::vhost { 'sample.example.net':
       directories => [
         { path            => '/srv/www',
@@ -1975,14 +2543,14 @@ An array of hashes used to override the [ErrorDocument](https://httpd.apache.org
         },
       ],
     }
-```
+~~~
 
-######`geoip_enable`
+###### `geoip_enable`
 
 Sets the [GeoIPEnable](http://dev.maxmind.com/geoip/legacy/mod_geoip2/#Configuration) directive.
 Note that you must declare `class {'apache::mod::geoip': }` before using this directive.
 
-```puppet
+~~~ puppet
     apache::vhost { 'first.example.com':
       docroot     => '/var/www/first',
       directories => [
@@ -1991,13 +2559,13 @@ Note that you must declare `class {'apache::mod::geoip': }` before using this di
         },
       ],
     }
-```
+~~~
 
-######`headers`
+###### `headers`
 
 Adds lines for [Header](http://httpd.apache.org/docs/current/mod/mod_headers.html#header) directives.
 
-```puppet
+~~~ puppet
     apache::vhost { 'sample.example.net':
       docroot     => '/path/to/directory',
       directories => {
@@ -2005,13 +2573,13 @@ Adds lines for [Header](http://httpd.apache.org/docs/current/mod/mod_headers.htm
         headers => 'Set X-Robots-Tag "noindex, noarchive, nosnippet"',
       },
     }
-```
+~~~
 
-######`index_options`
+###### `index_options`
 
 Allows configuration settings for [directory indexing](http://httpd.apache.org/docs/current/mod/mod_autoindex.html#indexoptions).
 
-```puppet
+~~~ puppet
     apache::vhost { 'sample.example.net':
       docroot     => '/path/to/directory',
       directories => [
@@ -2022,13 +2590,13 @@ Allows configuration settings for [directory indexing](http://httpd.apache.org/d
         },
       ],
     }
-```
+~~~
 
-######`index_order_default`
+###### `index_order_default`
 
 Sets the [default ordering](http://httpd.apache.org/docs/current/mod/mod_autoindex.html#indexorderdefault) of the directory index.
 
-```puppet
+~~~ puppet
     apache::vhost { 'sample.example.net':
       docroot     => '/path/to/directory',
       directories => [
@@ -2038,13 +2606,13 @@ Sets the [default ordering](http://httpd.apache.org/docs/current/mod/mod_autoind
         },
       ],
     }
-```
+~~~
 
-######`index_style_sheet`
+###### `index_style_sheet`
 
 Sets the [IndexStyleSheet](http://httpd.apache.org/docs/current/mod/mod_autoindex.html#indexstylesheet) which adds a CSS stylesheet to the directory index.
 
-```puppet
+~~~ puppet
     apache::vhost { 'sample.example.net':
       docroot     => '/path/to/directory',
       directories => [
@@ -2055,13 +2623,13 @@ Sets the [IndexStyleSheet](http://httpd.apache.org/docs/current/mod/mod_autoinde
         },
       ],
     }
-```
+~~~
 
-######`options`
+###### `options`
 
 Lists the [Options](http://httpd.apache.org/docs/current/mod/core.html#options) for the given Directory block.
 
-```puppet
+~~~ puppet
     apache::vhost { 'sample.example.net':
       docroot     => '/path/to/directory',
       directories => [
@@ -2070,13 +2638,13 @@ Lists the [Options](http://httpd.apache.org/docs/current/mod/core.html#options) 
         },
       ],
     }
-```
+~~~
 
-######`order`
+###### `order`
 
 Sets the order of processing Allow and Deny statements as per [Apache core documentation](http://httpd.apache.org/docs/2.2/mod/mod_authz_host.html#order). **Deprecated:** This parameter is being deprecated due to a change in Apache. It only works with Apache 2.2 and lower.
 
-```puppet
+~~~ puppet
     apache::vhost { 'sample.example.net':
       docroot     => '/path/to/directory',
       directories => [
@@ -2085,13 +2653,13 @@ Sets the order of processing Allow and Deny statements as per [Apache core docum
         },
       ],
     }
-```
+~~~
 
-######`passenger_enabled`
+###### `passenger_enabled`
 
 Sets the value for the [PassengerEnabled](http://www.modrails.com/documentation/Users%20guide%20Apache.html#PassengerEnabled) directory to 'on' or 'off'. Requires `apache::mod::passenger` to be included.
 
-```puppet
+~~~ puppet
     apache::vhost { 'sample.example.net':
       docroot     => '/path/to/directory',
       directories => [
@@ -2100,24 +2668,24 @@ Sets the value for the [PassengerEnabled](http://www.modrails.com/documentation/
         },
       ],
     }
-```
+~~~
 
 *Note:* Be aware that there is an [issue](http://www.conandalton.net/2010/06/passengerenabled-off-not-working.html) using the PassengerEnabled directive with the PassengerHighPerformance directive.
 
-######`php_value` and `php_flag`
+###### `php_value` and `php_flag`
 
 `php_value` sets the value of the directory, and `php_flag` uses a boolean to configure the directory. Further information can be found [here](http://php.net/manual/en/configuration.changes.php).
 
-######`php_admin_value` and `php_admin_flag`
+###### `php_admin_value` and `php_admin_flag`
 
 `php_admin_value` sets the value of the directory, and `php_admin_flag` uses a boolean to configure the directory. Further information can be found [here](http://php.net/manual/en/configuration.changes.php).
 
 
-######`satisfy`
+###### `satisfy`
 
 Sets a `Satisfy` directive as per the [Apache Core documentation](http://httpd.apache.org/docs/2.2/mod/core.html#satisfy). **Deprecated:** This parameter is being deprecated due to a change in Apache. It only works with Apache 2.2 and lower.
 
-```puppet
+~~~ puppet
     apache::vhost { 'sample.example.net':
       docroot     => '/path/to/directory',
       directories => [
@@ -2126,13 +2694,13 @@ Sets a `Satisfy` directive as per the [Apache Core documentation](http://httpd.a
         }
       ],
     }
-```
+~~~
 
-######`sethandler`
+###### `sethandler`
 
 Sets a `SetHandler` directive as per the [Apache Core documentation](http://httpd.apache.org/docs/2.2/mod/core.html#sethandler). An example:
 
-```puppet
+~~~ puppet
     apache::vhost { 'sample.example.net':
       docroot     => '/path/to/directory',
       directories => [
@@ -2141,13 +2709,13 @@ Sets a `SetHandler` directive as per the [Apache Core documentation](http://http
         }
       ],
     }
-```
+~~~
 
-######`rewrites`
+###### `rewrites`
 
 Creates URL [`rewrites`](#rewrites) rules in vhost directories. Expects an array of hashes, and the hash keys can be any of 'comment', 'rewrite_base', 'rewrite_cond', or 'rewrite_rule'.
 
-```puppet
+~~~ puppet
     apache::vhost { 'secure.example.net':
       docroot     => '/path/to/directory',
       directories => [
@@ -2166,15 +2734,15 @@ Creates URL [`rewrites`](#rewrites) rules in vhost directories. Expects an array
         },
       ],
     }
-```
+~~~
 
 ***Note*** If you include rewrites in your directories make sure you are also including `apache::mod::rewrite`. You may also want to consider setting the rewrites using the `rewrites` parameter in `apache::vhost` rather than setting the rewrites in the vhost directories.
 
-######`shib_request_setting`
+###### `shib_request_setting`
 
 Allows an valid content setting to be set or altered for the application request. This command takes two parameters, the name of the content setting, and the value to set it to.Check the Shibboleth [content setting documentation](https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPContentSettings) for valid settings. This key is disabled if `apache::mod::shib` is not defined. Check the [`mod_shib` documentation](https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPApacheConfig#NativeSPApacheConfig-Server/VirtualHostOptions) for more details.
 
-```puppet
+~~~ puppet
     apache::vhost { 'secure.example.net':
       docroot     => '/path/to/directory',
       directories => [
@@ -2184,17 +2752,17 @@ Allows an valid content setting to be set or altered for the application request
         },
       ],
     }
-```
+~~~
 
-######`shib_use_headers`
+###### `shib_use_headers`
 
 When set to 'On' this turns on the use of request headers to publish attributes to applications. Valid values for this key is 'On' or 'Off', and the default value is 'Off'. This key is disabled if `apache::mod::shib` is not defined. Check the [`mod_shib` documentation](https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPApacheConfig#NativeSPApacheConfig-Server/VirtualHostOptions) for more details.
 
-######`ssl_options`
+###### `ssl_options`
 
 String or list of [SSLOptions](https://httpd.apache.org/docs/current/mod/mod_ssl.html#ssloptions), which configure SSL engine run-time options. This handler takes precedence over SSLOptions set in the parent block of the vhost.
 
-```puppet
+~~~ puppet
     apache::vhost { 'secure.example.net':
       docroot     => '/path/to/directory',
       directories => [
@@ -2206,13 +2774,13 @@ String or list of [SSLOptions](https://httpd.apache.org/docs/current/mod/mod_ssl
         },
       ],
     }
-```
+~~~
 
-######`suphp`
+###### `suphp`
 
 A hash containing the 'user' and 'group' keys for the [suPHP_UserGroup](http://www.suphp.org/DocumentationView.html?file=apache/CONFIG) setting. It must be used with `suphp_engine => on` in the vhost declaration, and can only be passed within `directories`.
 
-```puppet
+~~~ puppet
     apache::vhost { 'secure.example.net':
       docroot     => '/path/to/directory',
       directories => [
@@ -2224,119 +2792,119 @@ A hash containing the 'user' and 'group' keys for the [suPHP_UserGroup](http://w
         },
       ],
     }
-```
+~~~
 
 ####SSL parameters for `apache::vhost`
 
 All of the SSL parameters for `::vhost` default to whatever is set in the base `apache` class. Use the below parameters to tweak individual SSL settings for specific vhosts.
 
-#####`ssl`
+##### `ssl`
 
 Enables SSL for the virtual host. SSL vhosts only respond to HTTPS queries. Valid values are 'true' or 'false'. Defaults to 'false'.
 
-#####`ssl_ca`
+##### `ssl_ca`
 
 Specifies the SSL certificate authority. Defaults to 'undef'.
 
-#####`ssl_cert`
+##### `ssl_cert`
 
 Specifies the SSL certification. Defaults are based on your OS: '/etc/pki/tls/certs/localhost.crt' for RedHat, '/etc/ssl/certs/ssl-cert-snakeoil.pem' for Debian, '/usr/local/etc/apache22/server.crt' for FreeBSD, and '/etc/ssl/apache2/server.crt' on Gentoo.
 
-#####`ssl_protocol`
+##### `ssl_protocol`
 
 Specifies [SSLProtocol](http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslprotocol). Expects an array of accepted protocols. Defaults to 'all', '-SSLv2', '-SSLv3'.
 
-#####`ssl_cipher`
+##### `ssl_cipher`
 
 Specifies [SSLCipherSuite](http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslciphersuite). Defaults to 'HIGH:MEDIUM:!aNULL:!MD5'.
 
-#####`ssl_honorcipherorder`
+##### `ssl_honorcipherorder`
 
 Sets [SSLHonorCipherOrder](http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslhonorcipherorder), which is used to prefer the server's cipher preference order. Defaults to 'On' in the base `apache` config.
 
-#####`ssl_certs_dir`
+##### `ssl_certs_dir`
 
 Specifies the location of the SSL certification directory. Defaults to '/etc/ssl/certs' on Debian, '/etc/pki/tls/certs' on RedHat, '/usr/local/etc/apache22' on FreeBSD, and '/etc/ssl/apache2' on Gentoo.
 
-#####`ssl_chain`
+##### `ssl_chain`
 
 Specifies the SSL chain. Defaults to 'undef'. (This default works out of the box, but it must be updated in the base `apache` class with your specific certificate information before being used in production.)
 
-#####`ssl_crl`
+##### `ssl_crl`
 
 Specifies the certificate revocation list to use. Defaults to 'undef'. (This default works out of the box but must be updated in the base `apache` class with your specific certificate information before being used in production.)
 
-#####`ssl_crl_path`
+##### `ssl_crl_path`
 
 Specifies the location of the certificate revocation list. Defaults to 'undef'. (This default works out of the box but must be updated in the base `apache` class with your specific certificate information before being used in production.)
 
-#####`ssl_crl_check`
+##### `ssl_crl_check`
 
 Sets the certificate revocation check level via the [SSLCARevocationCheck directive](http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcarevocationcheck), defaults to 'undef'. This default works out of the box but must be specified when using CRLs in production. Only applicable to Apache 2.4 or higher; the value is ignored on older versions.
 
-#####`ssl_key`
+##### `ssl_key`
 
 Specifies the SSL key. Defaults are based on your operating system: '/etc/pki/tls/private/localhost.key' for RedHat, '/etc/ssl/private/ssl-cert-snakeoil.key' for Debian, '/usr/local/etc/apache22/server.key' for FreeBSD, and '/etc/ssl/apache2/server.key' on Gentoo. (This default works out of the box but must be updated in the base `apache` class with your specific certificate information before being used in production.)
 
-#####`ssl_verify_client`
+##### `ssl_verify_client`
 
 Sets the [SSLVerifyClient](http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslverifyclient) directive, which sets the certificate verification level for client authentication. Valid values are: 'none', 'optional', 'require', and 'optional_no_ca'. Defaults to 'undef'.
 
-```puppet
+~~~ puppet
     apache::vhost { 'sample.example.net':
       …
       ssl_verify_client => 'optional',
     }
-```
+~~~
 
-#####`ssl_verify_depth`
+##### `ssl_verify_depth`
 
 Sets the [SSLVerifyDepth](http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslverifydepth) directive, which specifies the maximum depth of CA certificates in client certificate verification. Defaults to 'undef'.
 
-```puppet
+~~~ puppet
     apache::vhost { 'sample.example.net':
       …
       ssl_verify_depth => 1,
     }
-```
+~~~
 
-#####`ssl_options`
+##### `ssl_options`
 
 Sets the [SSLOptions](http://httpd.apache.org/docs/current/mod/mod_ssl.html#ssloptions) directive, which configures various SSL engine run-time options. This is the global setting for the given vhost and can be a string or an array. Defaults to 'undef'.
 
 A string:
 
-```puppet
+~~~ puppet
     apache::vhost { 'sample.example.net':
       …
       ssl_options => '+ExportCertData',
     }
-```
+~~~
 
 An array:
 
-```puppet
+~~~ puppet
     apache::vhost { 'sample.example.net':
       …
       ssl_options => [ '+StrictRequire', '+ExportCertData' ],
     }
-```
+~~~
 
-#####`ssl_openssl_conf_cmd`
+##### `ssl_openssl_conf_cmd`
 
 Sets the [SSLOpenSSLConfCmd](http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslopensslconfcmd) directive, which provides direct configuration of OpenSSL parameters. Defaults to 'undef'.
 
-#####`ssl_proxyengine`
+##### `ssl_proxyengine`
 
 Specifies whether or not to use [SSLProxyEngine](http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxyengine). Valid values are 'true' and 'false'. Defaults to 'false'.
 
-####Defined Type: FastCGI Server
+####Define: FastCGI Server
 
 This type is intended for use with mod_fastcgi. It allows you to define one or more external FastCGI servers to handle specific file types.
 
 Ex:
 
-```puppet
+~~~ puppet
 apache::fastcgi::server { 'php':
   host       => '127.0.0.1:9000',
   timeout    => 15,
@@ -2345,426 +2913,168 @@ apache::fastcgi::server { 'php':
   fcgi_alias => '/php.fcgi',
   file_type  => 'application/x-httpd-php'
 }
-```
+~~~
 
 Within your virtual host, you can then configure the specified file type to be handled by the fastcgi server specified above.
 
-```puppet
+~~~ puppet
 apache::vhost { 'www':
   ...
   custom_fragment => 'AddType application/x-httpd-php .php'
   ...
 }
-```
+~~~
 
-#####`host`
+##### `host`
 
 The hostname or IP address and TCP port number (1-65535) of the FastCGI server.
 
-#####`timeout`
+##### `timeout`
 
 The number of seconds of FastCGI application inactivity allowed before the request is aborted and the event is logged (at the error LogLevel). The inactivity timer applies only as long as a connection is pending with the FastCGI application. If a request is queued to an application, but the application doesn't respond (by writing and flushing) within this period, the request is aborted. If communication is complete with the application but incomplete with the client (the response is buffered), the timeout does not apply.
 
-#####`flush`
+##### `flush`
 
 Force a write to the client as data is received from the application. By default, mod_fastcgi buffers data in order to free the application as quickly as possible.
 
-#####`faux_path`
+##### `faux_path`
 
 `faux_path` does not have to exist in the local filesystem. URIs that Apache resolves to this filename are handled by this external FastCGI application.
 
-#####`alias`
+##### `alias`
 
 A unique alias. This is used internally to link the action with the FastCGI server.
 
-#####`file_type`
+##### `file_type`
 
 The MIME-type of the file to be processed by the FastCGI server.
 
-###Virtual Host Examples
-
-The apache module allows you to set up pretty much any configuration of virtual host you might need. This section addresses some common configurations, but look at the [Tests section](https://github.com/puppetlabs/puppetlabs-apache/tree/master/tests) for even more examples.
-
-Configure a vhost with a server administrator
-
-```puppet
-    apache::vhost { 'third.example.com':
-      port        => '80',
-      docroot     => '/var/www/third',
-      serveradmin => 'admin@example.com',
-    }
-```
-
-- - -
-
-Set up a vhost with aliased servers
-
-```puppet
-    apache::vhost { 'sixth.example.com':
-      serveraliases => [
-        'sixth.example.org',
-        'sixth.example.net',
-      ],
-      port          => '80',
-      docroot       => '/var/www/fifth',
-    }
-```
-
-- - -
-
-Configure a vhost with a cgi-bin
-
-```puppet
-    apache::vhost { 'eleventh.example.com':
-      port        => '80',
-      docroot     => '/var/www/eleventh',
-      scriptalias => '/usr/lib/cgi-bin',
-    }
-```
-
-- - -
-
-Set up a vhost with a rack configuration
-
-```puppet
-    apache::vhost { 'fifteenth.example.com':
-      port           => '80',
-      docroot        => '/var/www/fifteenth',
-      rack_base_uris => ['/rackapp1', '/rackapp2'],
-    }
-```
-
-- - -
-
-Set up a mix of SSL and non-SSL vhosts at the same domain
-
-```puppet
-    #The non-ssl vhost
-    apache::vhost { 'first.example.com non-ssl':
-      servername => 'first.example.com',
-      port       => '80',
-      docroot    => '/var/www/first',
-    }
-
-    #The SSL vhost at the same domain
-    apache::vhost { 'first.example.com ssl':
-      servername => 'first.example.com',
-      port       => '443',
-      docroot    => '/var/www/first',
-      ssl        => true,
-    }
-```
-
-- - -
-
-Configure a vhost to redirect non-SSL connections to SSL
-
-```puppet
-    apache::vhost { 'sixteenth.example.com non-ssl':
-      servername      => 'sixteenth.example.com',
-      port            => '80',
-      docroot         => '/var/www/sixteenth',
-      redirect_status => 'permanent',
-      redirect_dest   => 'https://sixteenth.example.com/'
-    }
-    apache::vhost { 'sixteenth.example.com ssl':
-      servername => 'sixteenth.example.com',
-      port       => '443',
-      docroot    => '/var/www/sixteenth',
-      ssl        => true,
-    }
-```
-
-- - -
-
-Set up IP-based vhosts on any listen port and have them respond to requests on specific IP addresses. In this example, we set listening on ports 80 and 81. This is required because the example vhosts are not declared with a port parameter.
-
-```puppet
-    apache::listen { '80': }
-    apache::listen { '81': }
-```
+### Private Defines
 
-Then we set up the IP-based vhosts
+#### Define: `apache::peruser::multiplexer`
 
-```puppet
-    apache::vhost { 'first.example.com':
-      ip       => '10.0.0.10',
-      docroot  => '/var/www/first',
-      ip_based => true,
-    }
-    apache::vhost { 'second.example.com':
-      ip       => '10.0.0.11',
-      docroot  => '/var/www/second',
-      ip_based => true,
-    }
-```
+This define checks if an Apache module has a class. If it does, it includes that class. If it does not, it passes the module name to the [`apache::mod`][] define.
 
-- - -
+#### Define: `apache::peruser::multiplexer`
 
-Configure a mix of name-based and IP-based vhosts. First, we add two IP-based vhosts on 10.0.0.10, one SSL and one non-SSL
+Enables the [`Peruser`][] module for FreeBSD only.
 
-```puppet
-    apache::vhost { 'The first IP-based vhost, non-ssl':
-      servername => 'first.example.com',
-      ip         => '10.0.0.10',
-      port       => '80',
-      ip_based   => true,
-      docroot    => '/var/www/first',
-    }
-    apache::vhost { 'The first IP-based vhost, ssl':
-      servername => 'first.example.com',
-      ip         => '10.0.0.10',
-      port       => '443',
-      ip_based   => true,
-      docroot    => '/var/www/first-ssl',
-      ssl        => true,
-    }
-```
+#### Define: `apache::peruser::processor`
 
-Then, we add two name-based vhosts listening on 10.0.0.20
+Enables the [`Peruser`][] module for FreeBSD only.
 
-```puppet
-    apache::vhost { 'second.example.com':
-      ip      => '10.0.0.20',
-      port    => '80',
-      docroot => '/var/www/second',
-    }
-    apache::vhost { 'third.example.com':
-      ip      => '10.0.0.20',
-      port    => '80',
-      docroot => '/var/www/third',
-    }
-```
+#### Define: `apache::security::file_link`
 
-If you want to add two name-based vhosts so that they answer on either 10.0.0.10 or 10.0.0.20, you **MUST** declare `add_listen => 'false'` to disable the otherwise automatic 'Listen 80', as it conflicts with the preceding IP-based vhosts.
+Links the `activated_rules` from [`apache::mod::security`][] to the respective CRS rules on disk.
 
-```puppet
-    apache::vhost { 'fourth.example.com':
-      port       => '80',
-      docroot    => '/var/www/fourth',
-      add_listen => false,
-    }
-    apache::vhost { 'fifth.example.com':
-      port       => '80',
-      docroot    => '/var/www/fifth',
-      add_listen => false,
-    }
-```
+### Templates
 
-###Load Balancing
+The Apache module relies heavily on templates to enable the [`apache::vhost`][] and [`apache::mod`][] defines. These templates are built based on [Facter][] facts specific to your operating system. Unless explicitly called out, most templates are not meant for configuration.
 
-####Defined Type: `apache::balancer`
+## Limitations
 
-`apache::balancer` creates an Apache balancer cluster. Each balancer cluster needs one or more balancer members, which are declared with [`apache::balancermember`](#defined-type-apachebalancermember).
+### Ubuntu 10.04
 
-One `apache::balancer` defined resource should be defined for each Apache load balanced set of servers. The `apache::balancermember` resources for all balancer members can be exported and collected on a single Apache load balancer server using exported resources.
+The [`apache::vhost::WSGIImportScript`][] parameter creates a statement inside the virtual host that is unsupported on older versions of Apache, causing it to fail. This will be remedied in a future refactoring.
 
-**Parameters within `apache::balancer`:**
+### RHEL/CentOS 5
 
-#####`name`
+The [`apache::mod::passenger`][] and [`apache::mod::proxy_html`][] classes are untested since repositories are missing compatible packages.
 
-Sets the balancer cluster's title. This parameter also sets the title of the conf.d file.
+### RHEL/CentOS 7
 
-#####`proxy_set`
+The [`apache::mod::passenger`][] class is untested as the EL7 repository is missing compatible packages, which also blocks us from testing the [`apache::vhost`][] define's [`rack_base_uri`][] parameter.
 
-Configures key-value pairs as [ProxySet](http://httpd.apache.org/docs/current/mod/mod_proxy.html#proxyset) lines. Accepts a hash, and defaults to '{}'.
+### General
 
-#####`collect_exported`
+This module is CI tested against both [open source Puppet][] and [Puppet Enterprise][] on:
 
-Determines whether or not to use exported resources. Valid values 'true' and 'false', defaults to 'true'.
+- CentOS 5 and 6
+- Ubuntu 12.04 and 14.04
+- Debian 7
+- RHEL 5, 6, and 7
 
-If you statically declare all of your backend servers, you should set this to 'false' to rely on existing declared balancer member resources. Also make sure to use `apache::balancermember` with array arguments.
+This module also provides functions for other distributions and operating systems, such as FreeBSD, Gentoo, and Amazon Linux, but is not formally tested on them and are subject to regressions.
 
-If you wish to dynamically declare your backend servers via [exported resources](http://docs.puppetlabs.com/guides/exported_resources.html) collected on a central node, you must set this parameter to 'true' in order to collect the exported balancer member resources that were exported by the balancer member nodes.
+### SELinux and custom paths
 
-If you choose not to use exported resources, all balancer members will be configured in a single Puppet run. If you are using exported resources, Puppet has to run on the balanced nodes, then run on the balancer.
+If [SELinux][] is in [enforcing mode][] and you want to use custom paths for `logroot`, `mod_dir`, `vhost_dir`, and `docroot`, you need to manage the files' context yourself.
 
-####Defined Type: `apache::balancermember`
+You can do this with Puppet:
 
-Defines members of [mod_proxy_balancer](http://httpd.apache.org/docs/current/mod/mod_proxy_balancer.html), which sets up a balancer member inside a listening service configuration block in etc/apache/apache.cfg on the load balancer.
+~~~ puppet
+exec { 'set_apache_defaults':
+  command => 'semanage fcontext -a -t httpd_sys_content_t "/custom/path(/.*)?"',
+  path    => '/bin:/usr/bin/:/sbin:/usr/sbin',
+  require => Package['policycoreutils-python'],
+}
 
-**Parameters within `apache::balancermember`:**
+package { 'policycoreutils-python':
+  ensure => installed,
+}
 
-#####`name`
+exec { 'restorecon_apache':
+  command => 'restorecon -Rv /apache_spec',
+  path    => '/bin:/usr/bin/:/sbin:/usr/sbin',
+  before  => Class['Apache::Service'],
+  require => Class['apache'],
+}
 
-Sets the title of the resource. This name also sets the name of the concat fragment.
+class { 'apache': }
 
-#####`balancer_cluster`
+host { 'test.server':
+  ip => '127.0.0.1',
+}
 
-Sets the Apache service's instance name. This must match the name of a declared `apache::balancer` resource. Required.
+file { '/custom/path':
+  ensure => directory,
+}
 
-#####`url`
+file { '/custom/path/include': 
+  ensure  => present, 
+  content => '#additional_includes',
+}
 
-Specifies the URL used to contact the balancer member server. Defaults to 'http://${::fqdn}/'.
+apache::vhost { 'test.server':
+  docroot             => '/custom/path',
+  additional_includes => '/custom/path/include',
+}
+~~~
 
-#####`options`
+You need to set the contexts using `semanage fcontext` instead of `chcon` because Puppet's `file` resources reset the values' context in the database if the resource doesn't specify it.
 
-An array of [options](http://httpd.apache.org/docs/2.2/mod/mod_proxy.html#balancermember) to be specified after the URL. Accepts any key-value pairs available to [ProxyPass](http://httpd.apache.org/docs/2.2/mod/mod_proxy.html#proxypass).
+### FreeBSD
 
-####Examples
+In order to use this module on FreeBSD, you _must_ use apache24-2.4.12 (www/apache24) or newer.
 
-To load balance with exported resources, export the `balancermember` from the balancer member
+## Development
 
-```puppet
-      @@apache::balancermember { "${::fqdn}-puppet00":
-        balancer_cluster => 'puppet00',
-        url              => "ajp://${::fqdn}:8009"
-        options          => ['ping=5', 'disablereuse=on', 'retry=5', 'ttl=120'],
-      }
-```
+### Contributing
 
-Then, on the proxy server, create the balancer cluster
+[Puppet Labs][] modules on the [Puppet Forge][] are open projects, and community contributions are essential for keeping them great. We can’t access the huge number of platforms and myriad hardware, software, and deployment configurations that Puppet is intended to serve.
 
-```puppet
-      apache::balancer { 'puppet00': }
-```
+We want to make it as easy as possible to contribute changes so our modules work in your environment, but we also need contributors to follow a few guidelines to help us maintain and improve the modules' quality.
 
-To load balance without exported resources, declare the following on the proxy
+For more information, please read the complete [module contribution guide][].
 
-```puppet
-    apache::balancer { 'puppet00': }
-    apache::balancermember { "${::fqdn}-puppet00":
-        balancer_cluster => 'puppet00',
-        url              => "ajp://${::fqdn}:8009"
-        options          => ['ping=5', 'disablereuse=on', 'retry=5', 'ttl=120'],
-      }
-```
+### Running tests
 
-Then declare `apache::balancer` and `apache::balancermember` on the proxy server.
+This project contains tests for both [rspec-puppet][] and [beaker-rspec][] to verify functionality. For detailed information on using these tools, please see their respective documentation.
 
-If you need to use ProxySet in the balancer config
+#### Testing quickstart: Ruby > 1.8.7
 
-```puppet
-      apache::balancer { 'puppet01':
-        proxy_set => {'stickysession' => 'JSESSIONID'},
-      }
-```
+~~~
+gem install bundler
+bundle install
+bundle exec rake spec
+bundle exec rspec spec/acceptance
+RS_DEBUG=yes bundle exec rspec spec/acceptance
+~~~
 
-##Reference
+#### Testing quickstart: Ruby = 1.8.7
 
-###Classes
-
-####Public Classes
-
-* [`apache`](#class-apache): Guides the basic setup of Apache.
-* `apache::dev`: Installs Apache development libraries. (*Note:* On FreeBSD, you must declare `apache::package` or `apache` before `apache::dev`.)
-* [`apache::mod::[name]`](#classes-apachemodname): Enables specific Apache HTTPD modules.
-
-####Private Classes
-
-* `apache::confd::no_accf`: Creates the no-accf.conf configuration file in conf.d, required by FreeBSD's Apache 2.4.
-* `apache::default_confd_files`: Includes conf.d files for FreeBSD.
-* `apache::default_mods`: Installs the Apache modules required to run the default configuration.
-* `apache::package`: Installs and configures basic Apache packages.
-* `apache::params`: Manages Apache parameters.
-* `apache::service`: Manages the Apache daemon.
-
-###Defined Types
-
-####Public Defined Types
-
-* `apache::balancer`: Creates an Apache balancer cluster.
-* `apache::balancermember`: Defines members of [mod_proxy_balancer](http://httpd.apache.org/docs/current/mod/mod_proxy_balancer.html).
-* `apache::listen`: Based on the title, controls which ports Apache binds to for listening. Adds [Listen](http://httpd.apache.org/docs/current/bind.html) directives to ports.conf in the Apache HTTPD configuration directory. Titles take the form '<port>', '<ipv4>:<port>', or '<ipv6>:<port>'.
-* `apache::mod`: Used to enable arbitrary Apache HTTPD modules for which there is no specific `apache::mod::[name]` class.
-* `apache::namevirtualhost`: Enables name-based hosting of a virtual host. Adds all [NameVirtualHost](http://httpd.apache.org/docs/current/vhosts/name-based.html) directives to the `ports.conf` file in the Apache HTTPD configuration directory. Titles take the form '\*', '*:<port>', '\_default_:<port>, '<ip>', or '<ip>:<port>'.
-* `apache::vhost`: Allows specialized configurations for virtual hosts that have requirements outside the defaults.
-
-####Private Defined Types
-
-* `apache::peruser::multiplexer`: Enables the [Peruser](http://www.freebsd.org/cgi/url.cgi?ports/www/apache22-peruser-mpm/pkg-descr) module for FreeBSD only.
-* `apache::peruser::processor`: Enables the [Peruser](http://www.freebsd.org/cgi/url.cgi?ports/www/apache22-peruser-mpm/pkg-descr) module for FreeBSD only.
-* `apache::security::file_link`: Links the activated_rules from apache::mod::security to the respective CRS rules on disk.
-
-###Templates
-
-The Apache module relies heavily on templates to enable the `vhost` and `apache::mod` defined types. These templates are built based on Facter facts around your operating system. Unless explicitly called out, most templates are not meant for configuration.
-
-##Limitations
-
-###Ubuntu 10.04
-
-The `apache::vhost::WSGIImportScript` parameter creates a statement inside the VirtualHost which is unsupported on older versions of Apache, causing this to fail.  This will be remedied in a future refactoring.
-
-###RHEL/CentOS 5
-
-The `apache::mod::passenger` and `apache::mod::proxy_html` classes are untested since repositories are missing compatible packages.
-
-###RHEL/CentOS 7
-
-The `apache::mod::passenger` class is untested as the repository does not have packages for EL7 yet.  The fact that passenger packages aren't available also makes us unable to test the `rack_base_uri` parameter in `apache::vhost`.
-
-###General
-
-This module is CI tested on Centos 5 & 6, Ubuntu 12.04 & 14.04, Debian 7, and RHEL 5, 6 & 7 platforms against both the OSS and Enterprise version of Puppet.
-
-The module contains support for other distributions and operating systems, such as FreeBSD, Gentoo and Amazon Linux, but is not formally tested on those and regressions can occur.
-
-###SELinux and Custom Paths
-
-If you are running with SELinux in enforcing mode and want to use custom paths for your `logroot`, `mod_dir`, `vhost_dir`, and `docroot`, you need to manage the context for the files yourself.
-
-Something along the lines of:
-
-```puppet
-        exec { 'set_apache_defaults':
-          command => 'semanage fcontext -a -t httpd_sys_content_t "/custom/path(/.*)?"',
-          path    => '/bin:/usr/bin/:/sbin:/usr/sbin',
-          require => Package['policycoreutils-python'],
-        }
-        package { 'policycoreutils-python': ensure => installed }
-        exec { 'restorecon_apache':
-          command => 'restorecon -Rv /apache_spec',
-          path    => '/bin:/usr/bin/:/sbin:/usr/sbin',
-          before  => Class['Apache::Service'],
-          require => Class['apache'],
-        }
-        class { 'apache': }
-        host { 'test.server': ip => '127.0.0.1' }
-        file { '/custom/path': ensure => directory, }
-        file { '/custom/path/include': ensure => present, content => '#additional_includes' }
-        apache::vhost { 'test.server':
-          docroot             => '/custom/path',
-          additional_includes => '/custom/path/include',
-        }
-```
-
-You need to set the contexts using `semanage fcontext` not `chcon` because `file {...}` resources reset the context to the values in the database if the resource isn't specifying the context.
-
-###FreeBSD
-
-In order to use this module on FreeBSD, you *must* use apache24-2.4.12 (www/apache24) or newer.
-
-##Development
-
-###Contributing
-
-Puppet Labs modules on the Puppet Forge are open projects, and community contributions are essential for keeping them great. We can’t access the huge number of platforms and myriad of hardware, software, and deployment configurations that Puppet is intended to serve.
-
-We want to keep it as easy as possible to contribute changes so that our modules work in your environment. There are a few guidelines that we need contributors to follow so that we can have a chance of keeping on top of things.
-
-Read the complete module [contribution guide](https://docs.puppetlabs.com/forge/contributing.html)
-
-###Running tests
-
-This project contains tests for both [rspec-puppet](http://rspec-puppet.com/) and [beaker-rspec](https://github.com/puppetlabs/beaker-rspec) to verify functionality. For in-depth information please see their respective documentation.
-
-Quickstart:
-
-####Ruby > 1.8.7
-
-```
-    gem install bundler
-    bundle install
-    bundle exec rake spec
-    bundle exec rspec spec/acceptance
-    RS_DEBUG=yes bundle exec rspec spec/acceptance
-```
-
-####Ruby = 1.8.7
-
-```
-    gem install bundler
-    bundle install --without system_tests
-    bundle exec rake spec
-```
+~~~
+gem install bundler
+bundle install --without system_tests
+bundle exec rake spec
+~~~

--- a/README.passenger.md
+++ b/README.passenger.md
@@ -13,7 +13,7 @@ Also, general apache module loading parameters can be supplied to enable using
 a customized passenger module in place of a default-package-based version of
 the module.
 
-# Operating system support and Passenger versions
+## Operating system support and Passenger versions
 
 The most important configuration directive for the Apache Passenger module is
 `PassengerRoot`. Its value depends on the Passenger version used (2.x, 3.x or
@@ -35,7 +35,7 @@ RHEL with EPEL6  | 3.0.21             | /usr/lib/ruby/gems/1.8/gems/passenger-3.
 As mentioned in `README.md` there are no compatible packages available for
 RHEL/CentOS 5 or RHEL/CentOS 7.
 
-## Configuration files and locations on RHEL/CentOS
+### Configuration files and locations on RHEL/CentOS
 
 Notice two important points:
 
@@ -55,7 +55,7 @@ directives as described in the remainder of this document are placed in
 
 This pertains *only* to RHEL/CentOS, *not* Debian and Ubuntu.
 
-## Third-party and custom Passenger packages and versions
+### Third-party and custom Passenger packages and versions
 
 The Passenger version distributed by the default OS packages may be too old to
 be useful. Newer versions may be installed via Gems, from source or from
@@ -75,7 +75,7 @@ For Passenger 4.x packages on Debian and Ubuntu the `PassengerRoot` directive
 should almost universally be set to
 `/usr/lib/ruby/vendor_ruby/phusion_passenger/locations.ini`.
 
-# Parameters for `apache::mod::passenger`
+## Parameters for `apache::mod::passenger`
 
 The following class parameters configure Passenger in a global, server-wide
 context.
@@ -95,12 +95,12 @@ class { 'apache::mod::passenger':
 The general form is using the all lower-case version of the configuration
 directive, with underscores instead of CamelCase.
 
-## Parameters used with passenger.conf
+### Parameters used with passenger.conf
 
 If you pass a default value to `apache::mod::passenger` it will be ignored and
 not passed through to the configuration file. 
 
-### passenger_root
+#### passenger_root
 
 The location to the Phusion Passenger root directory. This configuration option
 is essential to Phusion Passenger, and allows Phusion Passenger to locate its
@@ -112,7 +112,7 @@ information.
 
 http://www.modrails.com/documentation/Users%20guide%20Apache.html#_passengerroot_lt_directory_gt
 
-### passenger_default_ruby
+#### passenger_default_ruby
 
 This option specifies the default Ruby interpreter to use for web apps as well
 as for all sorts of internal Phusion Passenger helper scripts, e.g. the one
@@ -126,7 +126,7 @@ set to '/usr/bin/ruby'.
 
 http://www.modrails.com/documentation/Users%20guide%20Apache.html#PassengerDefaultRuby
 
-### passenger_ruby
+#### passenger_ruby
 
 This directive is the same as `passenger_default_ruby` for Passenger versions
 < 4.x and must be used instead of `passenger_default_ruby` for such versions.
@@ -141,28 +141,28 @@ Defaults to `/usr/bin/ruby` for all supported operating systems except Ubuntu
 
 http://www.modrails.com/documentation/Users%20guide%20Apache.html#PassengerRuby
 
-### passenger_high_performance
+#### passenger_high_performance
 
 Default is `off`. When turned `on` Passenger runs in a higher performance mode
 that can be less compatible with other Apache modules.
 
 http://www.modrails.com/documentation/Users%20guide%20Apache.html#PassengerHighPerformance
 
-### passenger_max_pool_size
+#### passenger_max_pool_size
 
 Sets the maximum number of Passenger application processes that may
 simultaneously run. The default value is 6.
 
 http://www.modrails.com/documentation/Users%20guide%20Apache.html#_passengermaxpoolsize_lt_integer_gt
 
-### passenger_pool_idle_time
+#### passenger_pool_idle_time
 
 The maximum number of seconds a Passenger Application process will be allowed
 to remain idle before being shut down. The default value is 300.
 
 http://www.modrails.com/documentation/Users%20guide%20Apache.html#PassengerPoolIdleTime
 
-### passenger_max_requests
+#### passenger_max_requests
 
 The maximum number of request a Passenger application will process before being
 restarted. The default value is 0, which indicates that a process will only
@@ -170,14 +170,14 @@ shut down if the Pool Idle Time (see above) expires.
 
 http://www.modrails.com/documentation/Users%20guide%20Apache.html#PassengerMaxRequests
 
-### passenger_stat_throttle_rate
+#### passenger_stat_throttle_rate
 
 Sets how often Passenger performs file system checks, at most once every _x_
 seconds. Default is 0, which means the checks are performed with every request.
 
 http://www.modrails.com/documentation/Users%20guide%20Apache.html#_passengerstatthrottlerate_lt_integer_gt
 
-### rack_autodetect
+#### rack_autodetect
 
 Should Passenger automatically detect if the document root of a virtual host is
 a Rack application. Not set by default (`undef`). Note that this directive has
@@ -186,7 +186,7 @@ Use this directive only on Passenger < 4.x.
 
 http://www.modrails.com/documentation/Users%20guide%20Apache.html#_rackautodetect_lt_on_off_gt
 
-### rails_autodetect
+#### rails_autodetect
 
 Should Passenger automatically detect if the document root of a virtual host is
 a Rails application.  Not set by default (`undef`). Note that this directive
@@ -195,13 +195,13 @@ instead. Use this directive only on Passenger < 4.x.
 
 http://www.modrails.com/documentation/Users%20guide%20Apache.html#_railsautodetect_lt_on_off_gt
 
-### passenger_use_global_queue
+#### passenger_use_global_queue
 
 Allows toggling of PassengerUseGlobalQueue.  NOTE: PassengerUseGlobalQueue is
 the default in Passenger 4.x and the versions >= 4.x have disabled this
 configuration option altogether.  Use with caution.
 
-### passenger_app_env
+#### passenger_app_env
 
 Sets the global default `PassengerAppEnv` for Passenger applications. Not set by
 default (`undef`) and thus defaults to Passenger's built-in value of 'production'.
@@ -209,43 +209,43 @@ This directive can be overridden in an `apache::vhost` resource.
 
 https://www.phusionpassenger.com/documentation/Users%20guide%20Apache.html#PassengerAppEnv
 
-## Parameters used to load the module
+### Parameters used to load the module
 
 Unlike the tuning parameters specified above, the following parameters are only
 used when loading customized passenger modules.
 
-### mod_package
+#### mod_package
 
 Allows overriding the default package name used for the passenger module
 package.
 
-### mod_package_ensure
+#### mod_package_ensure
 
 Allows overriding the package installation setting used by puppet when
 installing the passenger module. The default is 'present'.
 
-### mod_id
+#### mod_id
 
 Allows overriding the value used by apache to identify the passenger module.
 The default is 'passenger_module'.
 
-### mod_lib_path
+#### mod_lib_path
 
 Allows overriding the directory path used by apache when loading the passenger
 module. The default is the value of `$apache::params::lib_path`.
 
-### mod_lib
+#### mod_lib
 
 Allows overriding the library file name used by apache when loading the
 passenger module. The default is 'mod_passenger.so'.
 
-### mod_path
+#### mod_path
 
 Allows overriding the full path to the library file used by apache when loading
 the passenger module. The default is the concatenation of the `mod_lib_path`
 and `mod_lib` parameters.
 
-# Dependencies
+## Dependencies
 
 RedHat-based systems will need to configure additional package repositories in
 order to install Passenger, specifically:
@@ -256,7 +256,7 @@ order to install Passenger, specifically:
 Configuration of these repositories is beyond the scope of this module and is
 left to the user.
 
-# Attribution
+## Attribution
 
 The Passenger tuning parameters for the `apache::mod::passenger` Puppet class
 was modified by Aaron Hicks (hicksa@landcareresearch.co.nz) for work on the
@@ -268,7 +268,7 @@ PuppetLabs Apache module on GitHub.
 * http://www.nesi.org.nz//
 * https://tuakiri.ac.nz/confluence/display/Tuakiri/Home
 
-# Copyright and License
+## Copyright and License
 
 Copyright (C) 2012 [Puppet Labs](https://www.puppetlabs.com/) Inc
 


### PR DESCRIPTION
Massive reorg and style edit, bringing the way we present classes,
defines, and parameters in line with our established styles. Documents
several undocumented parameters and default values, especially in Apache
module classes.

This work is incomplete; there are many more undocumented parameters and
more style and formatting consistency issues to resolve.