### PR TITLE
Improve docroot flexibility with additional_includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1823,7 +1823,7 @@ Sets the list of resources to look for when a client requests an index of the di
 
 ##### `docroot`
 
-**Required**. Sets the [`DocumentRoot`][] location, from which Apache serves files.
+**Required**. Sets the [`DocumentRoot`][] location, from which Apache serves files. Can be explicitly set to undef if additional_includes is defined.
 
 ##### `docroot_group`
 

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -146,6 +146,12 @@ define apache::vhost(
     validate_array($rewrites)
     validate_hash($rewrites[0])
   }
+  # Validate the docroot as a string if any of the following are true:
+  # - $manage_docroot is true
+  # - $additional_includes is undefined or empty
+  if $manage_docroot or ! $additional_includes or empty($additional_includes) {
+    validate_string($docroot)
+  }
 
   # Input validation begins
 
@@ -252,7 +258,7 @@ define apache::vhost(
 
   # This ensures that the docroot exists
   # But enables it to be specified across multiple vhost resources
-  if ! defined(File[$docroot]) and $manage_docroot {
+  if $manage_docroot and ! defined(File[$docroot]) {
     file { $docroot:
       ensure  => directory,
       owner   => $docroot_owner,
@@ -419,7 +425,7 @@ define apache::vhost(
       fail("Apache::Vhost[${name}]: 'directories' must be either a Hash or an Array of Hashes")
     }
     $_directories = $directories
-  } else {
+  } elsif $docroot {
     $_directory = {
       provider       => 'directory',
       path           => $docroot,
@@ -440,6 +446,8 @@ define apache::vhost(
     }
 
     $_directories = [ merge($_directory, $_directory_version) ]
+  } else {
+    $_directories = []
   }
 
   ## Create a global LocationMatch if locations aren't defined

--- a/templates/vhost/_docroot.erb
+++ b/templates/vhost/_docroot.erb
@@ -2,6 +2,6 @@
   ## Vhost docroot
 <% if @virtual_docroot -%>
   VirtualDocumentRoot "<%= @virtual_docroot %>"
-<% else -%>
+<% elsif @docroot -%>
   DocumentRoot "<%= @docroot %>"
 <% end -%>


### PR DESCRIPTION
If DocumentRoot is in one of the files defined by additional_includes,
then we should NOT include it in the configuration we output.

Permit this only if $manage_docroot is false, $docroot is explicitly
undef, and $additional_includes is non-empty.

Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>

Rebase of #1153