### PR TITLE
(MODULES-2419) - Add mod_auth_kerb parameters to vhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -1964,6 +1964,51 @@ Usage typically looks like:
     }
 ~~~
 
+##### `auth_kerb`
+
+Enable mod_auth_kerb parameters for a virtual host. Valid values are 'true' or 'false'. Defaults to 'false'.
+
+Usage typically looks like:
+
+~~~ puppet
+    apache::vhost {'sample.example.net':
+      auth_kerb              => true,
+      krb_method_negotiate   => 'on',
+      krb_auth_realms        => ['EXAMPLE.ORG'],
+      krb_local_user_mapping => 'on',
+      directories            => { 
+        path         => '/var/www/html',
+        auth_name    => 'Kerberos Login',
+        auth_type    => 'Kerberos',
+        auth_require => 'valid-user',
+      }
+    }
+~~~
+
+##### `krb_method_negotiate`
+
+To enable or disable the use of the Negotiate method. Defaults is 'on'
+
+##### `krb_method_k5passwd`
+
+To enable or disable the use of password based authentication for Kerberos v5. Default is 'on'
+
+##### `krb_authoritative`
+
+If set to off this directive allow authentication controls to be pass on to another modules.  Default is 'on'
+
+##### `krb_auth_realms`
+
+Specifies an array Kerberos realm(s) to be used for authentication. Default is []
+
+##### `krb_5keytab`
+
+Location of the Kerberos V5 keytab file. Not set by default.
+
+##### `krb_local_user_mapping`
+
+Strips @REALM from username for further use. Not set by default.
+
 ##### `logroot`
 
 Specifies the location of the virtual host's logfiles. Defaults to '/var/log/<apache log location>/'.

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -313,6 +313,13 @@ describe 'apache::vhost', :type => :define do
           'passenger_start_timeout'     => '600',
           'passenger_pre_start'         => 'http://localhost/myapp',
           'add_default_charset'         => 'UTF-8',
+          'auth_kerb'                   => true,
+          'krb_method_negotiate'        => 'off',
+          'krb_method_k5passwd'         => 'off',
+          'krb_authoritative'           => 'off',
+          'krb_auth_realms'             => ['EXAMPLE.ORG','EXAMPLE.NET'],
+          'krb_5keytab'                 => '/tmp/keytab5',
+          'krb_local_user_mapping'      => 'off',
         }
       end
       let :facts do
@@ -432,6 +439,16 @@ describe 'apache::vhost', :type => :define do
       it { is_expected.to contain_concat__fragment('rspec.example.com-passenger') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-charsets') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-file_footer') }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-auth_kerb').with(
+        :content => /^\s+KrbMethodNegotiate\soff$/)}
+      it { is_expected.to contain_concat__fragment('rspec.example.com-auth_kerb').with(
+        :content => /^\s+KrbAuthoritative\soff$/)}
+      it { is_expected.to contain_concat__fragment('rspec.example.com-auth_kerb').with(
+        :content => /^\s+KrbAuthRealms\sEXAMPLE.ORG\sEXAMPLE.NET$/)}
+      it { is_expected.to contain_concat__fragment('rspec.example.com-auth_kerb').with(
+        :content => /^\s+Krb5Keytab\s\/tmp\/keytab5$/)}
+      it { is_expected.to contain_concat__fragment('rspec.example.com-auth_kerb').with(
+        :content => /^\s+KrbLocalUserMapping\soff$/)}
     end
     context 'set only aliases' do
       let :params do

--- a/templates/vhost/_auth_kerb.erb
+++ b/templates/vhost/_auth_kerb.erb
@@ -1,0 +1,23 @@
+<% if @auth_kerb -%>
+
+  ## Kerberos directives
+  <%- if @krb_method_negotiate -%>
+  KrbMethodNegotiate <%= @krb_method_negotiate %>
+  <%- end -%>
+  <%- if @krb_method_k5passwd -%>
+  KrbMethodK5Passwd <%= @krb_method_k5passwd %>
+  <%- end -%>
+  <%- if @krb_authoritative -%>
+  KrbAuthoritative <%= @krb_authoritative %>
+  <%- end -%>
+  <%- if @krb_auth_realms and @krb_auth_realms.length >= 1 -%>
+  KrbAuthRealms <%= @krb_auth_realms.join(' ') %>
+  <%- end -%>
+  <%- if @krb_5keytab -%>
+  Krb5Keytab <%= @krb_5keytab %>
+  <%- end -%>
+  <%- if @krb_local_user_mapping -%>
+  KrbLocalUserMapping <%= @krb_local_user_mapping -%>
+  <%- end -%>
+
+<% end -%>


### PR DESCRIPTION
https://tickets.puppetlabs.com/browse/MODULES-2419

The following kerberos parameters can be set within
a vhost.

  KrbMethodNegotiate
  KrbMethodK5Passwd
  KrbAuthoritative
  KrbAuthRealms
  Krb5Keytab
  KrbLocalUserMapping

Reference for mod_auth_kerb:
http://modauthkerb.sourceforge.net/configure.html
https://bugzilla.redhat.com/show_bug.cgi?id=970678