### PR TITLE
client auth for reverse proxy

### DIFF
--- a/templates/vhost/_ssl.erb
+++ b/templates/vhost/_ssl.erb
@@ -43,6 +43,9 @@
   <%- if @ssl_options -%>
   SSLOptions <%= Array(@ssl_options).join(' ') %>
   <%- end -%>
+  <%- if @ssl_proxy_machine_cert -%>
+  SSLProxyMachineCertificateFile "<%= @ssl_proxy_machine_cert %>"
+  <% end -%>
   <%- if @ssl_openssl_conf_cmd -%>
   SSLOpenSSLConfCmd       <%= @ssl_openssl_conf_cmd %>
   <%- end -%>


### PR DESCRIPTION
Add support to specify a client certificate so that the ssl reverse proxy can authenticate to an upstream source with a cert if needed.