### PR TITLE
Support reverse proxy client auth

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -25,6 +25,7 @@ define apache::vhost(
   $ssl_honorcipherorder        = undef,
   $ssl_verify_client           = undef,
   $ssl_verify_depth            = undef,
+  $ssl_proxy_machine_cert      = undef,
   $ssl_options                 = undef,
   $ssl_openssl_conf_cmd        = undef,
   $ssl_proxyengine             = false,
@@ -738,6 +739,7 @@ define apache::vhost(
   # - $ssl_honorcipherorder
   # - $ssl_verify_client
   # - $ssl_verify_depth
+  # - $ssl_proxy_machine_cert
   # - $ssl_options
   # - $ssl_openssl_conf_cmd
   # - $apache_version

--- a/templates/vhost/_ssl.erb
+++ b/templates/vhost/_ssl.erb
@@ -40,6 +40,9 @@
   <%- if @ssl_verify_depth -%>
   SSLVerifyDepth          <%= @ssl_verify_depth %>
   <%- end -%>
+  <% if @ssl_proxy_machine_cert -%>
+  SSLProxyMachineCertificateFile "<%= @ssl_proxy_machine_cert %>"
+  <% end -%>
   <%- if @ssl_options -%>
   SSLOptions <%= Array(@ssl_options).join(' ') %>
   <%- end -%>


### PR DESCRIPTION
Add support for the Apache SSLProxyMachineCertificateFile directive which allows the apache reverse proxy to use a client certificate to authenticate to its upstream