### PR TITLE
(MODULES-2458) Support for mod_auth_mellon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 [`apache::mod::<MODULE NAME>`]: #classes-apachemodmodule-name
 [`apache::mod::alias`]: #class-apachemodalias
 [`apache::mod::auth_cas`]: #class-apachemodauth_cas
+[`apache::mod::auth_mellon`]: #class-apachemodauth_mellon
 [`apache::mod::disk_cache`]: #class-apachemoddisk_cache
 [`apache::mod::event`]: #class-apachemodevent
 [`apache::mod::geoip`]: #class-apachemodgeoip
@@ -142,6 +143,7 @@
 [`mod_alias`]: https://httpd.apache.org/docs/current/mod/mod_alias.html
 [`mod_auth_cas`]: https://github.com/Jasig/mod_auth_cas
 [`mod_authnz_external`]: https://code.google.com/p/mod-auth-external/
+[`mod_auth_mellon`]: https://github.com/UNINETT/mod_auth_mellon
 [`mod_expires`]: http://httpd.apache.org/docs/current/mod/mod_expires.html
 [`mod_fcgid`]: https://httpd.apache.org/mod_fcgid/mod/mod_fcgid.html
 [`mod_geoip`]: http://dev.maxmind.com/geoip/legacy/mod_geoip2/
@@ -1176,6 +1178,7 @@ The following Apache modules have supported classes, many of which allow for par
 * `alias` (see [`apache::mod::alias`][])
 * `auth_basic`
 * `auth_cas`* (see [`apache::mod::auth_cas`][])
+* `auth_mellon`* (see [`apache::mod::auth_mellon`][])
 * `auth_kerb`
 * `authn_core`
 * `authn_file`
@@ -1302,6 +1305,26 @@ The `cas_login_url` and `cas_validate_url` parameters are required; several othe
 - `cas_validate_depth`: Limits the depth for chained certificate validation. Default: 'undef'.
 - `cas_validate_url`: **Required**. Sets the URL to use when validating a client-presented ticket in an HTTP query string.
 - `cas_version`: The CAS protocol version to adhere to. Valid options: '1', '2'. Default: '2'.
+
+##### Class: `apache::mod::auth_mellon`
+
+Installs and manages [`mod_auth_mellon`][]. It's parameters share names with the Apache module's directives.
+
+~~~puppet
+class{'apache::mod::auth_mellon':
+  mellon_cache_size => 101
+}
+~~~
+
+**Parameters within `apache::mod::auth_mellon`**:
+
+- `mellon_cache_size`: Size in megabytes of mellon cache.
+- `mellon_cache_entry_size`: Maximum size for single session.
+- `mellon_lock_file`: Location of lock file.
+- `mellon_post_directory`: Full path where post requests are saved.
+- `mellon_post_ttl`: Time to keep post requests.
+- `mellon_post_size`: Maximum size of post requests.
+- `mellon_post_count`: Maxmum number of post requests.
 
 ##### Class: `apache::mod::deflate`
 
@@ -2654,6 +2677,69 @@ Sets the [IndexStyleSheet](http://httpd.apache.org/docs/current/mod/mod_autoinde
       ],
     }
 ~~~
+
+###### `mellon_enable`
+
+Sets the [MellonEnable](https://github.com/UNINETT/mod_auth_mellon) to enable auth_melon on a location.
+
+~~~ puppet
+apache::vhost{'sample.example.net':
+  docroot => '/path/to/directory',
+  directories => [
+    { path                       => '/',
+      provider                   => 'directory',
+      mellon_enable              => 'info',
+      mellon_sp_private_key_file => '/etc/certs/${::fqdn}.key,
+      mellon_endpoint_path       => '/mellon',
+      mellon_set_env_no_prefix   => { 'ADFS_GROUP' => 'http://schemas.xmlsoap.org/claims/Group',
+                                      'ADFS_EMAIL' => 'http://schemas.xmlsoap.org/claims/EmailAddress'},
+      mellon_user => 'ADFS_LOGIN'
+    },
+    { path => '/protected',
+      provider => 'location',
+      mellon_enable => 'auth',
+      auth_type => 'Mellon',
+      auth_require => 'valid-user',
+      mellon_cond => ['ADFS_LOGIN userA [MAP]','ADFS_LOGIN userB [MAP]']
+    }
+  ]
+}
+
+###### `mellon_cond`
+
+Sets the [MellonCond](https://github.com/UNINETT/mod_auth_mellon) is an array of mellon conditions that must
+be met to grant access.
+
+
+###### `mellon_endpoint_path`
+
+Sets the [MellonEndpointPath](https://github.com/UNINETT/mod_auth_mellon) to set melon endpoint path.
+
+###### `mellon_idp_metadata_file`
+
+Sets the [MellonIDPMetadataFile](https://github.com/UNINETT/mod_auth_mellon) location of idp metadata file.
+
+###### `mellon_saml_rsponse_dump`
+
+Sets the [MellonSamlRepsponseDump](https://github.com/UNINETT/mod_auth_mellon) to enable debug of SAML.
+
+###### `mellon_set_env_no_prefix`
+
+Sets the [MellonSetEnvNoPrefix](https://github.com/UNINETT/mod_auth_mellon) is a hash of attribute names to map
+to environment variables.
+
+
+###### `mellon_sp_private_key_file`
+
+Sets the [MellonSPPrivateKeyFile](https://github.com/UNINETT/mod_auth_mellon) private key location of service provider.
+
+###### `mellon_sp_cert_file`
+
+Sets the [MellonSPCertFile](https://github.com/UNINETT/mod_auth_mellon) public key location of service provider.
+
+###### `mellon_user`
+
+Sets the [MellonUser](https://github.com/UNINETT/mod_auth_mellon) attribute we should use for the username.
 
 ###### `options`
 

--- a/manifests/mod/auth_mellon.pp
+++ b/manifests/mod/auth_mellon.pp
@@ -1,0 +1,24 @@
+class apache::mod::auth_mellon (
+  $mellon_cache_size = $::apache::params::mellon_cache_size,
+  $mellon_lock_file  = $::apache::params::mellon_lock_file,
+  $mellon_post_directory = $::apache::params::mellon_post_directory,
+  $mellon_cache_entry_size = undef,
+  $mellon_post_ttl = undef,
+  $mellon_post_size = undef,
+  $mellon_post_count = undef
+) {
+
+  ::apache::mod { 'auth_mellon': }
+
+  # Template uses
+  # - All variables beginning with mellon_
+  file { 'auth_mellon.conf':
+    ensure  => file,
+    path    => "${::apache::mod_dir}/auth_mellon.conf",
+    content => template('apache/mod/auth_mellon.conf.erb'),
+    require => [ Exec["mkdir ${::apache::mod_dir}"], ],
+    before  => File[$::apache::mod_dir],
+    notify  => Class['Apache::Service'],
+  }
+
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -75,6 +75,7 @@ class apache::params inherits ::apache::version {
     $mod_packages         = {
       'auth_cas'    => 'mod_auth_cas',
       'auth_kerb'   => 'mod_auth_kerb',
+      'auth_mellon' => 'mod_auth_mellon',
       'authnz_ldap' => $::apache::version::distrelease ? {
         '7'     => 'mod_ldap',
         default => 'mod_authz_ldap',
@@ -131,6 +132,9 @@ class apache::params inherits ::apache::version {
       $wsgi_socket_prefix = undef
     }
     $cas_cookie_path      = '/var/cache/mod_auth_cas/'
+    $mellon_lock_file     = '/run/mod_auth_mellon/lock'
+    $mellon_cache_size    = 100
+    $mellon_post_directory = undef
     $modsec_crs_package   = 'mod_security_crs'
     $modsec_crs_path      = '/usr/lib/modsecurity.d'
     $modsec_dir           = '/etc/httpd/modsecurity.d'
@@ -188,6 +192,7 @@ class apache::params inherits ::apache::version {
     $mod_packages        = {
       'auth_cas'    => 'libapache2-mod-auth-cas',
       'auth_kerb'   => 'libapache2-mod-auth-kerb',
+      'auth_mellon' => 'libapache2-mod-auth-mellon',
       'dav_svn'     => 'libapache2-svn',
       'fastcgi'     => 'libapache2-mod-fastcgi',
       'fcgid'       => 'libapache2-mod-fcgid',
@@ -218,6 +223,9 @@ class apache::params inherits ::apache::version {
     $mime_types_config    = '/etc/mime.types'
     $docroot              = '/var/www'
     $cas_cookie_path      = '/var/cache/apache2/mod_auth_cas/'
+    $mellon_lock_file     = undef
+    $mellon_cache_size    = undef
+    $mellon_post_directory = '/var/cache/apache2/mod_auth_mellon/'
     $modsec_crs_package   = 'modsecurity-crs'
     $modsec_crs_path      = '/usr/share/modsecurity-crs'
     $modsec_dir           = '/etc/modsecurity'
@@ -479,6 +487,9 @@ class apache::params inherits ::apache::version {
     $mime_types_config    = '/etc/mime.types'
     $docroot              = '/srv/www'
     $cas_cookie_path      = '/var/cache/apache2/mod_auth_cas/'
+    $mellon_lock_file     = undef
+    $mellon_cache_size    = undef
+    $mellon_post_directory = undef
     $alias_icons_path     = '/usr/share/apache2/icons'
     $error_documents_path = '/usr/share/apache2/error'
     $dev_packages        = ['libapr-util1-devel', 'libapr1-devel']

--- a/spec/classes/mod/auth_mellon_spec.rb
+++ b/spec/classes/mod/auth_mellon_spec.rb
@@ -1,0 +1,87 @@
+describe 'apache::mod::auth_mellon', :type => :class do
+  let :pre_condition do
+    'include apache'
+  end
+  context "on a Debian OS" do
+    let :facts do
+      {
+        :osfamily               => 'Debian',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
+        :lsbdistcodename        => 'squeeze',
+        :operatingsystem        => 'Debian',
+        :id                     => 'root',
+        :kernel                 => 'Linux',
+        :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :fqdn                   => 'test.example.com',
+        :is_pe                  => false,
+      }
+    end
+    describe 'with no parameters' do
+      it { should contain_apache__mod('auth_mellon') }
+      it { should contain_package('libapache2-mod-auth-mellon') }
+      it { should contain_file('auth_mellon.conf').with_path('/etc/apache2/mods-available/auth_mellon.conf') }
+      it { should contain_file('auth_mellon.conf').with_content("MellonPostDirectory \"\/var\/cache\/apache2\/mod_auth_mellon\/\"\n") }
+    end
+    describe 'with parameters' do
+      let :params do
+        { :mellon_cache_size => '200',
+          :mellon_cache_entry_size => '2010',
+          :mellon_lock_file => '/tmp/junk',
+          :mellon_post_directory => '/tmp/post',
+          :mellon_post_ttl => '5',
+          :mellon_post_size => '8',
+          :mellon_post_count => '10'
+        }
+      end
+      it { should contain_file('auth_mellon.conf').with_content(/^MellonCacheSize\s+200$/) }
+      it { should contain_file('auth_mellon.conf').with_content(/^MellonCacheEntrySize\s+2010$/) }
+      it { should contain_file('auth_mellon.conf').with_content(/^MellonLockFile\s+"\/tmp\/junk"$/) }
+      it { should contain_file('auth_mellon.conf').with_content(/^MellonPostDirectory\s+"\/tmp\/post"$/) }
+      it { should contain_file('auth_mellon.conf').with_content(/^MellonPostTTL\s+5$/) }
+      it { should contain_file('auth_mellon.conf').with_content(/^MellonPostSize\s+8$/) }
+      it { should contain_file('auth_mellon.conf').with_content(/^MellonPostCount\s+10$/) }
+    end
+
+  end
+  context "on a RedHat OS" do
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
+        :operatingsystem        => 'RedHat',
+        :id                     => 'root',
+        :kernel                 => 'Linux',
+        :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :fqdn                   => 'test.example.com',
+        :is_pe                  => false,
+      }
+    end
+    describe 'with no parameters' do
+      it { should contain_apache__mod('auth_mellon') }
+      it { should contain_package('mod_auth_mellon') }
+      it { should contain_file('auth_mellon.conf').with_path('/etc/httpd/conf.d/auth_mellon.conf') }
+      it { should contain_file('auth_mellon.conf').with_content("MellonCacheSize 100\nMellonLockFile \"/run/mod_auth_mellon/lock\"\n") }
+    end
+    describe 'with parameters' do
+      let :params do
+        { :mellon_cache_size => '200',
+          :mellon_cache_entry_size => '2010',
+          :mellon_lock_file => '/tmp/junk',
+          :mellon_post_directory => '/tmp/post',
+          :mellon_post_ttl => '5',
+          :mellon_post_size => '8',
+          :mellon_post_count => '10'
+        }
+      end
+      it { should contain_file('auth_mellon.conf').with_content(/^MellonCacheSize\s+200$/) }
+      it { should contain_file('auth_mellon.conf').with_content(/^MellonCacheEntrySize\s+2010$/) }
+      it { should contain_file('auth_mellon.conf').with_content(/^MellonLockFile\s+"\/tmp\/junk"$/) }
+      it { should contain_file('auth_mellon.conf').with_content(/^MellonPostDirectory\s+"\/tmp\/post"$/) }
+      it { should contain_file('auth_mellon.conf').with_content(/^MellonPostTTL\s+5$/) }
+      it { should contain_file('auth_mellon.conf').with_content(/^MellonPostSize\s+8$/) }
+      it { should contain_file('auth_mellon.conf').with_content(/^MellonPostCount\s+10$/) }
+    end
+  end
+end

--- a/templates/mod/auth_mellon.conf.erb
+++ b/templates/mod/auth_mellon.conf.erb
@@ -1,0 +1,21 @@
+<%- if @mellon_cache_size -%>
+MellonCacheSize <%= @mellon_cache_size %>
+<%- end -%>
+<%- if @mellon_cache_entry_size -%>
+MellonCacheEntrySize <%= @mellon_cache_entry_size %>
+<%- end -%>
+<%- if @mellon_lock_file -%>
+MellonLockFile "<%= @mellon_lock_file %>"
+<%- end -%>
+<%- if @mellon_post_directory -%>
+MellonPostDirectory "<%= @mellon_post_directory %>"
+<%- end -%>
+<%- if @mellon_post_ttl -%>
+MellonPostTTL <%= @mellon_post_ttl %>
+<%- end -%>
+<%- if @mellon_post_size -%>
+MellonPostSize <%= @mellon_post_size %>
+<%- end -%>
+<%- if @mellon_post_count -%>
+MellonPostCount <%= @mellon_post_count %>
+<%- end -%>

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -252,6 +252,37 @@
     ShibUseHeaders <%= directory['shib_use_headers'] %>
       <%- end -%>
     <%- end -%>
+    <%- if directory['mellon_enable'] -%>
+    MellonEnable "<%= directory['mellon_enable'] %>"
+      <%- if directory['mellon_endpoint_path'] -%>
+    MellonEndpointPath "<%= directory['mellon_endpoint_path'] %>"
+      <%- end -%>
+      <%- if directory['mellon_sp_private_key_file'] -%>
+    MellonSPPrivateKeyFile "<%= directory['mellon_sp_private_key_file'] %>"
+      <%- end -%>
+      <%- if directory['mellon_sp_cert_file'] -%>
+    MellonSPCertFile "<%= directory['mellon_sp_cert_file'] %>"
+      <%- end -%>
+      <%- if directory['mellon_idp_metadata_file'] -%>
+    MellonIDPMetadataFile "<%= directory['mellon_idp_metadata_file'] %>"
+      <%- end -%>
+      <%- if directory['mellon_set_env_no_prefix'] -%>
+        <%- directory['mellon_set_env_no_prefix'].each do |key, value| -%>
+    MellonSetEnvNoPrefix "<%= key %>" "<%= value %>"
+        <%- end -%>
+      <%- end -%>
+      <%- if directory['mellon_user'] -%>
+    MellonUser "<%= directory['mellon_user'] %>"
+      <%- end -%>
+      <%- if directory['mellon_saml_response_dump'] -%>
+    MellonSamlResponseDump "<%= directory['mellon_saml_response_dump'] %>"
+      <%- end -%>
+      <%- if directory['mellon_cond'] -%>
+        <%- Array(directory['mellon_cond']).each do |cond| -%>
+    MellonCond <%= cond %>
+         <%- end -%>
+      <%- end -%>
+    <%- end -%>
     <%- if directory['custom_fragment'] -%>
     <%= directory['custom_fragment'] %>
     <%- end -%>


### PR DESCRIPTION
mod_auth_melon is an authentication module
for apache. Configurations such as the following
are now supported.

```puppet
class{'apache':
      default_mods        => false,
      default_confd_files => false,
      default_vhost       => false,
}
class{'apache::mod::auth_mellon':
     mellon_cache_size => 101
}
apache::vhost{$::fqdn:
  docroot => '/var/www/html',
  port    => 443,
  ssl     => true,
  ssl_key => "/etc/certs/${::fqdn}.key",
  ssl_cert => "/etc/certs/${::fqdn}.cert",
  directories => [
      {  path           => '/',
         provider       => 'directory',
         mellon_enable  => 'info',
         mellon_merge_env_vars => 'On',
         mellon_endpoint_path => '/mellon',
         mellon_sp_private_key_file => "/etc/certs/${::fqdn}.key",
         mellon_sp_cert_file => "/etc/certs/${::fqdn}.cert",
         mellon_idp_metadata_file => "/etc/httpd/conf.d/mellon/FederationMetadata.xml",
         mellon_set_env_no_prefix => { "user" => "http://schemas.xmlsoap.org/claims/UPN",
                                   "ADFS_GROUP" => "http://schemas.xmlsoap.org/claims/Group",
                                   "ADFS_EMAIL" => "http://schemas.xmlsoap.org/claims/EmailAddress"},
         mellon_user => 'ADFS_LOGIN',
      },
      { path => '/protected',
        provider => 'location',
        auth_type => 'Mellon',
        auth_require => 'valid-user',
        mellon_enable => 'auth',
        mellon_cond => ['ADFS_LOGIN straylen [MAP]']
      },
  ]
}

```