### PR TITLE
Don't qualified call to defined resource type

### DIFF
--- a/manifests/mod/rewrite.pp
+++ b/manifests/mod/rewrite.pp
@@ -1,4 +1,4 @@
 class apache::mod::rewrite {
   include ::apache::params
-  ::apache::mod { 'rewrite': }
+  apache::mod { 'rewrite': }
 }


### PR DESCRIPTION
According to best practices:
(https://docs.puppetlabs.com/puppet/latest/reference/lang_defined_types.html#resource-uniqueness)

See these accepted PRs:
- https://github.com/theforeman/puppet-foreman/pull/346
- https://github.com/jfryman/puppet-nginx/pull/666