### PR TITLE
Geoip package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1363,6 +1363,7 @@ Installs and manages [`mod_geoip`][].
 **Parameters within `apache::mod::geoip`**:
 
 - `db_file`: Sets the path to your GeoIP database file. Valid options: a path, or an [array][] paths for multiple GeoIP database files. Default: `/usr/share/GeoIP/GeoIP.dat`.
+- `package_name`: Specify any package(s) needed for this to work.
 - `enable`: Determines whether to globally enable [`mod_geoip`][]. Valid options: Boolean. Default: 'false'.
 - `flag`: Sets the GeoIP flag. Valid options: 'CheckCache', 'IndexCache', 'MemoryCache', 'Standard'. Default: 'Standard'.
 - `output`: Defines which output variables to use. Valid options: 'All', 'Env', 'Request', 'Notes'. Default: 'All'.

--- a/manifests/mod/geoip.pp
+++ b/manifests/mod/geoip.pp
@@ -1,5 +1,6 @@
 class apache::mod::geoip (
   $enable                     = false,
+  $package_name               = undef,
   $db_file                    = '/usr/share/GeoIP/GeoIP.dat',
   $flag                       = 'Standard',
   $output                     = 'All',
@@ -8,7 +9,9 @@ class apache::mod::geoip (
   $scan_proxy_header_field    = undef,
   $use_last_xforwarededfor_ip = undef,
 ) {
-  ::apache::mod { 'geoip': }
+  ::apache::mod { 'geoip':
+    package => $package_name,
+  }
 
   # Template uses:
   # - enable


### PR DESCRIPTION
Currently, including `apache::mod::geoip` fails on at least Ubuntu 14.04 because a required lib is not installed (or is not being installed), and there's no way to tell it what supporting packages it might need.

This adds the ability to install any need package(s) when enabling mod_geoip.