### PR TITLE
Removed enforced .conf extension on custom_config.pp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1632,7 +1632,7 @@ Specifies an [array][] of [options](http://httpd.apache.org/docs/current/mod/mod
 
 #### Define: `apache::custom_config`
 
-Adds a custom configuration file to the Apache server's `conf.d` directory. If the file is invalid and this define's `$verify_config` parameter is 'true', Puppet throws an error during a Puppet run.
+Adds a custom configuration file to the Apache server's `conf.d` directory. If the file is invalid and this define's `$verify_config` parameter is 'true', Puppet throws an error during a Puppet run. Uses extension from name and does not change it .conf
 
 **Parameters within `apache::custom_config`**:
 

--- a/manifests/custom_config.pp
+++ b/manifests/custom_config.pp
@@ -31,7 +31,7 @@ define apache::custom_config (
 
   ## Apache include does not always work with spaces in the filename
   $filename_middle = regsubst($name, ' ', '_', 'G')
-  $filename = "${priority_prefix}${filename_middle}.conf"
+  $filename = "${priority_prefix}${filename_middle}"
 
   if ! $verify_config or $ensure == 'absent' {
     $notifies = Class['Apache::Service']

--- a/spec/defines/custom_config_spec.rb
+++ b/spec/defines/custom_config_spec.rb
@@ -61,12 +61,12 @@ describe 'apache::custom_config', :type => :define do
     })
     }
     it { is_expected.to contain_exec("remove rspec if invalid").with({
-      'command'     => '/bin/rm /dne/30-rspec.conf',
+      'command'     => '/bin/rm /dne/30-rspec',
       'unless'      => '/bin/true',
     })
     }
     it { is_expected.to contain_file("apache_rspec").with({
-      'path'   => '/dne/30-rspec.conf',
+      'path'   => '/dne/30-rspec',
       'ensure'  => 'present',
       'source' => 'puppet:///modules/apache/test',
       'require' => 'Package[httpd]',


### PR DESCRIPTION
The current custom_config automatically updates the file to use .conf
rather than rely on the name provided. Any configs/vhosts/etc. using
this have to predict this behavior rather than rely on what's provided
in the name of the config.

This is not exposed or configurable so removing it should help make
things easier from a configuration aspect.