### PR TITLE
Deflate "application/json" by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1332,7 +1332,7 @@ Installs and configures [`mod_deflate`][].
 
 **Parameters within `apache::mod::deflate`:**
 
-- `types`: An [array][] of [MIME types][MIME `content-type`] to be deflated. Default: [ 'text/html text/plain text/xml', 'text/css', 'application/x-javascript application/javascript application/ecmascript', 'application/rss+xml' ].
+- `types`: An [array][] of [MIME types][MIME `content-type`] to be deflated. Default: [ 'text/html text/plain text/xml', 'text/css', 'application/x-javascript application/javascript application/ecmascript', 'application/rss+xml', 'application/json' ].
 - `notes`: A [Hash][] where the key represents the type and the value represents the note name. Default: { 'Input'  => 'instream', 'Output' => 'outstream', 'Ratio'  => 'ratio' }
 
 ##### Class: `apache::mod::expires`

--- a/manifests/mod/deflate.pp
+++ b/manifests/mod/deflate.pp
@@ -3,7 +3,8 @@ class apache::mod::deflate (
     'text/html text/plain text/xml',
     'text/css',
     'application/x-javascript application/javascript application/ecmascript',
-    'application/rss+xml'
+    'application/rss+xml',
+    'application/json'
   ],
   $notes = {
     'Input'  => 'instream',


### PR DESCRIPTION
Hello,
How can I customize the "types" of "deflate " while using " default_mods " ?
I need to deflate "application/json".

JSON is a common text resource types on the web which should be served with HTTP compression:
https://zoompf.com/blog/2012/02/lose-the-wait-http-compression

Thks