### PR TITLE
Fix typo of MPM_PREFORK for FreeBSD package install

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -17,11 +17,11 @@ class apache::package (
         }
         'worker': {
           $set = 'MPM_WORKER'
-          $unset = 'MPM_PERFORK MPM_EVENT'
+          $unset = 'MPM_PREFORK MPM_EVENT'
         }
         'event': {
           $set = 'MPM_EVENT'
-          $unset = 'MPM_PERFORK MPM_WORKER'
+          $unset = 'MPM_PREFORK MPM_WORKER'
         }
         'itk': {
           $set = undef


### PR DESCRIPTION
Was unsetting 'MPM_PERFORK', so 'MPM_PREFORK' would not have been
unset correctly.