### PR TITLE
Removed enforced .conf extension on custom_config.pp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1668,6 +1668,10 @@ This parameter is only used if the [`verify_config`][] parameter's value is 'tru
 
 Specifies whether to validate the configuration file before notifying the Apache service. Valid options: Boolean. Default: `true`.
 
+##### `default_ext`
+
+Specifies what extension to append on end of custom config file. Set to '' to keep original extension. Default: `.conf`.
+
 #### Define: `apache::fastcgi::server`
 
 Defines one or more external FastCGI servers to handle specific file types. Use this define with [`mod_fastcgi`][FastCGI].

--- a/manifests/custom_config.pp
+++ b/manifests/custom_config.pp
@@ -7,6 +7,7 @@ define apache::custom_config (
   $source         = undef,
   $verify_command = $::apache::params::verify_command,
   $verify_config  = true,
+  $default_ext    = '.conf',
 ) {
 
   if $content and $source {
@@ -28,10 +29,11 @@ define apache::custom_config (
   } else {
     $priority_prefix = ''
   }
-
+  
+  
   ## Apache include does not always work with spaces in the filename
   $filename_middle = regsubst($name, ' ', '_', 'G')
-  $filename = "${priority_prefix}${filename_middle}.conf"
+  $filename = "${priority_prefix}${filename_middle}${default_ext}"
 
   if ! $verify_config or $ensure == 'absent' {
     $notifies = Class['Apache::Service']


### PR DESCRIPTION
The custom_config resource forcibly renamed the file to include .conf as
the extension. The behavior was not documented and did not reflect the
name of the resource in this case. Any configs including those would
need to remember to include .config even if the base file name did not
have it.

By adding the parameter and defaulting it to '.conf', this commit allows
backward compatibility while also allowing custom config extensions in
the future.