### PR TITLE
Allow external shibboleth repository on Debian OS family

### DIFF
--- a/manifests/mod/shib.pp
+++ b/manifests/mod/shib.pp
@@ -1,15 +1,30 @@
 class apache::mod::shib (
   $suppress_warning = false,
+  $use_external_repository = false,
 ) {
 
   if $::osfamily == 'RedHat' and ! $suppress_warning {
     warning('RedHat distributions do not have Apache mod_shib in their default package repositories.')
   }
 
+  if $::osfamily == 'Debian' and $use_external_repository {
+    if ! $suppress_warning {
+      warning('You have configure apache::mod::shib in a way that requires the configuration of')
+      warning('an external repository such as https://www.switch.ch/aai/guides/sp/installation')
+    }
+    $package = 'shibboleth'
+    $lib = 'mod_shib_22.so'
+  } else {
+    $package = undef
+    $lib = undef
+  }
+
   $mod_shib = 'shib2'
 
   apache::mod {$mod_shib:
-    id => 'mod_shib',
+    id      => 'mod_shib',
+    package => $package,
+    lib     => $lib,
   }
 
 }


### PR DESCRIPTION
1. Set apache::mod::shib::use_external_repository to true (in hiera or in class declaration).
2. Outside of apache module, enable a repository such as that at https://www.switch.ch/aai/guides/sp/installation that uses a package named shibboleth and a library named mod_shib_22.so. This is the only way to get Shibboleth 2.5 functionality in Debian 7 and it is not  obvious (one way or other) how well >2.5.3 is backported into Debian 7.

Should have 0 impact on existing use of Apache module. Possible future revision: I believe the switch.cc module will probably be named mod_shib_24.so on platforms with Apache 2.4. One might even rewrite the code to optionally build around the switch.cc repositories for every OS family as the are very multi-platform.