### PR TITLE
Add the ability to manage (or not to manage) the Apache configuration file (typically httpd.conf)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2185,6 +2185,10 @@ This directive is equivalent to proxy_pass, but takes regular expressions, see [
 
 Specifies the resource identifiers for a rack configuration. The file paths specified are listed as rack application roots for [Phusion Passenger](http://www.modrails.com/documentation/Users%20guide%20Apache.html#_railsbaseuri_and_rackbaseuri) in the _rack.erb template. Defaults to 'undef'.
 
+#####`passenger_base_uris`
+
+Used to specify that the given URI is a Phusion Passenger-served application. The file paths specified are listed as passenger application roots for [Phusion Passenger](https://www.phusionpassenger.com/documentation/Users%20guide%20Apache.html#PassengerBaseURI) in the _passenger_base_uris.erb template. Defaults to 'undef'.
+
 ##### `redirect_dest`
 
 Specifies the address to redirect to. Defaults to 'undef'.

--- a/README.md
+++ b/README.md
@@ -992,6 +992,12 @@ When 'false', stops Puppet from creating the group resource. Valid options: Bool
 
 If you have a group created from another Puppet module that you want to use to run Apache, set this to 'false'. Without this parameter, attempting to use a previously established group results in a duplicate resource error.
 
+##### `manage_conf_file`
+
+When 'false', stops Puppet from managing the main Apache configuration file (typically, `httpd.conf`).
+
+This is for instances when you have an existing environment that you would like to manage but you don't want Puppet to modify your existing httpd.conf file.
+
 ##### `manage_user`
 
 When 'false', stops Puppet from creating the user resource. Valid options: Boolean. Default: 'true'.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,6 +42,7 @@ class apache (
   $timeout                = '120',
   $httpd_dir              = $::apache::params::httpd_dir,
   $server_root            = $::apache::params::server_root,
+  $manage_conf_file       = $::apache::params::manage_conf_file,
   $conf_dir               = $::apache::params::conf_dir,
   $confd_dir              = $::apache::params::confd_dir,
   $vhost_dir              = $::apache::params::vhost_dir,
@@ -82,6 +83,7 @@ class apache (
   validate_bool($service_enable)
   validate_bool($service_manage)
   validate_bool($use_optional_includes)
+  validate_bool($manage_conf_file)
 
   $valid_mpms_re = $apache_version ? {
     '2.4'   => '(event|itk|peruser|prefork|worker)',
@@ -246,7 +248,7 @@ class apache (
     content => template('apache/ports_header.erb')
   }
 
-  if $::apache::conf_dir and $::apache::params::conf_file {
+  if $::apache::manage_conf_file and $::apache::conf_dir and $::apache::params::conf_file {
     case $::osfamily {
       'debian': {
         $error_log            = 'error.log'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,6 +25,9 @@ class apache::params inherits ::apache::version {
     $servername = $::hostname
   }
 
+  # Do we want to manage the $conf_file or keep the existing one intact?
+  $manage_conf_file = true
+
   # The default error log level
   $log_level = 'warn'
   $use_optional_includes = false

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -81,6 +81,7 @@ define apache::vhost(
   $redirectmatch_regexp        = undef,
   $redirectmatch_dest          = undef,
   $rack_base_uris              = undef,
+  $passenger_base_uris         = undef,
   $headers                     = undef,
   $request_headers             = undef,
   $filters                     = undef,
@@ -399,6 +400,11 @@ define apache::vhost(
     }
   }
 
+  # Load mod_passenger if needed and not yet loaded
+  if $passenger_base_uris {
+      include ::apache::mod::passenger
+  }
+
   # Load mod_fastci if needed and not yet loaded
   if $fastcgi_server and $fastcgi_socket {
     if ! defined(Class['apache::mod::fastcgi']) {
@@ -665,6 +671,16 @@ define apache::vhost(
       target  => "${priority_real}${filename}.conf",
       order   => 150,
       content => template('apache/vhost/_rack.erb'),
+    }
+  }
+
+  # Template uses:
+  # - $passenger_base_uris
+  if $passenger_base_uris {
+    concat::fragment { "${name}-passenger_uris":
+      target  => "${priority_real}${filename}.conf",
+      order   => 155,
+      content => template('apache/vhost/_passenger_base_uris.erb'),
     }
   }
 

--- a/spec/acceptance/apache_parameters_spec.rb
+++ b/spec/acceptance/apache_parameters_spec.rb
@@ -3,6 +3,12 @@ require_relative './version.rb'
 
 describe 'apache parameters', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
 
+  describe 'manage_conf_file => true' do
+    it 'doesnt do anything' do
+      pp = "class { 'apache': manage_conf_file => true }"
+      apply_manifest(pp, :catch_failures => true)
+    end
+
   # Currently this test only does something on FreeBSD.
   describe 'default_confd_files => false' do
     it 'doesnt do anything' do

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -252,6 +252,7 @@ describe 'apache::vhost', :type => :define do
           'redirectmatch_regexp'        => ['\.git$'],
           'redirectmatch_dest'          => ['http://www.example.com'],
           'rack_base_uris'              => ['/rackapp1'],
+          'passenger_base_uris'         => ['/passengerapp1'],
           'headers'                     => 'Set X-Robots-Tag "noindex, noarchive, nosnippet"',
           'request_headers'             => ['append MirrorID "mirror 12"'],
           'rewrites'                    => [

--- a/templates/vhost/_passenger_base_uris.erb
+++ b/templates/vhost/_passenger_base_uris.erb
@@ -1,0 +1,7 @@
+<% if @passenger_base_uris -%>
+
+  ## Enable passenger base uris
+<% Array(@passenger_base_uris).each do |uri| -%>
+  PassengerBaseURI <%= uri %>
+<% end -%>
+<% end -%>

--- a/tests/vhost.pp
+++ b/tests/vhost.pp
@@ -141,6 +141,7 @@ apache::vhost { 'fifteenth.example.com':
   rack_base_uris => ['/rackapp1', '/rackapp2'],
 }
 
+
 # Vhost to redirect non-ssl to ssl
 apache::vhost { 'sixteenth.example.com non-ssl':
   servername => 'sixteenth.example.com',
@@ -249,5 +250,12 @@ apache::vhost { 'twentyfirst.example.com':
   port               => '80',
   docroot            => '/var/www/twentyfirst',
   access_log_env_var => 'admin',
+}
+
+# Vhost with a passenger_base configuration
+apache::vhost { 'twentysecond.example.com':
+  port           => '80',
+  docroot        => '/var/www/twentysecond',
+  rack_base_uris => ['/passengerapp1', '/passengerapp2'],
 }
 


### PR DESCRIPTION
I've got a whole bunch of existing installations and I don't [yet] want Puppet to manage my httpd.conf file.  This will give administrators the ability to leave the configuration file alone while they migrate to a fully puppetized configuration.