### PR TITLE
MODULES-2613 Small style cleanup to templates/vhost/_additional_inclu…

### DIFF
--- a/templates/vhost/_additional_includes.erb
+++ b/templates/vhost/_additional_includes.erb
@@ -2,9 +2,8 @@
 
   ## Load additional static includes
 <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 && @use_optional_includes -%>
-IncludeOptional "<%= include %>"
+  IncludeOptional "<%= include %>"
 <%- else -%>
-Include "<%= include %>"
+  Include "<%= include %>"
 <%- end -%>
-
 <% end -%>


### PR DESCRIPTION
…des.erb

The file templates/vhost/_additional_includes.erb can use a small cleanup (IMHO).

Without this commit the includes are not nicely indented in line with the comment and the rest of the configuration file. This commit fixes that.