### PR TITLE
(MODULES-2616) Optionally set LimitRequestFieldSize on an apache::vhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -2009,6 +2009,10 @@ Location of the Kerberos V5 keytab file. Not set by default.
 
 Strips @REALM from username for further use. Not set by default.
 
+##### `limit_request_field_size`
+
+[Limits](http://httpd.apache.org/docs/2.4/mod/core.html#limitrequestfieldsize) the size of the HTTP request header allowed from the client. Default is 'undef'.
+
 ##### `logroot`
 
 Specifies the location of the virtual host's logfiles. Defaults to '/var/log/<apache log location>/'.

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -131,6 +131,7 @@ define apache::vhost(
   $krb_auth_realms             = [],
   $krb_5keytab                 = undef,
   $krb_local_user_mapping      = undef,
+  $limit_request_field_size    = undef,
 ) {
   # The base class must be included first because it is used by parameter defaults
   if ! defined(Class['apache']) {
@@ -222,6 +223,10 @@ define apache::vhost(
   }
 
   validate_bool($auth_kerb)
+
+  if $limit_request_field_size {
+    validate_integer($limit_request_field_size)
+  }
   # Input validation ends
 
   if $ssl and $ensure == 'present' {
@@ -944,6 +949,15 @@ define apache::vhost(
       target  => "${priority_real}${filename}.conf",
       order   => 330,
       content => template('apache/vhost/_filters.erb'),
+    }
+  }
+  # Template uses:
+  # - $limit_request_field_size
+  if $limit_request_field_size {
+    concat::fragment { "${name}-limits":
+      target  => "${priority_real}${filename}.conf",
+      order   => 330,
+      content => template('apache/vhost/_limits.erb'),
     }
   }
 

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -321,6 +321,7 @@ describe 'apache::vhost', :type => :define do
           'krb_auth_realms'             => ['EXAMPLE.ORG','EXAMPLE.NET'],
           'krb_5keytab'                 => '/tmp/keytab5',
           'krb_local_user_mapping'      => 'off',
+          'limit_request_field_size'    => '54321',
         }
       end
       let :facts do
@@ -450,6 +451,8 @@ describe 'apache::vhost', :type => :define do
         :content => /^\s+Krb5Keytab\s\/tmp\/keytab5$/)}
       it { is_expected.to contain_concat__fragment('rspec.example.com-auth_kerb').with(
         :content => /^\s+KrbLocalUserMapping\soff$/)}
+      it { is_expected.to contain_concat__fragment('rspec.example.com-limits').with(
+        :content => /^\s+LimitRequestFieldSize\s54321$/)}
     end
     context 'set only aliases' do
       let :params do
@@ -601,6 +604,7 @@ describe 'apache::vhost', :type => :define do
       it { is_expected.to_not contain_concat__fragment('rspec.example.com-fastcgi') }
       it { is_expected.to_not contain_concat__fragment('rspec.example.com-suexec') }
       it { is_expected.to_not contain_concat__fragment('rspec.example.com-charsets') }
+      it { is_expected.to_not contain_concat__fragment('rspec.example.com-limits') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-file_footer') }
     end
   end

--- a/templates/vhost/_limits.erb
+++ b/templates/vhost/_limits.erb
@@ -1,0 +1,5 @@
+
+  ## Limit Request Values
+<% if @limit_request_field_size -%>
+  LimitRequestFieldSize <%= @limit_request_field_size %>
+<% end -%>


### PR DESCRIPTION
Support setting of LimitRequestFieldSize on a vhost.

```puppet
apache::vhost{'foo':
  limit_request_field_size => 1234
}
```

by default value is unset.

http://httpd.apache.org/docs/2.4/mod/core.html#limitrequestfieldsize
https://tickets.puppetlabs.com/browse/MODULES-2616