### PR TITLE
(MODULES-2647) Optinally set parameters for mod_ext_filter module

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 [`apache::mod::auth_mellon`]: #class-apachemodauth_mellon
 [`apache::mod::disk_cache`]: #class-apachemoddisk_cache
 [`apache::mod::event`]: #class-apachemodevent
+[`apache::mod::ext_filter`]: #class-apachemodext_filter
 [`apache::mod::geoip`]: #class-apachemodgeoip
 [`apache::mod::itk`]: #class-apachemoditk
 [`apache::mod::passenger`]: #class-apachemodpassenger
@@ -145,6 +146,7 @@
 [`mod_authnz_external`]: https://code.google.com/p/mod-auth-external/
 [`mod_auth_mellon`]: https://github.com/UNINETT/mod_auth_mellon
 [`mod_expires`]: http://httpd.apache.org/docs/current/mod/mod_expires.html
+[`mod_ext_filter`]: http://httpd.apache.org/docs/current/mod/mod_ext_filter.html
 [`mod_fcgid`]: https://httpd.apache.org/mod_fcgid/mod/mod_fcgid.html
 [`mod_geoip`]: http://dev.maxmind.com/geoip/legacy/mod_geoip2/
 [`mod_info`]: https://httpd.apache.org/docs/current/mod/mod_info.html
@@ -1198,6 +1200,7 @@ The following Apache modules have supported classes, many of which allow for par
 * `disk_cache` (see [`apache::mod::disk_cache`][])
 * `event` (see [`apache::mod::event`][])
 * `expires`
+* `ext_filter` (see [`apache::mod::ext_filter`][])
 * `fastcgi`
 * `fcgid`
 * `filter`
@@ -1344,6 +1347,23 @@ Installs [`mod_expires`][] and uses the `expires.conf.erb` template to generate 
 - `expires_active`: Enables generation of `Expires` headers for a document realm. Default: 'true'.
 - `expires_default`: Default algorithm for calculating expiration time using [`ExpiresByType`][] syntax or [interval syntax][]. Default: undef.
 - `expires_by_type`: Describes a set of [MIME `content-type`][] and their expiration times. Valid options: An [array][] of [Hashes][Hash], with each Hash's key a valid MIME `content-type` (i.e. 'text/json') and its value following valid [interval syntax][]. Default: undef.
+
+##### Class: `apache::mod::ext_filter`
+
+Installs and configures [`mod_ext_filter`][].
+
+~~~ puppet
+class{'apache::mod::ext_filter':
+  ext_filter_define => {
+    'slowdown'       => 'mode=output cmd=/bin/cat preservescontentlength',
+    'puppetdb-strip' => 'mode=output outtype=application/json cmd="pdb-resource-filter"',
+  },
+}
+~~~
+
+**Parameters within `apache::mod::ext_filter`**:
+
+- `ext_filter_define`: A hash of filter names and their parameters. Default: undef.
 
 ##### Class: `apache::mod::fcgid`
 
@@ -2649,6 +2669,22 @@ An array of hashes used to override the [ErrorDocument](https://httpd.apache.org
               'document'   => '/service-unavail',
             },
           ],
+        },
+      ],
+    }
+~~~
+
+###### `ext_filter_options`
+
+Sets the [ExtFilterOptions](http://httpd.apache.org/docs/current/mod/mod_ext_filter.html) directive.
+Note that you must delcare `class {'apache::mod::ext_filter': }` before using this directive.
+
+~~~ puppet
+    apache::vhost{ 'filter.example.org':
+      docroot => '/var/www/filter',
+      directories => [
+        { path               => '/var/www/filter',
+          ext_filter_options => 'LogStderr Onfail=abort',
         },
       ],
     }

--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -50,6 +50,7 @@ class apache::default_mods (
         include ::apache::mod::actions
         include ::apache::mod::authn_core
         include ::apache::mod::cache
+        include ::apache::mod::ext_filter
         include ::apache::mod::mime
         include ::apache::mod::mime_magic
         include ::apache::mod::rewrite
@@ -63,7 +64,6 @@ class apache::default_mods (
         ::apache::mod { 'authz_dbm': }
         ::apache::mod { 'authz_owner': }
         ::apache::mod { 'expires': }
-        ::apache::mod { 'ext_filter': }
         ::apache::mod { 'include': }
         ::apache::mod { 'logio': }
         ::apache::mod { 'substitute': }

--- a/manifests/mod/ext_filter.pp
+++ b/manifests/mod/ext_filter.pp
@@ -1,0 +1,24 @@
+class apache::mod::ext_filter(
+  $ext_filter_define = undef
+) {
+
+  if $ext_filter_define {
+    validate_hash($ext_filter_define)
+  }
+
+  ::apache::mod { 'ext_filter': }
+
+  # Template uses
+  # -$ext_filter_define
+
+  if $ext_filter_define {
+    file { 'ext_filter.conf':
+      ensure  => file,
+      path    => "${::apache::mod_dir}/ext_filter.conf",
+      content => template('apache/mod/ext_filter.conf.erb'),
+      require => [ Exec["mkdir ${::apache::mod_dir}"], ],
+      before  => File[$::apache::mod_dir],
+      notify  => Class['Apache::Service'],
+    }
+  }
+}

--- a/spec/classes/mod/ext_filter_spec.rb
+++ b/spec/classes/mod/ext_filter_spec.rb
@@ -1,0 +1,66 @@
+describe 'apache::mod::ext_filter', :type => :class do
+  let :pre_condition do
+    'class { "apache":
+      default_mods => false,
+    }'
+  end
+  context "on a Debian OS" do
+    let :facts do
+      {
+        :osfamily               => 'Debian',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
+        :lsbdistcodename        => 'squeeze',
+        :operatingsystem        => 'Debian',
+        :id                     => 'root',
+        :kernel                 => 'Linux',
+        :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :fqdn                   => 'test.example.com',
+        :is_pe                  => false,
+      }
+    end
+    describe 'with no parameters' do
+      it { is_expected.to contain_apache__mod('ext_filter') }
+      it { is_expected.not_to contain_file('ext_filter.conf') }
+    end
+    describe 'with parameters' do
+      let :params do
+        { :ext_filter_define =>  {'filtA' => 'input=A output=B',
+                                  'filtB' => 'input=C cmd="C"' },
+        }
+      end
+      it { is_expected.to contain_file('ext_filter.conf').with_content(/^ExtFilterDefine\s+filtA\s+input=A output=B$/) }
+      it { is_expected.to contain_file('ext_filter.conf').with_content(/^ExtFilterDefine\s+filtB\s+input=C cmd="C"$/) }
+    end
+
+  end
+  context "on a RedHat OS" do
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
+        :operatingsystem        => 'RedHat',
+        :id                     => 'root',
+        :kernel                 => 'Linux',
+        :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :fqdn                   => 'test.example.com',
+        :is_pe                  => false,
+      }
+    end
+    describe 'with no parameters' do
+      it { is_expected.to contain_apache__mod('ext_filter') }
+      it { is_expected.not_to contain_file('ext_filter.conf') }
+    end
+    describe 'with parameters' do
+      let :params do
+        { :ext_filter_define =>  {'filtA' => 'input=A output=B',
+                                  'filtB' => 'input=C cmd="C"' },
+        }
+      end
+      it { is_expected.to contain_file('ext_filter.conf').with_path('/etc/httpd/conf.d/ext_filter.conf') }
+      it { is_expected.to contain_file('ext_filter.conf').with_content(/^ExtFilterDefine\s+filtA\s+input=A output=B$/) }
+      it { is_expected.to contain_file('ext_filter.conf').with_content(/^ExtFilterDefine\s+filtB\s+input=C cmd="C"$/) }
+    end
+  end
+end

--- a/templates/mod/ext_filter.conf.erb
+++ b/templates/mod/ext_filter.conf.erb
@@ -1,0 +1,6 @@
+# mod_ext_filter definitions
+<%- if @ext_filter_define.length >= 1 -%>
+<%- @ext_filter_define.keys.sort.each do |name| -%>
+ExtFilterDefine <%= name %> <%= @ext_filter_define[name] %>
+<%- end -%>
+<%- end -%>

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -198,6 +198,9 @@
     ExpiresByType <%= rule %>
     <%- end -%>
     <%- end -%>
+    <%- if directory['ext_filter_options'] -%>
+    ExtFilterOptions <%= directory['ext_filter_options'] %>
+    <%- end -%>
     <%- if directory['force_type'] -%>
     ForceType <%= directory['force_type'] %>
     <%- end -%>


### PR DESCRIPTION
Permits the

* ExtFilterDefine to be set multiple times on a server.
* ExtFilterOptions to be set on a directory context.

```puppet
class{'apache':
  default_mods => false,
  directories  => [
    { path               => '/var/www/filter',
      ext_filter_options => 'LogStderr Onfail=abort',
    },
  ],
}
class{'apache::mod::ext_filter':
  ext_filter_define => { 'slowdown'       => 'mode=output cmd=/bin/cat preservescontentlength',
                         'puppetdb-strip' => 'mode=output outtype=application/json cmd="pdb-resource-filter"'
  },
}
```