### PR TITLE
(MODULES-2649) Allow SetOutputFilter to be set on a directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2884,6 +2884,21 @@ Sets a `SetHandler` directive as per the [Apache Core documentation](http://http
     }
 ~~~
 
+###### `set_output_filter`
+
+Sets a `SetOutputFilter` directive as per [Apache Core documentation](http://httpd.apache.org/docs/current/mod/core.html#setoutputfilter). An example:
+
+~~~ puppet
+    apache::vhost{ 'filter.example.net':
+      docroot     => '/path/to/directory',
+      directories => [
+        { path              => '/path/to/directory',
+          set_output_filter => puppetdb-strip-resource-params,
+        },
+      ],
+    }
+~~~
+
 ###### `rewrites`
 
 Creates URL [`rewrites`](#rewrites) rules in vhost directories. Expects an array of hashes, and the hash keys can be any of 'comment', 'rewrite_base', 'rewrite_cond', or 'rewrite_rule'.

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -190,6 +190,9 @@ describe 'apache::vhost', :type => :define do
               'index_options'     => ['FancyIndexing'],
               'index_style_sheet' => '/styles/style.css',
             },
+            { 'path'              => '/var/www/files/output_filtered',
+              'set_output_filter' => 'output_filter',
+            },
           ],
           'error_log'                   => false,
           'error_log_file'              => 'httpd_error_log',
@@ -399,6 +402,8 @@ describe 'apache::vhost', :type => :define do
         :content => /^\s+IndexStyleSheet\s'\/styles\/style\.css'$/ ) }
       it { is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
         :content => /^\s+DirectoryIndex\sdisabled$/ ) }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
+        :content => /^\s+SetOutputFilter\soutput_filter$/ ) }
       it { is_expected.to contain_concat__fragment('rspec.example.com-additional_includes') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-logging') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-serversignature') }

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -239,6 +239,9 @@
     SetEnv <%= setenv %>
       <%- end -%>
     <%- end -%>
+    <%- if directory['set_output_filter'] -%>
+    SetOutputFilter <%= directory['set_output_filter'] %>
+    <%- end -%>
     <%- if @shibboleth_enabled -%>
       <%- if directory['shib_require_session'] and ! directory['shib_require_session'].empty? -%>
     ShibRequireSession <%= directory['shib_require_session'] %>


### PR DESCRIPTION
e.g

```puppet
apache::vhost{'abc.example.org':
  directories => [
    { path              => '/path/to/filtered',
      set_output_filter => 'puppetdb-filter',
    },
  ],
}
```

* https://tickets.puppetlabs.com/browse/MODULES-2649
* http://httpd.apache.org/docs/current/mod/core.html#setoutputfilter