### PR TITLE
Add configure option for the include pattern in vhost_enable dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -1126,7 +1126,7 @@ Changes your virtual host configuration files' location. Default: determined by 
 - **Gentoo**: `/etc/apache2/vhosts.d`
 - **Red Hat**: `/etc/httpd/conf.d`
 
-##### `vhost_enable_pattern`
+##### `vhost_include_pattern`
 
 Defines the pattern for files included from the `vhost_dir`. This defaults to '*', also for BC with previous versions of this module.
 

--- a/README.md
+++ b/README.md
@@ -1126,6 +1126,16 @@ Changes your virtual host configuration files' location. Default: determined by 
 - **Gentoo**: `/etc/apache2/vhosts.d`
 - **Red Hat**: `/etc/httpd/conf.d`
 
+##### `vhost_enable_pattern`
+
+Defines the pattern for files included from the `vhost_dir`. This defaults to '*', also for BC with previous versions of this module.
+
+However, you may want to set this to a value like '[^.#]\*.conf[^~]' to make sure files accidentally created in this directory (from version
+control systems, editor backups or the like) are *not* included in your server configuration.
+
+A value of '*.conf' is what is shipped by some operating systems. Also note that this module will, by default, create config files ending
+in '.conf'.
+
 ##### `user`
 
 Changes the user Apache uses to answer requests. Apache's parent process will continue to be run as root, but child processes will access resources as the user defined by this parameter.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,7 @@ class apache (
   $confd_dir              = $::apache::params::confd_dir,
   $vhost_dir              = $::apache::params::vhost_dir,
   $vhost_enable_dir       = $::apache::params::vhost_enable_dir,
+  $vhost_enable_pattern   = $::apache::params::vhost_enable_pattern,
   $mod_dir                = $::apache::params::mod_dir,
   $mod_enable_dir         = $::apache::params::mod_enable_dir,
   $mpm_module             = $::apache::params::mpm_module,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,7 +46,7 @@ class apache (
   $confd_dir              = $::apache::params::confd_dir,
   $vhost_dir              = $::apache::params::vhost_dir,
   $vhost_enable_dir       = $::apache::params::vhost_enable_dir,
-  $vhost_enable_pattern   = $::apache::params::vhost_enable_pattern,
+  $vhost_include_pattern  = $::apache::params::vhost_include_pattern,
   $mod_dir                = $::apache::params::mod_dir,
   $mod_enable_dir         = $::apache::params::mod_enable_dir,
   $mpm_module             = $::apache::params::mpm_module,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,7 +32,7 @@ class apache::params inherits ::apache::version {
   # should we use systemd module?
   $use_systemd = true
 
-  $vhost_enable_pattern = '*'
+  $vhost_include_pattern = '*'
 
   if $::operatingsystem == 'Ubuntu' and $::lsbdistrelease == '10.04' {
     $verify_command = '/usr/sbin/apache2ctl -t'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -32,6 +32,8 @@ class apache::params inherits ::apache::version {
   # should we use systemd module?
   $use_systemd = true
 
+  $vhost_enable_pattern = '*'
+
   if $::operatingsystem == 'Ubuntu' and $::lsbdistrelease == '10.04' {
     $verify_command = '/usr/sbin/apache2ctl -t'
   } else {

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -85,9 +85,9 @@ Include "<%= @confd_dir %>/*.conf"
 <%- end -%>
 <% if @vhost_load_dir != @confd_dir -%>
 <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
-IncludeOptional "<%= @vhost_load_dir %>/<%= @vhost_enable_pattern %>"
+IncludeOptional "<%= @vhost_load_dir %>/<%= @vhost_include_pattern %>"
 <%- else -%>
-Include "<%= @vhost_load_dir %>/<%= @vhost_enable_pattern %>"
+Include "<%= @vhost_load_dir %>/<%= @vhost_include_pattern %>"
 <%- end -%>
 <% end -%>
 

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -85,9 +85,9 @@ Include "<%= @confd_dir %>/*.conf"
 <%- end -%>
 <% if @vhost_load_dir != @confd_dir -%>
 <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
-IncludeOptional "<%= @vhost_load_dir %>/*"
+IncludeOptional "<%= @vhost_load_dir %>/<%= @vhost_enable_pattern %>"
 <%- else -%>
-Include "<%= @vhost_load_dir %>/*"
+Include "<%= @vhost_load_dir %>/<%= @vhost_enable_pattern %>"
 <%- end -%>
 <% end -%>
 


### PR DESCRIPTION
Since I've switched to using this module, it happened to me quite some times that I (for whatever reason) had to manually edit one of the files in the `vhost_enable_dir` and that after a server restart the changes seemed not to have any effect.

It turned out that my favorite editor created `backup~` files and that those were read by Apache *after* the original file.

If I remember correctly, at least Ubuntu uses an `*.conf` include pattern for this directory by default to prevent such mishaps. 

Of course, we cannot simply change this due to BC, but at least we should give users the option to configure this.