### PR TITLE
RC4 is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1513,7 +1513,7 @@ Installs [Apache SSL features][`mod_ssl`] and uses the `ssl.conf.erb` template t
 
 **Parameters within `apache::mod::ssl`**:
 
-- `ssl_cipher`: Default: 'HIGH:MEDIUM:!aNULL:!MD5'.
+- `ssl_cipher`: Default: 'HIGH:MEDIUM:!aNULL:!MD5:!RC4'.
 - `ssl_compression`: Default: 'false'.
 - `ssl_cryptodevice`: Default: 'builtin'.
 - `ssl_honorcipherorder`: Default: 'On'.

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -3,7 +3,7 @@ class apache::mod::ssl (
   $ssl_cryptodevice        = 'builtin',
   $ssl_options             = [ 'StdEnvVars' ],
   $ssl_openssl_conf_cmd    = undef,
-  $ssl_cipher              = 'HIGH:MEDIUM:!aNULL:!MD5',
+  $ssl_cipher              = 'HIGH:MEDIUM:!aNULL:!MD5:!RC4',
   $ssl_honorcipherorder    = 'On',
   $ssl_protocol            = [ 'all', '-SSLv2', '-SSLv3' ],
   $ssl_pass_phrase_dialog  = 'builtin',


### PR DESCRIPTION
ref https://community.qualys.com/blogs/securitylabs/2013/09/17/updated-ssltls-deployment-best-practices-deprecate-rc4 - usage will downgrade the SSL rating from A to B on their rating service at https://www.ssllabs.com/ssltest/