### PR TITLE
Install all modules before adding custom configs

### DIFF
--- a/manifests/custom_config.pp
+++ b/manifests/custom_config.pp
@@ -49,12 +49,13 @@ define apache::custom_config (
   }
 
   if $ensure == 'present' and $verify_config {
-    exec { "service notify for ${name}":
+    exec { "syntax verification for ${name}":
       command     => $verify_command,
       subscribe   => File["apache_${name}"],
       refreshonly => true,
       notify      => Class['Apache::Service'],
       before      => Exec["remove ${name} if invalid"],
+      require     => Anchor['::apache::modules_set_up']
     }
 
     exec { "remove ${name} if invalid":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -381,4 +381,8 @@ class apache (
       manage_docroot  => $default_ssl_vhost,
     }
   }
+
+  # This anchor can be used as a reference point for things that need to happen *after*
+  # all modules have been put in place.
+  anchor { '::apache::modules_set_up': }
 }

--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -162,4 +162,6 @@ define apache::mod (
       }
     }
   }
+
+  Apache::Mod[$name] -> Anchor['::apache::modules_set_up']
 }

--- a/spec/defines/custom_config_spec.rb
+++ b/spec/defines/custom_config_spec.rb
@@ -26,7 +26,7 @@ describe 'apache::custom_config', :type => :define do
         'content' => '# Test',
       }
     end
-    it { is_expected.to contain_exec("service notify for rspec").with({
+    it { is_expected.to contain_exec("syntax verification for rspec").with({
       'refreshonly' => 'true',
       'subscribe'   => 'File[apache_rspec]',
       'command'     => '/usr/sbin/apachectl -t',
@@ -56,7 +56,7 @@ describe 'apache::custom_config', :type => :define do
         'verify_command' => '/bin/true',
       }
     end
-    it { is_expected.to contain_exec("service notify for rspec").with({
+    it { is_expected.to contain_exec("syntax verification for rspec").with({
       'command'     => '/bin/true',
     })
     }
@@ -80,7 +80,7 @@ describe 'apache::custom_config', :type => :define do
         'verify_config' => false,
       }
     end
-    it { is_expected.to_not contain_exec('service notify for rspec') }
+    it { is_expected.to_not contain_exec('syntax verification for rspec') }
     it { is_expected.to_not contain_exec('remove rspec if invalid') }
     it { is_expected.to contain_file('apache_rspec').with({
       'notify' => 'Class[Apache::Service]'
@@ -93,7 +93,7 @@ describe 'apache::custom_config', :type => :define do
         'ensure' => 'absent'
       }
     end
-    it { is_expected.to_not contain_exec('service notify for rspec') }
+    it { is_expected.to_not contain_exec('syntax verification for rspec') }
     it { is_expected.to_not contain_exec('remove rspec if invalid') }
     it { is_expected.to contain_file('apache_rspec').with({
       'ensure' => 'absent',


### PR DESCRIPTION
When setting up a new machine from scratch and adding some `::apache::custom_config`s, I see these:

```
Info: /Stage[main]/Profiles::Apache/Apache::Custom_config[my-permissions-generic]/File[apache_my-permissions-generic]: Scheduling refresh of Exec[service notify for my-permissions-generic]
Info: /Stage[main]/Profiles::Apache/Apache::Custom_config[my-permissions-generic]/File[apache_my-permissions-generic]: Scheduling refresh of Exec[remove my-permissions-generic if invalid]
Notice: /Stage[main]/Profiles::Apache/Apache::Custom_config[my-permissions-generic]/Exec[service notify for my-permissions-generic]/returns: AH00526: Syntax error on line 22 of /etc/apache2/sites-enabled/000-some.site
Notice: /Stage[main]/Profiles::Apache/Apache::Custom_config[my-permissions-generic]/Exec[service notify for my-permissions-generic]/returns: Invalid command 'RewriteEngine', perhaps misspelled or defined by a module not included in the server configuration
Notice: /Stage[main]/Profiles::Apache/Apache::Custom_config[my-permissions-generic]/Exec[service notify for my-permissions-generic]/returns: Action '-t' failed.
Notice: /Stage[main]/Profiles::Apache/Apache::Custom_config[my-permissions-generic]/Exec[service notify for my-permissions-generic]/returns: The Apache error log may have more information.
```

What happens is that I have already put some custom virtual host in place that requires some module (e.g. mod_rewrite). Then, a `custom_config` is applied and triggers the config test. That test fails because the module (required by the virtual host) is not yet in place.

