### PR TITLE
(MODULES-2120) Allow empty docroot

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@
 [`logroot`]: #logroot
 [Log security]: http://httpd.apache.org/docs/current/logs.html#security
 
+[`manage_docroot`]: #manage_docroot
 [`manage_user`]: #manage_user
 [`manage_group`]: #manage_group
 [`MaxConnectionsPerChild`]: https://httpd.apache.org/docs/current/mod/mpm_common.html#maxconnectionsperchild
@@ -1885,6 +1886,8 @@ Sets the list of resources to look for when a client requests an index of the di
 ##### `docroot`
 
 **Required**. Sets the [`DocumentRoot`][] location, from which Apache serves files.
+
+If `docroot` and [`manage_docroot`][] are both set to `false`, no [`DocumentRoot`][] will be set and the accompanying `<Directory /path/to/directory>` block will not be created.
 
 ##### `docroot_group`
 

--- a/templates/vhost/_docroot.erb
+++ b/templates/vhost/_docroot.erb
@@ -2,6 +2,6 @@
   ## Vhost docroot
 <% if @virtual_docroot -%>
   VirtualDocumentRoot "<%= @virtual_docroot %>"
-<% else -%>
+<% elsif @docroot -%>
   DocumentRoot "<%= @docroot %>"
 <% end -%>


### PR DESCRIPTION
This is a single commit version of a similar pull request.
Ignoring the document root requires setting both docroot and manage_docroot to false.