### PR TITLE
RewriteLock support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1065,6 +1065,12 @@ If the [`vhost_dir`][] parameter's value differs from the [`confd_dir`][] parame
 
 Setting `purge_vhost_dir` to 'false' is a stopgap measure to allow the apache Puppet module to coexist with existing or otherwise unmanaged configurations within `vhost_dir`.
 
+##### `rewrite_lock`
+
+Allows setting a custom location for a rewrite lock - considered best practice if using a RewriteMap of type prg in the [`rewrites`][] parameter of your vhost. Default: 'undef'.
+
+This parameter only applies to Apache version 2.2 or lower and is ignored on newer versions.
+
 ##### `sendfile`
 
 Forces Apache to use the Linux kernel's `sendfile` support to serve static files, via the [`EnableSendfile`][] directive. Valid options: 'On', 'Off'. Default: 'On'.
@@ -2023,7 +2029,7 @@ Usage typically looks like:
       krb_method_negotiate   => 'on',
       krb_auth_realms        => ['EXAMPLE.ORG'],
       krb_local_user_mapping => 'on',
-      directories            => { 
+      directories            => {
         path         => '/var/www/html',
         auth_name    => 'Kerberos Login',
         auth_type    => 'Kerberos',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,7 +55,7 @@ class apache (
   $conf_template          = $::apache::params::conf_template,
   $servername             = $::apache::params::servername,
   $pidfile                = $::apache::params::pidfile,
-  $rewrite_lock           = false,
+  $rewrite_lock           = undef,
   $manage_user            = true,
   $manage_group           = true,
   $user                   = $::apache::params::user,
@@ -297,6 +297,10 @@ class apache (
       default   => false
     }
 
+    if $rewrite_lock {
+      validate_absolute_path($rewrite_lock)
+    }
+
     # Template uses:
     # - $pidfile
     # - $user
@@ -318,6 +322,7 @@ class apache (
     # - $server_tokens
     # - $server_signature
     # - $trace_enable
+    # - $rewrite_lock
     file { "${::apache::conf_dir}/${::apache::params::conf_file}":
       ensure  => file,
       content => template($conf_template),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,6 +55,7 @@ class apache (
   $conf_template          = $::apache::params::conf_template,
   $servername             = $::apache::params::servername,
   $pidfile                = $::apache::params::pidfile,
+  $rewrite_lock           = false,
   $manage_user            = true,
   $manage_group           = true,
   $user                   = $::apache::params::user,

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -156,23 +156,23 @@ describe 'apache', :type => :class do
             :apache_version => '2.2',
           }
         end
-    
+
        context "when default_type => 'none'" do
           let :params do
             { :default_type => 'none' }
           end
-    
+
           it { is_expected.to contain_file("/etc/apache2/apache2.conf").with_content %r{^DefaultType none$} }
         end
         context "when default_type => 'text/plain'" do
           let :params do
             { :default_type => 'text/plain' }
           end
-    
+
           it { is_expected.to contain_file("/etc/apache2/apache2.conf").with_content %r{^DefaultType text/plain$} }
         end
       end
-   
+
       context "with Apache version >= 2.4" do
         let :params do
           {
@@ -386,6 +386,37 @@ describe 'apache', :type => :class do
         end
 
         it { is_expected.to contain_file("/etc/httpd/conf/httpd.conf").with_content %r{^IncludeOptional "/etc/httpd/conf\.d/\*\.conf"$} }
+      end
+
+      context "with Apache version < 2.4" do
+        let :params do
+          {
+            :apache_version => '2.2',
+            :rewrite_lock => '/var/lock/subsys/rewrite-lock'
+          }
+        end
+
+        it { is_expected.to contain_file("/etc/httpd/conf/httpd.conf").with_content %r{^RewriteLock /var/lock/subsys/rewrite-lock$} }
+      end
+
+      context "with Apache version < 2.4" do
+        let :params do
+          {
+            :apache_version => '2.2'
+          }
+        end
+
+        it { is_expected.to contain_file("/etc/httpd/conf/httpd.conf").without_content %r{^RewriteLock [.]*$} }
+      end
+
+      context "with Apache version >= 2.4" do
+        let :params do
+          {
+            :apache_version => '2.4',
+            :rewrite_lock => '/var/lock/subsys/rewrite-lock'
+          }
+        end
+        it { is_expected.to contain_file("/etc/httpd/conf/httpd.conf").without_content %r{^RewriteLock [.]*$} }
       end
 
       context "when specifying slash encoding behaviour" do

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -11,6 +11,10 @@ KeepAlive <%= @keepalive %>
 MaxKeepAliveRequests <%= @max_keepalive_requests %>
 KeepAliveTimeout <%= @keepalive_timeout %>
 
+<%- if @rewrite_lock and scope.function_versioncmp([@apache_version, '2.2']) <= 0 -%>
+RewriteLock <%= @rewrite_lock %>
+<%- end -%>
+
 User <%= @user %>
 Group <%= @group %>
 


### PR DESCRIPTION
as addition to the [RewriteMap](https://github.com/puppetlabs/puppetlabs-apache/pull/900) feature i've added the option to define a [RewriteLock](http://httpd.apache.org/docs/2.2/mod/mod_rewrite.html#RewriteLock) for apache version <= 2.2 which is considered best practice when using a RewriteMap of type [prg](https://httpd.apache.org/docs/2.2/rewrite/rewritemap.html#prg)