### PR TITLE
#2544 Allow multiple IP addresses per vhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,16 @@ apache::vhost { 'ip.example.com':
 }
 ~~~
 
+It is also possible to configure more than one IP address per vhost by using an array of IP addresses for the [`ip`][] parameter:
+
+~~~ puppet
+apache::vhost { 'ip.example.com':
+  ip      => ['127.0.0.1','169.254.1.1'],
+  port    => '80',
+  docroot => '/var/www/ip',
+}
+~~~
+
 To configure a virtual host with [aliased servers][], refer to the aliases using the [`serveraliases`][] parameter:
 
 ~~~ puppet

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -339,8 +339,8 @@ define apache::vhost(
 
   if $ip {
     if $port {
-      $listen_addr_port = "${ip}:${port}"
-      $nvh_addr_port = "${ip}:${port}"
+      $listen_addr_port = suffix(any2array($ip),":${port}")
+      $nvh_addr_port = suffix(any2array($ip),":${port}")
     } else {
       $listen_addr_port = undef
       $nvh_addr_port = $ip
@@ -364,13 +364,13 @@ define apache::vhost(
     if $ip and defined(Apache::Listen["${port}"]) {
       fail("Apache::Vhost[${name}]: Mixing IP and non-IP Listen directives is not possible; check the add_listen parameter of the apache::vhost define to disable this")
     }
-    if ! defined(Apache::Listen["${listen_addr_port}"]) and $listen_addr_port and $ensure == 'present' {
-      ::apache::listen { "${listen_addr_port}": }
+    if $listen_addr_port and $ensure == 'present' {
+      ensure_resource('apache::listen', $listen_addr_port)
     }
   }
   if ! $ip_based {
-    if ! defined(Apache::Namevirtualhost[$nvh_addr_port]) and $ensure == 'present' and (versioncmp($apache_version, '2.4') < 0) {
-      ::apache::namevirtualhost { $nvh_addr_port: }
+    if $ensure == 'present' and (versioncmp($apache_version, '2.4') < 0) {
+      ensure_resource('apache::namevirtualhost', $nvh_addr_port)
     }
   }
 

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -190,6 +190,59 @@ describe 'apache::vhost define', :unless => UNSUPPORTED_PLATFORMS.include?(fact(
     end
   end
 
+  context 'new vhost with multiple IP addresses on port 80' do
+    it 'should configure one apache vhost with 2 ip addresses' do
+      pp = <<-EOS
+        class { 'apache':
+          default_vhost => false,
+        }
+        apache::vhost { 'example.com':
+          port     => '80',
+          ip       => ['127.0.0.1','::1'],
+          ip_based => true,
+          docroot  => '/var/www/html',
+        }
+        host { 'ipv4.example.com': ip => '127.0.0.1', }
+        host { 'ipv6.example.com': ip => '::1', }
+        file { '/var/www/html/index.html':
+          ensure  => file,
+          content => "Hello from vhost\\n",
+        }
+      EOS
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    describe service($service_name) do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
+    end
+
+    describe file("#{$vhost_dir}/25-example.com.conf") do
+      it { is_expected.to contain '<VirtualHost 127.0.0.1:80 ::1:80>' }
+      it { is_expected.to contain "ServerName example.com" }
+    end
+
+    describe file($ports_file) do
+      it { is_expected.to be_file }
+      it { is_expected.to contain 'Listen 127.0.0.1:80' }
+      it { is_expected.to contain 'Listen ::1:80' }
+      it { is_expected.not_to contain 'NameVirtualHost 127.0.0.1:80' }
+      it { is_expected.not_to contain 'NameVirtualHost ::1:80' }
+    end
+
+    it 'should answer to ipv4.example.com' do
+      shell("/usr/bin/curl ipv4.example.com:80", {:acceptable_exit_codes => 0}) do |r|
+        expect(r.stdout).to eq("Hello from vhost\n")
+      end
+    end
+
+    it 'should answer to ipv6.example.com' do
+      shell("/usr/bin/curl ipv6.example.com:80", {:acceptable_exit_codes => 0}) do |r|
+        expect(r.stdout).to eq("Hello from vhost\n")
+      end
+    end
+  end
+
   context 'apache_directories' do
     describe 'readme example, adapted' do
       it 'should configure a vhost with Files' do

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -459,6 +459,40 @@ describe 'apache::vhost', :type => :define do
       it { is_expected.to contain_concat__fragment('rspec.example.com-limits').with(
         :content => /^\s+LimitRequestFieldSize\s54321$/)}
     end
+    context 'vhost with multiple ip addresses' do
+      let :params do
+        {
+          'port'                        => '80',
+          'ip'                          => ['127.0.0.1','::1'],
+          'ip_based'                    => true,
+          'servername'                  => 'example.com',
+          'docroot'                     => '/var/www/html',
+          'add_listen'                  => true,
+          'ensure'                      => 'present'
+        }
+      end
+      let :facts do
+        {
+          :osfamily               => 'RedHat',
+          :operatingsystemrelease => '7',
+          :concat_basedir         => '/dne',
+          :operatingsystem        => 'RedHat',
+          :id                     => 'root',
+          :kernel                 => 'Linux',
+          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :kernelversion          => '3.6.2',
+          :is_pe                  => false,
+        }
+      end
+
+      it { is_expected.to compile }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-apache-header').with(
+        :content => /[.\/m]*<VirtualHost 127.0.0.1:80 ::1:80>[.\/m]*$/ ) }
+      it { is_expected.to contain_concat__fragment('Listen 127.0.0.1:80') }
+      it { is_expected.to contain_concat__fragment('Listen ::1:80') }
+      it { is_expected.to_not contain_concat__fragment('NameVirtualHost 127.0.0.1:80') }
+      it { is_expected.to_not contain_concat__fragment('NameVirtualHost ::1:80') }
+    end
     context 'set only aliases' do
       let :params do
         {

--- a/templates/vhost/_file_header.erb
+++ b/templates/vhost/_file_header.erb
@@ -3,7 +3,7 @@
 # Managed by Puppet
 # ************************************
 
-<VirtualHost <%= @nvh_addr_port %>>
+<VirtualHost <%= [@nvh_addr_port].flatten.compact.join(' ') %>>
   ServerName <%= @servername %>
 <% if @serveradmin -%>
   ServerAdmin <%= @serveradmin %>


### PR DESCRIPTION
To make a vhost reachable over 2 IP addresses we need to configure 2
similar vhosts which differ in the IP address. This change allows to use an array
of IPs.

Ticket: https://tickets.puppetlabs.com/browse/MODULES-2544

Since Release 0.9.0 we have a dependency on stdlib >= 2.4.x [CHANGELOG](https://github.com/puppetlabs/puppetlabs-apache/blob/master/CHANGELOG.md#backwards-incompatible-changes-1)
With the changes in this pull requests we need stdlib >= 4.0.0 since `suffix()`  is not available in Release 2.4.x [stdlib CHANGELOG](https://github.com/puppetlabs/puppetlabs-stdlib/blob/master/CHANGELOG.md#2013-03-26---richard-soderberg-rsoderbergmozillacom---400),  [Code](https://github.com/puppetlabs/puppetlabs-apache/pull/1229/files#diff-c918e8884948c0fae251b33071374150R343)