### PR TITLE
(MODULES-2651) Default document root update for Ubuntu 14.04 and Debian 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -907,7 +907,7 @@ class { 'apache':
 
 Sets the default [`DocumentRoot`][] location. Default: Determined by your operating system.
 
-- **Debian**: `/var/www`
+- **Debian**: `/var/www/html`
 - **FreeBSD**: `/usr/local/www/apache22/data`
 - **Gentoo**: `/var/www/localhost/htdocs`
 - **Red Hat**: `/var/www/html`

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -223,7 +223,11 @@ class apache::params inherits ::apache::version {
     $fastcgi_lib_path       = '/var/lib/apache2/fastcgi'
     $mime_support_package = 'mime-support'
     $mime_types_config    = '/etc/mime.types'
-    $docroot              = '/var/www'
+    if ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '13.10') >= 0) or ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '8') >= 0) {
+      $docroot              = '/var/www/html'
+    } else {
+      $docroot              = '/var/www'
+    }
     $cas_cookie_path      = '/var/cache/apache2/mod_auth_cas/'
     $mellon_lock_file     = undef
     $mellon_cache_size    = undef

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -235,6 +235,18 @@ describe 'apache', :type => :class do
       end
     end
 
+    context "8" do
+      let :facts do
+        super().merge({
+          :lsbdistcodename        => 'jessie',
+          :operatingsystemrelease => '8'
+        })
+      end
+      it { is_expected.to contain_file("/var/www/html").with(
+        'ensure'  => 'directory'
+         )
+        }
+      end
     context "on Ubuntu" do
       let :facts do
         super().merge({
@@ -242,6 +254,18 @@ describe 'apache', :type => :class do
         })
       end
 
+      context "14.04" do
+        let :facts do
+          super().merge({
+            :lsbdistrelease         => '14.04',
+            :operatingsystemrelease => '14.04'
+          })
+        end
+        it { is_expected.to contain_file("/var/www/html").with(
+          'ensure'  => 'directory'
+          )
+        }
+      end
       context "13.10" do
         let :facts do
           super().merge({


### PR DESCRIPTION
For security reasons Debian changes default docroot to /var/www/html. See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=730372