### PR TITLE
(MODULES-2756) Adding include ::apache so mkdir exec works properly

### DIFF
--- a/manifests/mod/deflate.pp
+++ b/manifests/mod/deflate.pp
@@ -12,6 +12,7 @@ class apache::mod::deflate (
     'Ratio'  => 'ratio'
   }
 ) {
+  include ::apache
   ::apache::mod { 'deflate': }
 
   file { 'deflate.conf':


### PR DESCRIPTION
This fixes a compile error where the require on Exec["mkdir ${::apache::mod_dir}"] was failing because it couldn't resolve ${::apache::mod_dir}.