### PR TITLE
(MODULES-2757) Adding if around ServerName in template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1093,6 +1093,8 @@ Sets the Apache server administrator's contact information via Apache's [`Server
 
 Sets the Apache server name via Apache's [`ServerName`][] directive. Default: the 'fqdn' fact reported by [Facter][].
 
+Setting to false will not set ServerName at all.
+
 ##### `server_root`
 
 Sets the Apache server's root directory via Apache's [`ServerRoot`][] directive. Default: determined by your operating system.

--- a/templates/vhost/_file_header.erb
+++ b/templates/vhost/_file_header.erb
@@ -4,7 +4,9 @@
 # ************************************
 
 <VirtualHost <%= [@nvh_addr_port].flatten.compact.join(' ') %>>
+<% if @servername -%>
   ServerName <%= @servername %>
+<% end -%>
 <% if @serveradmin -%>
   ServerAdmin <%= @serveradmin %>
 <% end -%>


### PR DESCRIPTION
Changing template to wrap ServerName in an if statement so you can set $::apache::vhost::servername to false and skip adding ServerName to the config.