### PR TITLE
(MODULES-2764) Enclose IPv6 addresses in square brackets

### DIFF
--- a/lib/puppet/parser/functions/enclose_ipv6.rb
+++ b/lib/puppet/parser/functions/enclose_ipv6.rb
@@ -10,6 +10,11 @@ Takes an array of ip addresses and encloses the ipv6 addresses with square brack
 
     require 'ipaddr'
 
+    rescuable_exceptions = [ ArgumentError ]
+    if defined?(IPAddr::InvalidAddressError)
+	    rescuable_exceptions << IPAddr::InvalidAddressError
+    end
+
     if (arguments.size != 1) then
       raise(Puppet::ParseError, "enclose_ipv6(): Wrong number of arguments "+
         "given #{arguments.size} for 1")
@@ -25,7 +30,7 @@ Takes an array of ip addresses and encloses the ipv6 addresses with square brack
     input.each do |val|
       begin
         ip = IPAddr.new(val)
-      rescue ArgumentError
+      rescue *rescuable_exceptions
         raise(Puppet::ParseError, "enclose_ipv6(): Wrong argument "+
           "given #{val} is not an ip address.")
       end

--- a/lib/puppet/parser/functions/enclose_ipv6.rb
+++ b/lib/puppet/parser/functions/enclose_ipv6.rb
@@ -1,0 +1,38 @@
+#
+# enclose_ipv6.rb
+#
+
+module Puppet::Parser::Functions
+  newfunction(:enclose_ipv6, :type => :rvalue, :doc => <<-EOS
+Takes an array of ip addresses and encloses the ipv6 addresses with square brackets.
+    EOS
+  ) do |arguments|
+
+    require 'ipaddr'
+
+    if (arguments.size != 1) then
+      raise(Puppet::ParseError, "enclose_ipv6(): Wrong number of arguments "+
+        "given #{arguments.size} for 1")
+    end
+    unless arguments[0].is_a?(String) or arguments[0].is_a?(Array) then
+      raise(Puppet::ParseError, "enclose_ipv6(): Wrong argument type "+
+        "given #{arguments[0].class} expected String or Array")
+    end
+
+    input = [arguments[0]].flatten.compact
+    result = []
+
+    input.each do |val|
+      begin
+        ip = IPAddr.new(val)
+      rescue ArgumentError
+        raise(Puppet::ParseError, "enclose_ipv6(): Wrong argument "+
+          "given #{val} is not an ip address.")
+      end
+      val = "[#{ip.to_s}]" if ip.ipv6?
+      result = [result,val]
+    end
+
+    return result.flatten.compact
+  end
+end

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -344,12 +344,13 @@ define apache::vhost(
   }
 
   if $ip {
+    $_ip = enclose_ipv6($ip)
     if $port {
-      $listen_addr_port = suffix(any2array($ip),":${port}")
-      $nvh_addr_port = suffix(any2array($ip),":${port}")
+      $listen_addr_port = suffix(any2array($_ip),":${port}")
+      $nvh_addr_port = suffix(any2array($_ip),":${port}")
     } else {
       $listen_addr_port = undef
-      $nvh_addr_port = $ip
+      $nvh_addr_port = $_ip
       if ! $servername and ! $ip_based {
         fail("Apache::Vhost[${name}]: must pass 'ip' and/or 'port' parameters for name-based vhosts")
       }
@@ -798,7 +799,7 @@ define apache::vhost(
   # - $krb_method_k5passwd
   # - $krb_authoritative
   # - $krb_auth_realms
-  # - $krb_5keytab 
+  # - $krb_5keytab
   # - $krb_local_user_mapping
   if $auth_kerb {
     concat::fragment { "${name}-auth_kerb":

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -218,22 +218,66 @@ describe 'apache::vhost define', :unless => UNSUPPORTED_PLATFORMS.include?(fact(
     end
 
     describe file("#{$vhost_dir}/25-example.com.conf") do
-      it { is_expected.to contain '<VirtualHost 127.0.0.1:80 ::1:80>' }
+      it { is_expected.to contain '<VirtualHost 127.0.0.1:80 [::1]:80>' }
       it { is_expected.to contain "ServerName example.com" }
     end
 
     describe file($ports_file) do
       it { is_expected.to be_file }
       it { is_expected.to contain 'Listen 127.0.0.1:80' }
-      it { is_expected.to contain 'Listen ::1:80' }
+      it { is_expected.to contain 'Listen [::1]:80' }
       it { is_expected.not_to contain 'NameVirtualHost 127.0.0.1:80' }
-      it { is_expected.not_to contain 'NameVirtualHost ::1:80' }
+      it { is_expected.not_to contain 'NameVirtualHost [::1]:80' }
     end
 
     it 'should answer to ipv4.example.com' do
       shell("/usr/bin/curl ipv4.example.com:80", {:acceptable_exit_codes => 0}) do |r|
         expect(r.stdout).to eq("Hello from vhost\n")
       end
+    end
+
+    it 'should answer to ipv6.example.com' do
+      shell("/usr/bin/curl ipv6.example.com:80", {:acceptable_exit_codes => 0}) do |r|
+        expect(r.stdout).to eq("Hello from vhost\n")
+      end
+    end
+  end
+
+  context 'new vhost with IPv6 address on port 80' do
+    it 'should configure one apache vhost with an ipv6 address' do
+      pp = <<-EOS
+        class { 'apache':
+          default_vhost  => false,
+        }
+        apache::vhost { 'example.com':
+          port           => '80',
+          ip             => '::1',
+          ip_based       => true,
+          docroot        => '/var/www/html',
+        }
+        host { 'ipv6.example.com': ip => '::1', }
+        file { '/var/www/html/index.html':
+          ensure  => file,
+          content => "Hello from vhost\\n",
+        }
+      EOS
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    describe service($service_name) do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
+    end
+
+    describe file("#{$vhost_dir}/25-example.com.conf") do
+      it { is_expected.to contain '<VirtualHost [::1]:80>' }
+      it { is_expected.to contain "ServerName example.com" }
+    end
+
+    describe file($ports_file) do
+      it { is_expected.to be_file }
+      it { is_expected.to contain 'Listen [::1]:80' }
+      it { is_expected.not_to contain 'NameVirtualHost [::1]:80' }
     end
 
     it 'should answer to ipv6.example.com' do

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -487,12 +487,46 @@ describe 'apache::vhost', :type => :define do
 
       it { is_expected.to compile }
       it { is_expected.to contain_concat__fragment('rspec.example.com-apache-header').with(
-        :content => /[.\/m]*<VirtualHost 127.0.0.1:80 ::1:80>[.\/m]*$/ ) }
+        :content => /[.\/m]*<VirtualHost 127.0.0.1:80 \[::1\]:80>[.\/m]*$/ ) }
       it { is_expected.to contain_concat__fragment('Listen 127.0.0.1:80') }
-      it { is_expected.to contain_concat__fragment('Listen ::1:80') }
+      it { is_expected.to contain_concat__fragment('Listen [::1]:80') }
       it { is_expected.to_not contain_concat__fragment('NameVirtualHost 127.0.0.1:80') }
-      it { is_expected.to_not contain_concat__fragment('NameVirtualHost ::1:80') }
+      it { is_expected.to_not contain_concat__fragment('NameVirtualHost [::1]:80') }
     end
+
+    context 'vhost with ipv6 address' do
+      let :params do
+        {
+          'port'                        => '80',
+          'ip'                          => '::1',
+          'ip_based'                    => true,
+          'servername'                  => 'example.com',
+          'docroot'                     => '/var/www/html',
+          'add_listen'                  => true,
+          'ensure'                      => 'present'
+        }
+      end
+      let :facts do
+        {
+          :osfamily               => 'RedHat',
+          :operatingsystemrelease => '7',
+          :concat_basedir         => '/dne',
+          :operatingsystem        => 'RedHat',
+          :id                     => 'root',
+          :kernel                 => 'Linux',
+          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :kernelversion          => '3.6.2',
+          :is_pe                  => false,
+        }
+      end
+
+      it { is_expected.to compile }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-apache-header').with(
+        :content => /[.\/m]*<VirtualHost \[::1\]:80>[.\/m]*$/ ) }
+      it { is_expected.to contain_concat__fragment('Listen [::1]:80') }
+      it { is_expected.to_not contain_concat__fragment('NameVirtualHost [::1]:80') }
+    end
+
     context 'set only aliases' do
       let :params do
         {

--- a/spec/unit/puppet/parser/functions/enclose_ipv6_spec.rb
+++ b/spec/unit/puppet/parser/functions/enclose_ipv6_spec.rb
@@ -1,0 +1,65 @@
+#! /usr/bin/env ruby -S rspec
+require 'spec_helper'
+
+describe "the enclose_ipv6 function" do
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+  it "should exist" do
+    expect(Puppet::Parser::Functions.function("enclose_ipv6")).to eq("function_enclose_ipv6")
+  end
+
+  it "should raise a ParseError if there is less than 1 arguments" do
+    expect { scope.function_enclose_ipv6([]) }.to( raise_error(Puppet::ParseError) )
+  end
+
+  it "should raise a ParseError if there is more than 1 arguments" do
+    expect { scope.function_enclose_ipv6(['argument1','argument2']) }.to( raise_error(Puppet::ParseError) )
+  end
+
+  it "should raise a ParseError when given garbage" do
+    expect { scope.function_enclose_ipv6(['garbage']) }.to( raise_error(Puppet::ParseError) )
+  end
+
+  it "should raise a ParseError when given something else than a string or an array" do
+    expect { scope.function_enclose_ipv6([['1' => '127.0.0.1']]) }.to( raise_error(Puppet::ParseError) )
+  end
+
+  it "should not raise a ParseError when given a single ip string" do
+    expect { scope.function_enclose_ipv6(['127.0.0.1']) }.to_not raise_error
+  end
+
+  it "should not raise a ParseError when given an array of ip strings" do
+    expect { scope.function_enclose_ipv6([['127.0.0.1','fe80::1']]) }.to_not raise_error
+  end
+
+  it "should not raise a ParseError when given differently notations of ip addresses" do
+    expect { scope.function_enclose_ipv6([['127.0.0.1','fe80::1','[fe80::1]']]) }.to_not raise_error
+  end
+
+  it "should raise a ParseError when given a wrong ipv4 address" do
+    expect { scope.function_enclose_ipv6(['127..0.0.1']) }.to( raise_error(Puppet::ParseError) )
+  end
+
+  it "should raise a ParseError when given a ipv4 address with square brackets" do
+    expect { scope.function_enclose_ipv6(['[127.0.0.1]']) }.to( raise_error(Puppet::ParseError) )
+  end
+
+  it "should raise a ParseError when given a wrong ipv6 address" do
+    expect { scope.function_enclose_ipv6(['fe80:::1']) }.to( raise_error(Puppet::ParseError) )
+  end
+
+  it "should embrace ipv6 adresses within an array of ip addresses" do
+    result = scope.function_enclose_ipv6([['127.0.0.1','fe80::1','[fe80::1]']])
+    expect(result).to(eq(['127.0.0.1','[fe80::1]','[fe80::1]']))
+  end
+
+  it "should embrace a single ipv6 adresse" do
+    result = scope.function_enclose_ipv6(['fe80::1'])
+    expect(result).to(eq(['[fe80::1]']))
+  end
+
+  it "should not embrace a single ipv4 adresse" do
+    result = scope.function_enclose_ipv6(['127.0.0.1'])
+    expect(result).to(eq(['127.0.0.1']))
+  end
+end


### PR DESCRIPTION
The apache module does enclose IPv6 addresses in square brackets as
apache recommends

Apache 2.2:
https://httpd.apache.org/docs/2.2/en/bind.html
https://httpd.apache.org/docs/2.2/en/mod/core.html#virtualhost
https://httpd.apache.org/docs/2.2/en/mod/core.html#namevirtualhost
Apache 2.4:
https://httpd.apache.org/docs/2.4/en/bind.html
https://httpd.apache.org/docs/2.4/en/mod/core.html#virtualhost

Ticket: https://tickets.puppetlabs.com/browse/MODULES-2764