### PR TITLE
Fix typo about dynamic AddHandler/AddType

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,7 +35,7 @@ class apache::params inherits ::apache::version {
       'type-map' => 'var'
       },
     'AddType'    => {
-      'type-map' => '.shtml'
+      'text/html' => '.shtml'
       },
     'AddOutputFilter' => {
       'INCLUDES'      => '.shtml'

--- a/spec/acceptance/mod_mime_spec.rb
+++ b/spec/acceptance/mod_mime_spec.rb
@@ -33,7 +33,7 @@ describe 'apache::mod::mime class', :unless => UNSUPPORTED_PLATFORMS.include?(fa
     describe file("#{mod_dir}/mime.conf") do
       it { is_expected.to contain "AddType application/x-compress .Z" }
       it { is_expected.to contain "AddHandler type-map var\n" }
-      it { is_expected.to contain "AddType type-map .shtml\n" }
+      it { is_expected.to contain "AddType text/html .shtml\n" }
       it { is_expected.to contain "AddOutputFilter INCLUDES .shtml\n" }
     end
   end


### PR DESCRIPTION
Hello, 

The last commit had introduced a new feature about adding dynamic AddHandler/AddType.
There is a little typo error. The "right" syntax should be :

AddType text/html .shtml

Regards

Olivier