### PR TITLE
Add missing parameters in mod_auth_kerb

### DIFF
--- a/README.md
+++ b/README.md
@@ -2074,6 +2074,18 @@ Location of the Kerberos V5 keytab file. Not set by default.
 
 Strips @REALM from username for further use. Not set by default.
 
+##### `krb_verify_kdc`
+
+This option can be used to disable the verification tickets against local keytab to prevent KDC spoofing attacks. Default is 'on'
+
+##### `krb_servicename`
+
+Specifies the service name that will be used by Apache for authentication. Corresponding key of this name must be stored in the keytab. Default is 'HTTP'
+
+##### `krb_save_credentials`
+
+This option enables credential saving functionality. Default is 'off'
+
 ##### `limit_request_field_size`
 
 [Limits](http://httpd.apache.org/docs/2.4/mod/core.html#limitrequestfieldsize) the size of the HTTP request header allowed from the client. Default is 'undef'.

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -131,6 +131,9 @@ define apache::vhost(
   $krb_auth_realms             = [],
   $krb_5keytab                 = undef,
   $krb_local_user_mapping      = undef,
+  $krb_verify_kdc              = 'on',
+  $krb_servicename             = 'HTTP',
+  $krb_save_credentials        = 'off',
   $limit_request_field_size    = undef,
 ) {
   # The base class must be included first because it is used by parameter defaults

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -456,6 +456,12 @@ describe 'apache::vhost', :type => :define do
         :content => /^\s+Krb5Keytab\s\/tmp\/keytab5$/)}
       it { is_expected.to contain_concat__fragment('rspec.example.com-auth_kerb').with(
         :content => /^\s+KrbLocalUserMapping\soff$/)}
+      it { is_expected.to contain_concat__fragment('rspec.example.com-auth_kerb').with(
+        :content => /^\s+KrbServiceName\sHTTP$/)}
+      it { is_expected.to contain_concat__fragment('rspec.example.com-auth_kerb').with(
+        :content => /^\s+KrbSaveCredentials\soff$/)}
+      it { is_expected.to contain_concat__fragment('rspec.example.com-auth_kerb').with(
+        :content => /^\s+KrbVerifyKDC\son$/)}
       it { is_expected.to contain_concat__fragment('rspec.example.com-limits').with(
         :content => /^\s+LimitRequestFieldSize\s54321$/)}
     end

--- a/templates/vhost/_auth_kerb.erb
+++ b/templates/vhost/_auth_kerb.erb
@@ -17,7 +17,16 @@
   Krb5Keytab <%= @krb_5keytab %>
   <%- end -%>
   <%- if @krb_local_user_mapping -%>
-  KrbLocalUserMapping <%= @krb_local_user_mapping -%>
+  KrbLocalUserMapping <%= @krb_local_user_mapping %>
+  <%- end -%>
+  <%- if @krb_verify_kdc -%>
+  KrbVerifyKDC <%= @krb_verify_kdc %>
+  <%- end -%>
+  <%- if @krb_servicename -%>
+  KrbServiceName <%= @krb_servicename %>
+  <%- end -%>
+  <%- if @krb_save_credentials -%>
+  KrbSaveCredentials <%= @krb_save_credentials -%>
   <%- end -%>
 
 <% end -%>


### PR DESCRIPTION
Hello, 

According to the http://modauthkerb.sourceforge.net/configure.html webpage,
the 3  following parameters are missing.

- KrbVerifyKDC
- KrbServiceName
- KrbSaveCredentials

Regards

Olivier