### PR TITLE
#FORGE-288 Apache::vhost module should support raw vhost configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 [`content`]: #content
 [custom error documents]: http://httpd.apache.org/docs/current/custom-error.html
 [`custom_fragment`]: #custom_fragment
+[`raw_vhost`]: #raw_vhost
 
 [`default_mods`]: #default_mods
 [`default_ssl_crl`]: #default_ssl_crl
@@ -1902,6 +1903,10 @@ Specifies the list of things to which Apache blocks access. Valid option: 'scm',
 ##### `custom_fragment`
 
 Passes a string of custom configuration directives to place at the end of the virtual host configuration. Default: 'undef'.
+
+##### `custom_fragment`
+
+Passes a string that contains raw content to generate vhost. It will be mutually exclusive with the other options for parameterizing vhost template. Default: 'undef'.
 
 ##### `default_vhost`
 

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -286,7 +286,7 @@ define apache::vhost(
   # if we use raw vhost option, we do not need to depend
   # on concat, because we have the final content already on place
   if $raw_vhost {
-    $before_dependency = []
+    $before_dependency = File["${priority_real}${filename}.conf"]
   }
   else {
     $before_dependency = Concat["${priority_real}${filename}.conf"]

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -462,7 +462,7 @@ define apache::vhost(
 
   # if raw vhost, just define the final content of vhost
   if $raw_vhost {
-    file { "${priority_real}{$filename}.conf":
+    file { "${priority_real}${filename}.conf":
       ensure  => $ensure,
       content => $raw_vhost,
       owner   => 'root',

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -709,7 +709,7 @@ define apache::vhost(
 
     # Template uses:
     # - $rack_base_uris
-     if $rack_base_uris {
+    if $rack_base_uris {
       concat::fragment { "${name}-rack":
         target  => "${priority_real}${filename}.conf",
         order   => 150,


### PR DESCRIPTION
Add a new raw_vhost parameter to apache::vhost . This parameter will be a string, that will allow to configure a vhost externally, passing a string with the final content.
For certain use cases, it will be simpler and will add also the flexibility needed.