### PR TITLE
Add support for changing mod_nss listen port (vol 2)

### DIFF
--- a/manifests/mod/nss.pp
+++ b/manifests/mod/nss.pp
@@ -1,7 +1,8 @@
 class apache::mod::nss (
   $transfer_log = "${::apache::params::logroot}/access.log",
   $error_log    = "${::apache::params::logroot}/error.log",
-  $passwd_file  = undef
+  $passwd_file  = undef,
+  $port     = 8443,
 ) {
   include ::apache::mod::mime
 

--- a/templates/mod/nss.conf.erb
+++ b/templates/mod/nss.conf.erb
@@ -17,7 +17,7 @@
 # Note: Configurations that use IPv6 but not IPv4-mapped addresses need two
 #       Listen directives: "Listen [::]:8443" and "Listen 0.0.0.0:443"
 #
-Listen 8443
+Listen <%= @port %>
 
 ##
 ##  SSL Global Context
@@ -84,7 +84,7 @@ NSSRequireSafeNegotiation off
 ## SSL Virtual Host Context
 ##
 
-<VirtualHost _default_:8443>
+<VirtualHost _default_:<%= @nss_port %>>
 
 #   General setup for the virtual host
 #DocumentRoot "/etc/httpd/htdocs"


### PR DESCRIPTION
I added ability to mod_nss to be able to change listen port from default 8443 to for example 443, which is default https(SSL) port. It is quite useful for us.