### PR TITLE
Leave require directive unmanaged

### DIFF
--- a/README.md
+++ b/README.md
@@ -2951,6 +2951,35 @@ Sets the value for the [PassengerEnabled](http://www.modrails.com/documentation/
 `php_admin_value` sets the value of the directory, and `php_admin_flag` uses a boolean to configure the directory. Further information can be found [here](http://php.net/manual/en/configuration.changes.php).
 
 
+###### `require`
+
+
+Sets a `Require` directive as per the [Apache Authz documentation](http://httpd.apache.org/docs/current/mod/mod_authz_core.html#require). If no `require` is set, it will default to `Require all granted`.
+
+~~~ puppet
+    apache::vhost { 'sample.example.net':
+      docroot     => '/path/to/directory',
+      directories => [
+        { path    => '/path/to/directory',
+          require => 'IP 10.17.42.23',
+        }
+      ],
+    }
+~~~
+
+If `require` is set to `unmanaged` it will not be set at all. This is useful for complex authentication/authorization requirements which are handled in a custom fragment.
+
+~~~ puppet
+    apache::vhost { 'sample.example.net':
+      docroot     => '/path/to/directory',
+      directories => [
+        { path    => '/path/to/directory',
+          require => 'unmanaged',
+        }
+      ],
+    }
+~~~
+
 ###### `satisfy`
 
 Sets a `Satisfy` directive as per the [Apache Core documentation](http://httpd.apache.org/docs/2.2/mod/core.html#satisfy). **Deprecated:** This parameter is being deprecated due to a change in Apache. It only works with Apache 2.2 and lower.

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -978,5 +978,72 @@ describe 'apache::vhost', :type => :define do
       let :facts do default_facts end
       it { expect { is_expected.to compile }.to raise_error }
     end
+    context 'default of require all granted' do
+      let :params do
+        {
+          'docroot'         => '/var/www/foo',
+          'directories'     => [
+            {
+              'path'     => '/var/www/foo/files',
+              'provider' => 'files',
+            },
+          ],
+
+        }
+      end
+      let :facts do
+        {
+          :osfamily               => 'RedHat',
+          :operatingsystemrelease => '7',
+          :concat_basedir         => '/dne',
+          :operatingsystem        => 'RedHat',
+          :id                     => 'root',
+          :kernel                 => 'Linux',
+          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :kernelversion          => '3.19.2',
+          :is_pe                  => false,
+        }
+      end
+
+      it { is_expected.to compile }
+      it { is_expected.to contain_file('25-rspec.example.com.conf') }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-directories') }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
+        :content => /^\s+Require all granted$/ ) }
+    end
+    context 'require unmanaged' do
+      let :params do
+        {
+          'docroot'         => '/var/www/foo',
+          'directories'     => [
+            {
+              'path'     => '/var/www/foo',
+              'require'  => 'unmanaged',
+            },
+          ],
+
+        }
+      end
+      let :facts do
+        {
+          :osfamily               => 'RedHat',
+          :operatingsystemrelease => '7',
+          :concat_basedir         => '/dne',
+          :operatingsystem        => 'RedHat',
+          :id                     => 'root',
+          :kernel                 => 'Linux',
+          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :kernelversion          => '3.19.2',
+          :is_pe                  => false,
+        }
+      end
+
+      it { is_expected.to compile }
+      it { is_expected.to contain_file('25-rspec.example.com.conf') }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-directories') }
+      it { is_expected.to_not contain_concat__fragment('rspec.example.com-directories').with(
+        :content => /^\s+Require all granted$/ )
+      }
+    end
   end
 end

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -57,7 +57,7 @@
       <%- end -%>
     <%- end -%>
     <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
-      <%- if directory['require'] and directory['require'] != '' -%>
+      <%- if directory['require'] && directory['require'] != '' && directory['require'] !~ /unmanaged/i -%>
         <%- Array(directory['require']).each do |req| -%>
     Require <%= req %>
         <%- end -%>
@@ -65,7 +65,7 @@
       <%- if directory['auth_require'] -%>
     Require <%= directory['auth_require'] %>
       <%- end -%>
-      <%- if !(directory['require'] and directory['require'] != '') && !(directory['auth_require']) -%>
+      <%- if !(directory['require'] && directory['require'] != '') && directory['require'] !~ /unmanaged/i && !(directory['auth_require']) -%>
     Require all granted
       <%- end -%>
     <%- else -%>


### PR DESCRIPTION
Instead to default require to 'Require all granted' if no 'require'
parameter is set for a directory, leave require unmanaged in apache 2.4
if needed. This is useful for complex authentication/authorization
requirements which are handled in a custom fragment.