### PR TITLE
(MODULES-2834) Support SSLProxyCheckPeerCN and SSLProxyCheckPeerName …

### DIFF
--- a/README.md
+++ b/README.md
@@ -3164,6 +3164,15 @@ Sets the [SSLProxyMachineCertificateFile](http://httpd.apache.org/docs/current/m
     }
 ~~~
 
+##### `ssl_proxy_check_peer_cn`
+ 
+Sets the [SSLProxyMachinePeerCN](http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxycheckpeercn) directive, which specified whether the remote server certificate's CN field is compared against the hostname of the request URL .  Defaults to 'undef'.
+
+
+##### `ssl_proxy_check_peer_name`
+ 
+Sets the [SSLProxyMachinePeerName](http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxycheckpeername) directive, which specified whether the remote server certificate's CN field is compared against the hostname of the request URL .  Defaults to 'undef'.
+
 ##### `ssl_options`
 
 Sets the [SSLOptions](http://httpd.apache.org/docs/current/mod/mod_ssl.html#ssloptions) directive, which configures various SSL engine run-time options. This is the global setting for the given vhost and can be a string or an array. Defaults to 'undef'.

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -25,6 +25,8 @@ define apache::vhost(
   $ssl_honorcipherorder        = undef,
   $ssl_verify_client           = undef,
   $ssl_verify_depth            = undef,
+  $ssl_proxy_check_peer_cn     = undef,
+  $ssl_proxy_check_peer_name   = undef,
   $ssl_proxy_machine_cert      = undef,
   $ssl_options                 = undef,
   $ssl_openssl_conf_cmd        = undef,
@@ -236,6 +238,14 @@ define apache::vhost(
   if $manage_docroot {
     validate_string($docroot)
   }
+
+  if $ssl_proxy_check_peer_cn {
+    validate_re($ssl_proxy_check_peer_cn,'(^on$|^off$)',"${ssl_proxy_check_peer_cn} is not permitted for ssl_proxy_check_peer_cn. Allowed values are 'on' or 'off'.")
+  }
+  if $ssl_proxy_check_peer_name {
+    validate_re($ssl_proxy_check_peer_name,'(^on$|^off$)',"${ssl_proxy_check_peer_name} is not permitted for ssl_proxy_check_peer_name. Allowed values are 'on' or 'off'.")
+  }
+
   # Input validation ends
 
   if $ssl and $ensure == 'present' {
@@ -784,6 +794,8 @@ define apache::vhost(
   # - $ssl_honorcipherorder
   # - $ssl_verify_client
   # - $ssl_verify_depth
+  # - $ssl_proxy_check_peer_cn
+  # - $ssl_proxy_check_peer_name
   # - $ssl_proxy_machine_cert
   # - $ssl_options
   # - $ssl_openssl_conf_cmd

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -154,7 +154,10 @@ describe 'apache::vhost', :type => :define do
           'ssl_verify_depth'            => '3',
           'ssl_options'                 => '+ExportCertData',
           'ssl_openssl_conf_cmd'        => 'DHParameters "foo.pem"',
+          'ssl_proxy_check_peer_cn'     => 'on',
+          'ssl_proxy_check_peer_name'   => 'on',
           'ssl_proxyengine'             => true,
+
           'priority'                    => '30',
           'default_vhost'               => true,
           'servername'                  => 'example.com',
@@ -432,6 +435,10 @@ describe 'apache::vhost', :type => :define do
       it { is_expected.to contain_concat__fragment('rspec.example.com-ssl') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-ssl').with(
         :content => /^\s+SSLOpenSSLConfCmd\s+DHParameters "foo.pem"$/ ) }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-ssl').with(
+        :content => /^\s+SSLProxyCheckPeerCN\s+on$/ ) }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-ssl').with(
+        :content => /^\s+SSLProxyCheckPeerName\s+on$/ ) }
       it { is_expected.to contain_concat__fragment('rspec.example.com-suphp') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-php_admin') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-header') }

--- a/templates/vhost/_ssl.erb
+++ b/templates/vhost/_ssl.erb
@@ -40,6 +40,12 @@
   <%- if @ssl_verify_depth -%>
   SSLVerifyDepth          <%= @ssl_verify_depth %>
   <%- end -%>
+  <%- if @ssl_proxy_check_peer_cn -%>
+  SSLProxyCheckPeerCN     <%= @ssl_proxy_check_peer_cn %>
+  <%- end -%>
+  <%- if @ssl_proxy_check_peer_name -%>
+  SSLProxyCheckPeerName   <%= @ssl_proxy_check_peer_name %>
+  <%- end -%>
   <%- if @ssl_proxy_machine_cert -%>
   SSLProxyMachineCertificateFile "<%= @ssl_proxy_machine_cert %>"
   <%- end -%>


### PR DESCRIPTION
…settings

Allows SSLProxyCheckPeerCN and SSLProxyCheckPeerName to be set on
an SSL enabled vhost.

```puppet
apache::vhost{'foo':
   ssl_proxy_check_peer_cn   => 'on',
   ssl_proxy_check_peer_name => 'on'
}
```

results in

```
SSLProxyCheckPeerCN  on
SSLProxyCheckPeerName on
```

apache configuration with in a vhost.

* https://tickets.puppetlabs.com/browse/MODULES-2834
* http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxycheckpeercn
* http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxycheckpeername