### PR TITLE
add ability to overide file name generation in custom_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1699,6 +1699,10 @@ Sets the directory in which Puppet places configuration files. Default: '$::apac
 
 Sets the configuration file's content. The `content` and [`source`][] parameters are exclusive of each other.
 
+##### `filename`
+
+Sets the name of the file under `confdir` in which Puppet stores the configuration.  The default behavior is to generate the file name from the `priority` parameter and the resource name.
+
 ##### `priority`
 
 Sets the configuration file's priority by prefixing its filename with this parameter's numeric value, as Apache processes configuration files in alphanumeric order. The default value is `25`.

--- a/spec/acceptance/custom_config_spec.rb
+++ b/spec/acceptance/custom_config_spec.rb
@@ -36,6 +36,24 @@ describe 'apache::custom_config define', :unless => UNSUPPORTED_PLATFORMS.includ
     end
   end
 
+  context 'with a custom filename' do
+    it 'should store content in the described file' do
+      pp = <<-EOS
+        class { 'apache': }
+        apache::custom_config { 'filename_test':
+          filename => 'custom_filename',
+          content  => '# just another comment',
+        }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    describe file("#{$confd_dir}/custom_filename") do
+      it { is_expected.to contain '# just another comment' }
+    end
+  end
+
   describe 'custom_config without priority prefix' do
     it 'applies cleanly' do
       pp = <<-EOS


### PR DESCRIPTION
We discussed this a couple times in modules triage.  I proposed it in in comments in PR #1201, but haven't seen any response from the pull requester.  I'm putting it up so we can review it separately.