### PR TITLE
Add ::apache::vhost::custom

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
 [`apache::params`]: #class-apacheparams
 [`apache::version`]: #class-apacheversion
 [`apache::vhost`]: #define-apachevhost
+[`apache::vhost::custom`]: #define-apachevhostcustom
 [`apache::vhost::WSGIImportScript`]: #wsgiimportscript
 [Apache HTTP Server]: http://httpd.apache.org
 [Apache modules]: http://httpd.apache.org/docs/current/mod/
@@ -740,6 +741,7 @@ apache::balancer { 'puppet01':
     - [Define: apache::mod](#define-apachemod)
     - [Define: apache::namevirtualhost](#define-apachenamevirtualhost)
     - [Define: apache::vhost](#define-apachevhost)
+    - [Define: apache::vhost::custom](#define-apachevhostcustom)
 - [**Private Defines**](#private-defines)
     - [Define: apache::default_mods::load](#define-default_mods-load)
     - [Define: apache::peruser::multiplexer](#define-apacheperusermultiplexer)
@@ -3243,6 +3245,26 @@ A unique alias. This is used internally to link the action with the FastCGI serv
 ##### `file_type`
 
 The MIME-type of the file to be processed by the FastCGI server.
+
+#### Define: `apache::vhost::custom`
+
+The `apache::vhost::custom` is a thin wrapper to the `apache::custom_config``
+define. We are simply overriding some of the default settings specifc to the
+vhost directory in Apache.
+
+**Parameters within `apache::vhost::custom`**:
+
+##### `content`
+
+Sets the configuration file's content.
+
+##### `ensure`
+
+Specifies if the vhost file is present or absent. Defaults to 'present'.
+
+##### `priority`
+
+Sets the relative load-order for Apache HTTPD VirtualHost configuration files. Defaults to '25'.
 
 ### Private Defines
 

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -497,6 +497,8 @@ define apache::vhost(
     require => Package['httpd'],
     notify  => Class['apache::service'],
   }
+  # NOTE(pabelanger): This code is duplicated in ::apache::vhost::custom and
+  # needs to be converted into something generic.
   if $::apache::vhost_enable_dir {
     $vhost_enable_dir = $::apache::vhost_enable_dir
     $vhost_symlink_ensure = $ensure ? {

--- a/spec/defines/vhost_custom_spec.rb
+++ b/spec/defines/vhost_custom_spec.rb
@@ -1,0 +1,99 @@
+require 'spec_helper'
+
+describe 'apache::vhost::custom', :type => :define do
+  let :title do
+    'rspec.example.com'
+  end
+  let :default_params do
+    {
+      :content => 'foobar'
+    }
+  end
+  describe 'os-dependent items' do
+    context "on RedHat based systems" do
+      let :default_facts do
+        {
+          :osfamily               => 'RedHat',
+          :operatingsystemrelease => '6',
+          :operatingsystem        => 'RedHat',
+          :concat_basedir         => '/dne',
+          :id                     => 'root',
+          :kernel                 => 'Linux',
+          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :is_pe                  => false,
+        }
+      end
+      let :params do default_params end
+      let :facts do default_facts end
+    end
+    context "on Debian based systems" do
+      let :default_facts do
+        {
+          :osfamily               => 'Debian',
+          :operatingsystemrelease => '6',
+          :lsbdistcodename        => 'squeeze',
+          :operatingsystem        => 'Debian',
+          :concat_basedir         => '/dne',
+          :id                     => 'root',
+          :kernel                 => 'Linux',
+          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :is_pe                  => false,
+        }
+      end
+      let :params do default_params end
+      let :facts do default_facts end
+      it { is_expected.to contain_file("apache_rspec.example.com").with(
+        :ensure  => 'present',
+        :content => 'foobar',
+        :path    => '/etc/apache2/sites-available/25-rspec.example.com.conf',
+      ) }
+      it { is_expected.to contain_file("25-rspec.example.com.conf symlink").with(
+        :ensure => 'link',
+        :path   => '/etc/apache2/sites-enabled/25-rspec.example.com.conf',
+        :target => '/etc/apache2/sites-available/25-rspec.example.com.conf'
+      ) }
+    end
+    context "on FreeBSD systems" do
+      let :default_facts do
+        {
+          :osfamily               => 'FreeBSD',
+          :operatingsystemrelease => '9',
+          :operatingsystem        => 'FreeBSD',
+          :concat_basedir         => '/dne',
+          :id                     => 'root',
+          :kernel                 => 'FreeBSD',
+          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :is_pe                  => false,
+        }
+      end
+      let :params do default_params end
+      let :facts do default_facts end
+      it { is_expected.to contain_file("apache_rspec.example.com").with(
+        :ensure  => 'present',
+        :content => 'foobar',
+        :path    => '/usr/local/etc/apache24/Vhosts/25-rspec.example.com.conf',
+      ) }
+    end
+    context "on Gentoo systems" do
+      let :default_facts do
+        {
+          :osfamily               => 'Gentoo',
+          :operatingsystem        => 'Gentoo',
+          :operatingsystemrelease => '3.16.1-gentoo',
+          :concat_basedir         => '/dne',
+          :id                     => 'root',
+          :kernel                 => 'Linux',
+          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
+          :is_pe                  => false,
+        }
+      end
+      let :params do default_params end
+      let :facts do default_facts end
+      it { is_expected.to contain_file("apache_rspec.example.com").with(
+        :ensure  => 'present',
+        :content => 'foobar',
+        :path    => '/etc/apache2/vhosts.d/25-rspec.example.com.conf',
+      ) }
+    end
+  end
+end


### PR DESCRIPTION
Here we are adding a thin wrapper to apache::custom_config but setting
default specific to the vhost apache folder.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>