### PR TITLE
(MODULES-2863) Set SSLProxy directives even if ssl is false

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -788,15 +788,11 @@ define apache::vhost(
   # - $ssl_crl_path
   # - $ssl_crl
   # - $ssl_crl_check
-  # - $ssl_proxyengine
   # - $ssl_protocol
   # - $ssl_cipher
   # - $ssl_honorcipherorder
   # - $ssl_verify_client
   # - $ssl_verify_depth
-  # - $ssl_proxy_check_peer_cn
-  # - $ssl_proxy_check_peer_name
-  # - $ssl_proxy_machine_cert
   # - $ssl_options
   # - $ssl_openssl_conf_cmd
   # - $apache_version
@@ -805,6 +801,19 @@ define apache::vhost(
       target  => "${priority_real}${filename}.conf",
       order   => 210,
       content => template('apache/vhost/_ssl.erb'),
+    }
+  }
+
+  # Template uses:
+  # - $ssl_proxyengine
+  # - $ssl_proxy_check_peer_cn
+  # - $ssl_proxy_check_peer_name
+  # - $ssl_proxy_machine_cert
+  if $ssl_proxyengine {
+    concat::fragment { "${name}-sslproxy":
+      target  => "${priority_real}${filename}.conf",
+      order   => 210,
+      content => template('apache/vhost/_sslproxy.erb'),
     }
   }
 

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -435,9 +435,12 @@ describe 'apache::vhost', :type => :define do
       it { is_expected.to contain_concat__fragment('rspec.example.com-ssl') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-ssl').with(
         :content => /^\s+SSLOpenSSLConfCmd\s+DHParameters "foo.pem"$/ ) }
-      it { is_expected.to contain_concat__fragment('rspec.example.com-ssl').with(
+      it { is_expected.to contain_concat__fragment('rspec.example.com-sslproxy') }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-sslproxy').with(
+        :content => /^\s+SSLProxyEngine On$/ ) }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-sslproxy').with(
         :content => /^\s+SSLProxyCheckPeerCN\s+on$/ ) }
-      it { is_expected.to contain_concat__fragment('rspec.example.com-ssl').with(
+      it { is_expected.to contain_concat__fragment('rspec.example.com-sslproxy').with(
         :content => /^\s+SSLProxyCheckPeerName\s+on$/ ) }
       it { is_expected.to contain_concat__fragment('rspec.example.com-suphp') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-php_admin') }
@@ -681,6 +684,7 @@ describe 'apache::vhost', :type => :define do
       it { is_expected.to_not contain_concat__fragment('rspec.example.com-serveralias') }
       it { is_expected.to_not contain_concat__fragment('rspec.example.com-setenv') }
       it { is_expected.to_not contain_concat__fragment('rspec.example.com-ssl') }
+      it { is_expected.to_not contain_concat__fragment('rspec.example.com-sslproxy') }
       it { is_expected.to_not contain_concat__fragment('rspec.example.com-suphp') }
       it { is_expected.to_not contain_concat__fragment('rspec.example.com-php_admin') }
       it { is_expected.to_not contain_concat__fragment('rspec.example.com-header') }
@@ -702,6 +706,18 @@ describe 'apache::vhost', :type => :define do
       end
       it { is_expected.to compile }
       it { is_expected.not_to contain_concat__fragment('rspec.example.com-docroot') }
+    end
+    context 'ssl_proxyengine without ssl' do
+      let :params do
+        {
+          'docroot'         => '/rspec/docroot',
+          'ssl'             => false,
+          'ssl_proxyengine' => true,
+        }
+      end
+      it { is_expected.to compile }
+      it { is_expected.not_to contain_concat__fragment('rspec.example.com-ssl') }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-sslproxy') }
     end
   end
   describe 'access logs' do

--- a/templates/vhost/_ssl.erb
+++ b/templates/vhost/_ssl.erb
@@ -22,9 +22,6 @@
   <%- if @ssl_crl_check && scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
   SSLCARevocationCheck    "<%= @ssl_crl_check %>"
   <%- end -%>
-  <%- if @ssl_proxyengine -%>
-  SSLProxyEngine On
-  <%- end -%>
   <%- if @ssl_protocol -%>
   SSLProtocol             <%= [@ssl_protocol].flatten.compact.join(' ') %>
   <%- end -%>
@@ -39,15 +36,6 @@
   <%- end -%>
   <%- if @ssl_verify_depth -%>
   SSLVerifyDepth          <%= @ssl_verify_depth %>
-  <%- end -%>
-  <%- if @ssl_proxy_check_peer_cn -%>
-  SSLProxyCheckPeerCN     <%= @ssl_proxy_check_peer_cn %>
-  <%- end -%>
-  <%- if @ssl_proxy_check_peer_name -%>
-  SSLProxyCheckPeerName   <%= @ssl_proxy_check_peer_name %>
-  <%- end -%>
-  <%- if @ssl_proxy_machine_cert -%>
-  SSLProxyMachineCertificateFile "<%= @ssl_proxy_machine_cert %>"
   <%- end -%>
   <%- if @ssl_options -%>
   SSLOptions <%= Array(@ssl_options).join(' ') %>

--- a/templates/vhost/_sslproxy.erb
+++ b/templates/vhost/_sslproxy.erb
@@ -1,0 +1,14 @@
+<% if @ssl_proxyengine -%>
+
+  # SSL Proxy directives
+  SSLProxyEngine On
+  <%- if @ssl_proxy_check_peer_cn -%>
+  SSLProxyCheckPeerCN     <%= @ssl_proxy_check_peer_cn %>
+  <%- end -%>
+  <%- if @ssl_proxy_check_peer_name -%>
+  SSLProxyCheckPeerName   <%= @ssl_proxy_check_peer_name %>
+  <%- end -%>
+  <%- if @ssl_proxy_machine_cert -%>
+  SSLProxyMachineCertificateFile "<%= @ssl_proxy_machine_cert %>"
+  <%- end -%>
+<% end -%>


### PR DESCRIPTION
RewriteRules and ProxyPass directives can require SSLProxy*
configurations even if SSLEngine is not enabled.

This PR should be updated with options added in #1268 once
that one is merged.