### PR TITLE
(MODULES-2682, FM-3919) Use more FilesMatch

### DIFF
--- a/templates/mod/fastcgi.conf.erb
+++ b/templates/mod/fastcgi.conf.erb
@@ -1,6 +1,8 @@
 # The Fastcgi Apache module configuration file is being
 # managed by Puppet and changes will be overwritten.
 <IfModule mod_fastcgi.c>
-  AddHandler fastcgi-script .fcgi
+  <FilesMatch ".+(\.fcgi)$">
+    SetHandler fastcgi-script
+  </FilesMatch>
   FastCgiIpcDir "<%= @fastcgi_lib_path %>"
 </IfModule>

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -106,7 +106,9 @@
     <%- end -%>
     <%- if directory['addhandlers'] and ! directory['addhandlers'].empty? -%>
       <%- [directory['addhandlers']].flatten.compact.each do |addhandler| -%>
-    AddHandler <%= addhandler['handler'] %> <%= Array(addhandler['extensions']).join(' ') %>
+    <FilesMatch ".+(<%= Array(addhandler['extensions']).collect { |s| Regexp.escape(s) }.join('|') %>)$">
+        SetHandler <%= addhandler['handler'] %>
+    </FilesMatch>
       <%- end -%>
     <%- end -%>
     <%- if directory['sethandler'] and directory['sethandler'] != '' -%>


### PR DESCRIPTION
FilesMatch and AddHandler do not interact correctly, which caused the fcgi
tests to (correctly) complain about php-cgi not being started for the fcgi
configuration.

Using FilesMatch in all cases addresses both the original security issue
(better) and leads to correct resolution of handlers again.