### PR TITLE
(MAINT) Fix conditional flag on mod_fcgid test.

### DIFF
--- a/spec/acceptance/mod_fcgid_spec.rb
+++ b/spec/acceptance/mod_fcgid_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'apache::mod::fcgid class', :if => ((fact('osfamily') == 'RedHat' and fact('operatingsystemmajrelease') != '5') or (fact('operatingsystem') != 'OracleLinux' and fact('operatingsystemmajrelease') != '7')) do
+describe 'apache::mod::fcgid class', :if => ((fact('osfamily') == 'RedHat' and fact('operatingsystemmajrelease') != '5') and !(fact('operatingsystem') == 'OracleLinux' and fact('operatingsystemmajrelease') == '7')) do
   context "default fcgid config" do
     it 'succeeds in puppeting fcgid' do
       pp = <<-EOS


### PR DESCRIPTION
The original line before the refactor in https://github.com/puppetlabs/puppetlabs-apache/pull/1282/files#diff-1eac7b1e1ab2d890671f09f88394db74L4 was a 2 tier conditional. The first is to NOT RUN the `describe` block on `UNSUPPORTED_PLATFORMS` and `OracleLinux 7`. Then the second conditional was to RUN the `context` block if `RedHat != 5`. So effectively, the combination of these conditionals leads to tests only running if on RedHat and version != 5 AND NOT OracleLinux 7

The refactor changed the conditional to:
`:if => ((fact('osfamily') == 'RedHat' and fact('operatingsystemmajrelease') != '5') or (fact('operatingsystem') != 'OracleLinux' and fact('operatingsystemmajrelease') != '7'))`

Due to the latter part after the `or`, the subsequent tests will run on all OS except OracleLinux7. 