### PR TITLE
Fixes paths and packages for the shib2 module on Debian

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -221,13 +221,20 @@ class apache::params inherits ::apache::version {
       'python'      => 'libapache2-mod-python',
       'rpaf'        => 'libapache2-mod-rpaf',
       'security'    => 'libapache2-modsecurity',
+      'shib2'       => 'libapache2-mod-shib2',
       'suphp'       => 'libapache2-mod-suphp',
       'wsgi'        => 'libapache2-mod-wsgi',
       'xsendfile'   => 'libapache2-mod-xsendfile',
       'shib2'       => 'libapache2-mod-shib2',
     }
+    if $::osfamily == 'Debian' and versioncmp($::operatingsystemrelease, '8') < 0 {
+      $shib2_lib = 'mod_shib_22.so'
+    } else {
+      $shib2_lib = 'mod_shib2.so'
+    }
     $mod_libs             = {
-      'php5' => 'libphp5.so',
+      'php5'  => 'libphp5.so',
+      'shib2' => $shib2_lib
     }
     $conf_template          = 'apache/httpd.conf.erb'
     $keepalive              = 'Off'


### PR DESCRIPTION
This allows the apache::mod::shib2 class to work on Debian hosts.