### PR TITLE
enable setting LimitRequestFieldSize globally as it does not actually…

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@
 [`KeepAliveTimeout`]: http://httpd.apache.org/docs/current/mod/core.html#keepalivetimeout
 [`keepalive` parameter]: #keepalive
 [`keepalive_timeout`]: #keepalive_timeout
+[`limitreqfieldsize`]: https://httpd.apache.org/docs/current/mod/core.html#limitrequestfieldsize
 
 [`lib`]: #lib
 [`lib_path`]: #lib_path
@@ -2102,10 +2103,6 @@ Specifies the service name that will be used by Apache for authentication. Corre
 ##### `krb_save_credentials`
 
 This option enables credential saving functionality. Default is 'off'
-
-##### `limit_request_field_size`
-
-[Limits](http://httpd.apache.org/docs/2.4/mod/core.html#limitrequestfieldsize) the size of the HTTP request header allowed from the client. Default is 'undef'.
 
 ##### `logroot`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,6 +63,7 @@ class apache (
   $keepalive              = $::apache::params::keepalive,
   $keepalive_timeout      = $::apache::params::keepalive_timeout,
   $max_keepalive_requests = $::apache::params::max_keepalive_requests,
+  $limitreqfieldsize      = '8190',
   $logroot                = $::apache::params::logroot,
   $logroot_mode           = $::apache::params::logroot_mode,
   $log_level              = $::apache::params::log_level,

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -136,7 +136,6 @@ define apache::vhost(
   $krb_verify_kdc              = 'on',
   $krb_servicename             = 'HTTP',
   $krb_save_credentials        = 'off',
-  $limit_request_field_size    = undef,
 ) {
   # The base class must be included first because it is used by parameter defaults
   if ! defined(Class['apache']) {
@@ -228,10 +227,6 @@ define apache::vhost(
   }
 
   validate_bool($auth_kerb)
-
-  if $limit_request_field_size {
-    validate_integer($limit_request_field_size)
-  }
 
   # Validate the docroot as a string if:
   # - $manage_docroot is true
@@ -982,15 +977,6 @@ define apache::vhost(
       target  => "${priority_real}${filename}.conf",
       order   => 330,
       content => template('apache/vhost/_filters.erb'),
-    }
-  }
-  # Template uses:
-  # - $limit_request_field_size
-  if $limit_request_field_size {
-    concat::fragment { "${name}-limits":
-      target  => "${priority_real}${filename}.conf",
-      order   => 330,
-      content => template('apache/vhost/_limits.erb'),
     }
   }
 

--- a/spec/acceptance/apache_parameters_spec.rb
+++ b/spec/acceptance/apache_parameters_spec.rb
@@ -354,6 +354,20 @@ describe 'apache parameters' do
     end
   end
 
+  describe 'limitrequestfieldsize' do
+    describe 'setup' do
+      it 'applies cleanly' do
+        pp = "class { 'apache': limitreqfieldsize => '16830' }"
+        apply_manifest(pp, :catch_failures => true)
+      end
+    end
+
+    describe file($conf_file) do
+      it { is_expected.to be_file }
+      it { is_expected.to contain 'LimitRequestFieldSize 16830' }
+    end
+  end
+
   describe 'logging' do
     describe 'setup' do
       it 'applies cleanly' do

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -326,8 +326,7 @@ describe 'apache::vhost', :type => :define do
           'krb_authoritative'           => 'off',
           'krb_auth_realms'             => ['EXAMPLE.ORG','EXAMPLE.NET'],
           'krb_5keytab'                 => '/tmp/keytab5',
-          'krb_local_user_mapping'      => 'off',
-          'limit_request_field_size'    => '54321',
+          'krb_local_user_mapping'      => 'off'
         }
       end
       let :facts do
@@ -472,8 +471,6 @@ describe 'apache::vhost', :type => :define do
         :content => /^\s+KrbSaveCredentials\soff$/)}
       it { is_expected.to contain_concat__fragment('rspec.example.com-auth_kerb').with(
         :content => /^\s+KrbVerifyKDC\son$/)}
-      it { is_expected.to contain_concat__fragment('rspec.example.com-limits').with(
-        :content => /^\s+LimitRequestFieldSize\s54321$/)}
     end
     context 'vhost with multiple ip addresses' do
       let :params do

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -10,6 +10,7 @@ Timeout <%= @timeout %>
 KeepAlive <%= @keepalive %>
 MaxKeepAliveRequests <%= @max_keepalive_requests %>
 KeepAliveTimeout <%= @keepalive_timeout %>
+LimitRequestFieldSize <%= @limitreqfieldsize %>
 
 <%- if @rewrite_lock and scope.function_versioncmp([@apache_version, '2.2']) <= 0 -%>
 RewriteLock <%= @rewrite_lock %>

--- a/templates/vhost/_limits.erb
+++ b/templates/vhost/_limits.erb
@@ -1,5 +1,0 @@
-
-  ## Limit Request Values
-<% if @limit_request_field_size -%>
-  LimitRequestFieldSize <%= @limit_request_field_size %>
-<% end -%>


### PR DESCRIPTION
… work to increase it, inside a vhost. We tested with Kerberos keys (which is why we need to increase - as they can be upto 12000 bytes long.. so a default of 8190 doesn't work :) 