### PR TITLE
	Added support for modsecurity parameter SecPcreMatchLimit and SecPcr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1631,6 +1631,8 @@ ${modsec_dir}/activated_rules.
 - `modsec_secruleengine`: Configures the modsec rules engine. Valid options: 'On', 'Off', and 'DetectionOnly'. Default: `modsec_secruleengine` in [`apache::params`][].
 - `restricted_extensions`: A space-separated list of prohibited file extensions. Default: '.asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/'.
 - `restricted_headers`: A list of restricted headers separated by slashes and spaces. Default: 'Proxy-Connection/ /Lock-Token/ /Content-Range/ /Translate/ /via/ /if/'.
+- `secpcrematchlimit`: Sets the number for the match limit in the PCRE library. Default: '1500'
+- `secpcrematchlimitrecursion`: Sets the number for the match limit recursion in the PCRE library. Default: '1500'
 
 ##### Class: `apache::mod::wsgi`
 

--- a/manifests/mod/security.pp
+++ b/manifests/mod/security.pp
@@ -3,6 +3,8 @@ class apache::mod::security (
   $activated_rules       = $::apache::params::modsec_default_rules,
   $modsec_dir            = $::apache::params::modsec_dir,
   $modsec_secruleengine  = $::apache::params::modsec_secruleengine,
+  $secpcrematchlimit = $::apache::params::secpcrematchlimit,
+  $secpcrematchlimitrecursion = $::apache::params::secpcrematchlimitrecursion,
   $allowed_methods       = 'GET HEAD POST OPTIONS',
   $content_types         = 'application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/x-amf',
   $restricted_extensions = '.asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/',
@@ -32,6 +34,8 @@ class apache::mod::security (
 
   # Template uses:
   # - $modsec_dir
+  # - secpcrematchlimit
+  # - secpcrematchlimitrecursion
   file { 'security.conf':
     ensure  => file,
     content => template('apache/mod/security.conf.erb'),

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -153,6 +153,8 @@ class apache::params inherits ::apache::version {
     $modsec_crs_package   = 'mod_security_crs'
     $modsec_crs_path      = '/usr/lib/modsecurity.d'
     $modsec_dir           = '/etc/httpd/modsecurity.d'
+    $secpcrematchlimit = 1500
+    $secpcrematchlimitrecursion = 1500
     $modsec_secruleengine = 'On'
     $modsec_default_rules = [
       'base_rules/modsecurity_35_bad_robots.data',
@@ -248,6 +250,8 @@ class apache::params inherits ::apache::version {
     $modsec_crs_package   = 'modsecurity-crs'
     $modsec_crs_path      = '/usr/share/modsecurity-crs'
     $modsec_dir           = '/etc/modsecurity'
+    $secpcrematchlimit = 1500
+    $secpcrematchlimitrecursion = 1500
     $modsec_secruleengine = 'On'
     $modsec_default_rules = [
       'base_rules/modsecurity_35_bad_robots.data',

--- a/templates/mod/security.conf.erb
+++ b/templates/mod/security.conf.erb
@@ -37,8 +37,8 @@
     SecRule MULTIPART_UNMATCHED_BOUNDARY "!@eq 0" \
       "id:'200003',phase:2,t:none,log,deny,status:44,msg:'Multipart parser detected a possible unmatched boundary.'"
 
-    SecPcreMatchLimit 1000
-    SecPcreMatchLimitRecursion 1000
+    SecPcreMatchLimit <%= @secpcrematchlimit %>
+    SecPcreMatchLimitRecursion <%= @secpcrematchlimitrecursion %>
 
     SecRule TX:/^MSC_/ "!@streq 0" \
       "id:'200004',phase:2,t:none,deny,msg:'ModSecurity internal error flagged: %{MATCHED_VAR_NAME}'"


### PR DESCRIPTION
…eMatchLimitRecursion

Set default PcreMatchLimit to 1000

fixed default variables for secpcrematchlimit(recursion) in params.pp