### PR TITLE
Add note about fastcgi usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -3228,6 +3228,8 @@ Specifies whether or not to use [SSLProxyEngine](http://httpd.apache.org/docs/cu
 
 This type is intended for use with mod_fastcgi. It allows you to define one or more external FastCGI servers to handle specific file types.
 
+** Note ** If using Ubuntu 10.04+, you'll need to manually enable the multiverse repository.
+
 Ex:
 
 ~~~ puppet

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -1330,6 +1330,13 @@ describe 'apache::vhost define' do
     describe 'fastcgi' do
       it 'applies cleanly' do
         pp = <<-EOS
+          if ($::operatingsystem == 'Ubuntu' and versioncpm($::operatingsystemrelease, '10.04' >= 0)) {
+            include ::apt
+            apt::ppa { 'multiverse':
+              before => Class['Apache::Mod::Fastcgi'],
+            }
+          }
+
           class { 'apache': }
           class { 'apache::mod::fastcgi': }
           host { 'test.server': ip => '127.0.0.1' }


### PR DESCRIPTION
libapache2-mod-fastcgi exists only in multiverse for Ubuntu, so warn
the user they need to enable it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>