### PR TITLE
fix validation error when empty array is passed as rewrites parameter

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -158,7 +158,9 @@ define apache::vhost(
   validate_bool($ssl_proxyengine)
   if $rewrites {
     validate_array($rewrites)
-    validate_hash($rewrites[0])
+    unless empty($rewrites) {
+      validate_hash($rewrites[0])
+    }
   }
 
   # Input validation begins

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -776,6 +776,18 @@ describe 'apache::vhost', :type => :define do
     end
   end # access logs
   describe 'validation' do
+    let :default_facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '6',
+        :concat_basedir         => '/dne',
+        :operatingsystem        => 'RedHat',
+        :id                     => 'root',
+        :kernel                 => 'Linux',
+        :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :is_pe                  => false,
+      }
+    end
     context 'bad ensure' do
       let :params do
         {
@@ -875,6 +887,16 @@ describe 'apache::vhost', :type => :define do
       end
       let :facts do default_facts end
       it { expect { is_expected.to compile }.to raise_error }
+    end
+    context 'empty rewrites' do
+      let :params do
+        {
+          'docroot'  => '/rspec/docroot',
+          'rewrites' => [],
+        }
+      end
+      let :facts do default_facts end
+      it { is_expected.to compile }
     end
     context 'bad suexec_user_group' do
       let :params do


### PR DESCRIPTION
Manifest compilation fails when an empty array is passed as rewrites
parameter to vhost defined type.
This commit makes the code to compile nicely.