### PR TITLE
Support proxy provider for vhost directories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2561,7 +2561,7 @@ The `directories` parameter within the `apache::vhost` class passes an array of 
 
 The `path` key sets the path for the directory, files, and location blocks. Its value must be a path for the 'directory', 'files', and 'location' providers, or a regex for the 'directorymatch', 'filesmatch', or 'locationmatch' providers. Each hash passed to `directories` **must** contain `path` as one of the keys.
 
-The `provider` key is optional. If missing, this key defaults to 'directory'. Valid values for `provider` are 'directory', 'files', 'location', 'directorymatch', 'filesmatch', or 'locationmatch'. If you set `provider` to 'directorymatch', it uses the keyword 'DirectoryMatch' in the Apache config file.
+The `provider` key is optional. If missing, this key defaults to 'directory'. Valid values for `provider` are 'directory', 'files', 'proxy', 'location', 'directorymatch', 'filesmatch', 'proxymatch' or 'locationmatch'. If you set `provider` to 'directorymatch', it uses the keyword 'DirectoryMatch' in the Apache config file.
 
 General `directories` usage looks something like
 

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -187,6 +187,10 @@ describe 'apache::vhost', :type => :define do
               'provider' => 'files',
               'require'  => 'all granted',
             },
+            {
+              'path'     => '*',
+              'provider' => 'proxy',
+            },
             { 'path'              => '/var/www/files/indexed_directory',
               'directoryindex'    => 'disabled',
               'options'           => ['Indexes','FollowSymLinks','MultiViews'],
@@ -390,6 +394,8 @@ describe 'apache::vhost', :type => :define do
       it { is_expected.to contain_concat__fragment('rspec.example.com-itk') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-fallbackresource') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-directories') }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
+        :content => /^\s+<Proxy "\*">$/ ) }
       it { is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
         :content => /^\s+Require valid-user$/ ) }
       it { is_expected.to contain_concat__fragment('rspec.example.com-directories').with(

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -17,7 +17,7 @@
       <%- end -%>
     <%- end -%>
     <%- if directory['path'] and directory['path'] != '' -%>
-      <%- if directory['provider'] and directory['provider'].match('(directory|location|files)') -%>
+      <%- if directory['provider'] and directory['provider'].match('(directory|location|files|proxy)') -%>
         <%- if /^(.*)match$/ =~ directory['provider'] -%>
           <%- provider = $1.capitalize + 'Match' -%>
         <%- else -%>


### PR DESCRIPTION
This simple commmit adds the ability to use a proxy provider for
directories.

http://httpd.apache.org/docs/current/sections.html

My use case is to have a <Proxy "*"> section to apply directives to all
my proxies definitions.