### PR TITLE
Put headers and request headers before proxy

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -677,6 +677,26 @@ define apache::vhost(
   }
 
   # Template uses:
+  # - $headers
+  if $headers and ! empty($headers) {
+    concat::fragment { "${name}-header":
+      target  => "${priority_real}${filename}.conf",
+      order   => 140,
+      content => template('apache/vhost/_header.erb'),
+    }
+  }
+
+  # Template uses:
+  # - $request_headers
+  if $request_headers and ! empty($request_headers) {
+    concat::fragment { "${name}-requestheader":
+      target  => "${priority_real}${filename}.conf",
+      order   => 150,
+      content => template('apache/vhost/_requestheader.erb'),
+    }
+  }
+
+  # Template uses:
   # - $proxy_dest
   # - $proxy_pass
   # - $proxy_pass_match
@@ -685,7 +705,7 @@ define apache::vhost(
   if $proxy_dest or $proxy_pass or $proxy_pass_match or $proxy_dest_match {
     concat::fragment { "${name}-proxy":
       target  => "${priority_real}${filename}.conf",
-      order   => 140,
+      order   => 160,
       content => template('apache/vhost/_proxy.erb'),
     }
   }
@@ -695,7 +715,7 @@ define apache::vhost(
   if $rack_base_uris {
     concat::fragment { "${name}-rack":
       target  => "${priority_real}${filename}.conf",
-      order   => 150,
+      order   => 170,
       content => template('apache/vhost/_rack.erb'),
     }
   }
@@ -705,7 +725,7 @@ define apache::vhost(
   if $passenger_base_uris {
     concat::fragment { "${name}-passenger_uris":
       target  => "${priority_real}${filename}.conf",
-      order   => 155,
+      order   => 175,
       content => template('apache/vhost/_passenger_base_uris.erb'),
     }
   }
@@ -726,7 +746,7 @@ define apache::vhost(
   if ($redirect_source and $redirect_dest) or ($redirectmatch_status and $redirectmatch_regexp and $redirectmatch_dest) {
     concat::fragment { "${name}-redirect":
       target  => "${priority_real}${filename}.conf",
-      order   => 160,
+      order   => 180,
       content => template('apache/vhost/_redirect.erb'),
     }
   }
@@ -740,7 +760,7 @@ define apache::vhost(
   if $rewrites or $rewrite_rule {
     concat::fragment { "${name}-rewrite":
       target  => "${priority_real}${filename}.conf",
-      order   => 170,
+      order   => 190,
       content => template('apache/vhost/_rewrite.erb'),
     }
   }
@@ -751,7 +771,7 @@ define apache::vhost(
   if ( $scriptalias or $scriptaliases != [] ) {
     concat::fragment { "${name}-scriptalias":
       target  => "${priority_real}${filename}.conf",
-      order   => 180,
+      order   => 200,
       content => template('apache/vhost/_scriptalias.erb'),
     }
   }
@@ -761,7 +781,7 @@ define apache::vhost(
   if $serveraliases and ! empty($serveraliases) {
     concat::fragment { "${name}-serveralias":
       target  => "${priority_real}${filename}.conf",
-      order   => 190,
+      order   => 210,
       content => template('apache/vhost/_serveralias.erb'),
     }
   }
@@ -772,7 +792,7 @@ define apache::vhost(
   if ($setenv and ! empty($setenv)) or ($setenvif and ! empty($setenvif)) {
     concat::fragment { "${name}-setenv":
       target  => "${priority_real}${filename}.conf",
-      order   => 200,
+      order   => 220,
       content => template('apache/vhost/_setenv.erb'),
     }
   }
@@ -798,7 +818,7 @@ define apache::vhost(
   if $ssl {
     concat::fragment { "${name}-ssl":
       target  => "${priority_real}${filename}.conf",
-      order   => 210,
+      order   => 230,
       content => template('apache/vhost/_ssl.erb'),
     }
   }
@@ -811,7 +831,7 @@ define apache::vhost(
   if $ssl_proxyengine {
     concat::fragment { "${name}-sslproxy":
       target  => "${priority_real}${filename}.conf",
-      order   => 210,
+      order   => 230,
       content => template('apache/vhost/_sslproxy.erb'),
     }
   }
@@ -827,7 +847,7 @@ define apache::vhost(
   if $auth_kerb {
     concat::fragment { "${name}-auth_kerb":
       target  => "${priority_real}${filename}.conf",
-      order   => 210,
+      order   => 230,
       content => template('apache/vhost/_auth_kerb.erb'),
     }
   }
@@ -839,7 +859,7 @@ define apache::vhost(
   if $suphp_engine == 'on' {
     concat::fragment { "${name}-suphp":
       target  => "${priority_real}${filename}.conf",
-      order   => 220,
+      order   => 240,
       content => template('apache/vhost/_suphp.erb'),
     }
   }
@@ -850,7 +870,7 @@ define apache::vhost(
   if ($php_values and ! empty($php_values)) or ($php_flags and ! empty($php_flags)) {
     concat::fragment { "${name}-php":
       target  => "${priority_real}${filename}.conf",
-      order   => 220,
+      order   => 240,
       content => template('apache/vhost/_php.erb'),
     }
   }
@@ -861,28 +881,8 @@ define apache::vhost(
   if ($php_admin_values and ! empty($php_admin_values)) or ($php_admin_flags and ! empty($php_admin_flags)) {
     concat::fragment { "${name}-php_admin":
       target  => "${priority_real}${filename}.conf",
-      order   => 230,
-      content => template('apache/vhost/_php_admin.erb'),
-    }
-  }
-
-  # Template uses:
-  # - $headers
-  if $headers and ! empty($headers) {
-    concat::fragment { "${name}-header":
-      target  => "${priority_real}${filename}.conf",
-      order   => 240,
-      content => template('apache/vhost/_header.erb'),
-    }
-  }
-
-  # Template uses:
-  # - $request_headers
-  if $request_headers and ! empty($request_headers) {
-    concat::fragment { "${name}-requestheader":
-      target  => "${priority_real}${filename}.conf",
       order   => 250,
-      content => template('apache/vhost/_requestheader.erb'),
+      content => template('apache/vhost/_php_admin.erb'),
     }
   }
 


### PR DESCRIPTION
I have scenario where I need the request headers template to be rendered before the proxy template so I can remove an Authorization header before it goes across the proxy, e.g., 

```
## Request header rules
## as per http://httpd.apache.org/docs/2.2/mod/mod_headers.html#requestheader
RequestHeader unset Authorization

## Proxy rules
...
```

When the `RequestHeader unset` directive is after the proxy section, the header is sent to the proxy.

This change allows the order parameter of the request headers template to be changed without affecting current behavior.