### PR TITLE
Add support for authnz_ldap

### DIFF
--- a/README.md
+++ b/README.md
@@ -2675,6 +2675,18 @@ Sets the value for [AuthAuthDigestShmemSize](http://httpd.apache.org/docs/curren
 
 Sets the value for [AuthGroupFile](https://httpd.apache.org/docs/current/mod/mod_authz_groupfile.html#authgroupfile), which sets the name of the text file containing the list of user groups for authorization.
 
+###### `auth_ldap_bind_dn`
+
+Sets the value for [AuthLDAPBindDN](https://httpd.apache.org/docs/current/mod/mod_authnz_ldap.html#authldapbinddn), which sets an optional DN to use in binding to the LDAP server.
+
+###### `auth_ldap_bind_password`
+
+Sets the value for [AuthLDAPBindPassword](https://httpd.apache.org/docs/current/mod/mod_authnz_ldap.html#authldapbindpassword), which sets the password used in conjuction with the bind DN.
+
+###### `auth_ldap_url`
+
+Sets the value for [AuthLDAPURL](https://httpd.apache.org/docs/current/mod/mod_authnz_ldap.html#authldapurl), which sets the URL specifying the LDAP search parameters.
+
 ###### `auth_name`
 
 Sets the value for [AuthName](http://httpd.apache.org/docs/current/mod/mod_authn_core.html#authname), which sets the name of the authorization realm.

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -492,6 +492,43 @@ describe 'apache::vhost define' do
         it { should be_running }
       end
 
+  context 'new proxy vhost on port 80' do
+    it 'should configure an apache proxy vhost' do
+      pp = <<-EOS
+        class { 'apache': }
+	apache::vhost { 'location.example.net':
+	  port        => '80', 
+	  docroot     => '/var/www/location',
+	  directories => [ 
+	    { 
+	      'path'                     => '/location',
+	      'provider'                 => 'location',
+	      'auth_require'             => 'ldap-group cn=Administrators, o=Example',
+	      'auth_type'                => 'Basic',
+	      'auth_basic_provider'      => 'ldap', 
+	      'auth_ldap_bind_dn'        => 'apache@example.com',
+	      'auth_ldap_bind_password'  => 'password', 
+	      'auth_ldap_url'            => 'ldap://ldap.example.com/?userPrincipalName?sub',
+	    },
+	  ],
+	}
+      EOS
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    describe file("#{$vhost_dir}/25-location.example.com.conf") do
+      it { is_expected.to contain '<VirtualHost \*:80>' }
+      it { is_expected.to contain 'ServerName location.example.com' }
+      it { is_expected.to contain '<Location "/location">' }
+      it { is_expected.to contain 'Require ldap-group cn=Administrators, o=Example' }
+      it { is_expected.to contain 'AuthType Basic' }
+      it { is_expected.to contain 'AuthBasicProvider ldap' }
+      it { is_expected.to contain 'AuthLDAPBindDN apache@example.com' }
+      it { is_expected.to contain 'AuthLDAPBindPassword password' }
+      it { is_expected.to contain 'AuthLDAPURL ldap://ldap.example.com/?userPrincipalName?sub' }
+    end
+  end
+
       it 'should answer to files.example.net' do
         shell("/usr/bin/curl -sSf files.example.net:80/foo/index.html", {:acceptable_exit_codes => 22}).stderr.should match(/curl: \(22\) The requested URL returned error: 401/)
         shell("/usr/bin/curl -sSf -u login:password files.example.net:80/foo/index.html").stdout.should eq("Hello World\n")

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -186,6 +186,15 @@
     <%- if directory['auth_group_file'] -%>
     AuthGroupFile <%= directory['auth_group_file'] %>
     <%- end -%>
+    <%- if directory['auth_ldap_bind_dn'] -%>
+    AuthLDAPBindDN <%= directory['auth_ldap_bind_dn'] %>
+    <%- end -%>
+    <%- if directory['auth_ldap_bind_password'] -%>
+    AuthLDAPBindPassword <%= directory['auth_ldap_bind_password'] %>
+    <%- end -%>
+    <%- if directory['auth_ldap_bind_url'] -%>
+    AuthLDAPURL <%= directory['auth_ldap_bind_url'] %>
+    <%- end -%>
     <%- if directory['fallbackresource'] -%>
     FallbackResource <%= directory['fallbackresource'] %>
     <%- end -%>

--- a/tests/vhost_ldap.pp
+++ b/tests/vhost_ldap.pp
@@ -1,0 +1,21 @@
+# Base class. Declares default vhost on port 80 and default ssl
+# vhost on port 443 listening on all interfaces and serving
+# $apache::docroot
+class { 'apache': }
+
+# location test
+apache::vhost { 'location.example.net':
+  docroot     => '/var/www/location',
+  directories => [
+    {
+      'path'                     => '/location',
+      'provider'                 => 'location',
+      'auth_require'             => 'ldap-group cn=Administrators, o=Example',
+      'auth_type'                => 'Basic',
+      'auth_basic_provider'      => 'ldap',
+      'auth_ldap_bind_dn'        => 'apache@example.com',
+      'auth_ldap_bind_password'  => 'password',
+      'auth_ldap_url'            => 'ldap://ldap.example.com/?userPrincipalName?sub',
+    },
+  ],
+}


### PR DESCRIPTION
README updated with LDAP directives

test for LDAP added

Acceptance tests added + A "," was missing in the test file.

LDAP instructions added to the directory template

README updated with LDAP directives

Acceptance tests added + A "," was missing in the test file.