### PR TITLE
MODULES-2956: Enable options within location block on proxy_match

### DIFF
--- a/README.md
+++ b/README.md
@@ -2242,7 +2242,7 @@ Specifies the destination address of a [ProxyPass](http://httpd.apache.org/docs/
 
 ##### `proxy_pass`
 
-Specifies an array of `path => URI` for a [ProxyPass](http://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypass) configuration. Defaults to 'undef'. Optionally parameters can be added as an array.
+Specifies an array of `path => URI` for a [ProxyPass](http://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypass) configuration. Defaults to 'undef'. Optionally parameters and location options can be added as an array.
 
 ~~~ puppet
 apache::vhost { 'site.name.fdqn':
@@ -2251,6 +2251,8 @@ apache::vhost { 'site.name.fdqn':
     { 'path' => '/a', 'url' => 'http://backend-a/' },
     { 'path' => '/b', 'url' => 'http://backend-b/' },
     { 'path' => '/c', 'url' => 'http://backend-a/c', 'params' => {'max'=>20, 'ttl'=>120, 'retry'=>300}},
+    { 'path' => '/c', 'url' => 'http://backend-a/c',
+      'options' => {'Require'=>'valid-user', 'AuthType'=>'Kerberos', 'AuthName'=>'Kerberos Login'}},
     { 'path' => '/l', 'url' => 'http://backend-xy',
       'reverse_urls' => ['http://backend-x', 'http://backend-y'] },
     { 'path' => '/d', 'url' => 'http://backend-a/d',
@@ -3190,12 +3192,12 @@ Sets the [SSLProxyMachineCertificateFile](http://httpd.apache.org/docs/current/m
 ~~~
 
 ##### `ssl_proxy_check_peer_cn`
- 
+
 Sets the [SSLProxyMachinePeerCN](http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxycheckpeercn) directive, which specified whether the remote server certificate's CN field is compared against the hostname of the request URL .  Defaults to 'undef'.
 
 
 ##### `ssl_proxy_check_peer_name`
- 
+
 Sets the [SSLProxyMachinePeerName](http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxycheckpeername) directive, which specified whether the remote server certificate's CN field is compared against the hostname of the request URL .  Defaults to 'undef'.
 
 ##### `ssl_options`

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -238,6 +238,11 @@ describe 'apache::vhost', :type => :define do
                       'retry'   => '0',
                       'timeout' => '5'
               },
+              'options'         => {
+                'Require'  =>'valid-user',
+                'AuthType' =>'Kerberos',
+                'AuthName' =>'"Kerberos Login"'
+              },
               'setenv'   => ['proxy-nokeepalive 1','force-proxy-request-1.0 1'],
             }
           ],
@@ -440,6 +445,13 @@ describe 'apache::vhost', :type => :define do
               /ProxyPassReverseCookiePath\s+\/a\s+http:\/\//) }
       it { is_expected.to contain_concat__fragment('rspec.example.com-proxy').with_content(
               /ProxyPassReverseCookieDomain\s+foo\s+http:\/\/foo/) }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-proxy').with_content(
+              /Require valid-user/) }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-proxy').with_content(
+              /AuthType Kerberos/) }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-proxy').with_content(
+              /AuthName "Kerberos Login"/) }
+
       it { is_expected.to contain_concat__fragment('rspec.example.com-rack') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-redirect') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-rewrite') }

--- a/templates/vhost/_proxy.erb
+++ b/templates/vhost/_proxy.erb
@@ -42,6 +42,11 @@
     SetEnv <%= setenv_var %>
     <%- end -%>
   <%- end -%>
+  <%- if proxy['options'] -%>
+    <%- proxy['options'].keys.sort.each do |key| -%>
+    <%= key %> <%= proxy['options'][key] %>
+    <%- end -%>
+  <%- end -%>
   </Location>
 <% end -%>
 <% [@proxy_pass_match].flatten.compact.each do |proxy| %>


### PR DESCRIPTION
In order to configure authentication within apache to be a reverse proxy for an authenticated resource authentication methods need to be defined within the Location block.  This allows defining those options (and any others someone may want) within that block.