### PR TITLE
Update docs for predefined LogFormats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1002,6 +1002,7 @@ LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combine
 LogFormat "%h %l %u %t \"%r\" %>s %b" common
 LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
+LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-agent}i\"" forwarded
 ~~~
 
 If your `log_formats` parameter contains one of those, it will be overwritten with **your** definition.


### PR DESCRIPTION
Add missed predefined "forwarded" log format into docs.