### PR TITLE
mod_proxy_wstunnel support

### DIFF
--- a/manifests/mod/proxy_wstunnel.pp
+++ b/manifests/mod/proxy_wstunnel.pp
@@ -1,0 +1,4 @@
+class apache::mod::proxy_wstunnel {
+  Class['::apache::mod::proxy_http'] -> Class['::apache::mod::proxy_wstunnel']
+  ::apache::mod { 'proxy_wstunnel': }
+}


### PR DESCRIPTION
This module allows Apache to proxy Websocket connections. The handling of the connections is supposed to be done by rewrite rules.