### PR TITLE
Expose the directory that is assumed/supposed to be used for virtual hosts

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -136,14 +136,14 @@ class apache::params inherits ::apache::version {
     $mime_support_package = 'mailcap'
     $mime_types_config    = '/etc/mime.types'
     $sites_root           = '/var/www'
-    $docroot              = "$sites_root/html"
+    $docroot              = "${sites_root}/html"
     $alias_icons_path     = $::apache::version::distrelease ? {
       '7'     => '/usr/share/httpd/icons',
-      default => "$sites_root/icons",
+      default => "${sites_root}/icons",
     }
     $error_documents_path = $::apache::version::distrelease ? {
       '7'     => '/usr/share/httpd/error',
-      default => "$sites_root/error"
+      default => "${sites_root}/error"
     }
     if $::osfamily == 'RedHat' {
       $wsgi_socket_prefix = '/var/run/wsgi'
@@ -249,7 +249,7 @@ class apache::params inherits ::apache::version {
     $mime_types_config    = '/etc/mime.types'
     $sites_root             = '/var/www'
     if ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '13.10') >= 0) or ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '8') >= 0) {
-      $docroot              = "$sites_root/html"
+      $docroot              = "${sites_root}/html"
     } else {
       $docroot              = $sites_root
     }
@@ -470,7 +470,7 @@ class apache::params inherits ::apache::version {
     $mime_types_config    = '/etc/mime.types'
     $wsgi_socket_prefix   = undef
     $sites_root           = '/var/www'
-    $docroot              = "$sites_root/localhost/htdocs"
+    $docroot              = "${sites_root}/localhost/htdocs"
     $alias_icons_path     = '/usr/share/apache2/icons'
     $error_documents_path = '/usr/share/apache2/error'
   } elsif $::osfamily == 'Suse' {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -135,14 +135,15 @@ class apache::params inherits ::apache::version {
     $fastcgi_lib_path     = undef
     $mime_support_package = 'mailcap'
     $mime_types_config    = '/etc/mime.types'
-    $docroot              = '/var/www/html'
+    $sites_root           = '/var/www'
+    $docroot              = "$sites_root/html"
     $alias_icons_path     = $::apache::version::distrelease ? {
       '7'     => '/usr/share/httpd/icons',
-      default => '/var/www/icons',
+      default => "$sites_root/icons",
     }
     $error_documents_path = $::apache::version::distrelease ? {
       '7'     => '/usr/share/httpd/error',
-      default => '/var/www/error'
+      default => "$sites_root/error"
     }
     if $::osfamily == 'RedHat' {
       $wsgi_socket_prefix = '/var/run/wsgi'
@@ -246,10 +247,11 @@ class apache::params inherits ::apache::version {
     $fastcgi_lib_path       = '/var/lib/apache2/fastcgi'
     $mime_support_package = 'mime-support'
     $mime_types_config    = '/etc/mime.types'
+    $sites_root             = '/var/www'
     if ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '13.10') >= 0) or ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '8') >= 0) {
-      $docroot              = '/var/www/html'
+      $docroot              = "$sites_root/html"
     } else {
-      $docroot              = '/var/www'
+      $docroot              = $sites_root
     }
     $cas_cookie_path      = '/var/cache/apache2/mod_auth_cas/'
     $mellon_lock_file     = undef
@@ -467,7 +469,8 @@ class apache::params inherits ::apache::version {
     $mime_support_package = 'app-misc/mime-types'
     $mime_types_config    = '/etc/mime.types'
     $wsgi_socket_prefix   = undef
-    $docroot              = '/var/www/localhost/htdocs'
+    $sites_root           = '/var/www'
+    $docroot              = "$sites_root/localhost/htdocs"
     $alias_icons_path     = '/usr/share/apache2/icons'
     $error_documents_path = '/usr/share/apache2/error'
   } elsif $::osfamily == 'Suse' {


### PR DESCRIPTION
Use case: I use to install virtual hosts in directories below `/var/www`. Some tools and cron jobs that need to traverse all the hosts could previously use `${::apache::docroot}` to find this directory.

However, fcc4d43f46ee2a0d835b7bbf1ba90387eabf3719 changed that setting (due to https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=730372) and left no variable, setting or pointer to the `/var/www` value.

It may be debatable whether a read-only value like this new `$sites_root` makes sense. But both the above Debian bug report as well as the README.md examples describe virtual hosts at `/var/www/some.host.name`, so I think a generic reference to it comes in handy.