### PR TITLE
add paramter to set config file permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1160,6 +1160,10 @@ Controls how Apache handles `TRACE` requests (per [RFC 2616][]) via the [`TraceE
 
 Controls whether the systemd module should be installed on Centos 7 servers, this is especially useful if using custom built rpms. This can either be 'true' or 'false, defaults to 'true'.
 
+##### `file_mode`
+
+The desired permissions mode for config files, in symbolic or numeric notation. This value must be a string. Defaults to '0644'.
+
 ##### `vhost_dir`
 
 Changes your virtual host configuration files' location. Default: determined by your operating system.

--- a/manifests/balancer.pp
+++ b/manifests/balancer.pp
@@ -49,7 +49,7 @@ define apache::balancer (
   concat { $target:
     owner  => '0',
     group  => '0',
-    mode   => '0644',
+    mode   => $::apache::file_mode,
     notify => Class['Apache::Service'],
   }
 

--- a/manifests/fastcgi/server.pp
+++ b/manifests/fastcgi/server.pp
@@ -15,7 +15,7 @@ define apache::fastcgi::server (
     path    => "${::apache::confd_dir}/fastcgi-pool-${name}.conf",
     owner   => 'root',
     group   => $::apache::params::root_group,
-    mode    => '0644',
+    mode    => $::apache::file_mode,
     content => template('apache/fastcgi/server.erb'),
     require => Exec["mkdir ${::apache::confd_dir}"],
     before  => File[$::apache::confd_dir],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,6 +79,7 @@ class apache (
   $use_optional_includes  = $::apache::params::use_optional_includes,
   $use_systemd            = $::apache::params::use_systemd,
   $mime_types_additional  = $::apache::params::mime_types_additional,
+  $file_mode              = $::apache::params::file_mode,
 ) inherits ::apache::params {
   validate_bool($default_vhost)
   validate_bool($default_ssl_vhost)
@@ -241,7 +242,7 @@ class apache (
   concat { $ports_file:
     owner   => 'root',
     group   => $::apache::params::root_group,
-    mode    => '0644',
+    mode    => $::apache::file_mode,
     notify  => Class['Apache::Service'],
     require => Package['httpd'],
   }

--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -81,7 +81,7 @@ define apache::mod (
     path    => "${mod_dir}/${_loadfile_name}",
     owner   => 'root',
     group   => $::apache::params::root_group,
-    mode    => '0644',
+    mode    => $::apache::file_mode,
     content => template('apache/mod/load.erb'),
     require => [
       Package['httpd'],
@@ -99,7 +99,7 @@ define apache::mod (
       target  => "${mod_dir}/${_loadfile_name}",
       owner   => 'root',
       group   => $::apache::params::root_group,
-      mode    => '0644',
+      mode    => $::apache::file_mode,
       require => [
         File[$_loadfile_name],
         Exec["mkdir ${enable_dir}"],
@@ -117,7 +117,7 @@ define apache::mod (
         target  => "${mod_dir}/${mod}.conf",
         owner   => 'root',
         group   => $::apache::params::root_group,
-        mode    => '0644',
+        mode    => $::apache::file_mode,
         require => [
           File["${mod}.conf"],
           Exec["mkdir ${enable_dir}"],
@@ -134,7 +134,7 @@ define apache::mod (
       target  => "${mod_dir}/${_loadfile_name}",
       owner   => 'root',
       group   => $::apache::params::root_group,
-      mode    => '0644',
+      mode    => $::apache::file_mode,
       require => [
         File[$_loadfile_name],
         Exec["mkdir ${enable_dir}"],
@@ -152,7 +152,7 @@ define apache::mod (
         target  => "${mod_dir}/${mod}.conf",
         owner   => 'root',
         group   => $::apache::params::root_group,
-        mode    => '0644',
+        mode    => $::apache::file_mode,
         require => [
           File["${mod}.conf"],
           Exec["mkdir ${enable_dir}"],

--- a/manifests/mod/event.pp
+++ b/manifests/mod/event.pp
@@ -27,7 +27,7 @@ class apache::mod::event (
   File {
     owner => 'root',
     group => $::apache::params::root_group,
-    mode  => '0644',
+    mode  => $::apache::file_mode,
   }
 
   # Template uses:

--- a/manifests/mod/itk.pp
+++ b/manifests/mod/itk.pp
@@ -35,7 +35,7 @@ class apache::mod::itk (
   File {
     owner => 'root',
     group => $::apache::params::root_group,
-    mode  => '0644',
+    mode  => $::apache::file_mode,
   }
 
   # Template uses:

--- a/manifests/mod/peruser.pp
+++ b/manifests/mod/peruser.pp
@@ -35,7 +35,7 @@ class apache::mod::peruser (
       File {
         owner => 'root',
         group => $::apache::params::root_group,
-        mode  => '0644',
+        mode  => $::apache::file_mode,
       }
 
       $mod_dir = $::apache::mod_dir

--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -50,7 +50,7 @@ class apache::mod::php (
     path    => "${::apache::mod_dir}/php5.conf",
     owner   => 'root',
     group   => $root_group,
-    mode    => '0644',
+    mode    => $::apache::file_mode,
     content => $manage_content,
     source  => $source,
     require => [

--- a/manifests/mod/prefork.pp
+++ b/manifests/mod/prefork.pp
@@ -24,7 +24,7 @@ class apache::mod::prefork (
   File {
     owner => 'root',
     group => $::apache::params::root_group,
-    mode  => '0644',
+    mode  => $::apache::file_mode,
   }
 
   # Template uses:

--- a/manifests/mod/worker.pp
+++ b/manifests/mod/worker.pp
@@ -79,7 +79,7 @@ class apache::mod::worker (
   File {
     owner => 'root',
     group => $::apache::params::root_group,
-    mode  => '0644',
+    mode  => $::apache::file_mode,
   }
 
   # Template uses:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -45,6 +45,9 @@ class apache::params inherits ::apache::version {
   # should we use systemd module?
   $use_systemd = true
 
+  # Default mode for files
+  $file_mode = '0644'
+
   $vhost_include_pattern = '*'
 
   if $::operatingsystem == 'Ubuntu' and $::lsbdistrelease == '10.04' {

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -504,7 +504,7 @@ define apache::vhost(
     path    => "${::apache::vhost_dir}/${priority_real}${filename}.conf",
     owner   => 'root',
     group   => $::apache::params::root_group,
-    mode    => '0644',
+    mode    => $::apache::file_mode,
     order   => 'numeric',
     require => Package['httpd'],
     notify  => Class['apache::service'],
@@ -523,7 +523,7 @@ define apache::vhost(
       target  => "${::apache::vhost_dir}/${priority_real}${filename}.conf",
       owner   => 'root',
       group   => $::apache::params::root_group,
-      mode    => '0644',
+      mode    => $::apache::file_mode,
       require => Concat["${priority_real}${filename}.conf"],
       notify  => Class['apache::service'],
     }

--- a/manifests/vhost/custom.pp
+++ b/manifests/vhost/custom.pp
@@ -30,7 +30,7 @@ define apache::vhost::custom(
       target  => "${::apache::vhost_dir}/${priority}-${filename}.conf",
       owner   => 'root',
       group   => $::apache::params::root_group,
-      mode    => '0644',
+      mode    => $::apache::file_mode,
       require => Apache::Custom_config[$filename],
     }
   }

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -835,6 +835,16 @@ describe 'apache', :type => :class do
         )
       }
     end
+    context 'with a custom file_mode parameter' do
+      let :params do {
+        :file_mode => '0640'
+      }
+      end
+      it { is_expected.to contain_concat("/etc/httpd/conf/ports.conf").with(
+        'mode' => '0640',
+      )
+      }
+    end
     context 'default vhost defaults' do
       it { is_expected.to contain_apache__vhost('default').with_ensure('present') }
       it { is_expected.to contain_apache__vhost('default-ssl').with_ensure('absent') }

--- a/spec/defines/mod_spec.rb
+++ b/spec/defines/mod_spec.rb
@@ -34,6 +34,20 @@ describe 'apache::mod', :type => :define do
       end
     end
 
+    describe "with file_mode set" do
+      let :pre_condition do
+        "class {'::apache': file_mode => '0640'}"
+      end
+      let :title do
+        'spec_m'
+      end
+      it "should manage the module load file" do
+        is_expected.to contain_file('spec_m.load').with({
+          :mode    => '0640',
+        } )
+      end
+    end
+
     describe "with shibboleth module and package param passed" do
       # name/title for the apache::mod define
       let :title do


### PR DESCRIPTION
This PR adds an parameter `file_mode` to specify the desired permissions mode the config files are created with.