### PR TITLE
fix vhosts listen to wildcard ip

### DIFF
--- a/lib/puppet/parser/functions/enclose_ipv6.rb
+++ b/lib/puppet/parser/functions/enclose_ipv6.rb
@@ -28,16 +28,18 @@ Takes an array of ip addresses and encloses the ipv6 addresses with square brack
     result = []
 
     input.each do |val|
-      begin
-        ip = IPAddr.new(val)
-      rescue *rescuable_exceptions
-        raise(Puppet::ParseError, "enclose_ipv6(): Wrong argument "+
-          "given #{val} is not an ip address.")
+      unless val == '*'
+        begin
+          ip = IPAddr.new(val)
+        rescue *rescuable_exceptions
+          raise(Puppet::ParseError, "enclose_ipv6(): Wrong argument "+
+                "given #{val} is not an ip address.")
+        end
+        val = "[#{ip.to_s}]" if ip.ipv6?
       end
-      val = "[#{ip.to_s}]" if ip.ipv6?
-      result = [result,val]
+      result << val
     end
 
-    return result.flatten.compact
+    return result.uniq
   end
 end

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -567,6 +567,39 @@ describe 'apache::vhost', :type => :define do
       it { is_expected.to_not contain_concat__fragment('NameVirtualHost [::1]:80') }
     end
 
+    context 'vhost with wildcard ip address' do
+      let :params do
+        {
+          'port'                        => '80',
+          'ip'                          => '*',
+          'ip_based'                    => true,
+          'servername'                  => 'example.com',
+          'docroot'                     => '/var/www/html',
+          'add_listen'                  => true,
+          'ensure'                      => 'present'
+        }
+      end
+      let :facts do
+        {
+          :osfamily               => 'RedHat',
+          :operatingsystemrelease => '7',
+          :concat_basedir         => '/dne',
+          :operatingsystem        => 'RedHat',
+          :id                     => 'root',
+          :kernel                 => 'Linux',
+          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :kernelversion          => '3.6.2',
+          :is_pe                  => false,
+        }
+      end
+
+      it { is_expected.to compile }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-apache-header').with(
+        :content => /[.\/m]*<VirtualHost \*:80>[.\/m]*$/ ) }
+      it { is_expected.to contain_concat__fragment('Listen *:80') }
+      it { is_expected.to_not contain_concat__fragment('NameVirtualHost *:80') }
+    end
+
     context 'set only aliases' do
       let :params do
         {

--- a/spec/unit/puppet/parser/functions/enclose_ipv6_spec.rb
+++ b/spec/unit/puppet/parser/functions/enclose_ipv6_spec.rb
@@ -28,6 +28,10 @@ describe "the enclose_ipv6 function" do
     expect { scope.function_enclose_ipv6(['127.0.0.1']) }.to_not raise_error
   end
 
+  it "should not raise a ParseError when given * as ip string" do
+    expect { scope.function_enclose_ipv6(['*']) }.to_not raise_error
+  end
+
   it "should not raise a ParseError when given an array of ip strings" do
     expect { scope.function_enclose_ipv6([['127.0.0.1','fe80::1']]) }.to_not raise_error
   end
@@ -49,8 +53,8 @@ describe "the enclose_ipv6 function" do
   end
 
   it "should embrace ipv6 adresses within an array of ip addresses" do
-    result = scope.function_enclose_ipv6([['127.0.0.1','fe80::1','[fe80::1]']])
-    expect(result).to(eq(['127.0.0.1','[fe80::1]','[fe80::1]']))
+    result = scope.function_enclose_ipv6([['127.0.0.1','fe80::1','[fe80::2]']])
+    expect(result).to(eq(['127.0.0.1','[fe80::1]','[fe80::2]']))
   end
 
   it "should embrace a single ipv6 adresse" do


### PR DESCRIPTION
```
apache::vhost { 'test':
  ip => '*',
}
```

currently fails. This PR fixes the behavior.