### PR TITLE
MODULES-2990: Gentoo - fix module includes in portage::makeconf

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -273,9 +273,24 @@ class apache (
         $scriptalias          = '/var/www/localhost/cgi-bin'
         $access_log_file      = 'access.log'
 
-        ::portage::makeconf { 'apache2_modules':
-          content => $default_mods,
+        if is_array($default_mods) {
+          if versioncmp($apache_version, '2.4') >= 0 {
+            if defined('apache::mod::ssl') {
+              ::portage::makeconf { 'apache2_modules':
+                content => concat($default_mods, [ 'authz_core', 'socache_shmcb' ]),
+              }
+            } else {
+              ::portage::makeconf { 'apache2_modules':
+                content => concat($default_mods, 'authz_core'),
+              }
+            }
+          } else {
+            ::portage::makeconf { 'apache2_modules':
+              content => $default_mods,
+            }
+          }
         }
+
         file { [
           '/etc/apache2/modules.d/.keep_www-servers_apache-2',
           '/etc/apache2/vhosts.d/.keep_www-servers_apache-2'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -442,19 +442,20 @@ class apache::params inherits ::apache::version {
     $suphp_configpath = '/etc/php5/apache2'
     $mod_packages     = {
       # NOTE: I list here only modules that are not included in www-servers/apache
-      'auth_kerb'  => 'www-apache/mod_auth_kerb',
-      'fcgid'      => 'www-apache/mod_fcgid',
-      'passenger'  => 'www-apache/passenger',
-      'perl'       => 'www-apache/mod_perl',
-      'php5'       => 'dev-lang/php',
-      'proxy_html' => 'www-apache/mod_proxy_html',
-      'proxy_fcgi' => 'www-apache/mod_proxy_fcgi',
-      'python'     => 'www-apache/mod_python',
-      'wsgi'       => 'www-apache/mod_wsgi',
-      'dav_svn'    => 'dev-vcs/subversion',
-      'xsendfile'  => 'www-apache/mod_xsendfile',
-      'rpaf'       => 'www-apache/mod_rpaf',
-      'xml2enc'    => 'www-apache/mod_xml2enc',
+      'auth_kerb'       => 'www-apache/mod_auth_kerb',
+      'authnz_external' => 'www-apache/mod_authnz_external',
+      'fcgid'           => 'www-apache/mod_fcgid',
+      'passenger'       => 'www-apache/passenger',
+      'perl'            => 'www-apache/mod_perl',
+      'php5'            => 'dev-lang/php',
+      'proxy_html'      => 'www-apache/mod_proxy_html',
+      'proxy_fcgi'      => 'www-apache/mod_proxy_fcgi',
+      'python'          => 'www-apache/mod_python',
+      'wsgi'            => 'www-apache/mod_wsgi',
+      'dav_svn'         => 'dev-vcs/subversion',
+      'xsendfile'       => 'www-apache/mod_xsendfile',
+      'rpaf'            => 'www-apache/mod_rpaf',
+      'xml2enc'         => 'www-apache/mod_xml2enc',
     }
     $mod_libs         = {
       'php5' => 'libphp5.so',


### PR DESCRIPTION
https://tickets.puppetlabs.com/browse/MODULES-2990

update module handling for gentoo when used apache 2.4
add module authnz_external as external package in gentoo
