### PR TITLE
add file_mode to mod manifests

### DIFF
--- a/manifests/mod/alias.pp
+++ b/manifests/mod/alias.pp
@@ -11,6 +11,7 @@ class apache::mod::alias(
     file { 'alias.conf':
       ensure  => file,
       path    => "${::apache::mod_dir}/alias.conf",
+      mode    => $::apache::file_mode,
       content => template('apache/mod/alias.conf.erb'),
       require => Exec["mkdir ${::apache::mod_dir}"],
       before  => File[$::apache::mod_dir],

--- a/manifests/mod/auth_cas.pp
+++ b/manifests/mod/auth_cas.pp
@@ -39,6 +39,7 @@ class apache::mod::auth_cas (
   file { 'auth_cas.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/auth_cas.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/auth_cas.conf.erb'),
     require => [ Exec["mkdir ${::apache::mod_dir}"], ],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/auth_mellon.pp
+++ b/manifests/mod/auth_mellon.pp
@@ -15,6 +15,7 @@ class apache::mod::auth_mellon (
   file { 'auth_mellon.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/auth_mellon.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/auth_mellon.conf.erb'),
     require => [ Exec["mkdir ${::apache::mod_dir}"], ],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/authnz_ldap.pp
+++ b/manifests/mod/authnz_ldap.pp
@@ -11,6 +11,7 @@ class apache::mod::authnz_ldap (
   file { 'authnz_ldap.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/authnz_ldap.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/authnz_ldap.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/autoindex.pp
+++ b/manifests/mod/autoindex.pp
@@ -4,6 +4,7 @@ class apache::mod::autoindex {
   file { 'autoindex.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/autoindex.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/autoindex.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/cgid.pp
+++ b/manifests/mod/cgid.pp
@@ -23,6 +23,7 @@ class apache::mod::cgid {
     file { 'cgid.conf':
       ensure  => file,
       path    => "${::apache::mod_dir}/cgid.conf",
+      mode    => $::apache::file_mode,
       content => template('apache/mod/cgid.conf.erb'),
       require => Exec["mkdir ${::apache::mod_dir}"],
       before  => File[$::apache::mod_dir],

--- a/manifests/mod/dav_fs.pp
+++ b/manifests/mod/dav_fs.pp
@@ -12,6 +12,7 @@ class apache::mod::dav_fs {
   file { 'dav_fs.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/dav_fs.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/dav_fs.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/deflate.pp
+++ b/manifests/mod/deflate.pp
@@ -17,6 +17,7 @@ class apache::mod::deflate (
   file { 'deflate.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/deflate.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/deflate.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/dir.pp
+++ b/manifests/mod/dir.pp
@@ -13,6 +13,7 @@ class apache::mod::dir (
   file { 'dir.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/dir.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/dir.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/disk_cache.pp
+++ b/manifests/mod/disk_cache.pp
@@ -32,6 +32,7 @@ class apache::mod::disk_cache (
   file { 'disk_cache.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/disk_cache.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/disk_cache.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/event.pp
+++ b/manifests/mod/event.pp
@@ -40,6 +40,7 @@ class apache::mod::event (
   # - $serverlimit
   file { "${::apache::mod_dir}/event.conf":
     ensure  => file,
+    mode    => $::apache::file_mode,
     content => template('apache/mod/event.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/expires.pp
+++ b/manifests/mod/expires.pp
@@ -12,6 +12,7 @@ class apache::mod::expires (
   file { 'expires.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/expires.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/expires.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/ext_filter.pp
+++ b/manifests/mod/ext_filter.pp
@@ -15,6 +15,7 @@ class apache::mod::ext_filter(
     file { 'ext_filter.conf':
       ensure  => file,
       path    => "${::apache::mod_dir}/ext_filter.conf",
+      mode    => $::apache::file_mode,
       content => template('apache/mod/ext_filter.conf.erb'),
       require => [ Exec["mkdir ${::apache::mod_dir}"], ],
       before  => File[$::apache::mod_dir],

--- a/manifests/mod/fastcgi.pp
+++ b/manifests/mod/fastcgi.pp
@@ -14,6 +14,7 @@ class apache::mod::fastcgi {
     file { 'fastcgi.conf':
       ensure  => file,
       path    => "${::apache::mod_dir}/fastcgi.conf",
+      mode    => $::apache::file_mode,
       content => template('apache/mod/fastcgi.conf.erb'),
       require => Exec["mkdir ${::apache::mod_dir}"],
       before  => File[$::apache::mod_dir],

--- a/manifests/mod/fcgid.pp
+++ b/manifests/mod/fcgid.pp
@@ -11,6 +11,7 @@ class apache::mod::fcgid(
   file { 'unixd_fcgid.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/unixd_fcgid.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/unixd_fcgid.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/geoip.pp
+++ b/manifests/mod/geoip.pp
@@ -22,6 +22,7 @@ class apache::mod::geoip (
   file { 'geoip.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/geoip.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/geoip.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/info.pp
+++ b/manifests/mod/info.pp
@@ -10,6 +10,7 @@ class apache::mod::info (
   file { 'info.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/info.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/info.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/itk.pp
+++ b/manifests/mod/itk.pp
@@ -47,6 +47,7 @@ class apache::mod::itk (
   # - $maxrequestsperchild
   file { "${::apache::mod_dir}/itk.conf":
     ensure  => file,
+    mode    => $::apache::file_mode,
     content => template('apache/mod/itk.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/ldap.pp
+++ b/manifests/mod/ldap.pp
@@ -11,6 +11,7 @@ class apache::mod::ldap (
   file { 'ldap.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/ldap.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/ldap.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/mime.pp
+++ b/manifests/mod/mime.pp
@@ -8,6 +8,7 @@ class apache::mod::mime (
   file { 'mime.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/mime.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/mime.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/mime_magic.pp
+++ b/manifests/mod/mime_magic.pp
@@ -6,6 +6,7 @@ class apache::mod::mime_magic (
   file { 'mime_magic.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/mime_magic.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/mime_magic.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/negotiation.pp
+++ b/manifests/mod/negotiation.pp
@@ -16,6 +16,7 @@ class apache::mod::negotiation (
   # Template uses no variables
   file { 'negotiation.conf':
     ensure  => file,
+    mode    => $::apache::file_mode,
     path    => "${::apache::mod_dir}/negotiation.conf",
     content => template('apache/mod/negotiation.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],

--- a/manifests/mod/nss.pp
+++ b/manifests/mod/nss.pp
@@ -18,6 +18,7 @@ class apache::mod::nss (
   file { 'nss.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/nss.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/nss.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/pagespeed.pp
+++ b/manifests/mod/pagespeed.pp
@@ -47,6 +47,7 @@ class apache::mod::pagespeed (
   file { 'pagespeed.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/pagespeed.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/pagespeed.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/peruser.pp
+++ b/manifests/mod/peruser.pp
@@ -52,6 +52,7 @@ class apache::mod::peruser (
       # - $mod_dir
       file { "${::apache::mod_dir}/peruser.conf":
         ensure  => file,
+        mode    => $::apache::file_mode,
         content => template('apache/mod/peruser.conf.erb'),
         require => Exec["mkdir ${::apache::mod_dir}"],
         before  => File[$::apache::mod_dir],

--- a/manifests/mod/proxy.pp
+++ b/manifests/mod/proxy.pp
@@ -8,6 +8,7 @@ class apache::mod::proxy (
   file { 'proxy.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/proxy.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/proxy.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/proxy_html.pp
+++ b/manifests/mod/proxy_html.pp
@@ -29,6 +29,7 @@ class apache::mod::proxy_html {
   file { 'proxy_html.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/proxy_html.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/proxy_html.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/remoteip.pp
+++ b/manifests/mod/remoteip.pp
@@ -19,6 +19,7 @@ class apache::mod::remoteip (
   file { 'remoteip.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/remoteip.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/remoteip.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/rpaf.pp
+++ b/manifests/mod/rpaf.pp
@@ -12,6 +12,7 @@ class apache::mod::rpaf (
   file { 'rpaf.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/rpaf.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/rpaf.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/security.pp
+++ b/manifests/mod/security.pp
@@ -35,6 +35,7 @@ class apache::mod::security (
   file { 'security.conf':
     ensure  => file,
     content => template('apache/mod/security.conf.erb'),
+    mode    => $::apache::file_mode,
     path    => "${::apache::mod_dir}/security.conf",
     owner   => $::apache::params::user,
     group   => $::apache::params::group,

--- a/manifests/mod/setenvif.pp
+++ b/manifests/mod/setenvif.pp
@@ -4,6 +4,7 @@ class apache::mod::setenvif {
   file { 'setenvif.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/setenvif.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/setenvif.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -73,6 +73,7 @@ class apache::mod::ssl (
   file { 'ssl.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/ssl.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/ssl.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/status.pp
+++ b/manifests/mod/status.pp
@@ -11,7 +11,7 @@
 #   values are 'On' or 'Off'.  Defaults to 'On'.
 # - $status_path is the path assigned to the Location directive which
 #   defines the URL to access the server status. Defaults to '/server-status'.
-# 
+#
 # Actions:
 # - Enable and configure Apache mod_status
 #
@@ -38,6 +38,7 @@ class apache::mod::status (
   file { 'status.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/status.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/status.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/suphp.pp
+++ b/manifests/mod/suphp.pp
@@ -5,6 +5,7 @@ class apache::mod::suphp (
   file {'suphp.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/suphp.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/suphp.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/userdir.pp
+++ b/manifests/mod/userdir.pp
@@ -11,6 +11,7 @@ class apache::mod::userdir (
   file { 'userdir.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/userdir.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/userdir.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],

--- a/manifests/mod/wsgi.pp
+++ b/manifests/mod/wsgi.pp
@@ -32,6 +32,7 @@ class apache::mod::wsgi (
   file {'wsgi.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/wsgi.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/wsgi.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],


### PR DESCRIPTION
This PR extends #1333 and adds the file_mode parameter to a lot of module manifests.
This is useful if you have to meet security regulations, e.g. change the file mode to '0640'.