### PR TITLE
add parameter root_directory_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1164,6 +1164,10 @@ Controls whether the systemd module should be installed on Centos 7 servers, thi
 
 The desired permissions mode for config files, in symbolic or numeric notation. This value must be a string. Defaults to '0644'.
 
+##### `root_directory_options`
+
+Array of the desired options for the / directory in httpd.conf. Defaults to 'FollowSymLinks'.
+
 ##### `vhost_dir`
 
 Changes your virtual host configuration files' location. Default: determined by your operating system.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -80,6 +80,7 @@ class apache (
   $use_systemd            = $::apache::params::use_systemd,
   $mime_types_additional  = $::apache::params::mime_types_additional,
   $file_mode              = $::apache::params::file_mode,
+  $root_directory_options = $::apache::params::root_directory_options,
 ) inherits ::apache::params {
   validate_bool($default_vhost)
   validate_bool($default_ssl_vhost)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -48,6 +48,9 @@ class apache::params inherits ::apache::version {
   # Default mode for files
   $file_mode = '0644'
 
+  # Default options for / directory
+  $root_directory_options = ['FollowSymLinks']
+
   $vhost_include_pattern = '*'
 
   if $::operatingsystem == 'Ubuntu' and $::lsbdistrelease == '10.04' {

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -845,9 +845,17 @@ describe 'apache', :type => :class do
       )
       }
     end
+    context 'with a custom root_directory_options parameter' do
+      let :params do {
+        :root_directory_options => ['-Indexes', '-FollowSymLinks']
+      }
+      end
+      it { is_expected.to contain_file("/etc/httpd/conf/httpd.conf").with_content %r{Options -Indexes -FollowSymLinks} }
+    end
     context 'default vhost defaults' do
       it { is_expected.to contain_apache__vhost('default').with_ensure('present') }
       it { is_expected.to contain_apache__vhost('default-ssl').with_ensure('absent') }
+      it { is_expected.to contain_file("/etc/httpd/conf/httpd.conf").with_content %r{Options FollowSymLinks} }
     end
     context 'without default non-ssl vhost' do
       let :params do {

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -31,7 +31,7 @@ AccessFileName .htaccess
 </FilesMatch>
 
 <Directory />
-  Options FollowSymLinks
+  Options <%= Array(@root_directory_options).join(' ') %>
   AllowOverride None
 </Directory>
 


### PR DESCRIPTION
This PR adds the parameter root_directory_options to the apache class in order to change the options in httpd.conf:
```
<Directory />
  Options FollowSymLinks
   AllowOverride None
 </Directory>
```

This is necessary for hardening of apache, e.g. it is done in the hardening.io project.