### PR TITLE
Preserve /etc/httpd/conf.d/passenger.conf on EL7

### DIFF
--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -35,7 +35,7 @@ class apache::mod::passenger (
   # Managed by the package, but declare it to avoid purging
   if $passenger_conf_package_file {
     file { 'passenger_package.conf':
-      path => "${::apache::mod_dir}/${passenger_conf_package_file}",
+      path => "${::apache::confd_dir}/${passenger_conf_package_file}",
     }
   }
 

--- a/spec/classes/mod/passenger_spec.rb
+++ b/spec/classes/mod/passenger_spec.rb
@@ -237,10 +237,9 @@ describe 'apache::mod::passenger', :type => :class do
   end
 
   context "on a RedHat OS" do
-    let :facts do
+    let :rh_facts do
       {
         :osfamily               => 'RedHat',
-        :operatingsystemrelease => '6',
         :concat_basedir         => '/dne',
         :operatingsystem        => 'RedHat',
         :id                     => 'root',
@@ -249,30 +248,46 @@ describe 'apache::mod::passenger', :type => :class do
         :is_pe                  => false,
       }
     end
-    it { is_expected.to contain_class("apache::params") }
-    it { is_expected.to contain_apache__mod('passenger') }
-    it { is_expected.to contain_package("mod_passenger") }
-    it { is_expected.to contain_file('passenger_package.conf').with({
-      'path' => '/etc/httpd/conf.d/passenger.conf',
-    }) }
-    it { is_expected.to contain_file('passenger_package.conf').without_content }
-    it { is_expected.to contain_file('passenger_package.conf').without_source }
-    it { is_expected.to contain_file('zpassenger.load').with({
-      'path' => '/etc/httpd/conf.d/zpassenger.load',
-    }) }
-    it { is_expected.to contain_file('passenger.conf').without_content(/PassengerRoot/) }
-    it { is_expected.to contain_file('passenger.conf').without_content(/PassengerRuby/) }
-    describe "with passenger_root => '/usr/lib/example'" do
-      let :params do
-        { :passenger_root => '/usr/lib/example' }
+
+    context "on EL6" do
+      let(:facts) { rh_facts.merge(:operatingsystemrelease => '6') }
+
+      it { is_expected.to contain_class("apache::params") }
+      it { is_expected.to contain_apache__mod('passenger') }
+      it { is_expected.to contain_package("mod_passenger") }
+      it { is_expected.to contain_file('passenger_package.conf').with({
+        'path' => '/etc/httpd/conf.d/passenger.conf',
+      }) }
+      it { is_expected.to contain_file('passenger_package.conf').without_content }
+      it { is_expected.to contain_file('passenger_package.conf').without_source }
+      it { is_expected.to contain_file('zpassenger.load').with({
+        'path' => '/etc/httpd/conf.d/zpassenger.load',
+      }) }
+      it { is_expected.to contain_file('passenger.conf').without_content(/PassengerRoot/) }
+      it { is_expected.to contain_file('passenger.conf').without_content(/PassengerRuby/) }
+      describe "with passenger_root => '/usr/lib/example'" do
+        let :params do
+          { :passenger_root => '/usr/lib/example' }
+        end
+        it { is_expected.to contain_file('passenger.conf').with_content(/^  PassengerRoot "\/usr\/lib\/example"$/) }
       end
-      it { is_expected.to contain_file('passenger.conf').with_content(/^  PassengerRoot "\/usr\/lib\/example"$/) }
+      describe "with passenger_ruby => /usr/lib/example/ruby" do
+        let :params do
+          { :passenger_ruby => '/usr/lib/example/ruby' }
+        end
+        it { is_expected.to contain_file('passenger.conf').with_content(/^  PassengerRuby "\/usr\/lib\/example\/ruby"$/) }
+      end
     end
-    describe "with passenger_ruby => /usr/lib/example/ruby" do
-      let :params do
-        { :passenger_ruby => '/usr/lib/example/ruby' }
-      end
-      it { is_expected.to contain_file('passenger.conf').with_content(/^  PassengerRuby "\/usr\/lib\/example\/ruby"$/) }
+
+    context "on EL7" do
+      let(:facts) { rh_facts.merge(:operatingsystemrelease => '7') }
+
+      it { is_expected.to contain_file('passenger_package.conf').with({
+        'path' => '/etc/httpd/conf.d/passenger.conf',
+      }) }
+      it { is_expected.to contain_file('zpassenger.load').with({
+        'path' => '/etc/httpd/conf.modules.d/zpassenger.load',
+      }) }
     end
   end
   context "on a FreeBSD OS" do


### PR DESCRIPTION
mod_passenger provides a passenger.conf containing PassengerRoot to
ensure the service starts up correctly.  On EL7, this is installed at
/etc/httpd/conf.d/passenger.conf and has been protected from purging
since 005bf61.

The change in 2a608592 to move LoadModule config files to
/etc/httpd/conf.modules.d/ on EL7 also affected the path of the
protected passenger.conf.  This change reverts the path change to match
the packages.

In summary, prior to 2a608592 (release 1.7.0):

- /etc/httpd/conf.d/passenger.conf with PassengerRoot (packaged)
- /etc/httpd/conf.d/passenger_extra.conf with apache::mod::passenger settings
- /etc/httpd/conf.d/zpassenger.load with LoadModule

In 2a608592 (release 1.8.0):

- /etc/httpd/conf.modules.d/passenger_extra.conf with apache::mod::passenger settings
- /etc/httpd/conf.modules.d/zpassenger.load with LoadModule
- /etc/httpd/conf.d/passenger.conf is purged

With this commit:

- /etc/httpd/conf.modules.d/passenger_extra.conf with apache::mod::passenger settings
- /etc/httpd/conf.modules.d/zpassenger.load with LoadModule
- /etc/httpd/conf.d/passenger.conf with PassengerRoot (packaged)

---

I targeted this at the 1.8.x branch, as it's a regression in 1.8.0 - is that OK?  I assume it'll get merged up to master and possibly put into a patch release this way.