### PR TITLE
Allow value of $ssl_mutex to be defined outside this module

### DIFF
--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -9,34 +9,39 @@ class apache::mod::ssl (
   $ssl_pass_phrase_dialog  = 'builtin',
   $ssl_random_seed_bytes   = '512',
   $ssl_sessioncachetimeout = '300',
+  $mutex                   = undef,
   $apache_version          = $::apache::apache_version,
   $package_name            = undef,
 ) {
 
-  case $::osfamily {
-    'debian': {
-      if versioncmp($apache_version, '2.4') >= 0 {
-        $ssl_mutex = 'default'
-      } elsif $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '10.04' {
-        $ssl_mutex = 'file:/var/run/apache2/ssl_mutex'
-      } else {
-        $ssl_mutex = "file:\${APACHE_RUN_DIR}/ssl_mutex"
+  if $mutex != undef {
+    $ssl_mutex = $mutex
+  } else {
+    case $::osfamily {
+      'debian': {
+        if versioncmp($apache_version, '2.4') >= 0 {
+          $ssl_mutex = 'default'
+        } elsif $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '10.04' {
+          $ssl_mutex = 'file:/var/run/apache2/ssl_mutex'
+        } else {
+          $ssl_mutex = "file:\${APACHE_RUN_DIR}/ssl_mutex"
+        }
       }
-    }
-    'redhat': {
-      $ssl_mutex = 'default'
-    }
-    'freebsd': {
-      $ssl_mutex = 'default'
-    }
-    'gentoo': {
-      $ssl_mutex = 'default'
-    }
-    'Suse': {
-      $ssl_mutex = 'default'
-    }
-    default: {
-      fail("Unsupported osfamily ${::osfamily}")
+      'redhat': {
+        $ssl_mutex = 'default'
+      }
+      'freebsd': {
+        $ssl_mutex = 'default'
+      }
+      'gentoo': {
+        $ssl_mutex = 'default'
+      }
+      'Suse': {
+        $ssl_mutex = 'default'
+      }
+      default: {
+        fail("Unsupported osfamily ${::osfamily}")
+      }
     }
   }
 


### PR DESCRIPTION
I'd like to override the value of ssl_mutex (https://github.com/puppetlabs/puppetlabs-apache/blob/master/manifests/mod/ssl.pp#L16-L41) and supply a value from an external source such as hiera.

e.g `apache::mod::ssl::mutex: 'posixsem'`

Why? http://blather.michaelwlucas.com/archives/678

Setting `$ssl_mutex = 'default'` is breaking our Apache install, but I can't re-assign the variable.

I can do a hiera lookup using an intermediate variable like:
``` puppet
  if $mutex != undef {
        $ssl_mutex = $mutex
  }
  else {
    ... current module behaviour....
  }
```

Is there a neater way to do this?  I'm more than happy to work on this module, as that's what I'm doing already to get it working in our installation.