### PR TITLE
Bugfix: require concat, not file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -345,7 +345,7 @@ class apache (
       ensure  => file,
       content => template($conf_template),
       notify  => Class['Apache::Service'],
-      require => [Package['httpd'], File[$ports_file]],
+      require => [Package['httpd'], Concat[$ports_file]],
     }
 
     # preserve back-wards compatibility to the times when default_mods was

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -504,7 +504,7 @@ describe 'apache', :type => :class do
       it { is_expected.to contain_file("/opt/rh/root/etc/httpd/conf/httpd.conf").with(
         'ensure'  => 'file',
         'notify'  => 'Class[Apache::Service]',
-        'require' => ['Package[httpd]', 'File[/etc/httpd/conf/ports.conf]'],
+        'require' => ['Package[httpd]', 'Concat[/etc/httpd/conf/ports.conf]'],
       ) }
     end
 


### PR DESCRIPTION
The $ports_file is created via the concat resource, not the file resource.

Therefore, the related require attribute should reference concat, not file.

This also fixes [bug 2850](https://tickets.puppetlabs.com/browse/MODULES-2850)