### PR TITLE
Use valid parameter name

### DIFF
--- a/manifests/mod/authnz_ldap.pp
+++ b/manifests/mod/authnz_ldap.pp
@@ -1,14 +1,22 @@
 class apache::mod::authnz_ldap (
-  $verifyServerCert = true,
+  $verify_server_cert = true,
+  $verifyServerCert   = undef,
 ) {
   include ::apache
   include '::apache::mod::ldap'
   ::apache::mod { 'authnz_ldap': }
 
-  validate_bool($verifyServerCert)
+  if $verifyServerCert {
+    warning('Class[\'apache::mod::authnz_ldap\'] parameter verifyServerCert is deprecated in favor of verify_server_cert')
+    $_verify_server_cert = $verifyServerCert
+  } else {
+    $_verify_server_cert = $verify_server_cert
+  }
+
+  validate_bool($_verify_server_cert)
 
   # Template uses:
-  # - $verifyServerCert
+  # - $_verify_server_cert
   file { 'authnz_ldap.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/authnz_ldap.conf",

--- a/spec/classes/mod/authnz_ldap_spec.rb
+++ b/spec/classes/mod/authnz_ldap_spec.rb
@@ -22,17 +22,17 @@ describe 'apache::mod::authnz_ldap', :type => :class do
       it { is_expected.to contain_class("apache::mod::ldap") }
       it { is_expected.to contain_apache__mod('authnz_ldap') }
 
-      context 'default verifyServerCert' do
+      context 'default verify_server_cert' do
         it { is_expected.to contain_file('authnz_ldap.conf').with_content(/^LDAPVerifyServerCert On$/) }
       end
 
-      context 'verifyServerCert = false' do
-        let(:params) { { :verifyServerCert => false } }
+      context 'verify_server_cert = false' do
+        let(:params) { { :verify_server_cert => false } }
         it { is_expected.to contain_file('authnz_ldap.conf').with_content(/^LDAPVerifyServerCert Off$/) }
       end
 
-      context 'verifyServerCert = wrong' do
-        let(:params) { { :verifyServerCert => 'wrong' } }
+      context 'verify_server_cert = wrong' do
+        let(:params) { { :verify_server_cert => 'wrong' } }
         it 'should raise an error' do
           expect { is_expected.to raise_error Puppet::Error }
         end
@@ -56,17 +56,17 @@ describe 'apache::mod::authnz_ldap', :type => :class do
       it { is_expected.to contain_class("apache::mod::ldap") }
       it { is_expected.to contain_apache__mod('authnz_ldap') }
 
-      context 'default verifyServerCert' do
+      context 'default verify_server_cert' do
         it { is_expected.to contain_file('authnz_ldap.conf').with_content(/^LDAPVerifyServerCert On$/) }
       end
 
-      context 'verifyServerCert = false' do
-        let(:params) { { :verifyServerCert => false } }
+      context 'verify_server_cert = false' do
+        let(:params) { { :verify_server_cert => false } }
         it { is_expected.to contain_file('authnz_ldap.conf').with_content(/^LDAPVerifyServerCert Off$/) }
       end
 
-      context 'verifyServerCert = wrong' do
-        let(:params) { { :verifyServerCert => 'wrong' } }
+      context 'verify_server_cert = wrong' do
+        let(:params) { { :verify_server_cert => 'wrong' } }
         it 'should raise an error' do
           expect { is_expected.to raise_error Puppet::Error }
         end

--- a/templates/mod/authnz_ldap.conf.erb
+++ b/templates/mod/authnz_ldap.conf.erb
@@ -1,4 +1,4 @@
-<% if @verifyServerCert == true -%>
+<% if @_verify_server_cert == true -%>
 LDAPVerifyServerCert On
 <% else -%>
 LDAPVerifyServerCert Off


### PR DESCRIPTION
According to this document, uppercase letters are not allowed:
https://docs.puppetlabs.com/puppet/latest/reference/lang_reserved.html#parameters