### PR TITLE
Disable passenger tests other than vhost

### DIFF
--- a/spec/acceptance/mod_passenger_spec.rb
+++ b/spec/acceptance/mod_passenger_spec.rb
@@ -2,9 +2,11 @@ require 'spec_helper_acceptance'
 require_relative './version.rb'
 
 describe 'apache::mod::passenger class' do
+  pending 'This cannot run in the same test run as apache::vhost with passenger
+  as the passenger.conf file is not yet managed by puppet and will be wiped out
+  between tests and not replaced'
   case fact('osfamily')
   when 'Debian'
-    mod_dir = '/etc/apache2/mods-available/'
     conf_file = "#{$mod_dir}/passenger.conf"
     load_file = "#{$mod_dir}/zpassenger.load"
 


### PR DESCRIPTION
The module does not yet manage passenger.conf with puppet and so any two
tests that use passenger with non-passenger tests between them will
cause failures.