### PR TITLE
Fix in custom fact "apache_version" for RHEL.

### DIFF
--- a/lib/facter/apache_version.rb
+++ b/lib/facter/apache_version.rb
@@ -2,7 +2,7 @@ Facter.add(:apache_version) do
   setcode do
     if Facter::Util::Resolution.which('apachectl')
       apache_version = Facter::Util::Resolution.exec('apachectl -v 2>&1')
-      %r{^Server version: Apache\/([\w\.]+) \(([\w]+)\)}.match(apache_version)[1]
+      %r{^Server version: Apache\/([\w\.]+) \(([\w ]+)\)}.match(apache_version)[1]
     end
   end
 end


### PR DESCRIPTION
The custom fact defined by lib/facter/apache_version.rb runs
"apachectl -v" and applies the following regular expression:

```
^Server version: Apache\/([\w\.]+) \(([\w]+)\)
```

On RHEL 7.1, running apachectl -v produces the following output:

```
Server version: Apache/2.4.6 (Red Hat Enterprise Linux)
```

The regex fails to match the output because it does not allow
for whitespace inside the parentheses.  The following modified
regex matches properly:

```
^Server version: Apache\/([\w\.]+) \(([\w ]+)\)
```