### PR TITLE
changed rpaf Configuration Directives: RPAF -> RPAF_

### DIFF
--- a/spec/classes/mod/rpaf_spec.rb
+++ b/spec/classes/mod/rpaf_spec.rb
@@ -26,25 +26,25 @@ describe 'apache::mod::rpaf', :type => :class do
     it { is_expected.to contain_file('rpaf.conf').with({
       'path' => '/etc/apache2/mods-available/rpaf.conf',
     }) }
-    it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAFenable On$/) }
+    it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAF_enable On$/) }
 
     describe "with sethostname => true" do
       let :params do
         { :sethostname => 'true' }
       end
-      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAFsethostname On$/) }
+      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAF_sethostname On$/) }
     end
     describe "with proxy_ips => [ 10.42.17.8, 10.42.18.99 ]" do
       let :params do
         { :proxy_ips => [ '10.42.17.8', '10.42.18.99' ] }
       end
-      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAFproxy_ips 10.42.17.8 10.42.18.99$/) }
+      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAF_proxyIPs 10.42.17.8 10.42.18.99$/) }
     end
     describe "with header => X-Real-IP" do
       let :params do
         { :header => 'X-Real-IP' }
       end
-      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAFheader X-Real-IP$/) }
+      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAF_header X-Real-IP$/) }
     end
   end
   context "on a FreeBSD OS" do
@@ -66,25 +66,25 @@ describe 'apache::mod::rpaf', :type => :class do
     it { is_expected.to contain_file('rpaf.conf').with({
       'path' => '/usr/local/etc/apache24/Modules/rpaf.conf',
     }) }
-    it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAFenable On$/) }
+    it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAF_enable On$/) }
 
     describe "with sethostname => true" do
       let :params do
         { :sethostname => 'true' }
       end
-      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAFsethostname On$/) }
+      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAF_sethostname On$/) }
     end
     describe "with proxy_ips => [ 10.42.17.8, 10.42.18.99 ]" do
       let :params do
         { :proxy_ips => [ '10.42.17.8', '10.42.18.99' ] }
       end
-      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAFproxy_ips 10.42.17.8 10.42.18.99$/) }
+      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAF_proxyIPs 10.42.17.8 10.42.18.99$/) }
     end
     describe "with header => X-Real-IP" do
       let :params do
         { :header => 'X-Real-IP' }
       end
-      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAFheader X-Real-IP$/) }
+      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAF_header X-Real-IP$/) }
     end
   end
   context "on a Gentoo OS" do
@@ -106,25 +106,25 @@ describe 'apache::mod::rpaf', :type => :class do
     it { is_expected.to contain_file('rpaf.conf').with({
       'path' => '/etc/apache2/modules.d/rpaf.conf',
     }) }
-    it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAFenable On$/) }
+    it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAF_enable On$/) }
 
     describe "with sethostname => true" do
       let :params do
         { :sethostname => 'true' }
       end
-      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAFsethostname On$/) }
+      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAF_sethostname On$/) }
     end
     describe "with proxy_ips => [ 10.42.17.8, 10.42.18.99 ]" do
       let :params do
         { :proxy_ips => [ '10.42.17.8', '10.42.18.99' ] }
       end
-      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAFproxy_ips 10.42.17.8 10.42.18.99$/) }
+      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAF_proxyIPs 10.42.17.8 10.42.18.99$/) }
     end
     describe "with header => X-Real-IP" do
       let :params do
         { :header => 'X-Real-IP' }
       end
-      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAFheader X-Real-IP$/) }
+      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAF_header X-Real-IP$/) }
     end
   end
 end

--- a/templates/mod/rpaf.conf.erb
+++ b/templates/mod/rpaf.conf.erb
@@ -1,15 +1,15 @@
 # Enable reverse proxy add forward
-RPAFenable On
-# RPAFsethostname will, when enabled, take the incoming X-Host header and
+RPAF_enable On
+# RPAF_sethostname will, when enabled, take the incoming X-Host header and
 # update the virtual host settings accordingly. This allows to have the same
 # hostnames as in the "real" configuration for the forwarding proxy.
 <% if @sethostname -%>
-RPAFsethostname On
+RPAF_sethostname On
 <% else -%>
-RPAFsethostname Off
+RPAF_sethostname Off
 <% end -%>
 # Which IPs are forwarding requests to us
-RPAFproxy_ips <%= Array(@proxy_ips).join(" ") %>
-# Setting RPAFheader allows you to change the header name to parse from the
+RPAF_proxyIPs <%= Array(@proxy_ips).join(" ") %>
+# Setting RPAF_header allows you to change the header name to parse from the
 # default X-Forwarded-For to something of your choice.
-RPAFheader <%= @header %>
+RPAF_header <%= @header %>


### PR DESCRIPTION
mod_rpaf: I changed the names of the different configuration directives as described on https://github.com/gnif/mod_rpaf
modified files:
spec/classes/mod/rpaf_spec.rb
templates/mod/rpaf.conf.erb

os: rhel/centos 6
- httpd-2.2
- mod_rpaf

