### PR TITLE
added extra var.:mod_full_path, where you can define the full path to…

### DIFF
--- a/manifests/mod/shib.pp
+++ b/manifests/mod/shib.pp
@@ -8,11 +8,11 @@ class apache::mod::shib (
     # RedHat distributions do not have Apache mod_shib in their default package repositories
     # use mod_full_path to set the full path for the shibboleth module
     if ($mod_full_path == undef) {
-      fail("apache::mod::shib os=$::osfamily mod_full_path must be specified!")
+      fail("os=${::osfamily} apache::mod::shib::mod_full_path must be specified!")
     }
     ::apache::mod { $mod_shib:
       id   => 'mod_shib',
-      path => "${mod_full_path}",
+      path => $mod_full_path,
     }
   }
   else {

--- a/manifests/mod/shib.pp
+++ b/manifests/mod/shib.pp
@@ -8,7 +8,7 @@ class apache::mod::shib (
     # RedHat distributions do not have Apache mod_shib in their default package repositories
     # use mod_full_path to set the full path for the shibboleth module
     if ($mod_full_path == undef) {
-      fail("os=${::osfamily} apache::mod::shib::mod_full_path must be specified!")
+      warning("os=${::osfamily} apache::mod::shib::mod_full_path undef.")
     }
     ::apache::mod { $mod_shib:
       id   => 'mod_shib',
@@ -21,4 +21,3 @@ class apache::mod::shib (
     }
   }
 }
-

--- a/manifests/mod/shib.pp
+++ b/manifests/mod/shib.pp
@@ -1,15 +1,24 @@
 class apache::mod::shib (
   $suppress_warning = false,
+  $mod_full_path = undef,
 ) {
-
-  if $::osfamily == 'RedHat' and ! $suppress_warning {
-    warning('RedHat distributions do not have Apache mod_shib in their default package repositories.')
-  }
-
   $mod_shib = 'shib2'
 
-  apache::mod {$mod_shib:
-    id => 'mod_shib',
+  if ($::osfamily == 'RedHat' or $::osfamily == 'CentOS') and ! $suppress_warning {
+    # RedHat distributions do not have Apache mod_shib in their default package repositories
+    # use mod_full_path to set the full path for the shibboleth module
+    if ($mod_full_path == undef) {
+      fail("apache::mod::shib os=$::osfamily mod_full_path must be specified!")
+    }
+    ::apache::mod { $mod_shib:
+      id   => 'mod_shib',
+      path => "${mod_full_path}",
+    }
   }
-
+  else {
+    apache::mod {$mod_shib:
+      id   => 'mod_shib',
+    }
+  }
 }
+


### PR DESCRIPTION
if os=redhat || centos 
use the mod_full_path var. to set the path to the shibboleth module 
ex. apache::mod::shib::mod_full_path: /usr/lib64/shibboleth/mod_shib_22.so
