### PR TITLE
Disable passenger tests on redhatish 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1493,7 +1493,7 @@ Installs and manages [`mod_info`][], which provides a comprehensive overview of 
 
 ##### Class: `apache::mod::passenger`
 
-Installs and manages [`mod_passenger`][].
+Installs and manages [`mod_passenger`][]. For RedHat based systems, please ensure that you meet the minimum requirements as described in the [passenger docs](https://www.phusionpassenger.com/library/install/apache/install/oss/el6/#step-1:-upgrade-your-kernel,-or-disable-selinux)
 
 **Parameters within `apache::mod::passenger`**:
 - `passenger_high_performance` Sets the [`PassengerHighPerformance`](https://www.phusionpassenger.com/library/config/apache/reference/#passengerhighperformance). Valid options: on, off. Default: undef.

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -1106,8 +1106,8 @@ describe 'apache::vhost define' do
     end
   end
 
-  # Passenger isn't even in EPEL on el-5
-  if (fact('osfamily') == 'RedHat' and fact('operatingsystemmajrelease') != '5')
+  # Passenger isn't even in EPEL on el-5 and needs a kernel update on el-6
+  if (fact('osfamily') == 'RedHat' and ! ['6','5'].include?(fact('operatingsystemmajrelease')))
     describe 'rack_base_uris' do
       before :all do
         pp = "if $::osfamily == 'RedHat' { include epel }"


### PR DESCRIPTION
RedHat 6 platforms need either their kernel updated (which we can't do
in testing) or selinux disabled and rebooted (which is silly) so lets
just disable the test.