### PR TITLE
Support socket communication option in apache::fastcgi::server

### DIFF
--- a/README.md
+++ b/README.md
@@ -3355,6 +3355,14 @@ apache::vhost { 'www':
 
 The hostname or IP address and TCP port number (1-65535) of the FastCGI server.
 
+It is also possible to pass a unix socket:
+
+``` puppet
+apache::fastcgi::server { 'php':
+  host        => '/var/run/fcgi.sock',
+}
+```
+
 ##### `timeout`
 
 The number of seconds of FastCGI application inactivity allowed before the request is aborted and the event is logged (at the error LogLevel). The inactivity timer applies only as long as a connection is pending with the FastCGI application. If a request is queued to an application, but the application doesn't respond (by writing and flushing) within this period, the request is aborted. If communication is complete with the application but incomplete with the client (the response is buffered), the timeout does not apply.

--- a/manifests/fastcgi/server.pp
+++ b/manifests/fastcgi/server.pp
@@ -11,6 +11,10 @@ define apache::fastcgi::server (
 
   Apache::Mod['fastcgi'] -> Apache::Fastcgi::Server[$title]
 
+  if is_absolute_path($host) {
+    $socket = $host
+  }
+
   file { "fastcgi-pool-${name}.conf":
     ensure  => present,
     path    => "${::apache::confd_dir}/fastcgi-pool-${name}.conf",

--- a/spec/defines/fastcgi_server_spec.rb
+++ b/spec/defines/fastcgi_server_spec.rb
@@ -133,8 +133,7 @@ Action application/x-httpd-php /php-www.fcgi
     describe ".conf content using socket communication" do
       let :params do
         {
-          :host       => :undef,
-          :socket     => '/var/run/fcgi.sock',
+          :host       => '/var/run/fcgi.sock',
           :timeout    => 30,
           :flush      => true,
           :faux_path  => '/var/www/php-www.fcgi',
@@ -143,7 +142,7 @@ Action application/x-httpd-php /php-www.fcgi
         }
       end
       let :expected do
-        'FastCGIExternalServer /var/www/php-www.fcgi -idle-timeout 30 -flush -socket /var/run/fcgi.sock
+'FastCGIExternalServer /var/www/php-www.fcgi -idle-timeout 30 -flush -socket /var/run/fcgi.sock
 Alias /php-www.fcgi /var/www/php-www.fcgi
 Action application/x-httpd-php /php-www.fcgi
 '

--- a/spec/defines/fastcgi_server_spec.rb
+++ b/spec/defines/fastcgi_server_spec.rb
@@ -108,7 +108,7 @@ describe 'apache::fastcgi::server', :type => :define do
         :is_pe                  => false,
       }
     end
-    describe ".conf content" do
+    describe ".conf content using TCP communication" do
       let :params do
         {
           :host       => '127.0.0.1:9001',
@@ -130,5 +130,28 @@ Action application/x-httpd-php /php-www.fcgi
         should contain_file("fastcgi-pool-www.conf").with_content(expected)
       end
     end
+    describe ".conf content using socket communication" do
+      let :params do
+        {
+          :host       => :undef,
+          :socket     => '/var/run/fcgi.sock',
+          :timeout    => 30,
+          :flush      => true,
+          :faux_path  => '/var/www/php-www.fcgi',
+          :fcgi_alias => '/php-www.fcgi',
+          :file_type  => 'application/x-httpd-php'
+        }
+      end
+      let :expected do
+        'FastCGIExternalServer /var/www/php-www.fcgi -idle-timeout 30 -flush -socket /var/run/fcgi.sock
+Alias /php-www.fcgi /var/www/php-www.fcgi
+Action application/x-httpd-php /php-www.fcgi
+'
+      end
+      it do
+        should contain_file("fastcgi-pool-www.conf").with_content(expected)
+      end
+    end
+
   end
 end

--- a/templates/fastcgi/server.erb
+++ b/templates/fastcgi/server.erb
@@ -4,13 +4,18 @@
   if @flush
     flush = " -flush"
   end
-  host = " -host #{@host}"
+  if @socket
+    host_or_socket = " -socket #{@socket}"
+  else
+    host_or_socket = " -host #{@host}"
+  end
+
   pass_header = ""
   if @pass_header and ! @pass_header.empty?
     pass_header = " -pass-header #{@pass_header}"
   end
 
-  options = timeout + flush + host + pass_header
+  options = timeout + flush + host_or_socket + pass_header
 -%>
 FastCGIExternalServer <%= @faux_path %><%= options %>
 Alias <%= @fcgi_alias %> <%= @faux_path %>


### PR DESCRIPTION
For local fcgi servers it makes sense to skip the TCP stack and communicate via socket.

This is also sugested in #MODULES-1405.

Instead of introducing a new parameter socket, validate functions are used to decide if we have a host or a socket in parameter `host`. 

It might be confusing to pass a socket path to a parameter named `host`, but changing the host parameter name to something like `host_or_socket` would introduce backwards incompatibility.