### PR TITLE
mod/ssl: Add option to configure SSL mutex

### DIFF
--- a/README.md
+++ b/README.md
@@ -1665,6 +1665,11 @@ Installs [Apache SSL features][`mod_ssl`] and uses the `ssl.conf.erb` template t
 - `ssl_protocol`: Default: [ 'all', '-SSLv2', '-SSLv3' ].
 - `ssl_random_seed_bytes`: Valid options: A string. Default: '512'.
 - `ssl_sessioncachetimeout`: Valid options: A string. Default: '300'.
+- `ssl_mutex`: Default: Determined based on the OS. Valid options: See [mod_ssl][mod_ssl] documentation.
+  - RedHat/FreeBSD/Suse/Gentoo: 'default'
+  - Debian/Ubuntu + Apache >= 2.4: 'default'
+  - Debian/Ubuntu + Apache < 2.4: 'file:\${APACHE_RUN_DIR}/ssl_mutex'
+  - Ubuntu 10.04: 'file:/var/run/apache2/ssl_mutex'
 
 To use SSL with a virtual host, you must either set the [`default_ssl_vhost`][] parameter in `::apache` to true **or** the [`ssl`][] parameter in [`apache::vhost`][] to true.
 

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -9,34 +9,39 @@ class apache::mod::ssl (
   $ssl_pass_phrase_dialog  = 'builtin',
   $ssl_random_seed_bytes   = '512',
   $ssl_sessioncachetimeout = '300',
+  $ssl_mutex               = undef,
   $apache_version          = $::apache::apache_version,
   $package_name            = undef,
 ) {
 
-  case $::osfamily {
-    'debian': {
-      if versioncmp($apache_version, '2.4') >= 0 {
-        $ssl_mutex = 'default'
-      } elsif $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '10.04' {
-        $ssl_mutex = 'file:/var/run/apache2/ssl_mutex'
-      } else {
-        $ssl_mutex = "file:\${APACHE_RUN_DIR}/ssl_mutex"
+  if $ssl_mutex {
+    $_ssl_mutex = $ssl_mutex
+  } else {
+    case $::osfamily {
+      'debian': {
+        if versioncmp($apache_version, '2.4') >= 0 {
+          $_ssl_mutex = 'default'
+        } elsif $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '10.04' {
+          $_ssl_mutex = 'file:/var/run/apache2/ssl_mutex'
+        } else {
+          $_ssl_mutex = "file:\${APACHE_RUN_DIR}/ssl_mutex"
+        }
       }
-    }
-    'redhat': {
-      $ssl_mutex = 'default'
-    }
-    'freebsd': {
-      $ssl_mutex = 'default'
-    }
-    'gentoo': {
-      $ssl_mutex = 'default'
-    }
-    'Suse': {
-      $ssl_mutex = 'default'
-    }
-    default: {
-      fail("Unsupported osfamily ${::osfamily}")
+      'redhat': {
+        $_ssl_mutex = 'default'
+      }
+      'freebsd': {
+        $_ssl_mutex = 'default'
+      }
+      'gentoo': {
+        $_ssl_mutex = 'default'
+      }
+      'Suse': {
+        $_ssl_mutex = 'default'
+      }
+      default: {
+        fail("Unsupported osfamily ${::osfamily}, please explicitly pass in \$ssl_mutex")
+      }
     }
   }
 

--- a/spec/classes/mod/ssl_spec.rb
+++ b/spec/classes/mod/ssl_spec.rb
@@ -161,5 +161,14 @@ describe 'apache::mod::ssl', :type => :class do
       end
       it { is_expected.to contain_file('ssl.conf').with_content(/^\s+SSLOpenSSLConfCmd DHParameters "foo.pem"$/)}
     end
+
+    context 'setting ssl_mutex' do
+      let :params do
+        {
+          :ssl_mutex => 'posixsem',
+        }
+      end
+      it { is_expected.to contain_file('ssl.conf').with_content(%r{^  SSLMutex posixsem$})}
+    end
   end
 end

--- a/templates/mod/ssl.conf.erb
+++ b/templates/mod/ssl.conf.erb
@@ -14,9 +14,9 @@
   SSLCompression On
 <% end -%>
   <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
-  Mutex <%= @ssl_mutex %>
+  Mutex <%= @_ssl_mutex %>
   <%- else -%>
-  SSLMutex <%= @ssl_mutex %>
+  SSLMutex <%= @_ssl_mutex %>
   <%- end -%>
   SSLCryptoDevice <%= @ssl_cryptodevice %>
   SSLHonorCipherOrder <%= @ssl_honorcipherorder %>


### PR DESCRIPTION
This allows the end user to explicitly define or override what the `SSLMutex` or `Mutex` configuration for Apache will be as the platform default might not always be desirable.

Supersedes #1346
Closes #1346