### PR TITLE
Ensure module packages are installed before evaluating conf.d dir

### DIFF
--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -64,7 +64,10 @@ define apache::mod (
         File[$_loadfile_name],
         File["${::apache::conf_dir}/${::apache::params::conf_file}"]
       ],
-      default => File[$_loadfile_name],
+      default => [
+        File[$_loadfile_name],
+        File[$::apache::confd_dir],
+      ],
     }
     # if there are any packages, they should be installed before the associated conf file
     Package[$_package] -> File<| title == "${mod}.conf" |>


### PR DESCRIPTION
The problem I'm running into on EL7 is that when the ssl module is enabled, the mod_ssl package gets installed and drops `/etc/httpd/conf.d/ssl.conf`. We want to remove that file, but the purge for `/etc/httpd/conf.d` is being evaluated before the mod_ssl package is being installed. Because both ports.conf and ssl.conf have Listen statements for port 443, apache won't start. On the second client run the `ssl.conf` file will be removed and apache starts fine.

This change ensures that the `mod_ssl` package gets installed prior to the purge on `/etc/httpd/conf.d` being evaluated so that the ssl.conf file gets removed on the first client run.