### PR TITLE
[MODULES-1628] Fix mod rewrite typo in examples

### DIFF
--- a/examples/vhost.pp
+++ b/examples/vhost.pp
@@ -151,7 +151,7 @@ apache::vhost { 'sixteenth.example.com non-ssl':
     {
       comment      => 'redirect non-SSL traffic to SSL site',
       rewrite_cond => ['%{HTTPS} off'],
-      rewrite_rule => ['(.*) https://%{HTTPS_HOST}%{REQUEST_URI}'],
+      rewrite_rule => ['(.*) https://%{HTTP_HOST}%{REQUEST_URI}'],
     }
   ]
 }
@@ -183,7 +183,7 @@ apache::vhost { 'sixteenth.example.com non-ssl old rewrite':
   port         => '80',
   docroot      => '/var/www/sixteenth',
   rewrite_cond => '%{HTTPS} off',
-  rewrite_rule => '(.*) https://%{HTTPS_HOST}%{REQUEST_URI}',
+  rewrite_rule => '(.*) https://%{HTTP_HOST}%{REQUEST_URI}',
 }
 apache::vhost { 'sixteenth.example.com ssl old rewrite':
   servername => 'sixteenth.example.com',


### PR DESCRIPTION
There is no HTTPS_HOST variable in mod_rewrite