### PR TITLE
Add JkMount/JkUnmount directives to vhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -2149,6 +2149,23 @@ apache::vhost { 'sample.example.net':
 }
 ```
 
+##### `jk_mounts`
+
+Sets up a virtual host with 'JkMount' and 'JkUnMount' directives to handle the paths for URL mapping between Tomcat and Apache. Default: undef.
+
+The parameter must be an array of hashes where each hash must contain the 'worker' and either the 'mount' or 'unmount' keys.
+
+Usage typically looks like:
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  jk_mounts => [
+    { mount   => '/*',     worker => 'tcnode1', },
+    { unmount => '/*.jpg', worker => 'tcnode1', },
+  ],
+}
+```
+
 ##### `auth_kerb`
 
 Enable [`mod_auth_kerb`][] parameters for a virtual host. Valid options: Boolean. Default: false.

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -129,6 +129,7 @@ define apache::vhost(
   $modsec_disable_ids          = undef,
   $modsec_disable_ips          = undef,
   $modsec_body_limit           = undef,
+  $jk_mounts                   = undef,
   $auth_kerb                   = false,
   $krb_method_negotiate        = 'on',
   $krb_method_k5passwd         = 'on',
@@ -991,6 +992,16 @@ define apache::vhost(
       target  => "${priority_real}${filename}.conf",
       order   => 330,
       content => template('apache/vhost/_filters.erb'),
+    }
+  }
+
+  # Template uses:
+  # - $jk_mounts
+  if $jk_mounts and ! empty($jk_mounts) {
+    concat::fragment { "${name}-jk_mounts":
+      target  => "${priority_real}${filename}.conf",
+      order   => 340,
+      content => template('apache/vhost/_jk_mounts.erb'),
     }
   }
 

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -338,6 +338,10 @@ describe 'apache::vhost', :type => :define do
           'passenger_start_timeout'     => '600',
           'passenger_pre_start'         => 'http://localhost/myapp',
           'add_default_charset'         => 'UTF-8',
+          'jk_mounts'                   => [
+            { 'mount'   => '/*',     'worker' => 'tcnode1', },
+            { 'unmount' => '/*.jpg', 'worker' => 'tcnode1', },
+          ],
           'auth_kerb'                   => true,
           'krb_method_negotiate'        => 'off',
           'krb_method_k5passwd'         => 'off',
@@ -484,6 +488,10 @@ describe 'apache::vhost', :type => :define do
       it { is_expected.to contain_concat__fragment('rspec.example.com-passenger') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-charsets') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-file_footer') }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-jk_mounts').with(
+        :content => /^\s+JkMount\s+\/\*\s+tcnode1$/)}
+      it { is_expected.to contain_concat__fragment('rspec.example.com-jk_mounts').with(
+        :content => /^\s+JkUnMount\s+\/\*\.jpg\s+tcnode1$/)}
       it { is_expected.to contain_concat__fragment('rspec.example.com-auth_kerb').with(
         :content => /^\s+KrbMethodNegotiate\soff$/)}
       it { is_expected.to contain_concat__fragment('rspec.example.com-auth_kerb').with(

--- a/templates/vhost/_jk_mounts.erb
+++ b/templates/vhost/_jk_mounts.erb
@@ -1,0 +1,12 @@
+<% if @jk_mounts and not @jk_mounts.empty? -%>
+
+  <%- @jk_mounts.each do |jk| -%>
+    <%- if jk.is_a?(Hash) -%>
+      <%- if jk.has_key?('mount') and jk.has_key?('worker') -%>
+  JkMount   <%= jk['mount'] %> <%= jk['worker'] %>
+      <%- elsif jk.has_key?('unmount') and jk.has_key?('worker') -%>
+  JkUnMount <%= jk['unmount'] %> <%= jk['worker'] %>
+      <%- end -%>
+    <%- end -%>
+  <%- end -%>
+<% end -%>


### PR DESCRIPTION
`mod_jk` is one of the possibilities to use Apache as a frontend to Tomcat. The module understands `JkMount` and `JkUnMount` directives to configure whether an URL should be handled by Apache or by Tomcat. This patch enhances `apache::vhost` to allow configuration of these two directives for a virtual host.