### PR TITLE
apache::balancer: Add a target parameter to write to a custom path

### DIFF
--- a/manifests/balancer.pp
+++ b/manifests/balancer.pp
@@ -23,6 +23,10 @@
 # Hash, default empty. If given, each key-value pair will be used as a ProxySet
 # line in the configuration.
 #
+# [*target*]
+# String, default undef. If given, path to the file the balancer definition will
+# be written.
+#
 # [*collect_exported*]
 # Boolean, default 'true'. True means 'collect exported @@balancermember
 # resources' (for the case when every balancermember node exports itself),
@@ -41,21 +45,27 @@
 define apache::balancer (
   $proxy_set = {},
   $collect_exported = true,
+  $target = undef,
 ) {
   include ::apache::mod::proxy_balancer
 
-  $target = "${::apache::params::confd_dir}/balancer_${name}.conf"
+  if $target {
+    $_target = $target
+  } else {
+    $_target = "${::apache::params::confd_dir}/balancer_${name}.conf"
+  }
 
-  concat { $target:
+  concat { "apache_balancer_${name}":
     owner  => '0',
     group  => '0',
+    path   => $_target,
     mode   => $::apache::file_mode,
     notify => Class['Apache::Service'],
   }
 
   concat::fragment { "00-${name}-header":
     ensure  => present,
-    target  => $target,
+    target  => "apache_balancer_${name}",
     order   => '01',
     content => "<Proxy balancer://${name}>\n",
   }
@@ -68,14 +78,14 @@ define apache::balancer (
 
   concat::fragment { "01-${name}-proxyset":
     ensure  => present,
-    target  => $target,
+    target  => "apache_balancer_${name}",
     order   => '19',
     content => inline_template("<% @proxy_set.keys.sort.each do |key| %> Proxyset <%= key %>=<%= @proxy_set[key] %>\n<% end %>"),
   }
 
   concat::fragment { "01-${name}-footer":
     ensure  => present,
-    target  => $target,
+    target  => "apache_balancer_${name}",
     order   => '20',
     content => "</Proxy>\n",
   }

--- a/manifests/balancermember.pp
+++ b/manifests/balancermember.pp
@@ -47,7 +47,7 @@ define apache::balancermember(
 
   concat::fragment { "BalancerMember ${name}":
     ensure  => present,
-    target  => "${::apache::params::confd_dir}/balancer_${balancer_cluster}.conf",
+    target  => "apache_balancer_${balancer_cluster}",
     content => inline_template(" BalancerMember ${url} <%= @options.join ' ' %>\n"),
   }
 }

--- a/spec/defines/balancer_spec.rb
+++ b/spec/defines/balancer_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe 'apache::balancer', :type => :define do
+  let :pre_condition do
+    'include apache'
+  end
+  let :facts do
+    {
+      :osfamily               => 'Debian',
+      :operatingsystem        => 'Debian',
+      :operatingsystemrelease => '6',
+      :lsbdistcodename        => 'squeeze',
+      :id                     => 'root',
+      :concat_basedir         => '/dne',
+      :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      :kernel                 => 'Linux',
+      :is_pe                  => false,
+    }
+  end
+  describe "accept a target parameter and use it" do
+    let :title do
+      'myapp'
+    end
+    let :params do
+      {
+        :target => '/tmp/myapp.conf'
+      }
+    end
+    it { should contain_concat('apache_balancer_myapp').with({
+      :path => "/tmp/myapp.conf",
+    })}
+  end
+end

--- a/spec/defines/balancermember_spec.rb
+++ b/spec/defines/balancermember_spec.rb
@@ -2,21 +2,7 @@ require 'spec_helper'
 
 describe 'apache::balancermember', :type => :define do
   let :pre_condition do
-    'include apache
-    apache::balancer {"balancer":}
-    apache::balancer {"balancer-external":}
-    apache::balancermember {"http://127.0.0.1:8080-external": url => "http://127.0.0.1:8080/", balancer_cluster => "balancer-external"}
-    '
-  end
-  let :title do
-    'http://127.0.0.1:8080/'
-  end
-  let :params do
-    {
-      :options          => [],
-      :url              => 'http://127.0.0.1:8080/',
-      :balancer_cluster => 'balancer-internal'
-    }
+    'include apache'
   end
   let :facts do
     {
@@ -32,6 +18,42 @@ describe 'apache::balancermember', :type => :define do
     }
   end
   describe "allows multiple balancermembers with the same url" do
+    let :pre_condition do
+      'apache::balancer {"balancer":}
+      apache::balancer {"balancer-external":}
+      apache::balancermember {"http://127.0.0.1:8080-external": url => "http://127.0.0.1:8080/", balancer_cluster => "balancer-external"}
+      '
+    end
+    let :title do
+      'http://127.0.0.1:8080/'
+    end
+    let :params do
+      {
+        :options          => [],
+        :url              => 'http://127.0.0.1:8080/',
+        :balancer_cluster => 'balancer-internal'
+      }
+    end
     it { should contain_concat__fragment('BalancerMember http://127.0.0.1:8080/') }
+  end
+  describe "allows balancermember with a different target" do
+    let :pre_condition do
+      'apache::balancer {"balancername": target => "/etc/apache/balancer.conf"}
+      apache::balancermember {"http://127.0.0.1:8080-external": url => "http://127.0.0.1:8080/", balancer_cluster => "balancername"}
+      '
+    end
+    let :title do
+      'http://127.0.0.1:8080/'
+    end
+    let :params do
+      {
+        :options          => [],
+        :url              => 'http://127.0.0.1:8080/',
+        :balancer_cluster => 'balancername'
+      }
+    end
+    it { should contain_concat__fragment('BalancerMember http://127.0.0.1:8080/').with({
+      :target => "apache_balancer_balancername",
+    })}
   end
 end


### PR DESCRIPTION
Thit commits implements a target parameter to the apache::balancer
definition to specify a different configuration path if needed (e.g with
a different suffix or in a different location).