### PR TITLE
Manage mod dir before things that depend on mods

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -189,6 +189,7 @@ class apache (
       purge   => $purge_mod_dir,
       notify  => Class['Apache::Service'],
       require => Package['httpd'],
+      before  => Anchor['::apache::modules_set_up'],
     }
   }
 


### PR DESCRIPTION
On Ubuntu Trusty, the default mpm module is "event". In
puppetlabs-apache, the default mpm module is "worker". These can't both
be loaded at once. The apache puppet module takes care of this by
purging the mods-enabled directory. However, if we try to run a syntax
check before the directory is purged, it fails. The
apache::custom_config defined type contains an "syntax verification for
${name}" exec that can potentially run before the event mod is unloaded.

This patch ensures that the module purging occurs before syntax check
happens so that the puppet run is successful.