### PR TITLE
Allow configuring mod_security's SecAuditLogParts

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@
 [Apache modules]: https://httpd.apache.org/docs/current/mod/
 [array]: https://docs.puppetlabs.com/puppet/latest/reference/lang_data_array.html
 
+[audit log]: https://github.com/SpiderLabs/ModSecurity/wiki/ModSecurity-2-Data-Formats#audit-log
+
 [beaker-rspec]: https://github.com/puppetlabs/beaker-rspec
 
 [certificate revocation list]: https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcarevocationfile
@@ -1706,6 +1708,7 @@ ${modsec\_dir}/activated\_rules.
 - `restricted_headers`: A list of restricted headers separated by slashes and spaces. Default: 'Proxy-Connection/ /Lock-Token/ /Content-Range/ /Translate/ /via/ /if/'.
 - `secpcrematchlimit`: Sets the number for the match limit in the PCRE library. Default: '1500'
 - `secpcrematchlimitrecursion`: Sets the number for the match limit recursion in the PCRE library. Default: '1500'
+- `audit_log_parts`: Sets the sections to be put in the [audit log][]. Default: 'ABIJDEFHZ'
 
 ##### Class: `apache::mod::wsgi`
 

--- a/manifests/mod/security.pp
+++ b/manifests/mod/security.pp
@@ -3,6 +3,7 @@ class apache::mod::security (
   $activated_rules       = $::apache::params::modsec_default_rules,
   $modsec_dir            = $::apache::params::modsec_dir,
   $modsec_secruleengine  = $::apache::params::modsec_secruleengine,
+  $audit_log_parts       = $::apache::params::modsec_audit_log_parts,
   $secpcrematchlimit = $::apache::params::secpcrematchlimit,
   $secpcrematchlimitrecursion = $::apache::params::secpcrematchlimitrecursion,
   $allowed_methods       = 'GET HEAD POST OPTIONS',
@@ -35,6 +36,7 @@ class apache::mod::security (
 
   # Template uses:
   # - $modsec_dir
+  # - $audit_log_parts
   # - secpcrematchlimit
   # - secpcrematchlimitrecursion
   file { 'security.conf':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,6 +47,8 @@ class apache::params inherits ::apache::version {
 
   $vhost_include_pattern = '*'
 
+  $modsec_audit_log_parts = 'ABIJDEFHZ'
+
   if $::operatingsystem == 'Ubuntu' and $::lsbdistrelease == '10.04' {
     $verify_command = '/usr/sbin/apache2ctl -t'
   } else {
@@ -159,7 +161,6 @@ class apache::params inherits ::apache::version {
     $mellon_lock_file     = '/run/mod_auth_mellon/lock'
     $mellon_cache_size    = 100
     $mellon_post_directory = undef
-    $modsec_audit_log_parts = 'ABIJDEFHZ'
     $modsec_crs_package   = 'mod_security_crs'
     $modsec_crs_path      = '/usr/lib/modsecurity.d'
     $modsec_dir           = '/etc/httpd/modsecurity.d'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -159,6 +159,7 @@ class apache::params inherits ::apache::version {
     $mellon_lock_file     = '/run/mod_auth_mellon/lock'
     $mellon_cache_size    = 100
     $mellon_post_directory = undef
+    $modsec_audit_log_parts = 'ABIJDEFHZ'
     $modsec_crs_package   = 'mod_security_crs'
     $modsec_crs_path      = '/usr/lib/modsecurity.d'
     $modsec_dir           = '/etc/httpd/modsecurity.d'

--- a/spec/classes/mod/security_spec.rb
+++ b/spec/classes/mod/security_spec.rb
@@ -47,7 +47,7 @@ describe 'apache::mod::security', :type => :class do
 
     describe 'with parameters' do
       let :params do
-        { :modsec_audit_log_parts => "ABCDZ"
+        { :audit_log_parts => "ABCDZ"
         }
       end
       it { should contain_file('security.conf').with_content("^\s*SecAuditLogParts ABCDZ$") }
@@ -100,7 +100,7 @@ describe 'apache::mod::security', :type => :class do
 
     describe 'with parameters' do
       let :params do
-        { :modsec_audit_log_parts => "ACEZ"
+        { :audit_log_parts => "ACEZ"
         }
       end
       it { should contain_file('security.conf').with_content("^\s*SecAuditLogParts ACEZ$") }

--- a/spec/classes/mod/security_spec.rb
+++ b/spec/classes/mod/security_spec.rb
@@ -27,6 +27,7 @@ describe 'apache::mod::security', :type => :class do
     it { should contain_file('security.conf').with(
       :path => '/etc/httpd/conf.modules.d/security.conf'
     ) }
+    it { should contain_file('security.conf').with_content("^\s*SecAuditLogParts ABJDEFHZ$") }
     it { should contain_file('/etc/httpd/modsecurity.d').with(
       :ensure => 'directory',
       :path => '/etc/httpd/modsecurity.d',
@@ -43,6 +44,13 @@ describe 'apache::mod::security', :type => :class do
       :path => '/etc/httpd/modsecurity.d/security_crs.conf'
     ) }
     it { should contain_apache__security__rule_link('base_rules/modsecurity_35_bad_robots.data') }
+
+    describe 'with parameters' do
+      let :params do
+        { :modsec_audit_log_parts => "ABCDZ"
+        }
+      end
+      it { should contain_file('security.conf').with_content("^\s*SecAuditLogParts ABCDZ$") }
   end
 
   context "on Debian based systems" do

--- a/spec/classes/mod/security_spec.rb
+++ b/spec/classes/mod/security_spec.rb
@@ -27,7 +27,7 @@ describe 'apache::mod::security', :type => :class do
     it { should contain_file('security.conf').with(
       :path => '/etc/httpd/conf.modules.d/security.conf'
     ) }
-    it { should contain_file('security.conf').with_content("^\s*SecAuditLogParts ABJDEFHZ$") }
+    it { should contain_file('security.conf').with_content %r{^\s+SecAuditLogParts ABIJDEFHZ$} }
     it { should contain_file('/etc/httpd/modsecurity.d').with(
       :ensure => 'directory',
       :path => '/etc/httpd/modsecurity.d',
@@ -50,7 +50,7 @@ describe 'apache::mod::security', :type => :class do
         { :audit_log_parts => "ABCDZ"
         }
       end
-      it { should contain_file('security.conf').with_content("^\s*SecAuditLogParts ABCDZ$") }
+      it { should contain_file('security.conf').with_content %r{^\s+SecAuditLogParts ABCDZ$} }
     end
   end
 
@@ -80,7 +80,7 @@ describe 'apache::mod::security', :type => :class do
     it { should contain_file('security.conf').with(
       :path => '/etc/apache2/mods-available/security.conf'
     ) }
-    it { should contain_file('security.conf').with_content("^\s*SecAuditLogParts ABJDEFHZ$") }
+    it { should contain_file('security.conf').with_content %r{^\s+SecAuditLogParts ABIJDEFHZ$} }
     it { should contain_file('/etc/modsecurity').with(
       :ensure => 'directory',
       :path => '/etc/modsecurity',
@@ -103,7 +103,7 @@ describe 'apache::mod::security', :type => :class do
         { :audit_log_parts => "ACEZ"
         }
       end
-      it { should contain_file('security.conf').with_content("^\s*SecAuditLogParts ACEZ$") }
+      it { should contain_file('security.conf').with_content  %r{^\s+SecAuditLogParts ACEZ$} }
     end
   end
 

--- a/spec/classes/mod/security_spec.rb
+++ b/spec/classes/mod/security_spec.rb
@@ -51,6 +51,7 @@ describe 'apache::mod::security', :type => :class do
         }
       end
       it { should contain_file('security.conf').with_content("^\s*SecAuditLogParts ABCDZ$") }
+    end
   end
 
   context "on Debian based systems" do
@@ -79,6 +80,7 @@ describe 'apache::mod::security', :type => :class do
     it { should contain_file('security.conf').with(
       :path => '/etc/apache2/mods-available/security.conf'
     ) }
+    it { should contain_file('security.conf').with_content("^\s*SecAuditLogParts ABJDEFHZ$") }
     it { should contain_file('/etc/modsecurity').with(
       :ensure => 'directory',
       :path => '/etc/modsecurity',
@@ -95,6 +97,14 @@ describe 'apache::mod::security', :type => :class do
       :path => '/etc/modsecurity/security_crs.conf'
     ) }
     it { should contain_apache__security__rule_link('base_rules/modsecurity_35_bad_robots.data') }
+
+    describe 'with parameters' do
+      let :params do
+        { :modsec_audit_log_parts => "ACEZ"
+        }
+      end
+      it { should contain_file('security.conf').with_content("^\s*SecAuditLogParts ACEZ$") }
+    end
   end
 
 end

--- a/templates/mod/security.conf.erb
+++ b/templates/mod/security.conf.erb
@@ -50,7 +50,7 @@
     SecDebugLogLevel 0
     SecAuditEngine RelevantOnly
     SecAuditLogRelevantStatus "^(?:5|4(?!04))"
-    SecAuditLogParts ABIJDEFHZ
+    SecAuditLogParts <%= @audit_log_parts %>
     SecAuditLogType Serial
     SecArgumentSeparator &
     SecCookieFormat 0


### PR DESCRIPTION
The default configuration for this includes "I" which is not always
always suitable, e.g. if you cannot tolerate POST parameters appearing
in your modsec_audit.log

You may want to omit `I` if mod_security is protecting a hypothetical
web service that accepts credit card data in a POST request, for
example.