### PR TITLE
disable mod_setenvif

### DIFF
--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -131,7 +131,7 @@ class apache::default_mods (
     include ::apache::mod::dir
     include ::apache::mod::mime
     include ::apache::mod::negotiation
-    include ::apache::mod::setenvif
+    #include ::apache::mod::setenvif
     ::apache::mod { 'auth_basic': }
 
     if versioncmp($apache_version, '2.4') >= 0 {


### PR DESCRIPTION
https://access.redhat.com/security/cve/CVE-2011-4415  

This is considered a Medium threat by Alert Logic, so disabling it because we don't use it.