### PR TITLE
Move all ensure parameters from concat::fragment to concat

### DIFF
--- a/manifests/balancer.pp
+++ b/manifests/balancer.pp
@@ -64,7 +64,6 @@ define apache::balancer (
   }
 
   concat::fragment { "00-${name}-header":
-    ensure  => present,
     target  => "apache_balancer_${name}",
     order   => '01',
     content => "<Proxy balancer://${name}>\n",
@@ -77,14 +76,12 @@ define apache::balancer (
   # concat fragments. We don't have to do anything about them.
 
   concat::fragment { "01-${name}-proxyset":
-    ensure  => present,
     target  => "apache_balancer_${name}",
     order   => '19',
     content => inline_template("<% @proxy_set.keys.sort.each do |key| %> Proxyset <%= key %>=<%= @proxy_set[key] %>\n<% end %>"),
   }
 
   concat::fragment { "01-${name}-footer":
-    ensure  => present,
     target  => "apache_balancer_${name}",
     order   => '20',
     content => "</Proxy>\n",

--- a/manifests/balancermember.pp
+++ b/manifests/balancermember.pp
@@ -46,7 +46,6 @@ define apache::balancermember(
 ) {
 
   concat::fragment { "BalancerMember ${name}":
-    ensure  => present,
     target  => "apache_balancer_${balancer_cluster}",
     content => inline_template(" BalancerMember ${url} <%= @options.join ' ' %>\n"),
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -242,6 +242,7 @@ class apache (
   }
 
   concat { $ports_file:
+    ensure  => present,
     owner   => 'root',
     group   => $::apache::params::root_group,
     mode    => $::apache::file_mode,
@@ -249,7 +250,6 @@ class apache (
     require => Package['httpd'],
   }
   concat::fragment { 'Apache ports header':
-    ensure  => present,
     target  => $ports_file,
     content => template('apache/ports_header.erb')
   }

--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -3,7 +3,6 @@ define apache::listen {
 
   # Template uses: $listen_addr_port
   concat::fragment { "Listen ${listen_addr_port}":
-    ensure  => present,
     target  => $::apache::ports_file,
     content => template('apache/listen.erb'),
   }

--- a/manifests/namevirtualhost.pp
+++ b/manifests/namevirtualhost.pp
@@ -3,7 +3,6 @@ define apache::namevirtualhost {
 
   # Template uses: $addr_port
   concat::fragment { "NameVirtualHost ${addr_port}":
-    ensure  => present,
     target  => $::apache::ports_file,
     content => template('apache/namevirtualhost.erb'),
   }


### PR DESCRIPTION
Deprecated in 1.1.x and has no effect in 2.x.  From commit 1919eb3, but
was reverted when temporarily removing 2.x support in f54393e.