### PR TITLE
Fix MODULES-3158 (any string interpreted as SSLCompression on)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1660,7 +1660,7 @@ Installs [Apache SSL features][`mod_ssl`] and uses the `ssl.conf.erb` template t
 - `ssl_cipher`: Default: 'HIGH:MEDIUM:!aNULL:!MD5:!RC4'.
 - `ssl_compression`: Default: false.
 - `ssl_cryptodevice`: Default: 'builtin'.
-- `ssl_honorcipherorder`: Default: 'On'.
+- `ssl_honorcipherorder`: Default: true.
 - `ssl_openssl_conf_cmd`: Default: undef.
 - `ssl_options`: Default: [ 'StdEnvVars' ]
 - `ssl_pass_phrase_dialog`: Default: 'builtin'.
@@ -3240,7 +3240,7 @@ Specifies [SSLCipherSuite](https://httpd.apache.org/docs/current/mod/mod_ssl.htm
 
 ##### `ssl_honorcipherorder`
 
-Sets [SSLHonorCipherOrder](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslhonorcipherorder), which is used to prefer the server's cipher preference order. Default: 'On' in the base `apache` config.
+Sets [SSLHonorCipherOrder](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslhonorcipherorder), to cause Apache to use the server's preferred order of ciphers rather than the client's preferred order. Default: true. In addition to true/false Boolean values, will also accept case-insensitive Strings 'on' or 'off'.
 
 ##### `ssl_certs_dir`
 

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -4,7 +4,7 @@ class apache::mod::ssl (
   $ssl_options             = [ 'StdEnvVars' ],
   $ssl_openssl_conf_cmd    = undef,
   $ssl_cipher              = 'HIGH:MEDIUM:!aNULL:!MD5:!RC4',
-  $ssl_honorcipherorder    = 'On',
+  $ssl_honorcipherorder    = true,
   $ssl_protocol            = [ 'all', '-SSLv2', '-SSLv3' ],
   $ssl_pass_phrase_dialog  = 'builtin',
   $ssl_random_seed_bytes   = '512',
@@ -44,6 +44,18 @@ class apache::mod::ssl (
       default: {
         fail("Unsupported osfamily ${::osfamily}, please explicitly pass in \$ssl_mutex")
       }
+    }
+  }
+
+  validate_bool($ssl_compression)
+
+  if is_bool($ssl_honorcipherorder) {
+    $_ssl_honorcipherorder = $ssl_honorcipherorder
+  } else {
+    $_ssl_honorcipherorder = $ssl_honorcipherorder ? {
+      'on'    => true,
+      'off'   => false,
+      default => true,
     }
   }
 

--- a/templates/mod/ssl.conf.erb
+++ b/templates/mod/ssl.conf.erb
@@ -19,7 +19,11 @@
   SSLMutex <%= @_ssl_mutex %>
   <%- end -%>
   SSLCryptoDevice <%= @ssl_cryptodevice %>
-  SSLHonorCipherOrder <%= @ssl_honorcipherorder %>
+<% if @_ssl_honorcipherorder -%>
+  SSLHonorCipherOrder On
+<% else -%>
+  SSLHonorCipherOrder Off
+<% end -%>
   SSLCipherSuite <%= @ssl_cipher %>
   SSLProtocol <%= @ssl_protocol.compact.join(' ') %>
 <% if @ssl_options -%>


### PR DESCRIPTION
1. Fix MODULES-3158 (any string interpreted as SSLCompression on)
1. Convert ssl_honorcipherorder to boolean, backport accepting 'on' or 'off'