### PR TITLE
Take igalic's suggestion to use bool2httpd

### DIFF
--- a/templates/mod/ssl.conf.erb
+++ b/templates/mod/ssl.conf.erb
@@ -10,20 +10,14 @@
   SSLPassPhraseDialog <%= @ssl_pass_phrase_dialog %>
   SSLSessionCache "shmcb:<%= @session_cache %>"
   SSLSessionCacheTimeout <%= @ssl_sessioncachetimeout %>
-<% if @ssl_compression -%>
-  SSLCompression On
-<% end -%>
+  SSLCompression <%= scope.function_bool2httpd([@ssl_compression]) %>
   <%- if scope.function_versioncmp([@_apache_version, '2.4']) >= 0 -%>
   Mutex <%= @_ssl_mutex %>
   <%- else -%>
   SSLMutex <%= @_ssl_mutex %>
   <%- end -%>
   SSLCryptoDevice <%= @ssl_cryptodevice %>
-<% if @_ssl_honorcipherorder -%>
-  SSLHonorCipherOrder On
-<% else -%>
-  SSLHonorCipherOrder Off
-<% end -%>
+  SSLHonorCipherOrder <%= scope.function_bool2httpd([@_ssl_honorcipherorder]) %>
   SSLCipherSuite <%= @ssl_cipher %>
   SSLProtocol <%= @ssl_protocol.compact.join(' ') %>
 <% if @ssl_options -%>


### PR DESCRIPTION
In #1398 @igalic suggests replacing 2 sections of the SSL configuration Ruby template with a function designed to safely convert Booleans to their Apache On/Off equivalent. This PR implements the suggestion.

The PR should be safe because #1398 modifies the Puppet code to ensure that each variable is already a boolean with the intended default value.