### PR TITLE
reverted rspec which was removed with PR 1409

### DIFF
--- a/spec/classes/mod/dev_spec.rb
+++ b/spec/classes/mod/dev_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'apache::mod::dev', :type => :class do
+  it_behaves_like "a mod class, without including apache"
+  let(:pre_condition) {[
+    'include apache'
+  ]}
+  
+  [
+    ['RedHat',  '6', 'Santiago', 'Linux'],
+    ['Debian',  '6', 'squeeze', 'Linux'],
+    ['FreeBSD', '9', 'FreeBSD', 'FreeBSD'],
+  ].each do |osfamily, operatingsystemrelease, lsbdistcodename, kernel|
+    context "on a #{osfamily} OS" do
+      let :facts do
+        {
+          :lsbdistcodename        => lsbdistcodename,
+          :osfamily               => osfamily,
+          :operatingsystem        => osfamily,
+          :operatingsystemrelease => operatingsystemrelease,
+          :is_pe                  => false,
+          :concat_basedir         => '/foo',
+          :id                     => 'root',
+          :path                   => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
+          :kernel                 => kernel
+        }
+      end
+      it { is_expected.to contain_class('apache::dev') }
+    end
+  end
+end


### PR DESCRIPTION
Just readded the rspec which was removed with the pull request solving the strict_variables issue.

Removing rspec to solve things is in my opinion not a good solution.  
