### PR TITLE
Fix in custom fact "apache_version" for OracleLinux.

### DIFF
--- a/lib/facter/apache_version.rb
+++ b/lib/facter/apache_version.rb
@@ -2,7 +2,7 @@ Facter.add(:apache_version) do
   setcode do
     if Facter::Util::Resolution.which('apachectl')
       apache_version = Facter::Util::Resolution.exec('apachectl -v 2>&1')
-      %r{^Server version: Apache\/([\w\.]+) \(([\w ]+)\)}.match(apache_version)[1]
+      %r{^Server version: Apache\/([\w\.]+) \(([\w ]*)\)}.match(apache_version)[1]
     end
   end
 end

--- a/spec/unit/apache_version_spec.rb
+++ b/spec/unit/apache_version_spec.rb
@@ -17,4 +17,17 @@ describe Facter::Util::Fact do
       end
     end
   end
+
+  describe 'apache_version with empty OS' do
+    context 'with value' do
+      before :each do
+        Facter::Util::Resolution.stubs(:which).with('apachectl').returns(true)
+        Facter::Util::Resolution.stubs(:exec).with('apachectl -v 2>&1').returns('Server version: Apache/2.4.6 ()
+                                                                                  Server built:   Nov 21 2015 05:34:59')
+      end
+      it do
+        expect(Facter.fact(:apache_version).value).to eq('2.4.6')
+      end
+    end
+  end
 end


### PR DESCRIPTION
The custom fact defined by lib/facter/apache_version.rb runs
"apachectl -v" and applies the following regular expression:

    ^Server version: Apache\/([\w\.]+) \(([\w ]+)\)

On OracleLinux 7.2, running apachectl -v produces the following output:

    Server version: Apache/2.4.6 ()
    Server built:   Nov 21 2015 05:34:59

The regex fails to match the output because it does not allow
nothing inside the parentheses.  The following modified
regex matches properly:

    ^Server version: Apache\/([\w\.]+) \(([\w ]*)\)