### PR TITLE
SSLCompression directive only available with apache 2.4.3

### DIFF
--- a/templates/mod/ssl.conf.erb
+++ b/templates/mod/ssl.conf.erb
@@ -10,9 +10,9 @@
   SSLPassPhraseDialog <%= @ssl_pass_phrase_dialog %>
   SSLSessionCache "shmcb:<%= @session_cache %>"
   SSLSessionCacheTimeout <%= @ssl_sessioncachetimeout %>
-  SSLCompression <%= scope.function_bool2httpd([@ssl_compression]) %>
   <%- if scope.function_versioncmp([@_apache_version, '2.4']) >= 0 -%>
   Mutex <%= @_ssl_mutex %>
+  SSLCompression <%= scope.function_bool2httpd([@ssl_compression]) %>
   <%- else -%>
   SSLMutex <%= @_ssl_mutex %>
   <%- end -%>


### PR DESCRIPTION
Commit: 3ccd3294dcd866bdc1cf3a3901bcc0b5d21a7c25 brokes apache 2.2 config.
http://httpd.apache.org/docs/2.4/mod/mod_ssl.html#sslcompression
