### PR TITLE
Adding SSLProxyCheckPeerExpire support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3314,11 +3314,11 @@ apache::vhost { 'sample.example.net':
 
 ##### `ssl_proxy_check_peer_cn`
 
-Sets the [SSLProxyMachinePeerCN](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxycheckpeercn) directive, which specifies whether the remote server certificate's CN field is compared against the hostname of the request URL. Valid options: 'on', 'off'. Default: undef.
+Sets the [SSLProxyCheckPeerCN](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxycheckpeercn) directive, which specifies whether the remote server certificate's CN field is compared against the hostname of the request URL. Valid options: 'on', 'off'. Default: undef.
 
 ##### `ssl_proxy_check_peer_name`
 
-Sets the [SSLProxyMachinePeerName](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxycheckpeername) directive, which specifies whether the remote server certificate's CN field is compared against the hostname of the request URL. Valid options: 'on', 'off'. Default: undef.
+Sets the [SSLProxyCheckPeerName](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxycheckpeername) directive, which specifies whether the remote server certificate's CN field is compared against the hostname of the request URL. Valid options: 'on', 'off'. Default: undef.
 
 ##### `ssl_proxy_check_peer_expire`
 

--- a/README.md
+++ b/README.md
@@ -3320,6 +3320,10 @@ Sets the [SSLProxyMachinePeerCN](https://httpd.apache.org/docs/current/mod/mod_s
 
 Sets the [SSLProxyMachinePeerName](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxycheckpeername) directive, which specifies whether the remote server certificate's CN field is compared against the hostname of the request URL. Valid options: 'on', 'off'. Default: undef.
 
+##### `ssl_proxy_check_peer_expire`
+
+Sets the [SSLProxyCheckPeerExpire](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxycheckpeerexpire) directive, which specifies whether the remote server certificate is checked for expiration or not. Valid options: 'on', 'off'. Default: undef.
+
 ##### `ssl_options`
 
 Sets the [SSLOptions](https://httpd.apache.org/docs/current/mod/mod_ssl.html#ssloptions) directive, which configures various SSL engine run-time options. This is the global setting for the given virtual host and can be a string or an array. Default: undef.

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -28,6 +28,7 @@ define apache::vhost(
   $ssl_proxy_verify            = undef,
   $ssl_proxy_check_peer_cn     = undef,
   $ssl_proxy_check_peer_name   = undef,
+  $ssl_proxy_check_peer_expire = undef,
   $ssl_proxy_machine_cert      = undef,
   $ssl_proxy_protocol          = undef,
   $ssl_options                 = undef,
@@ -251,6 +252,10 @@ define apache::vhost(
   }
   if $ssl_proxy_check_peer_name {
     validate_re($ssl_proxy_check_peer_name,'(^on$|^off$)',"${ssl_proxy_check_peer_name} is not permitted for ssl_proxy_check_peer_name. Allowed values are 'on' or 'off'.")
+  }
+
+  if $ssl_proxy_check_peer_expire {
+    validate_re($ssl_proxy_check_peer_expire,'(^on$|^off$)',"${ssl_proxy_check_peer_expire} is not permitted for ssl_proxy_check_peer_expire. Allowed values are 'on' or 'off'.")
   }
 
   # Input validation ends
@@ -842,6 +847,7 @@ define apache::vhost(
   # - $ssl_proxy_verify
   # - $ssl_proxy_check_peer_cn
   # - $ssl_proxy_check_peer_name
+  # - $ssl_proxy_check_peer_expire
   # - $ssl_proxy_machine_cert
   # - $ssl_proxy_protocol
   if $ssl_proxyengine {

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -157,6 +157,7 @@ describe 'apache::vhost', :type => :define do
           'ssl_proxy_verify'            => 'require',
           'ssl_proxy_check_peer_cn'     => 'on',
           'ssl_proxy_check_peer_name'   => 'on',
+          'ssl_proxy_check_peer_expire' => 'on',
           'ssl_proxyengine'             => true,
           'ssl_proxy_protocol'          => 'TLSv1.2',
 
@@ -476,6 +477,8 @@ describe 'apache::vhost', :type => :define do
         :content => /^\s+SSLProxyCheckPeerCN\s+on$/ ) }
       it { is_expected.to contain_concat__fragment('rspec.example.com-sslproxy').with(
         :content => /^\s+SSLProxyCheckPeerName\s+on$/ ) }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-sslproxy').with(
+        :content => /^\s+SSLProxyCheckPeerExpire\s+on$/ ) }
       it { is_expected.to contain_concat__fragment('rspec.example.com-sslproxy').with(
         :content => /^\s+SSLProxyProtocol\s+TLSv1.2$/ ) }
       it { is_expected.to contain_concat__fragment('rspec.example.com-suphp') }

--- a/templates/vhost/_sslproxy.erb
+++ b/templates/vhost/_sslproxy.erb
@@ -11,6 +11,9 @@
   <%- if @ssl_proxy_check_peer_name -%>
   SSLProxyCheckPeerName   <%= @ssl_proxy_check_peer_name %>
   <%- end -%>
+  <%- if @ssl_proxy_check_peer_expire -%>
+  SSLProxyCheckPeerExpire   <%= @ssl_proxy_check_peer_expire %>
+  <%- end -%>
   <%- if @ssl_proxy_machine_cert -%>
   SSLProxyMachineCertificateFile "<%= @ssl_proxy_machine_cert %>"
   <%- end -%>


### PR DESCRIPTION
Adding SSLProxyCheckPeerExpire support, and fixes a couple of copy/paste errors in the readme related to the SSL Proxy directives.