### PR TITLE
Add parameter passanger_log_level

### DIFF
--- a/README.md
+++ b/README.md
@@ -2311,6 +2311,10 @@ Sets [PassengerAppEnv](https://www.phusionpassenger.com/library/config/apache/re
 
 By default, Passenger log messages are written to the Apache global error log. With [PassengerLogFile](https://www.phusionpassenger.com/library/config/apache/reference/#passengerlogfile), you can configure those messages to be logged to a different file. This option is only available since Passenger 5.0.5.
 
+##### `passenger_log_level`
+
+This option allows to specify how much information should be written to the log file. If not set, [PassengerLogLevel](https://www.phusionpassenger.com/library/config/apache/reference/#passengerloglevel) will not show up in the configuration file and the defaults are used. For Passenger > 3.0.0 the default is '0', since 5.0.0 it's '3'.
+
 ##### `passenger_ruby`
 
 Sets [PassengerRuby](https://www.phusionpassenger.com/library/config/apache/reference/#passengerruby), the Ruby interpreter to use for the application, on this virtual host.

--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -17,6 +17,7 @@ class apache::mod::passenger (
   $passenger_use_global_queue       = undef,
   $passenger_app_env                = undef,
   $passenger_log_file               = undef,
+  $passenger_log_level              = undef,
   $manage_repo                      = true,
   $mod_package                      = undef,
   $mod_package_ensure               = undef,
@@ -92,6 +93,7 @@ class apache::mod::passenger (
   # - $passenger_stat_throttle_rate
   # - $passenger_use_global_queue
   # - $passenger_log_file
+  # - $passenger_log_level
   # - $passenger_app_env
   # - $rack_autodetect
   # - $rails_autodetect

--- a/spec/classes/mod/passenger_spec.rb
+++ b/spec/classes/mod/passenger_spec.rb
@@ -128,6 +128,12 @@ describe 'apache::mod::passenger', :type => :class do
       end
       it { is_expected.to contain_file('passenger.conf').with_content(%r{^  PassengerLogFile /var/log/apache2/passenger.log$}) }
     end
+    describe "with passenger_log_level => 3" do
+      let :params do
+        { :passenger_log_level => 3 }
+      end
+      it { is_expected.to contain_file('passenger.conf').with_content(%r{^  PassengerLogLevel 3$}) }
+    end
     describe "with mod_path => '/usr/lib/foo/mod_foo.so'" do
       let :params do
         { :mod_path => '/usr/lib/foo/mod_foo.so' }

--- a/templates/mod/passenger.conf.erb
+++ b/templates/mod/passenger.conf.erb
@@ -49,4 +49,7 @@
   <%- if @passenger_log_file -%>
   PassengerLogFile <%= @passenger_log_file %>
   <%- end -%>
+  <%- if @passenger_log_level -%>
+  PassengerLogLevel <%= @passenger_log_level %>
+  <%- end -%>
 </IfModule>


### PR DESCRIPTION
I added a parameter passenger_log_level to be able to configure the PassengerLogLevel option in passenger.conf.