### PR TITLE
Allow for pagespeed mod to automatically be updated to the latest version

### DIFF
--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -76,6 +76,7 @@ define apache::mod (
       ensure  => $package_ensure,
       require => Package['httpd'],
       before  => $package_before,
+      notify  => Class['apache::service'],
     }
   }
 

--- a/manifests/mod/pagespeed.pp
+++ b/manifests/mod/pagespeed.pp
@@ -33,6 +33,7 @@ class apache::mod::pagespeed (
   $message_buffer_size           = 100000,
   $additional_configuration      = {},
   $apache_version                = undef,
+  $package_ensure                = undef,
 ){
   include ::apache
   $_apache_version = pick($apache_version, $apache::apache_version)
@@ -42,7 +43,8 @@ class apache::mod::pagespeed (
   }
 
   apache::mod { 'pagespeed':
-    lib => $_lib,
+    lib            => $_lib,
+    package_ensure => $package_ensure,
   }
 
   # Template uses $_apache_version


### PR DESCRIPTION
Google recommends that we always stay on the latest version of mod-pagespeed-stable, which is what is installed with this module. I added changes here to allow for having the latest version of mod-pagespeed-stable.