### PR TITLE
fix incorrect use of .join() with newlines

### DIFF
--- a/templates/mod/pagespeed.conf.erb
+++ b/templates/mod/pagespeed.conf.erb
@@ -94,7 +94,7 @@ ModPagespeedMessageBufferSize <%= @message_buffer_size %>
 </Location>
 
 <% if @additional_configuration.is_a? Array -%>
-<%= @additional_configuration.join('\n') %>
+<%= @additional_configuration.join("\n") %>
 <% else -%>
 <% @additional_configuration.each_pair do |key, value| -%>
 <%= key %> <%= value %>


### PR DESCRIPTION
Assuming a puppet file with the following from `::apache::mod::pagespeed`
```
additional_configuration      => [
    "ModPagespeedEnableCachePurge $mod_pagespeed_enable_cache_purge",
    "ModPagespeedAnalyticsID $analytics_id",
    'ModPagespeedDisallow */APOS/*',
    'ModPagespeedDisallow */jasperserver-pro/*',
],  
```
this is evaluated:
```
<% if @additional_configuration.is_a? Array -%>
<%= @additional_configuration.join('\n') %>
<% else -%>
```
resulting in this...
```
ModPagespeedEnableCachePurge On\nModPagespeedAnalyticsID UA-xxxx-1\nModPagespeedDisallow */APOS/*\nModPagespeedDisallow */jasperserver-pro/*
```
Using double quotes for the .join("\n") makes it work correctly:
```
ModPagespeedEnableCachePurge On
ModPagespeedAnalyticsID UA-xxxx-1
ModPagespeedDisallow */APOS/*
ModPagespeedDisallow */jasperserver-pro/*
```
