### PR TITLE
Add simple <Limit> support + ProxyAddHeaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -2342,6 +2342,12 @@ Sets the [ProxyPreserveHost Directive](https://httpd.apache.org/docs/current/mod
 
 Setting this parameter to true enables the `Host:` line from an incoming request to be proxied to the host instead of hostname. Setting it to false sets this directive to 'Off'.
 
+##### `proxy_add_headers`
+
+Sets the [ProxyAddHeaders Directive](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxyaddheaders). Valid Options: Boolean. Default: false.
+
+This parameter controlls whether proxy-related HTTP headers (X-Forwarded-For, X-Forwarded-Host and X-Forwarded-Server) get sent to the backend server.
+
 ##### `proxy_error_override`
 
 Sets the [ProxyErrorOverride Directive](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxyerroroverride). This directive controls whether Apache should override error pages for proxied content. Default: false.

--- a/README.md
+++ b/README.md
@@ -3047,6 +3047,26 @@ apache::vhost { 'sample.example.net':
 }
 ```
 
+###### `limit`
+
+Creates a [Limit](https://httpd.apache.org/docs/current/mod/core.html#limit) block inside the Directory block, which can also contain `require` directives.
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot     => '/path/to/docroot',
+  directories => [
+    { path     => '/',
+      provider => 'location',
+      limit    => [
+        { methods => 'GET HEAD'
+          require => ['valid-user']
+        },
+      ],
+    },
+  ],
+}
+```
+
 ###### `mellon_enable`
 
 Sets the [MellonEnable][`mod_auth_mellon`] directory to enable [`mod_auth_mellon`][]. You can use [`apache::mod::auth_mellon`][] to install `mod_auth_mellon`.

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -80,6 +80,7 @@ define apache::vhost(
   $no_proxy_uris               = [],
   $no_proxy_uris_match         = [],
   $proxy_preserve_host         = false,
+  $proxy_add_headers           = undef,
   $proxy_error_override        = false,
   $redirect_source             = '/',
   $redirect_dest               = undef,
@@ -749,6 +750,7 @@ define apache::vhost(
   # - $proxy_pass
   # - $proxy_pass_match
   # - $proxy_preserve_host
+  # - $proxy_add_headers
   # - $no_proxy_uris
   if $proxy_dest or $proxy_pass or $proxy_pass_match or $proxy_dest_match {
     concat::fragment { "${name}-proxy":

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -115,6 +115,7 @@ describe 'apache::vhost define' do
       it { is_expected.to contain "ProxyPass" }
       it { is_expected.to contain "ProxyPreserveHost On" }
       it { is_expected.to contain "ProxyErrorOverride On" }
+      it { is_expected.not_to contain "ProxyAddHeaders" }
       it { is_expected.not_to contain "<Proxy \*>" }
     end
   end
@@ -142,6 +143,7 @@ describe 'apache::vhost define' do
       it { is_expected.to contain "ProxyPassMatch /foo http://backend-foo/" }
       it { is_expected.to contain "ProxyPreserveHost On" }
       it { is_expected.to contain "ProxyErrorOverride On" }
+      it { is_expected.not_to contain "ProxyAddHeaders" }
       it { is_expected.not_to contain "<Proxy \*>" }
     end
   end

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -310,6 +310,7 @@ describe 'apache::vhost', :type => :define do
           'no_proxy_uris'               => '/foo',
           'no_proxy_uris_match'         => '/foomatch',
           'proxy_preserve_host'         => true,
+          'proxy_add_headers'           => true,
           'proxy_error_override'        => true,
           'redirect_source'             => '/bar',
           'redirect_dest'               => '/',
@@ -525,6 +526,10 @@ describe 'apache::vhost', :type => :define do
               /SetEnv proxy-nokeepalive 1/) }
       it { is_expected.to contain_concat__fragment('rspec.example.com-proxy').with_content(
               /noquery interpolate/) }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-proxy').with_content(
+              /ProxyPreserveHost On/) }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-proxy').with_content(
+              /ProxyAddHeaders On/) }
       it { is_expected.to contain_concat__fragment('rspec.example.com-proxy').with_content(
               /ProxyPassReverseCookiePath\s+\/a\s+http:\/\//) }
       it { is_expected.to contain_concat__fragment('rspec.example.com-proxy').with_content(

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -237,6 +237,14 @@ describe 'apache::vhost', :type => :define do
             { 'path'              => '/var/www/files/output_filtered',
               'set_output_filter' => 'output_filter',
             },
+            { 'path'     => '/var/www/files',
+              'provider' => 'location',
+              'limit'    => [
+                { 'methods' => 'GET HEAD',
+                  'require' => ['valid-user']
+                },
+              ],
+            },
           ],
           'error_log'                   => false,
           'error_log_file'              => 'httpd_error_log',
@@ -496,6 +504,10 @@ describe 'apache::vhost', :type => :define do
         :content => /^\s+DirectoryIndex\sdisabled$/ ) }
       it { is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
         :content => /^\s+SetOutputFilter\soutput_filter$/ ) }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
+        :content => /^\s+<Limit GET HEAD>$/ ) }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
+        :content => /\s+<Limit GET HEAD>\s*Require valid-user\s*<\/Limit>/m ) }
       it { is_expected.to contain_concat__fragment('rspec.example.com-additional_includes') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-logging') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-serversignature') }

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -1,5 +1,6 @@
 <% if @_directories and ! @_directories.empty? -%>
 
+  <%- scope.setvar('_template_scope', {}) -%>
   ## Directories, there should at least be a declaration for <%= @docroot %>
   <%- [@_directories].flatten.compact.each do |directory| -%>
     <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
@@ -56,65 +57,14 @@
     AllowOverride None
       <%- end -%>
     <%- end -%>
-    <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
-      <%- if directory['require'] && directory['require'] != '' && directory['require'] !~ /unmanaged/i -%>
-        <%- if directory['require'].is_a?(Hash) -%>
-          <%- case directory['require']['enforce'].downcase -%>
-          <%- when 'all','none','any' then -%>
-    <Require<%= directory['require']['enforce'].capitalize %>>
-            <%- Array(directory['require']['requires']).each do |req| -%>
-      Require <%= req.strip %>
-            <%- end -%>
-    </Require<%= directory['require']['enforce'].capitalize %>>
-          <%- else -%>
-            <%- scope.function_warning(["Apache::Vhost: Require can only overwritten with all, none or any."]) -%>
-          <%- end -%>
-        <%- else -%>
-          <%- Array(directory['require']).each do |req| -%>
-    Require <%= req %>
-          <%- end -%>
-        <%- end -%>
-      <%- end -%>
-      <%- if directory['auth_require'] -%>
-    Require <%= directory['auth_require'] %>
-      <%- end -%>
-      <%- if !(directory['require'] && directory['require'] != '') && directory['require'] !~ /unmanaged/i && !(directory['auth_require']) -%>
-    Require all granted
-      <%- end -%>
-    <%- else -%>
-      <%- if directory['auth_require'] -%>
-    Require <%= directory['auth_require'] %>
-      <%- end -%>
-      <%- if directory['order'] and directory['order'] != '' -%>
-    Order <%= Array(directory['order']).join(',') %>
-      <%- else -%>
-    Order allow,deny
-      <%- end -%>
-      <%- if directory['deny'] and ! [ false, 'false', '' ].include?(directory['deny']) -%>
-        <%- if directory['deny'].kind_of?(Array) -%>
-          <%- Array(directory['deny']).each do |restrict| -%>
-    Deny <%=  restrict %>
-          <%- end -%>
-        <%- else -%>
-    Deny <%= directory['deny'] %>
-        <%- end -%>
-      <%- end -%>
-      <%- if directory['allow'] and ! [ false, 'false', '' ].include?(directory['allow']) -%>
-        <%- if directory['allow'].kind_of?(Array) -%>
-          <%- Array(directory['allow']).each do |access| -%>
-    Allow <%=  access %>
-        <%- end -%>
-      <%- else -%>
-    Allow <%= directory['allow'] %>
-      <%- end -%>
-      <%- elsif [ 'from all', 'from All' ].include?(directory['deny']) -%>
-      <%- elsif ! directory['deny'] and [ false, 'false', '' ].include?(directory['allow']) -%>
-    Deny from all
-      <%- else -%>
-    Allow from all
-      <%- end -%>
-      <%- if directory['satisfy'] and directory['satisfy'] != '' -%>
-    Satisfy <%= directory['satisfy'] %>
+    <%- scope.lookupvar('_template_scope')[:item] = directory -%>
+<%= scope.function_template(["apache/vhost/_require.erb"]) -%>
+    <%- if directory['limit'] && directory['limit'] != '' -%>
+      <%- Array(directory['limit']).each do |lim| -%>
+    <Limit <%= lim['methods'] %>>
+    <%- scope.lookupvar('_template_scope')[:item] = lim -%>
+    <%= scope.function_template(["apache/vhost/_require.erb"]) -%>
+    </Limit>
       <%- end -%>
     <%- end -%>
     <%- if directory['addhandlers'] and ! directory['addhandlers'].empty? -%>

--- a/templates/vhost/_proxy.erb
+++ b/templates/vhost/_proxy.erb
@@ -8,6 +8,13 @@
 <% else -%>
   ProxyPreserveHost Off
 <%- end -%>
+<%- if defined?(@proxy_add_headers) -%>
+  <%- if @proxy_add_headers -%>
+  ProxyAddHeaders On
+  <%- else -%>
+  ProxyAddHeaders Off
+  <%- end -%>
+<%- end -%>
 <% if @proxy_error_override -%>
   ProxyErrorOverride On
 <%- end -%>

--- a/templates/vhost/_require.erb
+++ b/templates/vhost/_require.erb
@@ -1,0 +1,62 @@
+<%- _item = scope.lookupvar('_template_scope')[:item] -%>
+<%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
+  <%- if _item['require'] && _item['require'] != '' && _item['require'] !~ /unmanaged/i -%>
+    <%- if _item['require'].is_a?(Hash) -%>
+      <%- case _item['require']['enforce'].downcase -%>
+      <%- when 'all','none','any' then -%>
+    <Require<%= _item['require']['enforce'].capitalize %>>
+        <%- Array(_item['require']['requires']).each do |req| -%>
+      Require <%= req.strip %>
+        <%- end -%>
+    </Require<%= _item['require']['enforce'].capitalize %>>
+      <%- else -%>
+        <%- scope.function_warning(["Apache::Vhost: Require can only overwritten with all, none or any."]) -%>
+      <%- end -%>
+    <%- else -%>
+      <%- Array(_item['require']).each do |req| -%>
+    Require <%= req %>
+      <%- end -%>
+    <%- end -%>
+  <%- end -%>
+  <%- if _item['auth_require'] -%>
+    Require <%= _item['auth_require'] %>
+  <%- end -%>
+  <%- if !(_item['require'] && _item['require'] != '') && _item['require'] !~ /unmanaged/i && !(_item['auth_require']) -%>
+    Require all granted
+  <%- end -%>
+<%- else -%>
+  <%- if _item['auth_require'] -%>
+    Require <%= _item['auth_require'] %>
+  <%- end -%>
+  <%- if _item['order'] and _item['order'] != '' -%>
+    Order <%= Array(_item['order']).join(',') %>
+  <%- else -%>
+    Order allow,deny
+  <%- end -%>
+  <%- if _item['deny'] and ! [ false, 'false', '' ].include?(_item['deny']) -%>
+    <%- if _item['deny'].kind_of?(Array) -%>
+      <%- Array(_item['deny']).each do |restrict| -%>
+    Deny <%=  restrict %>
+      <%- end -%>
+    <%- else -%>
+    Deny <%= _item['deny'] %>
+    <%- end -%>
+  <%- end -%>
+  <%- if _item['allow'] and ! [ false, 'false', '' ].include?(_item['allow']) -%>
+    <%- if _item['allow'].kind_of?(Array) -%>
+      <%- Array(_item['allow']).each do |access| -%>
+    Allow <%=  access %>
+    <%- end -%>
+  <%- else -%>
+    Allow <%= _item['allow'] %>
+  <%- end -%>
+  <%- elsif [ 'from all', 'from All' ].include?(_item['deny']) -%>
+  <%- elsif ! _item['deny'] and [ false, 'false', '' ].include?(_item['allow']) -%>
+    Deny from all
+  <%- else -%>
+    Allow from all
+  <%- end -%>
+  <%- if _item['satisfy'] and _item['satisfy'] != '' -%>
+    Satisfy <%= _item['satisfy'] %>
+  <%- end -%>
+<%- end -%>


### PR DESCRIPTION
The main commit in this PR introduces minimal support for the \<Limit\> block inside \<Location\> blocks.
To do this, the template code handling "Require" directives has been refactored to a template of its own to avoid code duplication. This new template in turn then gets included in the main _directories.erb template, both directly inside the \<Location\> block and also inside each \<Limit\> block.

Additionally, this PR also includes the relatively straightforward support for the ProxyAddHeaders directive.