### PR TITLE
Support mod_proxy_wstunnel for Apache 2.4+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1305,6 +1305,7 @@ The following Apache modules have supported classes, many of which allow for par
 * `proxy_balancer`
 * `proxy_html` (see [`apache::mod::proxy_html`][])
 * `proxy_http`
+* `proxy_wstunnel`
 * `python`
 * `reqtimeout`
 * `remoteip`\*
@@ -1635,6 +1636,9 @@ Default values depend on your operating system.
 ##### Class: `apache::mod::proxy_html`
 
 **Note**: There is no official package available for mod\_proxy\_html and thus it must be made available by means outside of the control of the apache module.
+
+##### Class: `apache::mod::proxy_wstunnel`
+Includes the mod\_proxy_\wstunnel module on Apache versions >= 2.4. For versions below, no action is taken.
 
 ##### Class: `apache::mod::reqtimeout`
 

--- a/manifests/mod/proxy_wstunnel.pp
+++ b/manifests/mod/proxy_wstunnel.pp
@@ -1,0 +1,9 @@
+class apache::mod::proxy_wstunnel (
+  $apache_version = $::apache::apache_version,
+) {
+  # including this class is a no-op for versions without the module
+  if versioncmp($apache_version, '2.4') >= 0 {
+    Class['::apache::mod::proxy_http'] -> Class['::apache::mod::proxy_wstunnel']
+    ::apache::mod { 'proxy_wstunnel': }
+  }
+}


### PR DESCRIPTION
Includes basic documentation. Derived from previous pull requests #1290 and #1325.