### PR TITLE
(MODULES-3140) explicitly rely on hasrestart if no restart command is…

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -38,12 +38,16 @@ class apache::service (
       $_service_ensure = undef
     }
   }
+
+  $service_hasrestart = $service_restart == undef
+
   if $service_manage {
     service { 'httpd':
-      ensure  => $_service_ensure,
-      name    => $service_name,
-      enable  => $service_enable,
-      restart => $service_restart
+      ensure     => $_service_ensure,
+      name       => $service_name,
+      enable     => $service_enable,
+      restart    => $service_restart,
+      hasrestart => $service_hasrestart,
     }
   }
 }


### PR DESCRIPTION
… passed

Apache always had a restart option for the init script and in some cases
does require special handling of the daemon when restarting, so this
prefers the init scripts' restart action over just stopping/starting it.