### PR TITLE
Expose verify_config in apache::vhost::custom

### DIFF
--- a/README.md
+++ b/README.md
@@ -3556,6 +3556,11 @@ Specifies if the virtual host file is present or absent. Valid options: 'absent'
 
 Sets the relative load order for Apache HTTPD VirtualHost configuration files. Default: '25'.
 
+##### `verify_config`
+
+Specifies whether to validate the configuration file before notifying the Apache service. Valid options: Boolean. Default: true.
+
+
 ### Private defined types
 
 #### Defined type: `apache::peruser::multiplexer`

--- a/manifests/vhost/custom.pp
+++ b/manifests/vhost/custom.pp
@@ -3,6 +3,7 @@ define apache::vhost::custom(
   $content,
   $ensure = 'present',
   $priority = '25',
+  $verify_config = true,
 ) {
   include ::apache
 
@@ -10,10 +11,11 @@ define apache::vhost::custom(
   $filename = regsubst($name, ' ', '_', 'G')
 
   ::apache::custom_config { $filename:
-    ensure   => $ensure,
-    confdir  => $::apache::vhost_dir,
-    content  => $content,
-    priority => $priority,
+    ensure        => $ensure,
+    confdir       => $::apache::vhost_dir,
+    content       => $content,
+    priority      => $priority,
+    verify_config => $verify_config,
   }
 
   # NOTE(pabelanger): This code is duplicated in ::apache::vhost and needs to


### PR DESCRIPTION
In many cases verify_config confuses more than it helps and users would
like to be able to turn it off. Expose the
$apache::custom_config::verify_config parameter in
apache::vhost::custom so custom vhost users can also turn this off.