### PR TITLE
Set default keepalive to On

### DIFF
--- a/README.md
+++ b/README.md
@@ -973,7 +973,7 @@ Sets the Apache server's base configuration directory. This is useful for specia
 
 ##### `keepalive`
 
-Determines whether to enable persistent HTTP connections with the [`KeepAlive`][] directive. Valid options: 'Off', 'On'. Default: 'Off'.
+Determines whether to enable persistent HTTP connections with the [`KeepAlive`][] directive. Valid options: 'Off', 'On'. Default: 'On'.
 
 If 'On', use the [`keepalive_timeout`][] and [`max_keepalive_requests`][] parameters to set relevant options.
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -137,7 +137,7 @@ class apache::params inherits ::apache::version {
       'nss'  => 'libmodnss.so',
     }
     $conf_template        = 'apache/httpd.conf.erb'
-    $keepalive            = 'Off'
+    $keepalive            = 'On'
     $keepalive_timeout    = 15
     $max_keepalive_requests = 100
     $fastcgi_lib_path     = undef

--- a/spec/acceptance/apache_parameters_spec.rb
+++ b/spec/acceptance/apache_parameters_spec.rb
@@ -353,14 +353,14 @@ describe 'apache parameters' do
   describe 'keepalive' do
     describe 'setup' do
       it 'applies cleanly' do
-        pp = "class { 'apache': keepalive => 'On', keepalive_timeout => '30', max_keepalive_requests => '200' }"
+        pp = "class { 'apache': keepalive => 'Off', keepalive_timeout => '30', max_keepalive_requests => '200' }"
         apply_manifest(pp, :catch_failures => true)
       end
     end
 
     describe file($conf_file) do
       it { is_expected.to be_file }
-      it { is_expected.to contain 'KeepAlive On' }
+      it { is_expected.to contain 'KeepAlive Off' }
       it { is_expected.to contain 'KeepAliveTimeout 30' }
       it { is_expected.to contain 'MaxKeepAliveRequests 200' }
     end


### PR DESCRIPTION
According to docs "In some cases this has been shown to result in an almost 50% speedup in latency times for HTML documents with many images."

Ref: http://httpd.apache.org/docs/2.4/mod/core.html#keepalive
