### PR TITLE
(maint) update apache::default_mods tests to work on debian 7

### DIFF
--- a/spec/acceptance/default_mods_spec.rb
+++ b/spec/acceptance/default_mods_spec.rb
@@ -20,6 +20,13 @@ describe 'apache::default_mods class' do
   end
 
   describe 'no default mods and failing' do
+    before :all do
+      pp = <<-PP
+      include apache::params
+      class { 'apache': default_mods => false, service_ensure => stopped, }
+      PP
+      apply_manifest(pp)
+    end
     # Using puppet_apply as a helper
     it 'should apply with errors' do
       pp = <<-EOS
@@ -39,14 +46,8 @@ describe 'apache::default_mods class' do
       apply_manifest(pp, { :expect_failures => true })
     end
 
-    # Are these the same?
     describe service($service_name) do
       it { is_expected.not_to be_running }
-    end
-    describe "service #{$service_name}" do
-      it 'should not be running' do
-        shell("pidof #{$service_name}", {:acceptable_exit_codes => 1})
-      end
     end
   end
 


### PR DESCRIPTION
Debian 7 and Ubuntu 12.04's init scripts will refuse to restart the service
if the configuration is broken. So this commit adds an explicit
configuration step to shutdown the apache before the test.