### PR TITLE
Set DAV parameters in a directory block

### DIFF
--- a/README.md
+++ b/README.md
@@ -2916,6 +2916,18 @@ ProxyStatus On',
 }
 ```
 
+###### `dav`
+
+Sets the value for [Dav](http://httpd.apache.org/docs/current/mod/mod_dav.html#dav), which determines if the WebDAV HTTP methods should be enabled. The value can be either `On`, `Off` or the name of the provider. A value of `On` enables the default filesystem provider implemented by the `mod_dav_fs` module.
+
+###### `dav_depth_infinity`
+
+Sets the value for [DavDepthInfinity](http://httpd.apache.org/docs/current/mod/mod_dav.html#davdepthinfinity), which is used to enable the processing of `PROPFIND` requests having a `Depth: Infinity` header.
+
+###### `dav_min_timeout`
+
+Sets the value for [DavMinTimeout](http://httpd.apache.org/docs/current/mod/mod_dav.html#davmintimeout), which sets the time the server holds a lock on a DAV resource. The value should be the number of seconds to set.
+
 ###### `deny`
 
 Sets a [Deny](https://httpd.apache.org/docs/2.2/mod/mod_authz_host.html#deny) directive, specifying which hosts are denied access to the server. **Deprecated:** This parameter is being deprecated due to a change in Apache. It only works with Apache 2.2 and lower. You can use it as a single string for one rule or as an array for more than one.

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -237,6 +237,11 @@ describe 'apache::vhost', :type => :define do
             { 'path'              => '/var/www/files/output_filtered',
               'set_output_filter' => 'output_filter',
             },
+            { 'path'               => '/var/www/dav',
+              'dav'                => 'filesystem',
+              'dav_depth_infinity' => true,
+              'dav_min_timeout'    => '600',
+            },
           ],
           'error_log'                   => false,
           'error_log_file'              => 'httpd_error_log',
@@ -496,6 +501,12 @@ describe 'apache::vhost', :type => :define do
         :content => /^\s+DirectoryIndex\sdisabled$/ ) }
       it { is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
         :content => /^\s+SetOutputFilter\soutput_filter$/ ) }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
+        :content => /^\s+Dav\sfilesystem$/ ) }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
+        :content => /^\s+DavDepthInfinity\sOn$/ ) }
+      it { is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
+        :content => /^\s+DavMinTimeout\s600$/ ) }
       it { is_expected.to contain_concat__fragment('rspec.example.com-additional_includes') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-logging') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-serversignature') }

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -165,6 +165,15 @@
     ErrorDocument <%= error_document['error_code'] %> <%= error_document['document'] %>
       <%- end -%>
     <%- end -%>
+    <%- if directory['dav'] -%>
+    Dav <%= directory['dav'] %>
+    <%- if directory['dav_depth_infinity'] -%>
+    DavDepthInfinity <%= scope.function_bool2httpd([directory['dav_depth_infinity']]) %>
+    <%- end -%>
+    <%- if directory['dav_min_timeout'] -%>
+    DavMinTimeout <%= directory['dav_min_timeout'] %>
+    <%- end -%>
+    <%- end -%>
     <%- if directory['auth_type'] -%>
     AuthType <%= directory['auth_type'] %>
     <%- end -%>


### PR DESCRIPTION
Currently the module supports the `mod_dav` and `mod_dav_fs` modules and also allows setting the `DAVLockDB` parameter. But actually activating DAV for a directory only seems to be possible by providing a custom fragment.

This PR adds support for the `dav` parameter and two other DAV related parameters in a vhost directory block.