### PR TITLE
dont fail if mpm_module is itk and class apache::mod::prefork is not defined

### DIFF
--- a/manifests/mod/itk.pp
+++ b/manifests/mod/itk.pp
@@ -25,7 +25,7 @@ class apache::mod::itk (
       }
     } else {
       if ! defined(Class['apache::mod::prefork']) {
-        fail('apache::mod::prefork is a prerequisite for apache::mod::itk, please arrange for it to be included.')
+        include ::apache::mod::prefork
       }
     }
   }


### PR DESCRIPTION
on apache >= 2.4

include apache::mod::prefork in manifests/mod/itk.pp instead.

because cant include apache::mod::prefork before class apache:

"Warning: Scope(Class[Apache::Mod::Prefork]): Could not look up qualified variable '::apache::apache_version'; class ::apache has not been evaluated" results in 
"Error: Could not find dependency Exec[mkdir ] for File[/prefork.conf] at apache/manifests/mod/prefork.pp:44"