### PR TITLE
setting options-hash in proxy_pass or proxy_match leads to syntax errors in Apache

### DIFF
--- a/README.md
+++ b/README.md
@@ -2435,7 +2435,7 @@ Specifies the destination address of a [ProxyPass](https://httpd.apache.org/docs
 
 ##### `proxy_pass`
 
-Specifies an array of `path => URI` values for a [ProxyPass](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypass) configuration. Default: undef. Parameters and location options can optionally be added as an array.
+Specifies an array of `path => URI` values for a [ProxyPass](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypass) configuration. Defaults to 'undef'. Optionally parameters can be added as an array.
 
 ``` puppet
 apache::vhost { 'site.name.fdqn':
@@ -2444,8 +2444,6 @@ apache::vhost { 'site.name.fdqn':
     { 'path' => '/a', 'url' => 'http://backend-a/' },
     { 'path' => '/b', 'url' => 'http://backend-b/' },
     { 'path' => '/c', 'url' => 'http://backend-a/c', 'params' => {'max'=>20, 'ttl'=>120, 'retry'=>300}},
-    { 'path' => '/c', 'url' => 'http://backend-a/c',
-      'options' => {'Require'=>'valid-user', 'AuthType'=>'Kerberos', 'AuthName'=>'Kerberos Login'}},
     { 'path' => '/l', 'url' => 'http://backend-xy',
       'reverse_urls' => ['http://backend-x', 'http://backend-y'] },
     { 'path' => '/d', 'url' => 'http://backend-a/d',

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -274,11 +274,6 @@ describe 'apache::vhost', :type => :define do
                       'retry'   => '0',
                       'timeout' => '5'
               },
-              'options'         => {
-                'Require'  =>'valid-user',
-                'AuthType' =>'Kerberos',
-                'AuthName' =>'"Kerberos Login"'
-              },
               'setenv'   => ['proxy-nokeepalive 1','force-proxy-request-1.0 1'],
             }
           ],
@@ -517,13 +512,6 @@ describe 'apache::vhost', :type => :define do
               /ProxyPassReverseCookiePath\s+\/a\s+http:\/\//) }
       it { is_expected.to contain_concat__fragment('rspec.example.com-proxy').with_content(
               /ProxyPassReverseCookieDomain\s+foo\s+http:\/\/foo/) }
-      it { is_expected.to contain_concat__fragment('rspec.example.com-proxy').with_content(
-              /Require valid-user/) }
-      it { is_expected.to contain_concat__fragment('rspec.example.com-proxy').with_content(
-              /AuthType Kerberos/) }
-      it { is_expected.to contain_concat__fragment('rspec.example.com-proxy').with_content(
-              /AuthName "Kerberos Login"/) }
-
       it { is_expected.to contain_concat__fragment('rspec.example.com-rack') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-redirect') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-rewrite') }

--- a/templates/vhost/_proxy.erb
+++ b/templates/vhost/_proxy.erb
@@ -41,11 +41,6 @@
   SetEnv <%= setenv_var %>
     <%- end -%>
   <%- end -%>
-  <%- if proxy['options'] -%>
-    <%- proxy['options'].keys.sort.each do |key| -%>
-    <%= key %> <%= proxy['options'][key] %>
-    <%- end -%>
-  <%- end -%>
 <% end -%>
 <% [@proxy_pass_match].flatten.compact.each do |proxy| %>
   ProxyPassMatch <%= proxy['path'] %> <%= proxy['url'] -%>


### PR DESCRIPTION
Revert "MODULES-2956: Enable options within location block on proxy_match"

this commit removes the location directive in _proxy.erb
proxy: remove workaround for old broken clients
99add117df452d2c513a3a7c36d9fd0416e696b9

this commit sets options in the location directive in _proxy.erb
MODULES-2956: Enable options within location block on proxy_match
db5b0bfb09959622ea1c6cc299b58057b94c588f

setting options-hash in proxy_pass or proxy_match now leads to syntax errors
in Apache like "AuthBasicProvider not allowed here"