### PR TITLE
mod_event: do not set parameters twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1366,7 +1366,7 @@ Installs and manages [`mod_mpm_event`][]. You can't include both `apache::mod::e
 **Parameters within `apache::mod::event`**:
 
 - `listenbacklog`: Sets the maximum length of the pending connections queue via the module's [`ListenBackLog`][] directive. Default: '511'.
-- `maxclients` (_Apache 2.3.12 or older_: `maxrequestworkers`): Sets the maximum number of connections Apache can simultaneously process, via the module's [`MaxRequestWorkers`][] directive. Default: '150'.
+- `maxrequestworkers` (_Apache 2.3.12 or older_: `maxclients`): Sets the maximum number of connections Apache can simultaneously process, via the module's [`MaxRequestWorkers`][] directive. Default: '150'.
 - `maxconnectionsperchild` (_Apache 2.3.8 or older_: `maxrequestsperchild`): Limits the number of connections a child server handles during its life, via the module's [`MaxConnectionsPerChild`][] directive. Default: '0'.
 - `maxsparethreads` and `minsparethreads`: Sets the maximum and minimum number of idle threads, via the [`MaxSpareThreads`][] and [`MinSpareThreads`][] directives. Default: '75' and '25', respectively.
 - `serverlimit`: Limits the configurable number of processes via the [`ServerLimit`][] directive. Default: '25'.

--- a/manifests/mod/event.pp
+++ b/manifests/mod/event.pp
@@ -1,16 +1,16 @@
 class apache::mod::event (
   $startservers           = '2',
   $maxclients             = '150',
+  $maxrequestworkers      = undef,
   $minsparethreads        = '25',
   $maxsparethreads        = '75',
   $threadsperchild        = '25',
   $maxrequestsperchild    = '0',
+  $maxconnectionsperchild = undef,
   $serverlimit            = '25',
   $apache_version         = $::apache::apache_version,
   $threadlimit            = '64',
   $listenbacklog          = '511',
-  $maxrequestworkers      = '250',
-  $maxconnectionsperchild = '0',
 ) {
   if defined(Class['apache::mod::itk']) {
     fail('May not include both apache::mod::event and apache::mod::itk on the same node')

--- a/spec/classes/mod/event_spec.rb
+++ b/spec/classes/mod/event_spec.rb
@@ -59,7 +59,7 @@ describe 'apache::mod::event', :type => :class do
     it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file') }
     it { is_expected.to contain_file("/etc/apache2/mods-enabled/event.conf").with_ensure('link') }
 
-    context "Test mpm_event params" do
+    context "Test mpm_event new params" do
       let :params do
         {
           :serverlimit            => '0',
@@ -78,6 +78,36 @@ describe 'apache::mod::event', :type => :class do
 
       it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*ServerLimit\s*0/) }
       it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*StartServers\s*1/) }
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').without_content(/^\s*MaxClients\s*2/) }
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*MinSpareThreads\s*3/) }
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*MaxSpareThreads\s*4/) }
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*ThreadsPerChild\s*5/) }
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').without_content(/^\s*MaxRequestsPerChild\s*6/) }
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*ThreadLimit\s*7/) }
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*ListenBacklog\s*8/) }
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*MaxRequestWorkers\s*9/) }
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*MaxConnectionsPerChild\s*10/) }
+    end
+
+    context "Test mpm_event old style params" do
+      let :params do
+        {
+          :serverlimit            => '0',
+          :startservers           => '1',
+          :maxclients             => '2',
+          :minsparethreads        => '3',
+          :maxsparethreads        => '4',
+          :threadsperchild        => '5',
+          :maxrequestsperchild    => '6',
+          :threadlimit            => '7',
+          :listenbacklog          => '8',
+          :maxrequestworkers      => :undef,
+          :maxconnectionsperchild => :undef,
+        }
+      end
+
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*ServerLimit\s*0/) }
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*StartServers\s*1/) }
       it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*MaxClients\s*2/) }
       it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*MinSpareThreads\s*3/) }
       it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*MaxSpareThreads\s*4/) }
@@ -85,8 +115,8 @@ describe 'apache::mod::event', :type => :class do
       it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*MaxRequestsPerChild\s*6/) }
       it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*ThreadLimit\s*7/) }
       it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*ListenBacklog\s*8/) }
-      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*MaxRequestWorkers\s*9/) }
-      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*MaxConnectionsPerChild\s*10/) }
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').without_content(/^\s*MaxRequestWorkers\s*9/) }
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').without_content(/^\s*MaxConnectionsPerChild\s*10/) }
     end
 
     context "with Apache version < 2.4" do

--- a/templates/mod/event.conf.erb
+++ b/templates/mod/event.conf.erb
@@ -1,13 +1,19 @@
 <IfModule mpm_event_module>
   ServerLimit            <%= @serverlimit %>
   StartServers           <%= @startservers %>
+  <%- if @maxrequestworkers -%>
+  MaxRequestWorkers      <%= @maxrequestworkers %>
+  <%- else -%>
   MaxClients             <%= @maxclients %>
+  <%- end -%>
   MinSpareThreads        <%= @minsparethreads %>
   MaxSpareThreads        <%= @maxsparethreads %>
   ThreadsPerChild        <%= @threadsperchild %>
+  <%- if @maxconnectionsperchild -%>
+  MaxConnectionsPerChild <%= @maxconnectionsperchild %>
+  <%- else -%>
   MaxRequestsPerChild    <%= @maxrequestsperchild %>
+  <%- end -%>
   ThreadLimit            <%= @threadlimit %>
   ListenBacklog          <%= @listenbacklog %>
-  MaxRequestWorkers      <%= @maxrequestworkers %>
-  MaxConnectionsPerChild <%= @maxconnectionsperchild %>
 </IfModule>


### PR DESCRIPTION
The Name of the Parameters MaxRequestWorkers and MaxConnectionsPerChild  for mod_event changed between versions as the README already shows (mixed up though).
The apache module should not set both the old and the new parameter name, but instead just one of them.

The old names are still supported so it's better (and safe) to set the old names than both.

See:
* https://httpd.apache.org/docs/current/en/mod/mpm_common.html#maxconnectionsperchild
* https://httpd.apache.org/docs/current/en/mod/mpm_common.html#maxrequestworkers