### PR TITLE
Revert "changed rpaf Configuration Directives: RPAF -> RPAF_"

### DIFF
--- a/spec/classes/mod/rpaf_spec.rb
+++ b/spec/classes/mod/rpaf_spec.rb
@@ -22,25 +22,25 @@ describe 'apache::mod::rpaf', :type => :class do
     it { is_expected.to contain_file('rpaf.conf').with({
       'path' => '/etc/apache2/mods-available/rpaf.conf',
     }) }
-    it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAF_enable On$/) }
+    it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAFenable On$/) }
 
     describe "with sethostname => true" do
       let :params do
         { :sethostname => 'true' }
       end
-      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAF_sethostname On$/) }
+      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAFsethostname On$/) }
     end
     describe "with proxy_ips => [ 10.42.17.8, 10.42.18.99 ]" do
       let :params do
         { :proxy_ips => [ '10.42.17.8', '10.42.18.99' ] }
       end
-      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAF_proxyIPs 10.42.17.8 10.42.18.99$/) }
+      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAFproxy_ips 10.42.17.8 10.42.18.99$/) }
     end
     describe "with header => X-Real-IP" do
       let :params do
         { :header => 'X-Real-IP' }
       end
-      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAF_header X-Real-IP$/) }
+      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAFheader X-Real-IP$/) }
     end
   end
   context "on a FreeBSD OS" do
@@ -62,25 +62,25 @@ describe 'apache::mod::rpaf', :type => :class do
     it { is_expected.to contain_file('rpaf.conf').with({
       'path' => '/usr/local/etc/apache24/Modules/rpaf.conf',
     }) }
-    it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAF_enable On$/) }
+    it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAFenable On$/) }
 
     describe "with sethostname => true" do
       let :params do
         { :sethostname => 'true' }
       end
-      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAF_sethostname On$/) }
+      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAFsethostname On$/) }
     end
     describe "with proxy_ips => [ 10.42.17.8, 10.42.18.99 ]" do
       let :params do
         { :proxy_ips => [ '10.42.17.8', '10.42.18.99' ] }
       end
-      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAF_proxyIPs 10.42.17.8 10.42.18.99$/) }
+      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAFproxy_ips 10.42.17.8 10.42.18.99$/) }
     end
     describe "with header => X-Real-IP" do
       let :params do
         { :header => 'X-Real-IP' }
       end
-      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAF_header X-Real-IP$/) }
+      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAFheader X-Real-IP$/) }
     end
   end
   context "on a Gentoo OS" do
@@ -102,25 +102,25 @@ describe 'apache::mod::rpaf', :type => :class do
     it { is_expected.to contain_file('rpaf.conf').with({
       'path' => '/etc/apache2/modules.d/rpaf.conf',
     }) }
-    it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAF_enable On$/) }
+    it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAFenable On$/) }
 
     describe "with sethostname => true" do
       let :params do
         { :sethostname => 'true' }
       end
-      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAF_sethostname On$/) }
+      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAFsethostname On$/) }
     end
     describe "with proxy_ips => [ 10.42.17.8, 10.42.18.99 ]" do
       let :params do
         { :proxy_ips => [ '10.42.17.8', '10.42.18.99' ] }
       end
-      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAF_proxyIPs 10.42.17.8 10.42.18.99$/) }
+      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAFproxy_ips 10.42.17.8 10.42.18.99$/) }
     end
     describe "with header => X-Real-IP" do
       let :params do
         { :header => 'X-Real-IP' }
       end
-      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAF_header X-Real-IP$/) }
+      it { is_expected.to contain_file('rpaf.conf').with_content(/^RPAFheader X-Real-IP$/) }
     end
   end
 end

--- a/templates/mod/rpaf.conf.erb
+++ b/templates/mod/rpaf.conf.erb
@@ -1,15 +1,15 @@
 # Enable reverse proxy add forward
-RPAF_enable On
-# RPAF_sethostname will, when enabled, take the incoming X-Host header and
+RPAFenable On
+# RPAFsethostname will, when enabled, take the incoming X-Host header and
 # update the virtual host settings accordingly. This allows to have the same
 # hostnames as in the "real" configuration for the forwarding proxy.
 <% if @sethostname -%>
-RPAF_sethostname On
+RPAFsethostname On
 <% else -%>
-RPAF_sethostname Off
+RPAFsethostname Off
 <% end -%>
 # Which IPs are forwarding requests to us
-RPAF_proxyIPs <%= Array(@proxy_ips).join(" ") %>
-# Setting RPAF_header allows you to change the header name to parse from the
+RPAFproxy_ips <%= Array(@proxy_ips).join(" ") %>
+# Setting RPAFheader allows you to change the header name to parse from the
 # default X-Forwarded-For to something of your choice.
-RPAF_header <%= @header %>
+RPAFheader <%= @header %>


### PR DESCRIPTION
This reverts commit 8ca7a6697ab907803789b2aa63e304f19e3497d3.

These changes are completely incompatible with mod_rpaf as provided in
Ubuntu 12.04 and Debian Jessie and Wheezy, and break the Apache
configuration and consequently the Puppet agent run.

I suspect these changes were made to be compatible with one of the
mod_rpaf forks (https://github.com/gnif/mod_rpaf) but I don't see how a
"random" fork should have precedence over, and break modules distributed
on the official channels.