### PR TITLE
Allow setting KeepAlive related options per vhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -2206,6 +2206,24 @@ apache::vhost { 'sample.example.net':
 }
 ```
 
+##### `keepalive`
+
+Determines whether to enable persistent HTTP connections with the [`KeepAlive`][] directive for the virtual host. Valid options: 'Off', 'On' and `undef`. Default: `undef`, meaning the global, server-wide [`KeepAlive`][] setting is in effect.
+
+Use the `keepalive_timeout` and `max_keepalive_requests` parameters to set relevant options for the virtual host.
+
+##### `keepalive_timeout`
+
+Sets the [`KeepAliveTimeout`] directive for the virtual host, which determines the amount of time to wait for subsequent requests on a persistent HTTP connection. Default: `undef`, meaning the global, server-wide [`KeepAlive`][] setting is in effect.
+
+This parameter is only relevant if either the global, server-wide [`keepalive` parameter][] or the per-vhost `keepalive` parameter is enabled.
+
+##### `max_keepalive_requests`
+
+Limits the number of requests allowed per connection to the virtual host. Default: `undef`, meaning the global, server-wide [`KeepAlive`][] setting is in effect.
+
+This parameter is only relevant if either the global, server-wide [`keepalive` parameter][] or the per-vhost `keepalive` parameter is enabled.
+
 ##### `auth_kerb`
 
 Enable [`mod_auth_kerb`][] parameters for a virtual host. Valid options: Boolean. Default: false.
@@ -3192,7 +3210,7 @@ apache::vhost { 'sample.example.net':
   docroot     => '/path/to/directory',
   directories => [
     { path    => '/path/to/directory',
-      require => { 
+      require => {
         enforce => 'all',
         require => ['group', 'not host host.example.com'],
       },

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -149,6 +149,9 @@ define apache::vhost(
   $krb_verify_kdc              = 'on',
   $krb_servicename             = 'HTTP',
   $krb_save_credentials        = 'off',
+  $keepalive                   = undef,
+  $keepalive_timeout           = undef,
+  $max_keepalive_requests      = undef,
 ) {
   # The base class must be included first because it is used by parameter defaults
   if ! defined(Class['apache']) {
@@ -262,6 +265,10 @@ define apache::vhost(
 
   if $ssl_proxy_check_peer_expire {
     validate_re($ssl_proxy_check_peer_expire,'(^on$|^off$)',"${ssl_proxy_check_peer_expire} is not permitted for ssl_proxy_check_peer_expire. Allowed values are 'on' or 'off'.")
+  }
+
+  if $keepalive {
+    validate_re($keepalive,'(^on$|^off$)',"${keepalive} is not permitted for keepalive. Allowed values are 'on' or 'off'.")
   }
 
   # Input validation ends
@@ -1048,6 +1055,18 @@ define apache::vhost(
       target  => "${priority_real}${filename}.conf",
       order   => 340,
       content => template('apache/vhost/_jk_mounts.erb'),
+    }
+  }
+
+  # Template uses:
+  # - $keepalive
+  # - $keepalive_timeout
+  # - $max_keepalive_requests
+  if $keepalive or $keepalive_timeout or $max_keepalive_requests {
+    concat::fragment { "${name}-keepalive_options":
+      target  => "${priority_real}${filename}.conf",
+      order   => 350,
+      content => template('apache/vhost/_keepalive_options.erb'),
     }
   }
 

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -201,7 +201,7 @@ describe 'apache::vhost', :type => :define do
               'path'     => '/var/www/files',
               'provider' => 'files',
               'require'  =>
-              { 
+              {
                 'enforce'  => 'all',
                 'requires' => ['all-valid1', 'all-valid2'],
               },
@@ -210,7 +210,7 @@ describe 'apache::vhost', :type => :define do
               'path'     => '/var/www/files',
               'provider' => 'files',
               'require'  =>
-              { 
+              {
                 'enforce'  => 'none',
                 'requires' => ['none-valid1', 'none-valid2'],
               },
@@ -219,7 +219,7 @@ describe 'apache::vhost', :type => :define do
               'path'     => '/var/www/files',
               'provider' => 'files',
               'require'  =>
-              { 
+              {
                 'enforce'  => 'any',
                 'requires' => ['any-valid1', 'any-valid2'],
               },
@@ -395,7 +395,10 @@ describe 'apache::vhost', :type => :define do
           'krb_authoritative'           => 'off',
           'krb_auth_realms'             => ['EXAMPLE.ORG','EXAMPLE.NET'],
           'krb_5keytab'                 => '/tmp/keytab5',
-          'krb_local_user_mapping'      => 'off'
+          'krb_local_user_mapping'      => 'off',
+          'keepalive'                   => 'on',
+          'keepalive_timeout'           => '100',
+          'max_keepalive_requests'      => '1000',
         }
       end
       let :facts do
@@ -600,6 +603,12 @@ describe 'apache::vhost', :type => :define do
         :content => /^\s+KrbSaveCredentials\soff$/)}
       it { is_expected.to contain_concat__fragment('rspec.example.com-auth_kerb').with(
         :content => /^\s+KrbVerifyKDC\son$/)}
+      it { is_expected.to contain_concat__fragment('rspec.example.com-keepalive_options').with(
+        :content => /^\s+KeepAlive\son$/)}
+      it { is_expected.to contain_concat__fragment('rspec.example.com-keepalive_options').with(
+        :content => /^\s+KeepAliveTimeout\s100$/)}
+      it { is_expected.to contain_concat__fragment('rspec.example.com-keepalive_options').with(
+        :content => /^\s+MaxKeepAliveRequests\s1000$/)}
     end
     context 'vhost with multiple ip addresses' do
       let :params do

--- a/templates/vhost/_keepalive_options.erb
+++ b/templates/vhost/_keepalive_options.erb
@@ -1,0 +1,9 @@
+<%- if @keepalive -%>
+  KeepAlive <%= @keepalive %>
+<%- end -%>
+<%- if @keepalive_timeout -%>
+  KeepAliveTimeout <%= @keepalive_timeout %>
+<%- end -%>
+<%- if @max_keepalive_requests -%>
+  MaxKeepAliveRequests <%= @max_keepalive_requests %>
+<%- end -%>


### PR DESCRIPTION
Introduce the parameters vhost::keepalive, vhost::keepalive_timeout and
vhost::max_keepalive_requests, which are all undef by default, meaning
the server-wide KeepAlive options will be in effect. This way the
KeepAlive settings can be changed on a per-vhost basis.

Includes updated documentation and basic spec tests.