### PR TITLE
Add class apache::vhosts to create apache::vhost resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,6 +741,7 @@ apache::balancer { 'puppet01':
 - [**Public classes**](#public-classes)
     - [Class: apache](#class-apache)
     - [Class: apache::dev](#class-apachedev)
+    - [Class: apache::vhosts](#class-apachevhosts)
     - [Classes: apache::mod::\*](#classes-apachemodname)
 - [**Private classes**](#private-classes)
     - [Class: apache::confd::no_accf](#class-apacheconfdno_accf)
@@ -1246,6 +1247,29 @@ The default value is determined by your operating system:
 - **Red Hat**: 'httpd-devel'
 
 > **Note**: On FreeBSD, you must declare the `apache::package` or `apache` classes before declaring `apache::dev`.
+
+#### Class: `apache::vhosts`
+
+Creates [`apache::vhost`][] defined types.
+
+**Parameters within `apache::vhosts`**:
+
+- `vhosts`: A [hash][] where the key represents the name and the value represents a [hash][] of [`apache::vhost`][] defined type's parameters. Default: '{}'
+
+> **Note**: See the [`apache::vhost`][] defined type's reference for a list of all virtual host parameters or [Configuring virtual hosts].
+
+For example, to create a [name-based virtual host][name-based virtual hosts] 'custom_vhost_1, you can declare the class with the `vhosts` parameter set to '{ "custom_vhost_1" => { "docroot" => "/var/www/custom_vhost_1", "port" => "81" }':
+
+``` puppet
+class { 'apache::vhosts':
+  vhosts => {
+    'custom_vhost_1' => {
+      'docroot' => '/var/www/custom_vhost_1',
+      'port'    => '81',
+    },
+  },
+}
+```
 
 #### Classes: `apache::mod::<MODULE NAME>`
 

--- a/manifests/vhosts.pp
+++ b/manifests/vhosts.pp
@@ -1,0 +1,6 @@
+class apache::vhosts (
+  $vhosts = {},
+) {
+  include ::apache
+  create_resources('apache::vhost', $vhosts)
+}

--- a/spec/acceptance/vhosts_spec.rb
+++ b/spec/acceptance/vhosts_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper_acceptance'
+require_relative './version.rb'
+
+describe 'apache::vhosts class' do
+  context 'custom vhosts defined via class apache::vhosts' do
+    it 'should create custom vhost config files' do
+      pp = <<-EOS
+        class { 'apache::vhosts':
+          vhosts => {
+            'custom_vhost_1' => {
+                'docroot' => '/var/www/custom_vhost_1',
+                'port' => '81',
+            },
+            'custom_vhost_2' => {
+                'docroot' => '/var/www/custom_vhost_2',
+                'port' => '82',
+            },
+          },
+        }
+      EOS
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    describe file("#{$vhost_dir}/25-custom_vhost_1.conf") do
+      it { is_expected.to contain '<VirtualHost \*:81>' }
+    end
+
+    describe file("#{$vhost_dir}/25-custom_vhost_2.conf") do
+      it { is_expected.to contain '<VirtualHost \*:82>' }
+    end
+  end
+end

--- a/spec/classes/vhosts_spec.rb
+++ b/spec/classes/vhosts_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe 'apache::vhosts', :type => :class do
+  context 'on all OSes' do
+    let :facts do
+      {
+          :id                     => 'root',
+          :kernel                 => 'Linux',
+          :osfamily               => 'RedHat',
+          :operatingsystem        => 'RedHat',
+          :operatingsystemrelease => '6',
+          :concat_basedir         => '/dne',
+          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :is_pe                  => false,
+      }
+    end
+    context 'with custom vhosts parameter' do
+      let :params do {
+          :vhosts => {
+              'custom_vhost_1' => {
+                  'docroot' => '/var/www/custom_vhost_1',
+                  'port' => '81',
+              },
+              'custom_vhost_2' => {
+                  'docroot' => '/var/www/custom_vhost_2',
+                  'port' => '82',
+              },
+          },
+      }
+      end
+      it { is_expected.to contain_apache__vhost('custom_vhost_1') }
+      it { is_expected.to contain_apache__vhost('custom_vhost_2') }
+    end
+  end
+end


### PR DESCRIPTION
This way it is possible to create apache::vhost resources directly via the main class without declaring them in a separate role or profile.