### PR TITLE
Add WSGIScriptAliasesMatch support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
   - `fastcgi_idle_timeout`
   - `modsec_disable_msgs`
   - `modsec_disable_tags`
+  - `wsgi_script_aliases_match`
 - Added ability for 2.4-style `RequireAll|RequireNone|RequireAny` directory permissions
 - Added ability for includes in vhost directory
 - Added directory values:

--- a/README.md
+++ b/README.md
@@ -2748,6 +2748,7 @@ Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi).
 * `wsgi_daemon_process_options`. _Optional._ Default: undef.
 * `wsgi_process_group`: Sets the group ID that the virtual host runs under. Default: undef.
 * `wsgi_script_aliases`: Requires a hash of web paths to filesystem .wsgi paths. Default: undef.
+* `wsgi_script_aliases_match`: Requires a hash of web path regexes to filesystem .wsgi paths. Default: undef
 * `wsgi_pass_authorization`: Uses the WSGI application to handle authorization instead of Apache when set to 'On'. For more information, see [mod_wsgi's WSGIPassAuthorization documentation] (https://modwsgi.readthedocs.org/en/latest/configuration-directives/WSGIPassAuthorization.html). Default: undef, leading Apache to use its default value of 'Off'.
 * `wsgi_chunked_request`: Enables support for chunked requests. Default: undef.
 

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -108,6 +108,7 @@ define apache::vhost(
   $wsgi_import_script          = undef,
   $wsgi_import_script_options  = undef,
   $wsgi_process_group          = undef,
+  $wsgi_script_aliases_match   = undef,
   $wsgi_script_aliases         = undef,
   $wsgi_pass_authorization     = undef,
   $wsgi_chunked_request        = undef,
@@ -205,6 +206,9 @@ define apache::vhost(
 
   if $wsgi_script_aliases {
     validate_hash($wsgi_script_aliases)
+  }
+  if $wsgi_script_aliases_match {
+    validate_hash($wsgi_script_aliases_match)
   }
   if $wsgi_daemon_process_options {
     validate_hash($wsgi_daemon_process_options)

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -1312,6 +1312,7 @@ describe 'apache::vhost define' do
             wsgi_daemon_process_options => {processes => '2'},
             wsgi_process_group          => 'nobody',
             wsgi_script_aliases         => { '/test' => '/test1' },
+            wsgi_script_aliases_match   => { '/test/([^/*])' => '/test1' },
             wsgi_pass_authorization     => 'On',
           }
         EOS
@@ -1334,6 +1335,7 @@ describe 'apache::vhost define' do
             wsgi_import_script_options  => { application-group => '%{GLOBAL}', process-group => 'wsgi' },
             wsgi_process_group          => 'nobody',
             wsgi_script_aliases         => { '/test' => '/test1' },
+            wsgi_script_aliases_match   => { '/test/([^/*])' => '/test1' },
             wsgi_pass_authorization     => 'On',
             wsgi_chunked_request        => 'On',
           }

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -354,6 +354,9 @@ describe 'apache::vhost', :type => :define do
           'wsgi_script_aliases'         => {
             '/' => '/var/www/demo.wsgi'
           },
+          'wsgi_script_aliases_match'   => {
+            '^/test/(^[/*)' => '/var/www/demo.wsgi'
+          },
           'wsgi_pass_authorization'     => 'On',
           'custom_fragment'             => '#custom string',
           'itk'                         => {

--- a/templates/vhost/_wsgi.erb
+++ b/templates/vhost/_wsgi.erb
@@ -12,6 +12,13 @@
 <% if @wsgi_process_group -%>
   WSGIProcessGroup <%= @wsgi_process_group %>
 <% end -%>
+<% if @wsgi_script_aliases_match and ! @wsgi_script_aliases_match.empty? -%>
+  <%- @wsgi_script_aliases_match.keys.sort.each do |key| -%>
+    <%- if key != '' and @wsgi_script_aliases_match[key] != ''-%>
+  WSGIScriptAliasMatch <%= key %> "<%= @wsgi_script_aliases_match[key] %>"
+    <%- end -%>
+  <%- end -%>
+<% end -%>
 <% if @wsgi_script_aliases and ! @wsgi_script_aliases.empty? -%>
   <%- @wsgi_script_aliases.keys.sort.each do |key| -%>
     <%- if key != '' and @wsgi_script_aliases[key] != ''-%>


### PR DESCRIPTION
I noticed that the PuppetLabs apache module has WSGIScriptAliases support but not WSGIScriptAliasesMatch support. i added this functionality as well as updated the tests. Let me know if I should make any changes. Thanks!