### PR TITLE
Only set SSLCompression when it is set to true.

### DIFF
--- a/spec/classes/mod/ssl_spec.rb
+++ b/spec/classes/mod/ssl_spec.rb
@@ -133,6 +133,46 @@ describe 'apache::mod::ssl', :type => :class do
       it { is_expected.to contain_file('ssl.conf').with_content(/^  SSLPassPhraseDialog builtin$/)}
     end
 
+    context "with Apache version < 2.4" do
+      let :params do
+        {
+          :apache_version => '2.2',
+        }
+      end
+      context 'ssl_compression with default value' do
+        it { is_expected.not_to contain_file('ssl.conf').with_content(/^  SSLCompression Off$/)}
+      end
+
+      context 'setting ssl_compression to true' do
+        let :params do
+          {
+            :ssl_compression => true,
+          }
+        end
+        it { is_expected.not_to contain_file('ssl.conf').with_content(/^  SSLCompression On$/)}
+      end
+    end
+    context "with Apache version >= 2.4" do
+      let :params do
+        {
+          :apache_version => '2.4',
+        }
+      end
+      context 'ssl_compression with default value' do
+        it { is_expected.not_to contain_file('ssl.conf').with_content(/^  SSLCompression Off$/)}
+      end
+
+      context 'setting ssl_compression to true' do
+        let :params do
+          {
+            :apache_version => '2.4',
+            :ssl_compression => true,
+          }
+        end
+        it { is_expected.to contain_file('ssl.conf').with_content(/^  SSLCompression On$/)}
+      end
+    end
+
     context 'setting ssl_pass_phrase_dialog' do
       let :params do
         {

--- a/templates/mod/ssl.conf.erb
+++ b/templates/mod/ssl.conf.erb
@@ -12,7 +12,9 @@
   SSLSessionCacheTimeout <%= @ssl_sessioncachetimeout %>
   <%- if scope.function_versioncmp([@_apache_version, '2.4']) >= 0 -%>
   Mutex <%= @_ssl_mutex %>
+    <%- if @ssl_compression -%>
   SSLCompression <%= scope.function_bool2httpd([@ssl_compression]) %>
+    <%- end -%>
   <%- else -%>
   SSLMutex <%= @_ssl_mutex %>
   <%- end -%>


### PR DESCRIPTION
The default for SSLCompression in Apache is 'Off' anyways, see:
https://httpd.apache.org/docs/2.4/mod/mod_ssl.html#sslcompression
therefore there is no real need to add that into the config file.

This will prevent problems on Apache versions that have
linked against SSL libraries that do not have SSLCompression
enabled. There, even SSLCompression Off will lead to:

H00526: Syntax error on line 14 of /etc/apache2/modules/ssl.conf:
Setting Compression mode unsupported; not implemented by the SSL library

and prevents Apache startup

Add some spec tests for that behaviour, depending on whether Apache
version >= 2.4 or not, since the template also differentiates.