### PR TITLE
mod_event: parameters can be unset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1367,14 +1367,14 @@ Installs and manages [`mod_mpm_event`][]. You can't include both `apache::mod::e
 
 **Parameters within `apache::mod::event`**:
 
-- `listenbacklog`: Sets the maximum length of the pending connections queue via the module's [`ListenBackLog`][] directive. Default: '511'.
-- `maxrequestworkers` (_Apache 2.3.12 or older_: `maxclients`): Sets the maximum number of connections Apache can simultaneously process, via the module's [`MaxRequestWorkers`][] directive. Default: '150'.
-- `maxconnectionsperchild` (_Apache 2.3.8 or older_: `maxrequestsperchild`): Limits the number of connections a child server handles during its life, via the module's [`MaxConnectionsPerChild`][] directive. Default: '0'.
-- `maxsparethreads` and `minsparethreads`: Sets the maximum and minimum number of idle threads, via the [`MaxSpareThreads`][] and [`MinSpareThreads`][] directives. Default: '75' and '25', respectively.
-- `serverlimit`: Limits the configurable number of processes via the [`ServerLimit`][] directive. Default: '25'.
-- `startservers`: Sets the number of child server processes created at startup, via the module's [`StartServers`][] directive. Default: '2'.
-- `threadlimit`: Limits the number of event threads via the module's [`ThreadLimit`][] directive. Default: '64'.
-- `threadsperchild`: Sets the number of threads created by each child process, via the [`ThreadsPerChild`][] directive. Default: '25'.
+- `listenbacklog`: Sets the maximum length of the pending connections queue via the module's [`ListenBackLog`][] directive. Default: '511'. Setting this to 'false' removes the parameter.
+- `maxrequestworkers` (_Apache 2.3.12 or older_: `maxclients`): Sets the maximum number of connections Apache can simultaneously process, via the module's [`MaxRequestWorkers`][] directive. Default: '150'. Setting these to 'false' removes the parameters.
+- `maxconnectionsperchild` (_Apache 2.3.8 or older_: `maxrequestsperchild`): Limits the number of connections a child server handles during its life, via the module's [`MaxConnectionsPerChild`][] directive. Default: '0'. Setting these to 'false' removes the parameters.
+- `maxsparethreads` and `minsparethreads`: Sets the maximum and minimum number of idle threads, via the [`MaxSpareThreads`][] and [`MinSpareThreads`][] directives. Default: '75' and '25', respectively. Setting these to 'false' removes the parameters.
+- `serverlimit`: Limits the configurable number of processes via the [`ServerLimit`][] directive. Default: '25'. Setting this to 'false' removes the parameter.
+- `startservers`: Sets the number of child server processes created at startup, via the module's [`StartServers`][] directive. Default: '2'. Setting this to 'false' removes the parameter.
+- `threadlimit`: Limits the number of event threads via the module's [`ThreadLimit`][] directive. Default: '64'. Setting this to 'false' removes the parameter.
+- `threadsperchild`: Sets the number of threads created by each child process, via the [`ThreadsPerChild`][] directive. Default: '25'. Setting this to 'false' removes the parameter.
 
 ##### Class: `apache::mod::auth_cas`
 

--- a/spec/classes/mod/event_spec.rb
+++ b/spec/classes/mod/event_spec.rb
@@ -78,11 +78,11 @@ describe 'apache::mod::event', :type => :class do
 
       it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*ServerLimit\s*0/) }
       it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*StartServers\s*1/) }
-      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').without_content(/^\s*MaxClients\s*2/) }
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').without_content(/^\s*MaxClients/) }
       it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*MinSpareThreads\s*3/) }
       it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*MaxSpareThreads\s*4/) }
       it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*ThreadsPerChild\s*5/) }
-      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').without_content(/^\s*MaxRequestsPerChild\s*6/) }
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').without_content(/^\s*MaxRequestsPerChild/) }
       it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*ThreadLimit\s*7/) }
       it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*ListenBacklog\s*8/) }
       it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*MaxRequestWorkers\s*9/) }
@@ -115,8 +115,38 @@ describe 'apache::mod::event', :type => :class do
       it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*MaxRequestsPerChild\s*6/) }
       it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*ThreadLimit\s*7/) }
       it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').with_content(/^\s*ListenBacklog\s*8/) }
-      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').without_content(/^\s*MaxRequestWorkers\s*9/) }
-      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').without_content(/^\s*MaxConnectionsPerChild\s*10/) }
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').without_content(/^\s*MaxRequestWorkers/) }
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').without_content(/^\s*MaxConnectionsPerChild/) }
+    end
+
+    context "Test mpm_event false params" do
+      let :params do
+        {
+          :serverlimit            => false,
+          :startservers           => false,
+          :maxclients             => false,
+          :minsparethreads        => false,
+          :maxsparethreads        => false,
+          :threadsperchild        => false,
+          :maxrequestsperchild    => false,
+          :threadlimit            => false,
+          :listenbacklog          => false,
+          :maxrequestworkers      => false,
+          :maxconnectionsperchild => false,
+        }
+      end
+
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').without_content(/^\s*ServerLimit/) }
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').without_content(/^\s*StartServers/) }
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').without_content(/^\s*MaxClients/) }
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').without_content(/^\s*MinSpareThreads/) }
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').without_content(/^\s*MaxSpareThreads/) }
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').without_content(/^\s*ThreadsPerChild/) }
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').without_content(/^\s*MaxRequestsPerChild/) }
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').without_content(/^\s*ThreadLimit/) }
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').without_content(/^\s*ListenBacklog/) }
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').without_content(/^\s*MaxRequestWorkers/) }
+      it { is_expected.to contain_file("/etc/apache2/mods-available/event.conf").with_ensure('file').without_content(/^\s*MaxConnectionsPerChild/) }
     end
 
     context "with Apache version < 2.4" do

--- a/templates/mod/event.conf.erb
+++ b/templates/mod/event.conf.erb
@@ -1,19 +1,33 @@
 <IfModule mpm_event_module>
+  <%- if @serverlimit -%>
   ServerLimit            <%= @serverlimit %>
+  <%- end -%>
+  <%- if @startservers -%>
   StartServers           <%= @startservers %>
+  <%- end -%>
   <%- if @maxrequestworkers -%>
   MaxRequestWorkers      <%= @maxrequestworkers %>
-  <%- else -%>
+  <%- elsif @maxclients -%>
   MaxClients             <%= @maxclients %>
   <%- end -%>
+  <%- if @minsparethreads -%>
   MinSpareThreads        <%= @minsparethreads %>
+  <%- end -%>
+  <%- if @maxsparethreads -%>
   MaxSpareThreads        <%= @maxsparethreads %>
+  <%- end -%>
+  <%- if @threadsperchild -%>
   ThreadsPerChild        <%= @threadsperchild %>
+  <%- end -%>
   <%- if @maxconnectionsperchild -%>
   MaxConnectionsPerChild <%= @maxconnectionsperchild %>
-  <%- else -%>
+  <%- elsif @maxrequestsperchild -%>
   MaxRequestsPerChild    <%= @maxrequestsperchild %>
   <%- end -%>
+  <%- if @threadlimit -%>
   ThreadLimit            <%= @threadlimit %>
+  <%- end -%>
+  <%- if @listenbacklog -%>
   ListenBacklog          <%= @listenbacklog %>
+  <%- end -%>
 </IfModule>


### PR DESCRIPTION
The commit adds the ability to unset mod_event parameters. This is useful if you want to use apache defaults.