### PR TITLE
(MODULES-3388) Include mpm_module classes instead of class declaration

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -366,7 +366,7 @@ class apache (
       all => $default_confd_files
     }
     if $mpm_module and $mpm_module != 'false' { # lint:ignore:quoted_booleans
-      class { "::apache::mod::${mpm_module}": }
+      include "::apache::mod::${mpm_module}"
     }
 
     $default_vhost_ensure = $default_vhost ? {


### PR DESCRIPTION
Change the use of an empty class declaration to an include statement.
This enables the relevant mpm_module to be safely declared elsewhere with custom parameters.