### PR TITLE
apache::balancer now respects apache::confd_dir

### DIFF
--- a/manifests/balancer.pp
+++ b/manifests/balancer.pp
@@ -52,7 +52,7 @@ define apache::balancer (
   if $target {
     $_target = $target
   } else {
-    $_target = "${::apache::params::confd_dir}/balancer_${name}.conf"
+    $_target = "${::apache::confd_dir}/balancer_${name}.conf"
   }
 
   concat { "apache_balancer_${name}":

--- a/spec/defines/balancer_spec.rb
+++ b/spec/defines/balancer_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'apache::balancer', :type => :define do
-  let :pre_condition do
-    'include apache'
+  let :title do
+    'myapp'
   end
   let :facts do
     {
@@ -17,17 +17,29 @@ describe 'apache::balancer', :type => :define do
       :is_pe                  => false,
     }
   end
-  describe "accept a target parameter and use it" do
-    let :title do
-      'myapp'
+  describe 'apache pre_condition with defaults' do
+    let :pre_condition do
+      'include apache'
     end
-    let :params do
-      {
-        :target => '/tmp/myapp.conf'
-      }
+    describe "accept a target parameter and use it" do
+      let :params do
+        {
+          :target => '/tmp/myapp.conf'
+        }
+      end
+      it { should contain_concat('apache_balancer_myapp').with({
+        :path => "/tmp/myapp.conf",
+      })}
+    end
+  end
+  describe 'apache pre_condition with conf_dir set' do 
+    let :pre_condition do
+      'class{"apache":
+          confd_dir => "/junk/path"
+       }'
     end
     it { should contain_concat('apache_balancer_myapp').with({
-      :path => "/tmp/myapp.conf",
+      :path => "/junk/path/balancer_myapp.conf",
     })}
   end
 end


### PR DESCRIPTION
Previously with a configuration of

```
class{'apache':
  confd_dir => '/my/directory':
}
balancer{'myb':}
```

balencer would create a file incorrectly in the default location
*/etc/apache2/conf.d/balancer_myb.conf*

balencer now uses the value *apache::confd_dir*.

A test case has been added for this bug.