### PR TITLE
fix and make 2.4 require docu more readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -3274,8 +3274,12 @@ apache::vhost { 'sample.example.net':
   directories => [
     { path    => '/path/to/directory',
       require => {
-        enforce => 'all',
-        require => ['group', 'not host host.example.com'],
+        enforce  => 'any',
+        requires => [
+          'ip 1.2.3.4',
+          'not host host.example.com',
+          'user xyz',
+        ],
       },
     },
   ],


### PR DESCRIPTION
When using the new Apache 2.4 Require(Any|All|None) syntax in puppet the hash value for this is named requires in the code and not require. Further more the array with require examples was not really easy readable.