### PR TITLE
mod_dumpio configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 [`apache::mod::authnz_ldap`]: #class-apachemodauthnz_ldap
 [`apache::mod::cluster`]: #class-apachemodcluster
 [`apache::mod::disk_cache`]: #class-apachemoddisk_cache
+[`apache::mod::dumpio`]: #class-apachemoddumpio
 [`apache::mod::event`]: #class-apachemodevent
 [`apache::mod::ext_filter`]: #class-apachemodext_filter
 [`apache::mod::geoip`]: #class-apachemodgeoip
@@ -160,7 +161,7 @@
 [`mod_authnz_external`]: https://github.com/phokz/mod-auth-external
 [`mod_auth_mellon`]: https://github.com/UNINETT/mod_auth_mellon
 [`mod_disk_cache`]: https://httpd.apache.org/docs/2.2/mod/mod_disk_cache.html
-[`mod_cache_disk`]: https://httpd.apache.org/docs/current/mod/mod_cache_disk.html
+[`mod_dumpio`]: https://httpd.apache.org/docs/2.4/mod/mod_dumpio.html
 [`mod_expires`]: https://httpd.apache.org/docs/current/mod/mod_expires.html
 [`mod_ext_filter`]: https://httpd.apache.org/docs/current/mod/mod_ext_filter.html
 [`mod_fcgid`]: https://httpd.apache.org/mod_fcgid/mod/mod_fcgid.html
@@ -1306,6 +1307,7 @@ The following Apache modules have supported classes, many of which allow for par
 * `dev`
 * `dir`\*
 * `disk_cache` (see [`apache::mod::disk_cache`][])
+* `dumpio` (see [`apache::mod::dumpio`][])
 * `event` (see [`apache::mod::event`][])
 * `expires`
 * `ext_filter` (see [`apache::mod::ext_filter`][])
@@ -1384,6 +1386,26 @@ class {'::apache::mod::disk_cache':
   cache_root => '/path/to/cache',
 }
 ```
+##### Class: `apache::mod::diskio`
+
+Installs and configures [`mod_diskio`][].
+
+```puppet
+class{'apache':
+  default_mods => false,
+  log_level    => 'dumpio:trace7',
+}
+class{'apache::mod::diskio':
+  disk_io_input  => 'On',
+  disk_io_output => 'Off',
+}
+```
+
+
+**Parameters withing `apache::mod::diskio`**:
+
+- `dump_io_input`: Dump all input data to the error log. Must be `On` or `Off`, defaults to `Off`
+- `dump_io_output`: Dump all output data to the error log. Must be `On` or `Off`, defaults to `Off`
 
 ##### Class: `apache::mod::event`
 

--- a/manifests/mod/dumpio.pp
+++ b/manifests/mod/dumpio.pp
@@ -1,0 +1,20 @@
+class apache::mod::dumpio(
+  $dump_io_input  = 'Off',
+  $dump_io_output = 'Off',
+) {
+
+  validate_re(downcase($dump_io_input), '^(on|off)$', "${dump_io_input} is not supported for dump_io_input.  Allowed values are 'On' and 'Off'.")
+  validate_re(downcase($dump_io_output), '^(on|off)$', "${dump_io_output} is not supported for dump_io_output.  Allowed values are 'On' and 'Off'.")
+
+  ::apache::mod { 'dumpio': }
+  file{'dumpio.conf':
+    ensure  => file,
+    path    => "${::apache::mod_dir}/dumpio.conf",
+    mode    => $::apache::file_mode,
+    content => template('apache/mod/dumpio.conf.erb'),
+    require => Exec["mkdir ${::apache::mod_dir}"],
+    before  => File[$::apache::mod_dir],
+    notify  => Class['apache::service'],
+  }
+
+}

--- a/spec/classes/mod/dumpio_spec.rb
+++ b/spec/classes/mod/dumpio_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe 'apache::mod::dumpio', :type => :class do
+  context "on a Debian OS" do
+    let :pre_condition do
+      'class{"apache":
+         default_mods => false,
+         mod_dir    => "/tmp/junk",
+       }'
+    end
+    let :facts do
+      {
+        :lsbdistcodename           => 'squeeze',
+        :osfamily                  => 'Debian',
+        :operatingsystemrelease    => '6',
+        :operatingsystemmajrelease => '6',
+        :concat_basedir            => '/dne',
+        :operatingsystem           => 'Debian',
+        :id                        => 'root',
+        :kernel                    => 'Linux',
+        :path                      => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :is_pe                  => false,
+      }
+    end
+    context "default configuration fore parameters" do
+      it { should compile }
+      it { should contain_class('apache::mod::dumpio') }
+      it { should contain_file("dumpio.conf").with_path("/tmp/junk/dumpio.conf") }
+      it { should contain_file("dumpio.conf").with_content(/^\s*DumpIOInput\s+"Off"$/)}
+      it { should contain_file("dumpio.conf").with_content(/^\s*DumpIOOutput\s+"Off"$/)}
+    end
+    context "with dumpio_input set to On" do
+      let :params do
+        {
+          :dump_io_input => 'On',
+        }
+      end
+      it { should contain_file("dumpio.conf").with_content(/^\s*DumpIOInput\s+"On"$/)}
+      it { should contain_file("dumpio.conf").with_content(/^\s*DumpIOOutput\s+"Off"$/)}
+    end
+    context "with dumpio_ouput set to On" do
+      let :params do
+        {
+          :dump_io_output => 'On',
+        }
+      end
+      it { should contain_file("dumpio.conf").with_content(/^\s*DumpIOInput\s+"Off"$/)}
+      it { should contain_file("dumpio.conf").with_content(/^\s*DumpIOOutput\s+"On"$/)}
+    end
+  end
+end

--- a/templates/mod/dumpio.conf.erb
+++ b/templates/mod/dumpio.conf.erb
@@ -1,0 +1,3 @@
+# https://httpd.apache.org/docs/2.4/mod/mod_dumpio.html
+DumpIOInput "<%= @dump_io_input %>"
+DumpIOOutput "<%= @dump_io_output %>"


### PR DESCRIPTION
New module class for dumpio with parameters for enabling input and/or
output dumping.

```puppet
class{'apache':
  default_mods => false,
  log_level    => 'dumpio:trace7',
}
class{'apache::mod::diskio':
  disk_io_input  => 'On',
  disk_io_output => 'Off',
}
```

* https://httpd.apache.org/docs/2.4/mod/mod_dumpio.html