### PR TITLE
Manage default root directory access rights

### DIFF
--- a/README.md
+++ b/README.md
@@ -1193,6 +1193,10 @@ Sets the desired permissions mode for config files, in symbolic or numeric notat
 
 Array of the desired options for the / directory in httpd.conf. Defaults to 'FollowSymLinks'.
 
+##### `root_directory_secured`
+
+Sets the default access policy for the / directory in httpd.conf. A value of 'false' allows access to all resources that are missing a more specific access policy. A value of 'true' denies access to all resources by default. In this case more specific rules must be used to allow access to these resources (e.g. in a directory block using the [`directories`](#parameter-directories-for-apachevhost) parameter). Valid options: Boolean. Default: false.
+
 ##### `vhost_dir`
 
 Changes your virtual host configuration files' location. Default: determined by your operating system.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,6 +81,7 @@ class apache (
   $mime_types_additional  = $::apache::params::mime_types_additional,
   $file_mode              = $::apache::params::file_mode,
   $root_directory_options = $::apache::params::root_directory_options,
+  $root_directory_secured = false,
 ) inherits ::apache::params {
   validate_bool($default_vhost)
   validate_bool($default_ssl_vhost)
@@ -89,6 +90,7 @@ class apache (
   validate_bool($service_enable)
   validate_bool($service_manage)
   validate_bool($use_optional_includes)
+  validate_bool($root_directory_secured)
 
   $valid_mpms_re = $apache_version ? {
     '2.4'   => '(event|itk|peruser|prefork|worker)',
@@ -343,6 +345,7 @@ class apache (
     # - $server_signature
     # - $trace_enable
     # - $rewrite_lock
+    # - $root_directory_secured
     file { "${::apache::conf_dir}/${::apache::params::conf_file}":
       ensure  => file,
       content => template($conf_template),

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -852,6 +852,22 @@ describe 'apache', :type => :class do
       end
       it { is_expected.to contain_file("/etc/httpd/conf/httpd.conf").with_content %r{Options -Indexes -FollowSymLinks} }
     end
+    context 'with a custom root_directory_secured parameter and Apache < 2.4' do
+      let :params do {
+        :apache_version => '2.2',
+        :root_directory_secured => true
+      }
+      end
+      it { is_expected.to contain_file("/etc/httpd/conf/httpd.conf").with_content %r{Options FollowSymLinks\n\s+AllowOverride None\n\s+Order deny,allow\n\s+Deny from all} }
+    end
+    context 'with a custom root_directory_secured parameter and Apache >= 2.4' do
+      let :params do {
+        :apache_version => '2.4',
+        :root_directory_secured => true
+      }
+      end
+      it { is_expected.to contain_file("/etc/httpd/conf/httpd.conf").with_content %r{Options FollowSymLinks\n\s+AllowOverride None\n\s+Require all denied} }
+    end
     context 'default vhost defaults' do
       it { is_expected.to contain_apache__vhost('default').with_ensure('present') }
       it { is_expected.to contain_apache__vhost('default-ssl').with_ensure('absent') }

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -33,6 +33,14 @@ AccessFileName .htaccess
 <Directory />
   Options <%= Array(@root_directory_options).join(' ') %>
   AllowOverride None
+<%- if @root_directory_secured -%>
+<%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
+  Require all denied
+<%- else -%>
+  Order deny,allow
+  Deny from all
+<%- end -%>
+<%- end -%>
 </Directory>
 
 <% if @default_charset -%>


### PR DESCRIPTION
Currently the root directory setting in httpd.conf provides an open access policy. By default Apache has access to all directories on the host. In some cases it may be desirable to deny access by default and explicitly configure access rights to every resource.

This patch adds the boolean `root_directory_secured` parameter to the main class. Setting this parameter to `true` will add a `Deny from all` (Apache 2.2) or a `Require all denied` (Apache 2.4) directive to the Apache config for the root directory. Setting the parameter to `false` will leave out these directives. The parameter default is `false` to remain backwards compatible.