### PR TITLE
Add apache::mod::socache_shmcb so it can be included multiple times

### DIFF
--- a/manifests/mod/socache_shmcb.pp
+++ b/manifests/mod/socache_shmcb.pp
@@ -1,0 +1,3 @@
+class apache::mod::socache_shmcb {
+    ::apache::mod { 'socache_shmcb': }
+}

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -72,7 +72,7 @@ class apache::mod::ssl (
   }
 
   if versioncmp($_apache_version, '2.4') >= 0 {
-    ::apache::mod { 'socache_shmcb': }
+    include ::apache::mod::socache_shmcb
   }
 
   # Template uses


### PR DESCRIPTION
I am not sure if this is the best way to address this: I already got `::apache::mod { 'socache_shmcb': }` in my Apache profile classes because I need it to support database-backed authentication.

Now I would like to include `apache::mod::ssl` as well which in turn also declares `::apache::mod { 'socache_shmcb': }`.

If there is a better (more "Puppet" way) of solving this, please let me know. Otherwise, I hope that this PR allows to simply `include apache::mod::socache_shmcb` and be set.
