### PR TITLE
Added support for apache 2.4 on Amazon Linux

### DIFF
--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -50,7 +50,12 @@ define apache::mod (
   if $package {
     $_package = $package
   } elsif has_key($mod_packages, $mod) { # 2.6 compatibility hack
-    $_package = $mod_packages[$mod]
+    if ($::apache::apache_version == '2.4' and $::operatingsystem =~ /^[Aa]mazon$/) {
+      # On amazon linux we need to prefix our package name with mod24 instead of mod to support apache 2.4
+      $_package = regsubst($mod_packages[$mod],'^(mod_)?(.*)','mod24_\2')
+    } else {
+      $_package = $mod_packages[$mod]
+    }
   } else {
     $_package = undef
   }


### PR DESCRIPTION
It's now possible to use the default_mods parameter in combination with apache_version 2.4 on an Amazon Linux system