### PR TITLE
Fix non breaking space (MODULES-3503)

### DIFF
--- a/templates/mod/remoteip.conf.erb
+++ b/templates/mod/remoteip.conf.erb
@@ -3,7 +3,7 @@ RemoteIPHeader <%= @header %>
 
 <%- if @proxy_ips -%>
 # Declare client intranet IP addresses trusted to present
-# the RemoteIPHeader value
+# the RemoteIPHeader value
 <%-   [@proxy_ips].flatten.each do |proxy| -%>
 RemoteIPInternalProxy <%= proxy %>
 <%-   end -%>


### PR DESCRIPTION
Hi,
There is a non breaking space in the file templates/mod/remoteip.conf.erb :

```
jeo@brs:~/dev/tmp/puppetlabs-apache/templates/mod$ cat -A remoteip.conf.erb 
..
# Declare client intranet IP addresses trusted to present$
#M-BM- the RemoteIPHeader value$
..
```

This breaks Puppet runs : 

```
root@monserver /data/sites/web-all-share-01/htdocs/data # puppet agent -t --no-noop
Info: Using configured environment 'master'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for myserver
Info: Applying configuration version '1466490720'
Error: invalid byte sequence in US-ASCII
Error: /Stage[main]/Apache::Mod::Remoteip/File[remoteip.conf]/content: change from {md5}0751dee096af1710db45615e82ccc979 to {md5}7db1e4a128ab3879d330416c6972e033 failed: invalid byte sequence in US-ASCII
```