### PR TITLE
Simplify MPM setup on FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1081,8 +1081,6 @@ You must set this to false to explicitly declare the following classes with cust
 - [`apache::mod::prefork`][]
 - [`apache::mod::worker`][]
 
-> **Note**: Switching between different MPMs on FreeBSD is possible but quite difficult. Before changing `mpm_module`, you must uninstall all packages that depend on your installed Apache server.
-
 ##### `package_ensure`
 
 Controls the `package` resource's [`ensure`][] attribute. Valid options: 'absent', 'installed' (or the equivalent 'present'), or a version string. Default: 'installed'.

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -24,17 +24,14 @@ class apache::package (
         }
         default: { fail("MPM module ${mpm_module} not supported on FreeBSD") }
       }
-
-      $apache_package = $::apache::apache_name
     }
     default: {
-      $apache_package = $::apache::apache_name
     }
   }
 
   package { 'httpd':
     ensure => $ensure,
-    name   => $apache_package,
+    name   => $::apache::apache_name,
     notify => Class['Apache::Service'],
   }
 }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -12,20 +12,12 @@ class apache::package (
     'FreeBSD': {
       case $mpm_module {
         'prefork': {
-          $set = 'MPM_PREFORK'
-          $unset = 'MPM_WORKER MPM_EVENT'
         }
         'worker': {
-          $set = 'MPM_WORKER'
-          $unset = 'MPM_PREFORK MPM_EVENT'
         }
         'event': {
-          $set = 'MPM_EVENT'
-          $unset = 'MPM_PREFORK MPM_WORKER'
         }
         'itk': {
-          $set = undef
-          $unset = undef
           package { 'www/mod_mpm_itk':
             ensure => installed,
           }
@@ -33,23 +25,6 @@ class apache::package (
         default: { fail("MPM module ${mpm_module} not supported on FreeBSD") }
       }
 
-      # Configure ports to have apache build options set correctly
-      if $set {
-        file_line { 'apache SET options in /etc/make.conf':
-          ensure => $ensure,
-          path   => '/etc/make.conf',
-          line   => "apache24_SET_FORCE=${set}",
-          match  => '^apache24_SET_FORCE=.*',
-          before => Package['httpd'],
-        }
-        file_line { 'apache UNSET options in /etc/make.conf':
-          ensure => $ensure,
-          path   => '/etc/make.conf',
-          line   => "apache24_UNSET_FORCE=${unset}",
-          match  => '^apache24_UNSET_FORCE=.*',
-          before => Package['httpd'],
-        }
-      }
       $apache_package = $::apache::apache_name
     }
     default: {


### PR DESCRIPTION
Hi,

The FreeBSD `www/apache24` package is now friendlier at switching MPM :cake: 

This remove a lot of code from `manifests/package.pp`, and I wonder if it would not be even better to get rid of the switch / case too.  If so, please tell me and I'll add a commit on top of this.

Thanks !
