### PR TITLE
Fix MODULES-3548

### DIFF
--- a/manifests/mod/cgi.pp
+++ b/manifests/mod/cgi.pp
@@ -1,6 +1,7 @@
 class apache::mod::cgi {
   case $::osfamily {
     'FreeBSD': {}
+    'Suse': {}
     default: {
       Class['::apache::mod::prefork'] -> Class['::apache::mod::cgi']
     }

--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -36,7 +36,12 @@ class apache::version {
       $default = '2.4'
     }
     'Suse': {
-      $default = '2.2'
+      if ($::operatingsystemmajrelease == '12') {
+        $default = '2.4'
+      } else {
+        $default = '2.2'
+      }
+
     }
     default: {
       fail("Class['apache::version']: Unsupported osfamily: ${::osfamily}")


### PR DESCRIPTION
Hi,

SLES 12 has Apache 2.4 Prefork installed. See:
https://tickets.puppetlabs.com/browse/MODULES-3548

I think this pull request fixes some of the issues. 

Greetings

Floek