### PR TITLE
add force option to confd file resource

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -172,6 +172,7 @@ class apache (
     ensure  => directory,
     recurse => true,
     purge   => $purge_confd,
+    force   => $purge_confd,
     notify  => Class['Apache::Service'],
     require => Package['httpd'],
   }


### PR DESCRIPTION
We've encountered an issue with Puppet trying to purge the confdir. We organise our Apache config in a conf.d style manner. When Puppet is instructed to purge a directory which contains directories it will complain that you must set the force parameter to really delete directories (see https://docs.puppet.com/puppet/3.8/reference/type.html#file-attribute-purge).
We think that purging the confdir should also include directories that may be present.
What do you think about this?

```
Notice: /Stage[main]/Apache/File[/etc/httpd/conf.d/test.d]: Not removing directory; use 'force' to override
```