### PR TITLE
Remove CAS comment

### DIFF
--- a/templates/vhost/_auth_cas.erb
+++ b/templates/vhost/_auth_cas.erb
@@ -1,6 +1,4 @@
 <% if @cas_enabled -%>
-
-  # mod_auth_cas configuration
   <%- if @cas_cookie_path -%>
   CASCookiePath <%= @cas_cookie_path %>
   <%- end -%>


### PR DESCRIPTION
The CAS directives are explicit (they start with CAS), and the comment was seen even without any CAS option set