### PR TITLE
MODULES-3682 - config of auth_dbd, include dbd, allow AuthnProviderAlias

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 [`apache::mod::alias`]: #class-apachemodalias
 [`apache::mod::auth_cas`]: #class-apachemodauth_cas
 [`apache::mod::auth_mellon`]: #class-apachemodauth_mellon
+[`apache::mod::authn_dbd`]: #class-apachemodauthn_dbd
 [`apache::mod::authnz_ldap`]: #class-apachemodauthnz_ldap
 [`apache::mod::cluster`]: #class-apachemodcluster
 [`apache::mod::disk_cache`]: #class-apachemoddisk_cache
@@ -159,7 +160,9 @@
 [`mod_auth_cas`]: https://github.com/Jasig/mod_auth_cas
 [`mod_auth_kerb`]: http://modauthkerb.sourceforge.net/configure.html
 [`mod_authnz_external`]: https://github.com/phokz/mod-auth-external
+[`mod_auth_dbd`]: http://httpd.apache.org/docs/current/mod/mod_authn_dbd.html
 [`mod_auth_mellon`]: https://github.com/UNINETT/mod_auth_mellon
+[`mod_dbd`]: http://httpd.apache.org/docs/current/mod/mod_dbd.html
 [`mod_disk_cache`]: https://httpd.apache.org/docs/2.2/mod/mod_disk_cache.html
 [`mod_dumpio`]: https://httpd.apache.org/docs/2.4/mod/mod_dumpio.html
 [`mod_expires`]: https://httpd.apache.org/docs/current/mod/mod_expires.html
@@ -1295,6 +1298,7 @@ The following Apache modules have supported classes, many of which allow for par
 * `auth_mellon`\* (see [`apache::mod::auth_mellon`][])
 * `auth_kerb`
 * `authn_core`
+* `authn_dbd`\* (see [`apache::mod::authn_dbd`][])
 * `authn_file`
 * `authnz_ldap`\* (see [`apache::mod::authnz_ldap`][])
 * `authz_default`
@@ -1307,6 +1311,7 @@ The following Apache modules have supported classes, many of which allow for par
 * `dav`
 * `dav_fs`
 * `dav_svn`\*
+* `dbd`
 * `deflate\`
 * `dev`
 * `dir`\*
@@ -1482,6 +1487,29 @@ class{ 'apache::mod::auth_mellon':
 - `mellon_post_ttl`: Time to keep post requests. Default: undef.
 - `mellon_post_size`: Maximum size of post requests. Default: undef.
 - `mellon_post_count`: Maximum number of post requests. Default: undef.
+
+##### Class: `apache::mod::authn_dbd`
+
+Installs `mod_authn_dbd` and uses `authn_dbd.conf.erb` template to generate its configuration.  Optionally creates AuthnProviderAlias.
+
+``` puppet
+class { 'apache::mod::authn_dbd':
+  $authn_dbd_params =>
+    'host=db01 port=3306 user=apache password=xxxxxx dbname=apacheauth',
+  $authn_dbd_query  => 'SELECT password FROM authn WHERE user = %s',
+  $authn_dbd_alias  => 'db_auth',
+}
+```
+
+** Parameters within `apache::mod::authn_dbd`
+- `authn_dbd_alias`: Name for the AuthnProviderAlias.
+- `authn_dbd_dbdriver`: Which db driver to use.  Default: mysql.
+- `authn_dbd_exptime`: corresponds to DBDExptime.  Default: 300.
+- `authn_dbd_keep`: corresponds to DBDKeep.  Default: 8.
+- `authn_dbd_max`: corresponds to DBDMax.  Default: 20.
+- `authn_dbd_min`: corresponds to DBDMin.  Default: 4.
+- `authn_dbd_params`: **Required**. Corresponds to DBDParams for the connection string.
+- `authn_dbd_query`: is the query used to test a user and password for authentication.
 
 ##### Class: `apache::mod::authnz_ldap`
 

--- a/manifests/mod/authn_dbd.pp
+++ b/manifests/mod/authn_dbd.pp
@@ -1,0 +1,30 @@
+class apache::mod::authn_dbd (
+  $authn_dbd_params,
+  $authn_dbd_dbdriver    = 'mysql',
+  $authn_dbd_query       = undef,
+  $authn_dbd_min         = '4',
+  $authn_dbd_max         = '20',
+  $authn_dbd_keep        = '8',
+  $authn_dbd_exptime     = '300',
+  $authn_dbd_alias       = undef,
+) inherits ::apache::params {
+  include ::apache
+  include ::apache::mod::dbd
+  ::apache::mod { 'authn_dbd': }
+
+  if $authn_dbd_alias {
+  include ::apache::mod::authn_core
+  }
+
+  # Template uses
+  # - All variables beginning with authn_dbd
+  file { 'authn_dbd.conf':
+    ensure  => file,
+    path    => "${::apache::mod_dir}/authn_dbd.conf",
+    mode    => $::apache::file_mode,
+    content => template('apache/mod/authn_dbd.conf.erb'),
+    require => [ Exec["mkdir ${::apache::mod_dir}"], ],
+    before  => File[$::apache::mod_dir],
+    notify  => Class['Apache::Service'],
+  }
+}

--- a/manifests/mod/dbd.pp
+++ b/manifests/mod/dbd.pp
@@ -1,0 +1,3 @@
+class apache::mod::dbd {
+  ::apache::mod { 'dbd': }
+}

--- a/spec/classes/mod/authn_dbd_spec.rb
+++ b/spec/classes/mod/authn_dbd_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe 'apache::mod::authn_dbd', :type => :class do
+  context "default params" do
+    let :params do
+      {
+        :authn_dbd_params => 'host=db_host port=3306 user=apache password=###### dbname=apache_auth',
+      }
+    end
+
+    it_behaves_like "a mod class, without including apache"
+  end
+
+  context "default configuration with parameters" do
+    let :params do
+      {
+        :authn_dbd_params => 'host=db_host port=3306 user=apache password=###### dbname=apache_auth',
+        :authn_dbd_alias  => 'db_authn',
+        :authn_dbd_query  => 'SELECT password FROM authn WHERE username = %s'
+      }
+    end
+
+    context "on a Debian OS", :compile do
+      let :facts do
+        {
+          :id                     => 'root',
+          :kernel                 => 'Linux',
+          :lsbdistcodename        => 'squeeze',
+          :osfamily               => 'Debian',
+          :operatingsystem        => 'Debian',
+          :operatingsystemrelease => '6',
+          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :concat_basedir         => '/dne',
+          :is_pe                  => false,
+        }
+      end
+      it { is_expected.to contain_class("apache::params") }
+      it { is_expected.to contain_apache__mod("authn_dbd") }
+      it { is_expected.to contain_apache__mod("dbd") }
+      it { is_expected.to contain_file("authn_dbd.conf").with_path('/etc/apache2/mods-available/authn_dbd.conf') }
+    end
+
+    context "on a RedHat OS", :compile do
+      let :facts do
+        {
+          :id                     => 'root',
+          :kernel                 => 'Linux',
+          :osfamily               => 'RedHat',
+          :operatingsystem        => 'RedHat',
+          :operatingsystemrelease => '6',
+          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :concat_basedir         => '/dne',
+          :is_pe                  => false,
+        }
+      end
+      it { is_expected.to contain_class("apache::params") }
+      it { is_expected.to contain_apache__mod("authn_dbd") }
+      it { is_expected.to contain_apache__mod("dbd") }
+      it { is_expected.to contain_file("authn_dbd.conf").with_path('/etc/httpd/conf.d/authn_dbd.conf') }
+    end
+  end
+end

--- a/templates/mod/authn_dbd.conf.erb
+++ b/templates/mod/authn_dbd.conf.erb
@@ -1,0 +1,17 @@
+#Database Management
+DBDriver <%= @authn_dbd_dbdriver %>
+
+#Connection string: database name and login credentials
+DBDParams "<%= @authn_dbd_params %>"
+
+#Parameters for Connection Pool Management
+DBDMin     <%= @authn_dbd_min %>
+DBDMax     <%= @authn_dbd_max %>
+DBDKeep    <%= @authn_dbd_keep %>
+DBDExptime <%= @authn_dbd_exptime %>
+
+<%- if @authn_dbd_alias -%>
+<AuthnProviderAlias dbd <%= @authn_dbd_alias %>>
+  AuthDBDUserPWQuery "<%= @authn_dbd_query %>"
+</AuthnProviderAlias>
+<%- end -%>


### PR DESCRIPTION
There was previously no facility to configure dbd for use with
authn_dbd.  I want to keep the apache config I required within the scope
of this module.