### PR TITLE
Add some more passenger params

### DIFF
--- a/README.md
+++ b/README.md
@@ -2573,6 +2573,18 @@ Sets [PassengerUser](https://www.phusionpassenger.com/library/config/apache/refe
 
 Sets the [`PassengerHighPerformance`](https://www.phusionpassenger.com/library/config/apache/reference/#passengerhighperformance) parameter. Valid options: 'true', 'false'. Default: undef.
 
+##### `passenger_nodejs`
+
+Sets the [`PassengerNodejs`](https://www.phusionpassenger.com/library/config/apache/reference/#passengernodejs), the NodeJS interpreter to use for the application, on this virtual host.
+
+##### `passenger_sticky_sessions`
+
+Sets the [`PassengerStickySessions`](https://www.phusionpassenger.com/library/config/apache/reference/#passengerstickysessions) parameter. Valid options: 'true', 'false'. Default: undef.
+
+##### `passenger_startup_file`
+
+Sets the [`PassengerStartupFile`](https://www.phusionpassenger.com/library/config/apache/reference/#passengerstartupfile) path. This path is relative to the application root.
+
 ##### `php_flags & values`
 
 Allows per-virtual host setting [`php_value`s or `php_flag`s](http://php.net/manual/en/configuration.changes.php). These flags or values can be overwritten by a user or an application. Default: '{}'.

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -135,6 +135,9 @@ define apache::vhost(
   $passenger_pre_start         = undef,
   $passenger_user              = undef,
   $passenger_high_performance  = undef,
+  $passenger_nodejs            = undef,
+  $passenger_sticky_sessions   = undef,
+  $passenger_startup_file      = undef,
   $add_default_charset         = undef,
   $modsec_disable_vhost        = undef,
   $modsec_disable_ids          = undef,
@@ -292,6 +295,10 @@ define apache::vhost(
     validate_re($keepalive,'(^on$|^off$)',"${keepalive} is not permitted for keepalive. Allowed values are 'on' or 'off'.")
   }
 
+  if $passenger_sticky_sessions {
+    validate_bool($passenger_sticky_sessions)
+  }
+
   # Input validation ends
 
   if $ssl and $ensure == 'present' {
@@ -316,7 +323,7 @@ define apache::vhost(
     include ::apache::mod::suexec
   }
 
-  if $passenger_app_root or $passenger_app_env or $passenger_ruby or $passenger_min_instances or $passenger_start_timeout or $passenger_pre_start or $passenger_user or $passenger_high_performance {
+  if $passenger_app_root or $passenger_app_env or $passenger_ruby or $passenger_min_instances or $passenger_start_timeout or $passenger_pre_start or $passenger_user or $passenger_high_performance or $passenger_nodejs or $passenger_sticky_sessions or $passenger_startup_file {
     include ::apache::mod::passenger
   }
 
@@ -1046,7 +1053,10 @@ define apache::vhost(
   # - $passenger_start_timeout
   # - $passenger_pre_start
   # - $passenger_user
-  if $passenger_app_root or $passenger_app_env or $passenger_ruby or $passenger_min_instances or $passenger_start_timeout or $passenger_pre_start or $passenger_user {
+  # - $passenger_nodejs
+  # - $passenger_sticky_sessions
+  # - $passenger_startup_file
+  if $passenger_app_root or $passenger_app_env or $passenger_ruby or $passenger_min_instances or $passenger_start_timeout or $passenger_pre_start or $passenger_user or $passenger_nodejs or $passenger_sticky_sessions or $passenger_startup_file{
     concat::fragment { "${name}-passenger":
       target  => "${priority_real}${filename}.conf",
       order   => 300,

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -387,6 +387,9 @@ describe 'apache::vhost', :type => :define do
           'passenger_pre_start'         => 'http://localhost/myapp',
           'passenger_high_performance'  => true,
           'passenger_user'              => 'sandbox',
+          'passenger_nodejs'            => '/usr/bin/node',
+          'passenger_sticky_sessions'   => true,
+          'passenger_startup_file'      => 'bin/www',
           'add_default_charset'         => 'UTF-8',
           'jk_mounts'                   => [
             { 'mount'   => '/*',     'worker' => 'tcnode1', },

--- a/templates/vhost/_passenger.erb
+++ b/templates/vhost/_passenger.erb
@@ -22,3 +22,12 @@
 <% if @passenger_high_performance -%>
   PassengerHighPerformance <%= scope.function_bool2httpd([@passenger_high_performance]) %>
 <% end -%>
+<% if @passenger_nodejs -%>
+  PassengerNodejs <%= @passenger_nodejs -%>
+<% end -%>
+<% if @passenger_sticky_sessions -%>
+  PassengerStickySessions <%= scope.function_bool2httpd([@passenger_sticky_sessions]) %>
+<% end -%>
+<% if @passenger_startup_file -%>
+  PassengerStartupFile <%= @passenger_startup_file -%>
+<% end -%>


### PR DESCRIPTION
For passenger NodeJS Apps we need some more params
- passenger_nodejs (https://www.phusionpassenger.com/library/config/apache/reference/#passengernodejs) - Available with 4.0.24
- passenger_sticky_sessions (https://www.phusionpassenger.com/library/config/apache/reference/#passengerstickysessions) - Available with 4.0.45
- passenger_startup_file (https://www.phusionpassenger.com/library/config/apache/reference/#passengerstartupfile) - Passenger has a good default, but for Express app generator we must set this param. Available with 4.0.25

If you need anything, let me know

Greetings Reamer