### PR TITLE
move IncludeOptional to bottom of configuration

### DIFF
--- a/templates/mod/security.conf.erb
+++ b/templates/mod/security.conf.erb
@@ -1,13 +1,4 @@
 <IfModule mod_security2.c>
-    # ModSecurity Core Rules Set configuration
-<%- if scope.function_versioncmp([scope.lookupvar('::apache::apache_version'), '2.4']) >= 0 -%>
-    IncludeOptional <%= @modsec_dir %>/*.conf
-    IncludeOptional <%= @modsec_dir %>/activated_rules/*.conf
-<%- else -%>
-    Include <%= @modsec_dir %>/*.conf
-    Include <%= @modsec_dir %>/activated_rules/*.conf
-<%- end -%>
-
     # Default recommended configuration
     SecRuleEngine <%= @modsec_secruleengine %>
     SecRequestBodyAccess On
@@ -71,4 +62,13 @@
     SecUploadDir /var/lib/mod_security
 <% end -%>
     SecUploadKeepFiles Off
+
+    # ModSecurity Core Rules Set configuration
+<%- if scope.function_versioncmp([scope.lookupvar('::apache::apache_version'), '2.4']) >= 0 -%>
+    IncludeOptional <%= @modsec_dir %>/*.conf
+    IncludeOptional <%= @modsec_dir %>/activated_rules/*.conf
+<%- else -%>
+    Include <%= @modsec_dir %>/*.conf
+    Include <%= @modsec_dir %>/activated_rules/*.conf
+<%- end -%>
 </IfModule>


### PR DESCRIPTION
By moving the Include statements to the bottom of the configuration file rules 200001, 200002, and 200003 defined in modsecurity.conf can be disabled/modified in included files such as `/etc/httpd/modsecurity.d/activated_rules/modsecurity_crs_60_customrules.conf`.

In the current configuration the Includes are evaluated first which means the rule set is ordered as such:
```
SecRuleRemoveById 200003
SecRule MULTIPART_UNMATCHED_BOUNDARY "!@eq 0" \
    "id:'200003',phase:2,t:none,log,deny,status:44,msg:'Multipart parser detected a possible unmatched boundary.'"
```
Unfortunately when ordered like this, the rule is enforced.

Fedora 24 has moved the Include statements at the bottom of the configuration file. The other option would be to add parameters to `apache::mod::security` to disable these rules.