### PR TITLE
Update trace option to Off

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,7 +73,7 @@ class apache (
   $apache_version         = $::apache::version::default,
   $server_tokens          = 'OS',
   $server_signature       = 'On',
-  $trace_enable           = 'On',
+  $trace_enable           = 'Off',
   $allow_encoded_slashes  = undef,
   $package_ensure         = 'installed',
   $use_optional_includes  = $::apache::params::use_optional_includes,


### PR DESCRIPTION
Requesting to change   $trace_enable = 'Off',

This has caused some issues with customers using Red Hat Satellite 6 and causing security scanner software to raise red flags. Here is the downstream BZ for reference. 

https://bugzilla.redhat.com/show_bug.cgi?id=1305782