### PR TITLE
Allow no_proxy settings to work with more settings

### DIFF
--- a/templates/vhost/_proxy.erb
+++ b/templates/vhost/_proxy.erb
@@ -18,6 +18,16 @@
 <% if @proxy_error_override -%>
   ProxyErrorOverride On
 <%- end -%>
+<%- if @proxy_dest or @proxy_pass -%>
+  <%- Array(@no_proxy_uris).each do |uri| -%>
+  ProxyPass <%= uri %> !
+  <%- end -%>
+<%- end -%>
+<%- if @proxy_dest_match or @proxy_pass_match -%>
+  <%- Array(@no_proxy_uris_match).each do |uri| -%>
+  ProxyPassMatch <%= uri %> !
+  <%- end -%>
+<%- end -%>
 <%- [@proxy_pass].flatten.compact.each do |proxy| -%>
   ProxyPass <%= proxy['path'] %> <%= proxy['url'] -%>
   <%- if proxy['params'] -%>
@@ -71,16 +81,10 @@
   <%- end -%>
 <% end -%>
 <% if @proxy_dest -%>
-<%- Array(@no_proxy_uris).each do |uri| -%>
-  ProxyPass        <%= uri %> !
-<% end -%>
   ProxyPass        / <%= @proxy_dest %>/
   ProxyPassReverse / <%= @proxy_dest %>/
 <% end -%>
 <% if @proxy_dest_match -%>
-<%- Array(@no_proxy_uris_match).each do |uri| -%>
-  ProxyPassMatch   <%= uri %> !
-<% end -%>
   ProxyPassMatch   / <%= @proxy_dest_match %>/
   ProxyPassReverse / <%= @proxy_dest_reverse_match %>/
 <% end -%>


### PR DESCRIPTION
Previously you could only set the no_proxy settings with a single
proxy_dest or proxy_dest_match
Now you can also use it with proxy_pass and proxy_pass_match
