### PR TITLE
Corrected typo/ Needed parens for definition

### DIFF
--- a/manifests/namevirtualhost.pp
+++ b/manifests/namevirtualhost.pp
@@ -1,4 +1,4 @@
-define apache::namevirtualhost {
+define apache::namevirtualhost (
   $addr_port = $name
 
   # Template uses: $addr_port
@@ -6,4 +6,4 @@ define apache::namevirtualhost {
     target  => $::apache::ports_file,
     content => template('apache/namevirtualhost.erb'),
   }
-}
+)


### PR DESCRIPTION
Using class {'::apache::namevirtualhost'} presently returns saying the class is undefined.