### PR TITLE
Allow no_proxy_uris to be used within proxy_pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -2620,6 +2620,8 @@ apache::vhost { 'site.name.fdqn':
       'setenv' => ['proxy-nokeepalive 1','force-proxy-request-1.0 1']},
     { 'path' => '/g', 'url' => 'http://backend-g/',
       'reverse_cookies' => [{'path' => '/g', 'url' => 'http://backend-g/',}, {'domain' => 'http://backend-g', 'url' => 'http:://backend-g',},], },
+    { 'path' => '/h', 'url' => 'http://backend-h/h',
+      'no_proxy_uris' => ['/h/admin', '/h/server-status'] },
   ],
 }
 ```

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -273,6 +273,8 @@ describe 'apache::vhost', :type => :define do
               'path'            => '/a',
               'url'             => 'http://backend-a/',
               'keywords'        => ['noquery', 'interpolate'],
+              'no_proxy_uris'       => ['/a/foo', '/a/bar'],
+              'no_proxy_uris_match' => ['/a/foomatch'],
               'reverse_cookies' => [
 								{
                   'path'          => '/a',
@@ -295,6 +297,8 @@ describe 'apache::vhost', :type => :define do
               'path'     => '/a',
               'url'      => 'http://backend-a/',
               'keywords' => ['noquery', 'interpolate'],
+              'no_proxy_uris'       => ['/a/foo', '/a/bar'],
+              'no_proxy_uris_match' => ['/a/foomatch'],
               'params'   => {
                       'retry'   => '0',
                       'timeout' => '5'

--- a/templates/vhost/_proxy.erb
+++ b/templates/vhost/_proxy.erb
@@ -19,6 +19,12 @@
   ProxyErrorOverride On
 <%- end -%>
 <%- [@proxy_pass].flatten.compact.each do |proxy| -%>
+  <%- Array(proxy['no_proxy_uris']).each do |uri| -%>
+  ProxyPass <%= uri %> !
+  <%- end -%>
+  <%- Array(proxy['no_proxy_uris_match']).each do |uri| -%>
+  ProxyPassMatch <%= uri %> !
+  <%- end -%>
   ProxyPass <%= proxy['path'] %> <%= proxy['url'] -%>
   <%- if proxy['params'] -%>
     <%- proxy['params'].keys.sort.each do |key| -%> <%= key %>=<%= proxy['params'][key] -%>
@@ -50,6 +56,12 @@
   <%- end -%>
 <% end -%>
 <% [@proxy_pass_match].flatten.compact.each do |proxy| %>
+  <%- Array(proxy['no_proxy_uris']).each do |uri| -%>
+  ProxyPass <%= uri %> !
+  <%- end -%>
+  <%- Array(proxy['no_proxy_uris_match']).each do |uri| -%>
+  ProxyPassMatch <%= uri %> !
+  <%- end -%>
   ProxyPassMatch <%= proxy['path'] %> <%= proxy['url'] -%>
   <%- if proxy['params'] -%>
     <%- proxy['params'].keys.sort.each do |key| -%> <%= key %>=<%= proxy['params'][key] -%>


### PR DESCRIPTION
Previously, proxy_pass and proxy_pass_match configuration blocks did not
support using no_proxy_uris and no_proxy_uris_match. These parameters
required the use of proxy_dest, but mixing proxy_pass and proxy_dest
results in undesired duplication of ProxyPass config lines.

Fix by allowing no_proxy_uris and no_proxy_uris_match to be used within
proxy_pass and proxy_pass_match configuration blocks.

This PR is similar to #1521 but addresses the problem better in my opinion.
