### PR TITLE
Bug - Port numbers must be quoted

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -384,7 +384,7 @@ class apache (
 
     ::apache::vhost { 'default':
       ensure          => $default_vhost_ensure,
-      port            => 80,
+      port            => '80',
       docroot         => $docroot,
       scriptalias     => $scriptalias,
       serveradmin     => $serveradmin,
@@ -400,7 +400,7 @@ class apache (
     }
     ::apache::vhost { 'default-ssl':
       ensure          => $default_ssl_vhost_ensure,
-      port            => 443,
+      port            => '443',
       ssl             => true,
       docroot         => $docroot,
       scriptalias     => $scriptalias,


### PR DESCRIPTION
The default port numbers for apache must be quoted to avoid errors
when running a catalog in the puppet agent.  This fixes https://tickets.puppetlabs.com/browse/MODULES-3871