### PR TITLE
[MODULES-3882] Don't write empty servername for vhost to template

### DIFF
--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -727,6 +727,34 @@ describe 'apache::vhost define' do
       it { is_expected.to be_file }
       it { is_expected.not_to contain 'NameVirtualHost test.server' }
     end
+    describe file("#{$vhost_dir}/25-test.server.conf") do
+      it { is_expected.to be_file }
+      it { is_expected.to contain "ServerName test.server" }
+    end
+  end
+
+  describe 'ip_based and no servername' do
+    it 'applies cleanly' do
+      pp = <<-EOS
+        class { 'apache': }
+        host { 'test.server': ip => '127.0.0.1' }
+        apache::vhost { 'test.server':
+          docroot    => '/tmp',
+          ip_based   => true,
+          servername => '',
+        }
+      EOS
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    describe file($ports_file) do
+      it { is_expected.to be_file }
+      it { is_expected.not_to contain 'NameVirtualHost test.server' }
+    end
+    describe file("#{$vhost_dir}/25-test.server.conf") do
+      it { is_expected.to be_file }
+      it { is_expected.not_to contain "ServerName" }
+    end
   end
 
   describe 'add_listen' do

--- a/templates/vhost/_file_header.erb
+++ b/templates/vhost/_file_header.erb
@@ -4,7 +4,7 @@
 # ************************************
 
 <VirtualHost <%= [@nvh_addr_port].flatten.compact.join(' ') %>>
-<% if @servername -%>
+<% if @servername and not @servername.empty? -%>
   ServerName <%= @servername %>
 <% end -%>
 <% if @serveradmin -%>


### PR DESCRIPTION
If an empty servername is given to a vhost, it shouldn't be written
to the configuration file. Else we'll end up with an invalid
configuration and httpd will fail to start. It is actually valid not
to have a Servername, and in this case, httpd will route only based
on the IP.

This resolves bug https://tickets.puppetlabs.com/browse/MODULES-3882