### PR TITLE
Settings to control modcluster request size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1834,6 +1834,10 @@ ${modsec\_dir}/activated\_rules.
 - `error_anomaly_score`: Sets the scoring points of the error severity level for the Collaborative Detection Mode in the OWASP ModSecurity Core Rule Set. Default: '4'.
 - `warning_anomaly_score`: Sets the scoring points of the warning severity level for the Collaborative Detection Mode in the OWASP ModSecurity Core Rule Set. Default: '3'.
 - `notice_anomaly_score`: Sets the scoring points of the notice severity level for the Collaborative Detection Mode in the OWASP ModSecurity Core Rule Set. Default: '2'.
+- `secrequestmaxnumargs`: Sets the Maximum number of arguments in the request. Default: '255'.
+- `secrequestbodylimit`:  Sets the maximum request body size ModSecurity will accept for buffering.. Default: '13107200'.
+- `secrequestbodynofileslimit`: Sets the maximum request body size ModSecurity will accept for buffering, excluding the size of any files being transported in the request. Default: '131072'.
+- `secrequestbodyinmemorylimit`: Sets the maximum request body size that ModSecurity will store in memory. Default: '131072'
 
 ##### Class: `apache::mod::wsgi`
 

--- a/manifests/mod/security.pp
+++ b/manifests/mod/security.pp
@@ -1,24 +1,28 @@
 class apache::mod::security (
-  $crs_package                = $::apache::params::modsec_crs_package,
-  $activated_rules            = $::apache::params::modsec_default_rules,
-  $modsec_dir                 = $::apache::params::modsec_dir,
-  $modsec_secruleengine       = $::apache::params::modsec_secruleengine,
-  $audit_log_relevant_status  = '^(?:5|4(?!04))',
-  $audit_log_parts            = $::apache::params::modsec_audit_log_parts,
-  $secpcrematchlimit          = $::apache::params::secpcrematchlimit,
-  $secpcrematchlimitrecursion = $::apache::params::secpcrematchlimitrecursion,
-  $allowed_methods            = 'GET HEAD POST OPTIONS',
-  $content_types              = 'application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/x-amf',
-  $restricted_extensions      = '.asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/',
-  $restricted_headers         = '/Proxy-Connection/ /Lock-Token/ /Content-Range/ /Translate/ /via/ /if/',
-  $secdefaultaction           = 'deny',
-  $anomaly_score_blocking     = 'off',
-  $inbound_anomaly_threshold  = '5',
-  $outbound_anomaly_threshold = '4',
-  $critical_anomaly_score     = '5',
-  $error_anomaly_score        = '4',
-  $warning_anomaly_score      = '3',
-  $notice_anomaly_score       = '2',
+  $crs_package                 = $::apache::params::modsec_crs_package,
+  $activated_rules             = $::apache::params::modsec_default_rules,
+  $modsec_dir                  = $::apache::params::modsec_dir,
+  $modsec_secruleengine        = $::apache::params::modsec_secruleengine,
+  $audit_log_relevant_status   = '^(?:5|4(?!04))',
+  $audit_log_parts             = $::apache::params::modsec_audit_log_parts,
+  $secpcrematchlimit           = $::apache::params::secpcrematchlimit,
+  $secpcrematchlimitrecursion  = $::apache::params::secpcrematchlimitrecursion,
+  $allowed_methods             = 'GET HEAD POST OPTIONS',
+  $content_types               = 'application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/x-amf',
+  $restricted_extensions       = '.asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/',
+  $restricted_headers          = '/Proxy-Connection/ /Lock-Token/ /Content-Range/ /Translate/ /via/ /if/',
+  $secdefaultaction            = 'deny',
+  $anomaly_score_blocking      = 'off',
+  $inbound_anomaly_threshold   = '5',
+  $outbound_anomaly_threshold  = '4',
+  $critical_anomaly_score      = '5',
+  $error_anomaly_score         = '4',
+  $warning_anomaly_score       = '3',
+  $notice_anomaly_score        = '2',
+  $secrequestmaxnumargs        = '255',
+  $secrequestbodylimit         = '13107200',
+  $secrequestbodynofileslimit  = '131072',
+  $secrequestbodyinmemorylimit = '131072',
 ) inherits ::apache::params {
   include ::apache
 
@@ -53,6 +57,9 @@ class apache::mod::security (
   # - $audit_log_parts
   # - secpcrematchlimit
   # - secpcrematchlimitrecursion
+  # - secrequestbodylimit
+  # - secrequestbodynofileslimit
+  # - secrequestbodyinmemorylimit
   file { 'security.conf':
     ensure  => file,
     content => template('apache/mod/security.conf.erb'),
@@ -99,6 +106,7 @@ class apache::mod::security (
   # - $content_types
   # - $restricted_extensions
   # - $restricted_headers
+  # - $secrequestmaxnumargs
   file { "${modsec_dir}/security_crs.conf":
     ensure  => file,
     content => template('apache/mod/security_crs.conf.erb'),

--- a/templates/mod/security.conf.erb
+++ b/templates/mod/security.conf.erb
@@ -13,9 +13,9 @@
     SecRequestBodyAccess On
     SecRule REQUEST_HEADERS:Content-Type "text/xml" \
       "id:'200000',phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=XML"
-    SecRequestBodyLimit 13107200
-    SecRequestBodyNoFilesLimit 131072
-    SecRequestBodyInMemoryLimit 131072
+    SecRequestBodyLimit <%= @secrequestbodylimit %>
+    SecRequestBodyNoFilesLimit <%= @secrequestbodynofileslimit %>
+    SecRequestBodyInMemoryLimit <%= @secrequestbodyinmemorylimit %>
     SecRequestBodyLimitAction Reject
     SecRule REQBODY_ERROR "!@eq 0" \
       "id:'200001', phase:2,t:none,log,deny,status:400,msg:'Failed to parse request body.',logdata:'%{reqbody_error_msg}',severity:2"

--- a/templates/mod/security_crs.conf.erb
+++ b/templates/mod/security_crs.conf.erb
@@ -211,7 +211,7 @@ SecAction \
   "id:'900006', \
   phase:1, \
   t:none, \
-  setvar:tx.max_num_args=255, \
+  setvar:tx.max_num_args=<%= @secrequestmaxnumargs %>, \
   nolog, \
   pass"
 


### PR DESCRIPTION
We use an implementation of CAS SSO and  recently we had  problems with modsecurity request size blocking. So, we had made some changes, creating parameters to control request body size and arguments.
