### PR TITLE
Let SSLCertificateKeyFile be optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -3608,7 +3608,7 @@ Sets the certificate revocation check level via the [SSLCARevocationCheck direct
 
 ##### `ssl_key`
 
-Specifies the SSL key. Defaults are based on your operating system: '/etc/pki/tls/private/localhost.key' for RedHat, '/etc/ssl/private/ssl-cert-snakeoil.key' for Debian, '/usr/local/etc/apache22/server.key' for FreeBSD, and '/etc/ssl/apache2/server.key' on Gentoo. (This default works out of the box but must be updated in the base `apache` class with your specific certificate information before being used in production.)
+Specifies the SSL key.  Set to false for no SSL key.  Defaults are based on your operating system: '/etc/pki/tls/private/localhost.key' for RedHat, '/etc/ssl/private/ssl-cert-snakeoil.key' for Debian, '/usr/local/etc/apache22/server.key' for FreeBSD, and '/etc/ssl/apache2/server.key' on Gentoo. (This default works out of the box but must be updated in the base `apache` class with your specific certificate information before being used in production.)
 
 ##### `ssl_verify_client`
 

--- a/templates/vhost/_ssl.erb
+++ b/templates/vhost/_ssl.erb
@@ -3,7 +3,9 @@
   ## SSL directives
   SSLEngine on
   SSLCertificateFile      "<%= @ssl_cert %>"
+  <%- if @ssl_key -%>
   SSLCertificateKeyFile   "<%= @ssl_key %>"
+  <%- end -%>
   <%- if @ssl_chain -%>
   SSLCertificateChainFile "<%= @ssl_chain %>"
   <%- end -%>


### PR DESCRIPTION
The parameter SSLCertificateKeyFile is actually optional.  A private key doesn't need to be supplied when using wildcard SSL certs, for example.  This PR patches the module to permit specifying ssl_key => false for appache::vhost, to work around the otherwise hardcoded default of .../localhost.key.