### PR TITLE
Remove lines that create noise/spam on ubuntu

### DIFF
--- a/lib/facter/apache_version.rb
+++ b/lib/facter/apache_version.rb
@@ -2,11 +2,9 @@ Facter.add(:apache_version) do
   setcode do
     if Facter::Util::Resolution.which('apachectl')
       apache_version = Facter::Util::Resolution.exec('apachectl -v 2>&1')
-      puts "Matching apachectl '#{apache_version}'"
       %r{^Server version: Apache\/(\d+.\d+(.\d+)?)}.match(apache_version)[1]
     elsif Facter::Util::Resolution.which('apache2ctl')
       apache_version = Facter::Util::Resolution.exec('apache2ctl -v 2>&1')
-      puts "Matching apache2ctl '#{apache_version}'"
       %r{^Server version: Apache\/(\d+.\d+(.\d+)?)}.match(apache_version)[1]
     end
   end


### PR DESCRIPTION
Revert the "puts" lines that cause unnecessary output/spam on any puppet run on ubuntu/xenial 

user@puppetagent-01:~$ sudo facter -p
Matching apachectl 'Server version: Apache/2.4.18 (Ubuntu)
Server built:   2016-07-14T12:32:26'
aio_agent_version => 1.7.0
apache_version => 2.4.18
apt_has_updates => true
... (etc)
