### PR TITLE
Add path to shibboleth lib

### DIFF
--- a/manifests/mod/shib.pp
+++ b/manifests/mod/shib.pp
@@ -1,5 +1,6 @@
 class apache::mod::shib (
   $suppress_warning = false,
+  $mod_full_path = undef,
 ) {
   include ::apache
   if $::osfamily == 'RedHat' and ! $suppress_warning {
@@ -9,7 +10,7 @@ class apache::mod::shib (
   $mod_shib = 'shib2'
 
   apache::mod {$mod_shib:
-    id => 'mod_shib',
+    id   => 'mod_shib',
+    path => $mod_full_path,
   }
-
 }


### PR DESCRIPTION
Shibboleth can be installed in very different location using different
names depending on the version, os... We add a parameter to specify the
location of the current shibboleth library path.