### PR TITLE
Do not set ssl_certs_dir on FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -3678,7 +3678,7 @@ Specifies the location of the SSL certification directory. Default: Depends on t
 
 - **Debian:** '/etc/ssl/certs'
 - **Red Hat:** '/etc/pki/tls/certs'
-- **FreeBSD:** '/usr/local/etc/apache22'
+- **FreeBSD:** undef
 - **Gentoo:** '/etc/ssl/apache2'
 
 ##### `ssl_chain`

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -355,7 +355,7 @@ class apache::params inherits ::apache::version {
     $dev_packages     = undef
     $default_ssl_cert = '/usr/local/etc/apache24/server.crt'
     $default_ssl_key  = '/usr/local/etc/apache24/server.key'
-    $ssl_certs_dir    = '/usr/local/etc/apache24'
+    $ssl_certs_dir    = undef
     $passenger_conf_file = 'passenger.conf'
     $passenger_conf_package_file = undef
     $passenger_root   = '/usr/local/lib/ruby/gems/2.0/gems/passenger-4.0.58'


### PR DESCRIPTION
The previously configured directory (apache configuration directory) does NOT contain certificates by default, resulting in an error when starting apache if certificates are elsewhere (i.e. a VirtualHost with constomized vertificate and key):

~~~
[Tue Oct 18 16:34:17.074516 2016] [ssl:emerg] [pid 57102:tid 34397585408] AH01896: Unable to determine list of acceptable CA certificates for client authentication
~~~

While here, sync the README which was outdated.