### PR TITLE
Move ssl.conf to main conf directory on EL7

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,6 +68,7 @@ class apache (
   $logroot_mode           = $::apache::params::logroot_mode,
   $log_level              = $::apache::params::log_level,
   $log_formats            = {},
+  $ssl_file               = $::apache::params::ssl_file,
   $ports_file             = $::apache::params::ports_file,
   $docroot                = $::apache::params::docroot,
   $apache_version         = $::apache::version::default,

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -90,7 +90,7 @@ class apache::mod::ssl (
   # $_apache_version
   file { 'ssl.conf':
     ensure  => file,
-    path    => "${::apache::mod_dir}/ssl.conf",
+    path    => $::apache::ssl_file,
     mode    => $::apache::file_mode,
     content => template('apache/mod/ssl.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -74,6 +74,7 @@ class apache::params inherits ::apache::version {
     $vhost_dir            = "${httpd_dir}/conf.d"
     $vhost_enable_dir     = undef
     $conf_file            = 'httpd.conf'
+    $ssl_file             = "${confd_dir}/ssl.conf"
     $ports_file           = "${conf_dir}/ports.conf"
     $pidfile              = 'run/httpd.pid'
     $logroot              = '/var/log/httpd'
@@ -210,6 +211,7 @@ class apache::params inherits ::apache::version {
     $vhost_dir           = "${httpd_dir}/sites-available"
     $vhost_enable_dir    = "${httpd_dir}/sites-enabled"
     $conf_file           = 'apache2.conf'
+    $ssl_file             = "${mod_dir}/ssl.conf"
     $ports_file          = "${conf_dir}/ports.conf"
     $pidfile             = "\${APACHE_PID_FILE}"
     $logroot             = '/var/log/apache2'
@@ -346,6 +348,7 @@ class apache::params inherits ::apache::version {
     $vhost_dir        = "${httpd_dir}/Vhosts"
     $vhost_enable_dir = undef
     $conf_file        = 'httpd.conf'
+    $ssl_file         = "${mod_dir}/ssl.conf"
     $ports_file       = "${conf_dir}/ports.conf"
     $pidfile          = '/var/run/httpd.pid'
     $logroot          = '/var/log/apache24'
@@ -415,6 +418,7 @@ class apache::params inherits ::apache::version {
     $vhost_dir        = "${httpd_dir}/vhosts.d"
     $vhost_enable_dir = undef
     $conf_file        = 'httpd.conf'
+    $ssl_file         = "${mod_dir}/ssl.conf"
     $ports_file       = "${conf_dir}/ports.conf"
     $logroot          = '/var/log/apache2'
     $logroot_mode     = undef
@@ -482,6 +486,7 @@ class apache::params inherits ::apache::version {
     $vhost_dir           = "${httpd_dir}/sites-available"
     $vhost_enable_dir    = "${httpd_dir}/sites-enabled"
     $conf_file           = 'httpd.conf'
+    $ssl_file            = "${mod_dir}/ssl.conf"
     $ports_file          = "${conf_dir}/ports.conf"
     $pidfile             = '/var/run/httpd2.pid'
     $logroot             = '/var/log/apache2'


### PR DESCRIPTION
This is solving a problem with the SSL configuration on a Red Hat-based
OS that results in a duplicate 'Listen 443' statement after a package
update, causing Apache to no longer start.

The mod_ssl packaging ships a default ssl.conf in apache's main conf
dir, that among other things, contains 'Listen 443'.

However, this module puts all the Listen statements in ports.conf
centralized.

Generally this is no problem, because the module would purge the conf
directory.  Apache hums along happily -- until the apache package gets
an update and it restores the default ssl.conf into
/etc/httpd/conf.d/ssl.conf as no such file exists by the name on EL7
(the module's ssl.conf goes into conf.modules.d).

Apache will then fail to start with this error until puppet runs again:

```
    Address already in use: AH00072: make_sock: could not bind to address 0.0.0.0:443
```

The RPM won't overwrite the file if it's changed, but it does put it
back when removed.  So to avoid this problem, this change moves the
ssl.conf to the Apache conf dir on EL7. That replaces the one created by
the RPM.

When the package is updated, it won't touch the ssl.conf and apache
will continue to work.
