### PR TITLE
Bugfix: don't use a different name because port is not specified

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -449,7 +449,7 @@ define apache::vhost(
       $nvh_addr_port = "${vhost_name}:${port}"
     } else {
       $listen_addr_port = undef
-      $nvh_addr_port = $name
+      $nvh_addr_port = $vhost_name
       if ! $servername {
         fail("Apache::Vhost[${name}]: must pass 'ip' and/or 'port' parameters, and/or 'servername' parameter")
       }


### PR DESCRIPTION
When the port is not specified, the name of the <VirtualHost> tag is taken to
be the resource name, instead of the vhost name.
