### PR TITLE
[MODULES-3744] Processes $crs_package before $modsec_dir

### DIFF
--- a/manifests/mod/security.pp
+++ b/manifests/mod/security.pp
@@ -54,7 +54,10 @@ class apache::mod::security (
   if $crs_package  {
     package { $crs_package:
       ensure => 'latest',
-      before => File[$::apache::confd_dir],
+      before => [
+        File[$::apache::confd_dir],
+        File[$modsec_dir],
+      ],
     }
   }
 


### PR DESCRIPTION
Class apache::mod::security created 2 files with conflicting configs:
/etc/httpd/modsecurity.d/modsecurity_crs_10_config.conf
/etc/httpd/modsecurity.d/security_crs.conf

File[$modsec_dir] purges this directory and creates latter file
but Package[$crs_package] creates former file in the same directory

This change makes the package be managed before the directory,
so the former file is guaranteed to be purged
