### PR TITLE
Allow user to specify alternative package and library names for shibboleth module

### DIFF
--- a/manifests/mod/shib.pp
+++ b/manifests/mod/shib.pp
@@ -1,6 +1,8 @@
 class apache::mod::shib (
   $suppress_warning = false,
-  $mod_full_path = undef,
+  $mod_full_path    = undef,
+  $package_name     = undef,
+  $mod_lib          = undef,
 ) {
   include ::apache
   if $::osfamily == 'RedHat' and ! $suppress_warning {
@@ -10,7 +12,9 @@ class apache::mod::shib (
   $mod_shib = 'shib2'
 
   apache::mod {$mod_shib:
-    id   => 'mod_shib',
-    path => $mod_full_path,
+    id      => 'mod_shib',
+    path    => $mod_full_path,
+    package => $package_name,
+    lib     => $mod_lib,
   }
 }


### PR DESCRIPTION
If left `undef`, they remain the values set in `params.pp`. The context is that more up-to-date packages are typically available from external repositories such as from [Switch](https://www.switch.ch/aai/guides/sp/installation/) but they use different package names (that force the OS packages to uninstall) and potentially different library files. These parameters allow a generic way to override the defaults without affecting existing configurations. I have tried to mimic the parameter names used in other modules under `manifests/mod/*` for consistency.
