### PR TITLE
Validate wsgi_chunked_request parameter for vhost

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -209,6 +209,12 @@ define apache::vhost(
     Allowed values are 'on' and 'off'.")
   }
 
+  if $wsgi_chunked_request {
+    validate_re(downcase($wsgi_chunked_request), '^(on|off)$',
+    "${wsgi_chunked_request} is not supported for wsgi_chunked_request.
+    Allowed values are 'on' and 'off'.")
+  }
+
   # Deprecated backwards-compatibility
   if $rewrite_base {
     warning('Apache::Vhost: parameter rewrite_base is deprecated in favor of rewrites')


### PR DESCRIPTION
Same as with wsgi_pass_authorization, it only accepts on and off as
values (ignoring the case). So this introduces a similar validation
for wsgi_chunked_request.