### PR TITLE
Don't fail if first element of  is not an hash before flattening

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -192,7 +192,8 @@ define apache::vhost(
   if $rewrites {
     validate_array($rewrites)
     unless empty($rewrites) {
-      validate_hash($rewrites[0])
+      $rewrites_flattened = delete_undef_values(flatten([$rewrites]))
+      validate_hash($rewrites_flattened[0])
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/puppetlabs/puppetlabs-apache",
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 2.4.0 < 5.0.0"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.2.0 < 5.0.0"},
     {"name":"puppetlabs/concat","version_requirement":">= 1.1.1 < 3.0.0"}
   ],
   "data_provider": null,


### PR DESCRIPTION
The template is using [@rewrites].flatten.compact which maps to Puppet's delete_undef_values(flatten([]))