### PR TITLE
(maint) adds to conditional to allow for empty servername

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -450,7 +450,7 @@ define apache::vhost(
     } else {
       $listen_addr_port = undef
       $nvh_addr_port = $name
-      if ! $servername {
+      if ! $servername and $servername != '' {
         fail("Apache::Vhost[${name}]: must pass 'ip' and/or 'port' parameters, and/or 'servername' parameter")
       }
     }


### PR DESCRIPTION
An empty string is false on Puppet 3, so this line was causing a failure on acceptance tests on 3.8. '' should be allowed for $servername per https://github.com/puppetlabs/puppetlabs-apache/pull/1526 