### PR TITLE
ModSec debug logs to use apache logroot parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1905,6 +1905,7 @@ ${modsec\_dir}/activated\_rules.
 - `secdefaultaction`: Configures the Mode of Operation, Self-Contained ('deny') vs. Collaborative Detection ('pass'), for the OWASP ModSecurity Core Rule Set. Default: 'deny'. Fuller values can be set too like "log,auditlog,deny,status:406,tag:'SLA 24/7'"
 - `secpcrematchlimit`: Sets the number for the match limit in the PCRE library. Default: '1500'
 - `secpcrematchlimitrecursion`: Sets the number for the match limit recursion in the PCRE library. Default: '1500'
+- `logroot`: Configures the location of audit and debug logs.  Defaults to apache log directory (Redhat: /var/log/httpd Debian: /var/log/apache2)
 - `audit_log_releavant_status`: Configures which response status code is to be considered relevant for the purpose of audit logging. Defaults: '^(?:5|4(?!04))'.
 - `audit_log_parts`: Sets the sections to be put in the [audit log][]. Default: 'ABIJDEFHZ'
 - `anomaly_score_blocking`: De-/Activates the Collaborative Detection Blocking of the OWASP ModSecurity Core Rule Set. Default: off.

--- a/manifests/mod/security.pp
+++ b/manifests/mod/security.pp
@@ -1,4 +1,5 @@
 class apache::mod::security (
+  $logroot                    = $::apache::params::logroot,
   $crs_package                = $::apache::params::modsec_crs_package,
   $activated_rules            = $::apache::params::modsec_default_rules,
   $modsec_dir                 = $::apache::params::modsec_dir,
@@ -54,6 +55,7 @@ class apache::mod::security (
   }
 
   # Template uses:
+  # - logroot
   # - $modsec_dir
   # - $audit_log_parts
   # - secpcrematchlimit

--- a/spec/classes/mod/security_spec.rb
+++ b/spec/classes/mod/security_spec.rb
@@ -28,8 +28,12 @@ describe 'apache::mod::security', :type => :class do
     it { should contain_file('security.conf').with(
       :path => '/etc/httpd/conf.modules.d/security.conf'
     ) }
-    it { should contain_file('security.conf').with_content %r{^\s+SecAuditLogRelevantStatus "\^\(\?:5\|4\(\?!04\)\)"$} }
-    it { should contain_file('security.conf').with_content %r{^\s+SecAuditLogParts ABIJDEFHZ$} }
+    it { should contain_file('security.conf')
+      .with_content(%r{^\s+SecAuditLogRelevantStatus "\^\(\?:5\|4\(\?!04\)\)"$})
+      .with_content(%r{^\s+SecAuditLogParts ABIJDEFHZ$})
+      .with_content(%r{^\s+SecDebugLog /var/log/httpd/modsec_debug.log$})
+      .with_content(%r{^\s+SecAuditLog /var/log/httpd/modsec_audit.log$})
+    }
     it { should contain_file('/etc/httpd/modsecurity.d').with(
       :ensure => 'directory',
       :path   => '/etc/httpd/modsecurity.d',
@@ -99,8 +103,12 @@ describe 'apache::mod::security', :type => :class do
     it { should contain_file('security.conf').with(
       :path => '/etc/apache2/mods-available/security.conf'
     ) }
-    it { should contain_file('security.conf').with_content %r{^\s+SecAuditLogRelevantStatus "\^\(\?:5\|4\(\?!04\)\)"$} }
-    it { should contain_file('security.conf').with_content %r{^\s+SecAuditLogParts ABIJDEFHZ$} }
+    it { should contain_file('security.conf')
+      .with_content(%r{^\s+SecAuditLogRelevantStatus "\^\(\?:5\|4\(\?!04\)\)"$})
+      .with_content(%r{^\s+SecAuditLogParts ABIJDEFHZ$})
+      .with_content(%r{^\s+SecDebugLog /var/log/apache2/modsec_debug.log$})
+      .with_content(%r{^\s+SecAuditLog /var/log/apache2/modsec_audit.log$})
+    }
     it { should contain_file('/etc/modsecurity').with(
       :ensure => 'directory',
       :path   => '/etc/modsecurity',

--- a/templates/mod/security.conf.erb
+++ b/templates/mod/security.conf.erb
@@ -49,8 +49,8 @@
     SecArgumentSeparator &
     SecCookieFormat 0
 <%- if scope.lookupvar('::osfamily') == 'Debian' -%>
-    SecDebugLog /var/log/apache2/modsec_debug.log
-    SecAuditLog /var/log/apache2/modsec_audit.log
+    SecDebugLog <%= @logroot %>/modsec_debug.log
+    SecAuditLog <%= @logroot %>/modsec_audit.log
     SecTmpDir /var/cache/modsecurity
     SecDataDir /var/cache/modsecurity
     SecUploadDir /var/cache/modsecurity
@@ -61,8 +61,8 @@
     SecDataDir /var/lib/mod_security
     SecUploadDir /var/lib/mod_security
 <% else -%>
-    SecDebugLog /var/log/httpd/modsec_debug.log
-    SecAuditLog /var/log/httpd/modsec_audit.log
+    SecDebugLog <%= @logroot %>/modsec_debug.log
+    SecAuditLog <%= @logroot %>/modsec_audit.log
     SecTmpDir /var/lib/mod_security
     SecDataDir /var/lib/mod_security
     SecUploadDir /var/lib/mod_security


### PR DESCRIPTION
Pass logroot paramter through to mod security.  

Allows log directory to be configured for custom installs.