### PR TITLE
Add SSL stapling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1179,6 +1179,12 @@ Determines whether Puppet manages the HTTPD service's state. Valid options: Bool
 
 Determines whether Puppet should use a specific command to restart the HTTPD service. Valid options: a command to restart the Apache service. Default: undef, which uses the [default Puppet behavior][Service attribute restart].
 
+##### `ssl_stapling`
+
+Specifies whether or not to use [SSLUseStapling](http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslusestapling). Valid options: Boolean. Default: false. It is possible to override this on a vhost level.
+
+This parameter only applies to Apache 2.4 or higher and is ignored on older versions.
+
 ##### `timeout`
 
 Sets Apache's [`TimeOut`][] directive, which defines the number of seconds Apache waits for certain events before failing a request. Default: 120.
@@ -3784,6 +3790,24 @@ Sets the [SSLOpenSSLConfCmd](https://httpd.apache.org/docs/current/mod/mod_ssl.h
 ##### `ssl_proxyengine`
 
 Specifies whether or not to use [SSLProxyEngine](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxyengine). Valid options: Boolean. Default: true.
+
+##### `ssl_stapling`
+
+Specifies whether or not to use [SSLUseStapling](http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslusestapling). Valid options: Boolean or undef. Default: undef, meaning use what is set globally.
+
+This parameter only applies to Apache 2.4 or higher and is ignored on older versions.
+
+##### `ssl_stapling_timeout`
+
+Can be used to set the [SSLStaplingResponderTimeout](http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslstaplingrespondertimeout) directive. No default.
+
+This parameter only applies to Apache 2.4 or higher and is ignored on older versions.
+
+##### `ssl_stapling_return_errors`
+
+Can be used to set the [SSLStaplingReturnResponderErrors](http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslstaplingreturnrespondererrors) directive. No default.
+
+This parameter only applies to Apache 2.4 or higher and is ignored on older versions.
 
 #### Defined type: FastCGI Server
 

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -9,6 +9,7 @@ class apache::mod::ssl (
   $ssl_pass_phrase_dialog  = 'builtin',
   $ssl_random_seed_bytes   = '512',
   $ssl_sessioncachetimeout = '300',
+  $ssl_stapling            = false,
   $ssl_mutex               = undef,
   $apache_version          = undef,
   $package_name            = undef,
@@ -67,6 +68,16 @@ class apache::mod::ssl (
     'Suse'    => '/var/lib/apache2/ssl_scache(512000)'
   }
 
+  validate_bool($ssl_stapling)
+
+  $stapling_cache = $::osfamily ? {
+    'debian'  => "\${APACHE_RUN_DIR}/ocsp(32768)",
+    'redhat'  => '/run/httpd/ssl_stapling(32768)',
+    'freebsd' => '/var/run/ssl_stapling(32768)',
+    'gentoo'  => '/var/run/ssl_stapling(32768)',
+    'Suse'    => '/var/lib/apache2/ssl_stapling(32768)',
+  }
+
   if $::osfamily == 'Suse' {
     if defined(Class['::apache::mod::worker']){
       $suse_path = '/usr/lib64/apache2-worker'
@@ -96,6 +107,7 @@ class apache::mod::ssl (
   # $ssl_options
   # $ssl_openssl_conf_cmd
   # $session_cache
+  # $stapling_cache
   # $ssl_mutex
   # $ssl_random_seed_bytes
   # $ssl_sessioncachetimeout

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -34,6 +34,9 @@ define apache::vhost(
   $ssl_options                 = undef,
   $ssl_openssl_conf_cmd        = undef,
   $ssl_proxyengine             = false,
+  $ssl_stapling                = undef,
+  $ssl_stapling_timeout        = undef,
+  $ssl_stapling_return_errors  = undef,
   $priority                    = undef,
   $default_vhost               = false,
   $servername                  = $name,
@@ -189,6 +192,9 @@ define apache::vhost(
   validate_bool($ssl)
   validate_bool($default_vhost)
   validate_bool($ssl_proxyengine)
+  if $ssl_stapling != undef {
+    validate_bool($ssl_stapling)
+  }
   if $rewrites {
     validate_array($rewrites)
     unless empty($rewrites) {
@@ -919,6 +925,7 @@ define apache::vhost(
   # - $ssl_verify_depth
   # - $ssl_options
   # - $ssl_openssl_conf_cmd
+  # - $ssl_stapling
   # - $apache_version
   if $ssl {
     concat::fragment { "${name}-ssl":

--- a/spec/classes/mod/ssl_spec.rb
+++ b/spec/classes/mod/ssl_spec.rb
@@ -151,6 +151,14 @@ describe 'apache::mod::ssl', :type => :class do
         end
         it { is_expected.not_to contain_file('ssl.conf').with_content(/^  SSLCompression On$/)}
       end
+      context 'setting ssl_stapling to true' do
+        let :params do
+          {
+            :ssl_stapling => true,
+          }
+        end
+        it { is_expected.not_to contain_file('ssl.conf').with_content(/^  SSLUseStapling/)}
+      end
     end
     context "with Apache version >= 2.4" do
       let :params do
@@ -170,6 +178,15 @@ describe 'apache::mod::ssl', :type => :class do
           }
         end
         it { is_expected.to contain_file('ssl.conf').with_content(/^  SSLCompression On$/)}
+      end
+      context 'setting ssl_stapling to true' do
+        let :params do
+          {
+            :apache_version => '2.4',
+            :ssl_stapling => true,
+          }
+        end
+        it { is_expected.to contain_file('ssl.conf').with_content(/^  SSLUseStapling On$/)}
       end
     end
 

--- a/templates/mod/ssl.conf.erb
+++ b/templates/mod/ssl.conf.erb
@@ -20,6 +20,10 @@
   <%- end -%>
   SSLCryptoDevice <%= @ssl_cryptodevice %>
   SSLHonorCipherOrder <%= scope.function_bool2httpd([@_ssl_honorcipherorder]) %>
+<% if scope.function_versioncmp([@_apache_version, '2.4']) >= 0 -%>
+  SSLUseStapling <%= scope.function_bool2httpd([@ssl_stapling]) %>
+  SSLStaplingCache "shmcb:<%= @stapling_cache %>"
+<% end -%>
   SSLCipherSuite <%= @ssl_cipher %>
   SSLProtocol <%= @ssl_protocol.compact.join(' ') %>
 <% if @ssl_options -%>

--- a/templates/vhost/_ssl.erb
+++ b/templates/vhost/_ssl.erb
@@ -43,4 +43,13 @@
   <%- if @ssl_openssl_conf_cmd -%>
   SSLOpenSSLConfCmd       <%= @ssl_openssl_conf_cmd %>
   <%- end -%>
+  <%- if not @ssl_stapling.nil? && scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
+  SSLUseStapling <%= scope.function_bool2httpd([@ssl_stapling]) %>
+  <%- end -%>
+  <%- if @ssl_stapling_timeout && scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
+  SSLStaplingResponderTimeout <%= @ssl_stapling_timeout %>
+  <%- end -%>
+  <%- if @ssl_stapling_return_errors && scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
+  SSLStaplingReturnResponderErrors <%= @ssl_stapling_return_errors %>
+  <%- end -%>
 <% end -%>


### PR DESCRIPTION
It is possible to set a global default stapling on/off
Per vhost this can be overridden.

Based on initial pull request https://github.com/puppetlabs/puppetlabs-apache/pull/907 by David Teirney <david.teirney@orionhealth.com>