### PR TITLE
custom facts shouldn't break structured facts

### DIFF
--- a/lib/facter/apache_version.rb
+++ b/lib/facter/apache_version.rb
@@ -2,11 +2,11 @@ Facter.add(:apache_version) do
   setcode do
     if Facter::Util::Resolution.which('apachectl')
       apache_version = Facter::Util::Resolution.exec('apachectl -v 2>&1')
-      puts "Matching apachectl '#{apache_version}'"
+      Facter.debug "Matching apachectl '#{apache_version}'"
       %r{^Server version: Apache\/(\d+.\d+(.\d+)?)}.match(apache_version)[1]
     elsif Facter::Util::Resolution.which('apache2ctl')
       apache_version = Facter::Util::Resolution.exec('apache2ctl -v 2>&1')
-      puts "Matching apache2ctl '#{apache_version}'"
+      Facter.debug "Matching apache2ctl '#{apache_version}'"
       %r{^Server version: Apache\/(\d+.\d+(.\d+)?)}.match(apache_version)[1]
     end
   end


### PR DESCRIPTION
Change the `puts` output to `Facter.debug` so that our structured facts remain side-effect free in normal runs, and can just be piped into tools like `jq`