### PR TITLE
Avoid relative classname inclusion

### DIFF
--- a/examples/apache.pp
+++ b/examples/apache.pp
@@ -1,6 +1,6 @@
-include apache
-include apache::mod::php
-include apache::mod::cgi
-include apache::mod::userdir
-include apache::mod::disk_cache
-include apache::mod::proxy_http
+include ::apache
+include ::apache::mod::php
+include ::apache::mod::cgi
+include ::apache::mod::userdir
+include ::apache::mod::disk_cache
+include ::apache::mod::proxy_http

--- a/examples/dev.pp
+++ b/examples/dev.pp
@@ -1,1 +1,1 @@
-include apache::mod::dev
+include ::apache::mod::dev

--- a/examples/init.pp
+++ b/examples/init.pp
@@ -1,1 +1,1 @@
-include apache
+include ::apache

--- a/examples/mod_load_params.pp
+++ b/examples/mod_load_params.pp
@@ -1,7 +1,7 @@
 # Tests the path and identifier parameters for the apache::mod class
 
 # Base class for clarity:
-class { 'apache': }
+class { '::apache': }
 
 
 # Exaple parameter usage:

--- a/examples/mods.pp
+++ b/examples/mods.pp
@@ -3,7 +3,7 @@
 # Base class. Declares default vhost on port 80 and default ssl
 # vhost on port 443 listening on all interfaces and serving
 # $apache::docroot, and declaring our default set of modules.
-class { 'apache':
+class { '::apache':
   default_mods => true,
 }
 

--- a/examples/mods_custom.pp
+++ b/examples/mods_custom.pp
@@ -3,7 +3,7 @@
 # Base class. Declares default vhost on port 80 and default ssl
 # vhost on port 443 listening on all interfaces and serving
 # $apache::docroot, and declaring a custom set of modules.
-class { 'apache':
+class { '::apache':
   default_mods => [
     'info',
     'alias',

--- a/examples/php.pp
+++ b/examples/php.pp
@@ -1,4 +1,4 @@
-class { 'apache':
+class { '::apache':
   mpm_module => 'prefork',
 }
-include apache::mod::php
+include ::apache::mod::php

--- a/examples/vhost.pp
+++ b/examples/vhost.pp
@@ -5,7 +5,7 @@
 # Base class. Declares default vhost on port 80 and default ssl
 # vhost on port 443 listening on all interfaces and serving
 # $apache::docroot
-class { 'apache': }
+class { '::apache': }
 
 # Most basic vhost
 apache::vhost { 'first.example.com':

--- a/examples/vhost_directories.pp
+++ b/examples/vhost_directories.pp
@@ -1,7 +1,7 @@
 # Base class. Declares default vhost on port 80 and default ssl
 # vhost on port 443 listening on all interfaces and serving
 # $apache::docroot
-class { 'apache': }
+class { '::apache': }
 
 # Example from README adapted.
 apache::vhost { 'readme.example.net':

--- a/examples/vhost_filter.pp
+++ b/examples/vhost_filter.pp
@@ -1,5 +1,5 @@
 # Base class. Declares default vhost on port 80 with filters.
-class { 'apache': }
+class { '::apache': }
 
 # Example from README adapted.
 apache::vhost { 'readme.example.net':

--- a/examples/vhost_ip_based.pp
+++ b/examples/vhost_ip_based.pp
@@ -3,7 +3,7 @@
 
 # Base class. Turn off the default vhosts; we will be declaring
 # all vhosts below.
-class { 'apache':
+class { '::apache':
   default_vhost => false,
 }
 

--- a/examples/vhost_proxypass.pp
+++ b/examples/vhost_proxypass.pp
@@ -5,7 +5,7 @@
 # Base class. Declares default vhost on port 80 and default ssl
 # vhost on port 443 listening on all interfaces and serving
 # $apache::docroot
-class { 'apache': }
+class { '::apache': }
 
 # Most basic vhost with proxy_pass
 apache::vhost { 'first.example.com':

--- a/examples/vhost_ssl.pp
+++ b/examples/vhost_ssl.pp
@@ -3,7 +3,7 @@
 
 # Base class. Turn off the default vhosts; we will be declaring
 # all vhosts below.
-class { 'apache':
+class { '::apache':
   default_vhost => false,
 }
 

--- a/examples/vhosts_without_listen.pp
+++ b/examples/vhosts_without_listen.pp
@@ -4,7 +4,7 @@
 
 # Base class. Turn off the default vhosts; we will be declaring
 # all vhosts below.
-class { 'apache':
+class { '::apache':
   default_vhost => false,
 }
 

--- a/manifests/fastcgi/server.pp
+++ b/manifests/fastcgi/server.pp
@@ -7,7 +7,7 @@ define apache::fastcgi::server (
   $file_type     = 'application/x-httpd-php',
   $pass_header   = undef,
 ) {
-  include apache::mod::fastcgi
+  include ::apache::mod::fastcgi
 
   Apache::Mod['fastcgi'] -> Apache::Fastcgi::Server[$title]
 


### PR DESCRIPTION
Including a class by a relative name might lead to unexpected results;
in addition to that there is also a small performance penalty.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>