### PR TITLE
Add missing trailing commas

### DIFF
--- a/examples/vhost.pp
+++ b/examples/vhost.pp
@@ -153,7 +153,7 @@ apache::vhost { 'sixteenth.example.com non-ssl':
       rewrite_cond => ['%{HTTPS} off'],
       rewrite_rule => ['(.*) https://%{HTTP_HOST}%{REQUEST_URI}'],
     }
-  ]
+  ],
 }
 
 # Rewrite a URL to lower case
@@ -167,7 +167,7 @@ apache::vhost { 'sixteenth.example.com non-ssl':
       rewrite_map  => ['lc int:tolower'],
       rewrite_rule => ['(.*) ${lc:$1} [R=301,L]'],
     }
-  ]
+  ],
 }
 
 apache::vhost { 'sixteenth.example.com ssl':

--- a/examples/vhost_proxypass.pp
+++ b/examples/vhost_proxypass.pp
@@ -29,7 +29,7 @@ apache::vhost { 'second.example.com':
       'url'    => 'http://localhost:8080/second',
       'params' => {
         'retry'   => '0',
-        'timeout' => '5'
+        'timeout' => '5',
         }
     },
   ],
@@ -58,7 +58,7 @@ apache::vhost { 'fourth.example.com':
       'url'      => 'http://localhost:8080/fourth',
       'params'   => {
         'retry'   => '0',
-        'timeout' => '5'
+        'timeout' => '5',
         },
       'keywords' => ['noquery', 'interpolate']
     },

--- a/manifests/custom_config.pp
+++ b/manifests/custom_config.pp
@@ -60,7 +60,7 @@ define apache::custom_config (
       refreshonly => true,
       notify      => Class['Apache::Service'],
       before      => Exec["remove ${name} if invalid"],
-      require     => Anchor['::apache::modules_set_up']
+      require     => Anchor['::apache::modules_set_up'],
     }
 
     exec { "remove ${name} if invalid":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -137,7 +137,7 @@ class apache (
   if $manage_group {
     group { $group:
       ensure  => present,
-      require => Package['httpd']
+      require => Package['httpd'],
     }
   }
 
@@ -258,7 +258,7 @@ class apache (
   }
   concat::fragment { 'Apache ports header':
     target  => $ports_file,
-    content => template('apache/ports_header.erb')
+    content => template('apache/ports_header.erb'),
   }
 
   if $::apache::conf_dir and $::apache::params::conf_file {
@@ -284,7 +284,7 @@ class apache (
 
       file { [
         '/etc/apache2/modules.d/.keep_www-servers_apache-2',
-        '/etc/apache2/vhosts.d/.keep_www-servers_apache-2'
+        '/etc/apache2/vhosts.d/.keep_www-servers_apache-2',
       ]:
         ensure  => absent,
         require => Package['httpd'],
@@ -343,7 +343,7 @@ class apache (
       }
     }
     class { '::apache::default_confd_files':
-      all => $default_confd_files
+      all => $default_confd_files,
     }
     if $mpm_module and $mpm_module != 'false' { # lint:ignore:quoted_booleans
       include "::apache::mod::${mpm_module}"

--- a/manifests/mod/cgi.pp
+++ b/manifests/mod/cgi.pp
@@ -8,7 +8,7 @@ class apache::mod::cgi {
 
   if $::osfamily == 'Suse' {
     ::apache::mod { 'cgi':
-      lib_path => '/usr/lib64/apache2-prefork'
+      lib_path => '/usr/lib64/apache2-prefork',
     }
   } else {
     ::apache::mod { 'cgi': }

--- a/manifests/mod/cgid.pp
+++ b/manifests/mod/cgid.pp
@@ -20,7 +20,7 @@ class apache::mod::cgid {
 
   if $::osfamily == 'Suse' {
     ::apache::mod { 'cgid':
-      lib_path => '/usr/lib64/apache2-worker'
+      lib_path => '/usr/lib64/apache2-worker',
     }
   } else {
     ::apache::mod { 'cgid': }

--- a/manifests/mod/deflate.pp
+++ b/manifests/mod/deflate.pp
@@ -4,12 +4,12 @@ class apache::mod::deflate (
     'text/css',
     'application/x-javascript application/javascript application/ecmascript',
     'application/rss+xml',
-    'application/json'
+    'application/json',
   ],
   $notes = {
     'Input'  => 'instream',
     'Output' => 'outstream',
-    'Ratio'  => 'ratio'
+    'Ratio'  => 'ratio',
   }
 ) {
   include ::apache

--- a/manifests/mod/info.pp
+++ b/manifests/mod/info.pp
@@ -14,7 +14,7 @@ class apache::mod::info (
       $suse_path = '/usr/lib64/apache2-prefork'
     }
     ::apache::mod { 'info':
-      lib_path => $suse_path
+      lib_path => $suse_path,
     }
   } else {
     ::apache::mod { 'info': }

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -75,7 +75,7 @@ class apache::mod::ssl (
     }
     ::apache::mod { 'ssl':
       package  => $package_name,
-      lib_path => $suse_path
+      lib_path => $suse_path,
     }
   } else {
     ::apache::mod { 'ssl':

--- a/manifests/mpm.pp
+++ b/manifests/mpm.pp
@@ -102,7 +102,7 @@ define apache::mpm (
     }
     'freebsd': {
       class { '::apache::package':
-        mpm_module => $mpm
+        mpm_module => $mpm,
       }
     }
     'gentoo': {
@@ -132,7 +132,7 @@ define apache::mpm (
         if $mpm == 'itk' {
           file { "${lib_path}/mod_mpm_itk.so":
             ensure => link,
-            target => "${lib_path}/mpm_itk.so"
+            target => "${lib_path}/mpm_itk.so",
           }
         }
       }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -262,7 +262,7 @@ class apache::params inherits ::apache::version {
       $shib2_lib = 'mod_shib2.so'
     }
     $mod_libs             = {
-      'shib2' => $shib2_lib
+      'shib2' => $shib2_lib,
     }
     $conf_template          = 'apache/httpd.conf.erb'
     $keepalive              = 'Off'
@@ -507,7 +507,7 @@ class apache::params inherits ::apache::version {
         'php5'        => 'apache2-mod_php5',
         'python'      => 'apache2-mod_python',
         'security'    => 'apache2-mod_security2',
-        'worker'      => 'apache2-worker'
+        'worker'      => 'apache2-worker',
         }
     } else {
       $mod_packages        = {

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1086,7 +1086,7 @@ define apache::vhost(
     concat::fragment { "${name}-security":
       target  => "${priority_real}${filename}.conf",
       order   => 320,
-      content => template('apache/vhost/_security.erb')
+      content => template('apache/vhost/_security.erb'),
     }
   }
 


### PR DESCRIPTION
As per style guide v2.0, there must be trailing commas after all
resource attributes and parameter definitions.

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>