### PR TITLE
(MODULES-4213) Allow global rewrite rules inheritance in vhosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2868,6 +2868,35 @@ apache::vhost { 'site.name.fdqn':
 
 Refer to the [`mod_rewrite` documentation][`mod_rewrite`] for more details on what is possible with rewrite rules and conditions.
 
+##### `rewrite_inherit`
+
+Determines whether the virtual host inherits global rewrite rules. Default: false.
+
+Rewrite rules may be specified globally (in `$conf_file` or `$confd_dir`) or inside the virtual host `.conf` file. By default, virtual hosts do not inherit global settings. To activate inheritance, specify the `rewrites` parameter and set `rewrite_inherit` parameter to `true`:
+
+``` puppet
+apache::vhost { 'site.name.fdqn':
+  …
+  rewrites => [
+    <rules>,
+  ],
+  rewrite_inherit => true,
+}
+```
+
+> **Note**: The `rewrites` parameter is **required** for this to have effect
+
+###### Some background
+
+Apache activates global `Rewrite` rules inheritance if the virtual host files contains the following directives:
+
+``` ApacheConf
+RewriteEngine On
+RewriteOptions Inherit
+```
+
+Refer to the [official `mod_rewrite` documentation](https://httpd.apache.org/docs/2.2/mod/mod_rewrite.html), section "Rewriting in Virtual Hosts".
+
 ##### `scriptalias`
 
 Defines a directory of CGI scripts to be aliased to the path '/cgi-bin', such as '/usr/scripts'. Default: undef.

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -100,6 +100,7 @@ define apache::vhost(
   $rewrite_base                = undef,
   $rewrite_rule                = undef,
   $rewrite_cond                = undef,
+  $rewrite_inherit             = false,
   $setenv                      = [],
   $setenvif                    = [],
   $setenvifnocase              = [],

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -1113,8 +1113,8 @@ describe 'apache::vhost', :type => :define do
     context 'inherit global rewrite rules' do
       let :params do
         {
-          'docroot'  => '/rspec/docroot',
-          'rewrites'                    => [
+          'docroot'         => '/rspec/docroot',
+          'rewrites'        => [
             {
               'rewrite_rule' => ['^index\.html$ welcome.html']
             }

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -1110,22 +1110,6 @@ describe 'apache::vhost', :type => :define do
       let :facts do default_facts end
       it { is_expected.to compile }
     end
-    context 'inherit global rewrite rules' do
-      let :params do
-        {
-          'docroot'         => '/rspec/docroot',
-          'rewrites'        => [
-            {
-              'rewrite_rule' => ['^index\.html$ welcome.html']
-            }
-          ],
-          'rewrite_inherit' => true,
-        }
-      end
-      it { is_expected.to contain_concat__fragment('rspec.example.com-rewrite').with(
-        :content => /RewriteOptions Inherit/
-      )}
-    end
     context 'bad suexec_user_group' do
       let :params do
         {

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -1110,6 +1110,21 @@ describe 'apache::vhost', :type => :define do
       let :facts do default_facts end
       it { is_expected.to compile }
     end
+    context 'inherit global rewrite rules' do
+      let :params do
+        {
+          'docroot'  => '/rspec/docroot',
+          'rewrites'                    => [
+            {
+              'rewrite_rule' => ['^index\.html$ welcome.html']
+            }
+          'rewrite_inherit' => true,
+        }
+      end
+      it { is_expected.to contain_concat__fragment('rspec.example.com-rewrite').with(
+        :content => /^RewriteOptions Inherit$/
+      )}
+    end
     context 'bad suexec_user_group' do
       let :params do
         {

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -1118,6 +1118,7 @@ describe 'apache::vhost', :type => :define do
             {
               'rewrite_rule' => ['^index\.html$ welcome.html']
             }
+          ],
           'rewrite_inherit' => true,
         }
       end

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -1123,7 +1123,7 @@ describe 'apache::vhost', :type => :define do
         }
       end
       it { is_expected.to contain_concat__fragment('rspec.example.com-rewrite').with(
-        :content => /^RewriteOptions Inherit$/
+        :content => /RewriteOptions Inherit/
       )}
     end
     context 'bad suexec_user_group' do

--- a/templates/vhost/_rewrite.erb
+++ b/templates/vhost/_rewrite.erb
@@ -1,6 +1,9 @@
 <%- if @rewrites -%>
   ## Rewrite rules
   RewriteEngine On
+  <%- if @rewrite_inherit -%>
+  RewriteOptions Inherit
+  <%- end -%>
   <%- if @rewrite_base -%>
   RewriteBase <%= @rewrite_base %>
   <%- end -%>


### PR DESCRIPTION
Apache module rewrite allows virtual hosts to inherit global rules
if their conf files contain the directive "**RewriteOptions Inherit**"
among rewrite rules

This change includes this directive depending on a boolean parameter
in `apache::vhost` class - **rewrite_inherit** - which defaults to false