### PR TITLE
MODULES-4247 - Adds support of ProxyPassReverse directive without matching ProxyPass or ProxyPassMatch to apache::vhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -2750,6 +2750,20 @@ apache::vhost { 'site.name.fdqn':
 * `params`. *Optional.* Allows for ProxyPass key-value parameters, such as connection settings.
 * `setenv`. *Optional.* Sets [environment variables](https://httpd.apache.org/docs/current/mod/mod_proxy.html#envsettings) for the proxy directive. Valid options: array.
 
+##### `proxy_pass_reverse`
+
+Specifies an array of `path => URI` values for a [ProxyPassReverse](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassreverse) configuration without matching [ProxyPass](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypass). Defaults to 'undef'.
+
+``` puppet
+apache::vhost { 'site.name.fdqn':
+  …
+  proxy_pass => [
+    { 'path' => '/a', 'url' => 'http://backend-a/' },
+    { 'path' => '/b', 'url' => 'http://backend-b/' },
+  ],
+}
+```
+
 ##### `proxy_dest_match`
 
 This directive is equivalent to [`proxy_dest`][], but takes regular expressions, see [ProxyPassMatch](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassmatch) for details.

--- a/README.md
+++ b/README.md
@@ -2757,7 +2757,7 @@ Specifies an array of `path => URI` values for a [ProxyPassReverse](https://http
 ``` puppet
 apache::vhost { 'site.name.fdqn':
   …
-  proxy_pass => [
+  proxy_pass_reverse => [
     { 'path' => '/a', 'url' => 'http://backend-a/' },
     { 'path' => '/b', 'url' => 'http://backend-b/' },
   ],

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -76,6 +76,7 @@ define apache::vhost(
   $proxy_dest_reverse_match    = undef,
   $proxy_pass                  = undef,
   $proxy_pass_match            = undef,
+  $proxy_pass_reverse          = undef,
   $suphp_addhandler            = $::apache::params::suphp_addhandler,
   $suphp_engine                = $::apache::params::suphp_engine,
   $suphp_configpath            = $::apache::params::suphp_configpath,
@@ -498,7 +499,7 @@ define apache::vhost(
   }
 
   # Load mod_proxy if needed and not yet loaded
-  if ($proxy_dest or $proxy_pass or $proxy_pass_match or $proxy_dest_match) {
+  if ($proxy_dest or $proxy_pass or $proxy_pass_match or $proxy_dest_match or $proxy_pass_reverse) {
     if ! defined(Class['apache::mod::proxy']) {
       include ::apache::mod::proxy
     }
@@ -829,7 +830,8 @@ define apache::vhost(
   # - $proxy_preserve_host
   # - $proxy_add_headers
   # - $no_proxy_uris
-  if $proxy_dest or $proxy_pass or $proxy_pass_match or $proxy_dest_match {
+  # - $proxy_pass_reverse
+  if $proxy_dest or $proxy_pass or $proxy_pass_match or $proxy_dest_match or $proxy_pass_reverse {
     concat::fragment { "${name}-proxy":
       target  => "${priority_real}${filename}.conf",
       order   => 160,

--- a/templates/vhost/_proxy.erb
+++ b/templates/vhost/_proxy.erb
@@ -18,6 +18,9 @@
 <% if @proxy_error_override -%>
   ProxyErrorOverride On
 <%- end -%>
+<%- [@proxy_pass_reverse].flatten.compact.each do |reverse_proxy| -%>
+  ProxyPassReverse <%= reverse_proxy['path'] %> <%= reverse_proxy['url'] %>
+<%- end -%>
 <%- [@proxy_pass].flatten.compact.each do |proxy| -%>
   <%- Array(proxy['no_proxy_uris']).each do |uri| -%>
   ProxyPass <%= uri %> !


### PR DESCRIPTION
The current version of Apache module (1.11.0) supports ProxyPassReverse directive only as part of ProxyPass or ProxyPassMatch configuration.

ProxyPassReverse directive can also be used in conjunction with the proxy feature (RewriteRule ... [P]) from mod_rewrite, without matching ProxyPass or ProxyPassMatch. This change allows managing ProxyPassReverse on its own by using proxy_pass_reverse parameter of apache::vhost.

https://tickets.puppetlabs.com/browse/MODULES-4247