### PR TITLE
[apache::mod::cgi] Fix: ordering constraint for mod_cgi

### DIFF
--- a/manifests/mod/cgi.pp
+++ b/manifests/mod/cgi.pp
@@ -2,7 +2,9 @@ class apache::mod::cgi {
   case $::osfamily {
     'FreeBSD': {}
     default: {
-      Class['::apache::mod::prefork'] -> Class['::apache::mod::cgi']
+      if $::apache::mpm_module =~ /^(itk|peruser|prefork)$/ {
+        Class["::apache::mod::${::apache::mpm_module}"] -> Class['::apache::mod::cgi']
+      }
     }
   }
 


### PR DESCRIPTION
`mod_cgi` is used on other MPM implementations than just `prefork`,
so we have to enforce resource ordering against these too.