### PR TITLE
Adds apache::mod::macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1595,6 +1595,7 @@ The following Apache modules have supported classes, many of which allow for par
 * `jk` (see [`apache::mod::jk`])
 * `ldap` (see [`apache::mod::ldap`][])
 * `lookup_identity`
+* `macro` (see [`apache:mod:macro`][])
 * `mime`
 * `mime_magic`\*
 * `negotiation`

--- a/manifests/mod/macro.pp
+++ b/manifests/mod/macro.pp
@@ -1,0 +1,4 @@
+class apache::mod::macro {
+  include ::apache
+  ::apache::mod { 'macro': }
+}


### PR DESCRIPTION
Adds `apache::mod::macro`.

https://httpd.apache.org/docs/trunk/mod/mod_macro.html