### PR TITLE
add parser function apache_pw_hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -5067,6 +5067,13 @@ Links the `activated_rules` from [`apache::mod::security`][] to the respective C
 
 The Apache module relies heavily on templates to enable the [`apache::vhost`][] and [`apache::mod`][] defined types. These templates are built based on [Facter][] facts specific to your operating system. Unless explicitly called out, most templates are not meant for configuration.
 
+### Functions
+#### apache_pw_hash
+Hashes a password in a format suitable for htpasswd files read by apache.
+
+Currently uses SHA-hashes, because although this format is considered insecure, its the
+most secure format supported by the most platforms.
+
 ## Limitations
 
 ### General

--- a/lib/puppet/parser/functions/apache_pw_hash.rb
+++ b/lib/puppet/parser/functions/apache_pw_hash.rb
@@ -1,0 +1,14 @@
+Puppet::Parser::Functions::newfunction(:apache_pw_hash, :type => :rvalue, :doc => <<-EOS
+Hashes a password in a format suitable for htpasswd files read by apache.
+
+Currently uses SHA-hashes, because although this format is considered insecure, its the
+most secure format supported by the most platforms.
+EOS
+) do |args|
+  raise(Puppet::ParseError, "apache_pw_hash() wrong number of arguments. Given: #{args.size} for 1)") if args.size != 1
+  raise(Puppet::ParseError, "apache_pw_hash(): first argument must be a string") unless args[0].is_a? String
+  raise(Puppet::ParseError, "apache_pw_hash(): first argument must not be empty") if args[0].empty?
+
+  password = args[0]
+  return '{SHA}' + Base64.strict_encode64(Digest::SHA1.digest(password))
+end

--- a/spec/unit/puppet/parser/functions/apache_pw_hash_spec.rb
+++ b/spec/unit/puppet/parser/functions/apache_pw_hash_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe "the apache_pw_hash function" do
+  let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
+
+  it "should exist" do
+    expect(Puppet::Parser::Functions.function("apache_pw_hash")).to eq("function_apache_pw_hash")
+  end
+
+  it "should raise a ParseError if there is less than 1 arguments" do
+    expect { scope.function_apache_pw_hash([]) }.to( raise_error(Puppet::ParseError))
+  end
+
+  it "should raise an Puppet::ParseError if argument is an empty string" do
+    expect { scope.function_apache_pw_hash(['']) }.to( raise_error(Puppet::ParseError))
+  end
+
+  context "when argument is not a string" do
+    it { expect { scope.function_apache_pw_hash([1]) }.to( raise_error(Puppet::ParseError)) }
+    it { expect { scope.function_apache_pw_hash([true]) }.to( raise_error(Puppet::ParseError)) }
+    it { expect { scope.function_apache_pw_hash([{}]) }.to( raise_error(Puppet::ParseError)) }
+    it { expect { scope.function_apache_pw_hash([[]]) }.to( raise_error(Puppet::ParseError)) }
+  end
+
+  it "should raise an Puppet::ParseError if argument is not a string" do
+    expect { scope.function_apache_pw_hash([1]) }.to( raise_error(Puppet::ParseError))
+  end
+
+  it "should return proper hash" do
+    expect(scope.function_apache_pw_hash(['test'])).to(eq('{SHA}qUqP5cyxm6YcTAhz05Hph5gvu9M='))
+  end
+end


### PR DESCRIPTION
This commit adds a new parser function apache_pw_hash, which
allows generating password hashes to be used in htpasswd files.