### PR TITLE
ensure csr_package is 'installed' instead of 'latest'

### DIFF
--- a/manifests/mod/security.pp
+++ b/manifests/mod/security.pp
@@ -53,7 +53,7 @@ class apache::mod::security (
 
   if $crs_package  {
     package { $crs_package:
-      ensure => 'latest',
+      ensure => 'installed',
       before => [
         File[$::apache::confd_dir],
         File[$modsec_dir],


### PR DESCRIPTION
mod/security.pp is the only module that ensures the package is `latest`. This change makes the behavior of `mod/security.pp` consistent.

Other modules ensure `present` or `installed`
- mod.pp = present
- mod/php.pp = present
- mod/mime.php = installed