### PR TITLE
MODULES-4391 add SSLProxyVerifyDepth and SSLProxyCACertificateFile directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -3800,6 +3800,14 @@ Sets the [SSLProxyProtocol](https://httpd.apache.org/docs/current/mod/mod_ssl.ht
 
 Sets the [SSLProxyVerify](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxyverify) directive, which configures certificate verification of the remote server when a proxy is configured to forward requests to a remote SSL server. Default: undef.
 
+##### `ssl_proxy_verify_depth`
+
+Sets the [SSLProxyVerifyDepth](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxyverifydepth) directive, which configures how deeply mod_ssl should verify before deciding that the remote server does not have a valid certificate. (A depth of 0 means that self-signed remote server certificates are accepted only, the default depth of 1 means the remote server certificate can be self-signed or has to be signed by a CA which is directly known to the server) Default: undef.
+
+##### `ssl_proxy_ca_cert`
+
+Sets the [SSLProxyCACertificateFile](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxycacertificatefile) directive, which specifies an all-in-one file where you can assemble the Certificates of Certification Authorities (CA) whose remote servers you deal with. These are used for Remote Server Authentication. This file should be a concatenation of the PEM-encoded certificate files in order of preference. Default: undef.
+
 ##### `ssl_proxy_machine_cert`
 
 Sets the [SSLProxyMachineCertificateFile](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxymachinecertificatefile) directive, which specifies an all-in-one file where you keep the certs and keys used for this server to authenticate itself to remote servers. This file should be a concatenation of the PEM-encoded certificate files in order of preference. Default: undef.

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -26,6 +26,8 @@ define apache::vhost(
   $ssl_verify_client           = undef,
   $ssl_verify_depth            = undef,
   $ssl_proxy_verify            = undef,
+  $ssl_proxy_verify_depth      = undef,
+  $ssl_proxy_ca_cert           = undef,
   $ssl_proxy_check_peer_cn     = undef,
   $ssl_proxy_check_peer_name   = undef,
   $ssl_proxy_check_peer_expire = undef,
@@ -292,6 +294,10 @@ define apache::vhost(
 
   if $ssl_proxy_verify {
     validate_re($ssl_proxy_verify,'^(none|optional|require|optional_no_ca)$',"${ssl_proxy_verify} is not permitted for ssl_proxy_verify. Allowed values are 'none', 'optional', 'require' or 'optional_no_ca'.")
+  }
+
+  if $ssl_proxy_verify_depth {
+    validate_integer($ssl_proxy_verify_depth)
   }
 
   if $ssl_proxy_check_peer_cn {
@@ -955,6 +961,8 @@ define apache::vhost(
   # Template uses:
   # - $ssl_proxyengine
   # - $ssl_proxy_verify
+  # - $ssl_proxy_verify_depth
+  # - $ssl_proxy_ca_cert
   # - $ssl_proxy_check_peer_cn
   # - $ssl_proxy_check_peer_name
   # - $ssl_proxy_check_peer_expire

--- a/templates/vhost/_sslproxy.erb
+++ b/templates/vhost/_sslproxy.erb
@@ -5,6 +5,12 @@
   <%- if @ssl_proxy_verify -%>
   SSLProxyVerify <%= @ssl_proxy_verify %>
   <%- end -%>
+  <%- if @ssl_proxy_verify_depth -%>
+  SSLProxyVerifyDepth <%= @ssl_proxy_verify_depth %>
+  <%- end -%>
+  <%- if @ssl_proxy_ca_cert -%>
+  SSLProxyCACertificateFile "<%= @ssl_proxy_ca_cert %>"
+  <%- end -%>
   <%- if @ssl_proxy_check_peer_cn -%>
   SSLProxyCheckPeerCN     <%= @ssl_proxy_check_peer_cn %>
   <%- end -%>


### PR DESCRIPTION
The SSLProxyVerifyDepth and SSLProxyCACertificateFile directives are missing and should be added to the vhost/_sslproxy.erb template.
https://httpd.apache.org/docs/2.4/mod/mod_ssl.html#sslproxyverifydepth
https://httpd.apache.org/docs/2.4/mod/mod_ssl.html#sslproxycacertificatefile

https://tickets.puppetlabs.com/browse/MODULES-4391