### PR TITLE
Modules-4500 Add optional "AdvertiseFrequency" directive in cluster.conf template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1606,6 +1606,7 @@ class { '::apache::mod::cluster':
 
 - `port`: mod_cluster listen port. Default: '6666'.
 - `server_advertise`: Whether the server should advertise. Default: true.
+- `advertise_frequency`: Interval between advertise messages in seconds[.miliseconds]. Default: 10.
 - `manager_allowed_network`: Network allowed to access the mod_cluster_manager. Default: '127.0.0.1'.
 - `keep_alive_timeout`: Keep-alive timeout. Default: 60.
 - `max_keep_alive_requests`: Max number of requests kept alive. Default: 0

--- a/manifests/mod/cluster.pp
+++ b/manifests/mod/cluster.pp
@@ -9,6 +9,7 @@ class apache::mod::cluster (
   $manager_allowed_network = '127.0.0.1',
   $max_keep_alive_requests = 0,
   $server_advertise = true,
+  $advertise_frequency = undef,
 ) {
 
   include ::apache

--- a/templates/mod/cluster.conf.erb
+++ b/templates/mod/cluster.conf.erb
@@ -12,6 +12,9 @@ Listen <%= @ip %>:<%= @port %>
 
   ManagerBalancerName <%= @balancer_name %>
   ServerAdvertise <%= scope.function_bool2httpd([@server_advertise]) %>
+  <%- if @server_advertise == true and @advertise_frequency != nil -%>
+  AdvertiseFrequency <%= advertise_frequency %>
+  <%- end -%>
 
   <Location /mod_cluster_manager>
     SetHandler mod_cluster-manager


### PR DESCRIPTION
If calling class defines `advertise_frequency`, and `server_advertise` is `true`, this change adds the directive `AdvertiseFrequency` in mod_cluster virtual host conf file template