### PR TITLE
Add param for AllowOverride in the userdir.conf template

### DIFF
--- a/manifests/mod/userdir.pp
+++ b/manifests/mod/userdir.pp
@@ -3,6 +3,7 @@ class apache::mod::userdir (
   $dir = 'public_html',
   $disable_root = true,
   $apache_version = undef,
+  $overrides = [ 'FileInfo', 'AuthConfig', 'Limit', 'Indexes' ],
   $options = [ 'MultiViews', 'Indexes', 'SymLinksIfOwnerMatch', 'IncludesNoExec' ],
 ) {
   include ::apache

--- a/templates/mod/userdir.conf.erb
+++ b/templates/mod/userdir.conf.erb
@@ -5,7 +5,7 @@
   UserDir <%= @home %>/*/<%= @dir %>
 
   <Directory "<%= @home %>/*/<%= @dir %>">
-    AllowOverride FileInfo AuthConfig Limit Indexes
+    AllowOverride <%= @overrides.join(' ') %>
     Options <%= @options.join(' ') %>
     <Limit GET POST OPTIONS>
       <%- if scope.function_versioncmp([@_apache_version, '2.4']) >= 0 -%>


### PR DESCRIPTION
#4516 Add param for AllowOverride values in userdir template

Add a param to the apache::mod::userdir class to accept an array of override value. Replace the hardcoded list in the userdir.conf.erb template with an array join, similar to the existing Options line. Use the previously hardcoded values as the default for the overrides param.

The AllowOverride directive values were previously hardcoded in the template.

https://tickets.puppetlabs.com/browse/MODULES-4516