### PR TITLE
MODULES-4737 - Additional class params for mod ssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1906,7 +1906,9 @@ Installs [Apache SSL features][`mod_ssl`] and uses the `ssl.conf.erb` template t
 - `ssl_options`: Default: [ 'StdEnvVars' ]
 - `ssl_pass_phrase_dialog`: Default: 'builtin'.
 - `ssl_protocol`: Default: [ 'all', '-SSLv2', '-SSLv3' ].
+- `ssl_proxy_protocol`: Default: [].
 - `ssl_random_seed_bytes`: Valid options: A string. Default: '512'.
+- `ssl_sessioncache`: Valid options: A string. Default: '300'.
 - `ssl_sessioncachetimeout`: Valid options: A string. Default: '300'.
 - `ssl_mutex`: Default: Determined based on the OS. Valid options: See [mod_ssl][mod_ssl] documentation.
   - RedHat/FreeBSD/Suse/Gentoo: 'default'

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -6,15 +6,17 @@ class apache::mod::ssl (
   $ssl_cipher                 = 'HIGH:MEDIUM:!aNULL:!MD5:!RC4',
   $ssl_honorcipherorder       = true,
   $ssl_protocol               = [ 'all', '-SSLv2', '-SSLv3' ],
+  $ssl_proxy_protocol         = [],
   $ssl_pass_phrase_dialog     = 'builtin',
   $ssl_random_seed_bytes      = '512',
+  $ssl_sessioncache           = $::apache::params::ssl_sessioncache,
   $ssl_sessioncachetimeout    = '300',
   $ssl_stapling               = false,
   $ssl_stapling_return_errors = undef,
   $ssl_mutex                  = undef,
   $apache_version             = undef,
   $package_name               = undef,
-) {
+) inherits ::apache::params {
   include ::apache
   include ::apache::mod::mime
   $_apache_version = pick($apache_version, $apache::apache_version)
@@ -51,6 +53,9 @@ class apache::mod::ssl (
 
   validate_bool($ssl_compression)
 
+  validate_array($ssl_proxy_protocol)
+  validate_string($ssl_sessioncache)
+
   if is_bool($ssl_honorcipherorder) {
     $_ssl_honorcipherorder = $ssl_honorcipherorder
   } else {
@@ -59,14 +64,6 @@ class apache::mod::ssl (
       'off'   => false,
       default => true,
     }
-  }
-
-  $session_cache = $::osfamily ? {
-    'debian'  => "\${APACHE_RUN_DIR}/ssl_scache(512000)",
-    'redhat'  => '/var/cache/mod_ssl/scache(512000)',
-    'freebsd' => '/var/run/ssl_scache(512000)',
-    'gentoo'  => '/var/run/ssl_scache(512000)',
-    'Suse'    => '/var/lib/apache2/ssl_scache(512000)'
   }
 
   validate_bool($ssl_stapling)
@@ -111,7 +108,7 @@ class apache::mod::ssl (
   # $ssl_honorcipherorder
   # $ssl_options
   # $ssl_openssl_conf_cmd
-  # $session_cache
+  # $ssl_sessioncache
   # $stapling_cache
   # $ssl_mutex
   # $ssl_random_seed_bytes

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -85,6 +85,7 @@ class apache::params inherits ::apache::version {
     $default_ssl_cert     = '/etc/pki/tls/certs/localhost.crt'
     $default_ssl_key      = '/etc/pki/tls/private/localhost.key'
     $ssl_certs_dir        = '/etc/pki/tls/certs'
+    $ssl_sessioncache     = '/var/cache/mod_ssl/scache(512000)'
     $passenger_conf_file  = 'passenger_extra.conf'
     $passenger_conf_package_file = 'passenger.conf'
     $passenger_root       = undef
@@ -221,6 +222,7 @@ class apache::params inherits ::apache::version {
     $default_ssl_cert    = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
     $default_ssl_key     = '/etc/ssl/private/ssl-cert-snakeoil.key'
     $ssl_certs_dir       = '/etc/ssl/certs'
+    $ssl_sessioncache    = "\${APACHE_RUN_DIR}/ssl_scache(512000)"
     $suphp_addhandler    = 'x-httpd-php'
     $suphp_engine        = 'off'
     $suphp_configpath    = '/etc/php5/apache2'
@@ -359,6 +361,7 @@ class apache::params inherits ::apache::version {
     $default_ssl_cert = '/usr/local/etc/apache24/server.crt'
     $default_ssl_key  = '/usr/local/etc/apache24/server.key'
     $ssl_certs_dir    = undef
+    $ssl_sessioncache  = '/var/run/ssl_scache(512000)'
     $passenger_conf_file = 'passenger.conf'
     $passenger_conf_package_file = undef
     $passenger_root   = '/usr/local/lib/ruby/gems/2.0/gems/passenger-4.0.58'
@@ -428,6 +431,7 @@ class apache::params inherits ::apache::version {
     $default_ssl_cert = '/etc/ssl/apache2/server.crt'
     $default_ssl_key  = '/etc/ssl/apache2/server.key'
     $ssl_certs_dir    = '/etc/ssl/apache2'
+    $ssl_sessioncache  = '/var/run/ssl_scache(512000)'
     $passenger_root   = '/usr'
     $passenger_ruby   = '/usr/bin/ruby'
     $passenger_conf_file = 'passenger.conf'
@@ -496,6 +500,7 @@ class apache::params inherits ::apache::version {
     $default_ssl_cert    = '/etc/apache2/ssl.crt/server.crt'
     $default_ssl_key     = '/etc/apache2/ssl.key/server.key'
     $ssl_certs_dir       = '/etc/ssl/certs'
+    $ssl_sessioncache    = '/var/lib/apache2/ssl_scache(512000)'
     $suphp_addhandler    = 'x-httpd-php'
     $suphp_engine        = 'off'
     $suphp_configpath    = '/etc/php5/apache2'

--- a/spec/classes/mod/ssl_spec.rb
+++ b/spec/classes/mod/ssl_spec.rb
@@ -42,6 +42,7 @@ describe 'apache::mod::ssl', :type => :class do
       it { is_expected.to contain_apache__mod('ssl') }
       it { is_expected.to contain_package('httpd24-mod_ssl') }
       it { is_expected.not_to contain_package('mod_ssl') }
+      it { is_expected.to contain_file('ssl.conf').with_content(%r{^  SSLSessionCache "shmcb:/var/cache/mod_ssl/scache\(512000\)"$})}
     end
   end
 
@@ -96,6 +97,7 @@ describe 'apache::mod::ssl', :type => :class do
     end
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('ssl') }
+    it { is_expected.to contain_file('ssl.conf').with_content(%r{^  SSLSessionCache "shmcb:/var/run/ssl_scache\(512000\)"$})}
   end
 
   context 'on a Suse OS' do
@@ -113,6 +115,7 @@ describe 'apache::mod::ssl', :type => :class do
     end
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('ssl') }
+    it { is_expected.to contain_file('ssl.conf').with_content(%r{^  SSLSessionCache "shmcb:/var/lib/apache2/ssl_scache\(512000\)"$})}
   end
   # Template config doesn't vary by distro
   context "on all distros" do
@@ -233,6 +236,22 @@ describe 'apache::mod::ssl', :type => :class do
         }
       end
       it { is_expected.to contain_file('ssl.conf').with_content(%r{^  SSLMutex posixsem$})}
+    end
+    context 'setting ssl_sessioncache' do
+      let :params do
+        {
+          :ssl_sessioncache => '/tmp/customsessioncache(51200)',
+        }
+      end
+      it { is_expected.to contain_file('ssl.conf').with_content(%r{^  SSLSessionCache "shmcb:/tmp/customsessioncache\(51200\)"$})}
+    end
+    context 'setting ssl_proxy_protocol' do
+      let :params do
+        {
+          :ssl_proxy_protocol => [ '-ALL', '+TLSv1'],
+        }
+      end
+      it { is_expected.to contain_file('ssl.conf').with_content(%r{^  SSLProxyProtocol -ALL \+TLSv1$})}
     end
   end
 end

--- a/templates/mod/ssl.conf.erb
+++ b/templates/mod/ssl.conf.erb
@@ -8,7 +8,7 @@
   AddType application/x-pkcs7-crl    .crl
 
   SSLPassPhraseDialog <%= @ssl_pass_phrase_dialog %>
-  SSLSessionCache "shmcb:<%= @session_cache %>"
+  SSLSessionCache "shmcb:<%= @ssl_sessioncache %>"
   SSLSessionCacheTimeout <%= @ssl_sessioncachetimeout %>
   <%- if scope.function_versioncmp([@_apache_version, '2.4']) >= 0 -%>
   Mutex <%= @_ssl_mutex %>
@@ -29,6 +29,9 @@
 <% end -%>
   SSLCipherSuite <%= @ssl_cipher %>
   SSLProtocol <%= @ssl_protocol.compact.join(' ') %>
+<% if not @ssl_proxy_protocol.empty? -%>
+  SSLProxyProtocol <%= @ssl_proxy_protocol.compact.join(' ') %>
+<% end -%>
 <% if @ssl_options -%>
   SSLOptions <%= @ssl_options.compact.join(' ') %>
 <% end -%>


### PR DESCRIPTION
Here is the PR related to [MODULES-4737](https://tickets.puppetlabs.com/browse/MODULES-4737)

- ssl_sessioncache which defaults to OS specific value in params.pp
- ssl_proxy_protocol which defaults to an empty array which means using
  Apache defaults (see [Apache doc]( https://httpd.apache.org/docs/current/en/mod/mod_ssl.html#sslproxyprotocol) for more details)