### PR TITLE
Enable configuring CA file in ssl.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1202,6 +1202,10 @@ Determines whether Puppet manages the HTTPD service's state. Valid options: Bool
 
 Determines whether Puppet should use a specific command to restart the HTTPD service. Valid options: a command to restart the Apache service. Default: undef, which uses the [default Puppet behavior][Service attribute restart].
 
+##### `ssl_ca`
+
+Specifies the SSL certificate authority. [SSLCACertificateFile](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcacertificatefile). Default: undef. It is possible to override this on a vhost level.
+
 ##### `ssl_stapling`
 
 Specifies whether or not to use [SSLUseStapling](http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslusestapling). Valid options: Boolean. Default: false. It is possible to override this on a vhost level.

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -3,6 +3,7 @@ class apache::mod::ssl (
   $ssl_cryptodevice           = 'builtin',
   $ssl_options                = [ 'StdEnvVars' ],
   $ssl_openssl_conf_cmd       = undef,
+  $ssl_ca                     = undef,
   $ssl_cipher                 = 'HIGH:MEDIUM:!aNULL:!MD5:!RC4',
   $ssl_honorcipherorder       = true,
   $ssl_protocol               = [ 'all', '-SSLv2', '-SSLv3' ],
@@ -104,6 +105,7 @@ class apache::mod::ssl (
   #
   # $ssl_compression
   # $ssl_cryptodevice
+  # $ssl_ca
   # $ssl_cipher
   # $ssl_honorcipherorder
   # $ssl_options

--- a/spec/classes/mod/ssl_spec.rb
+++ b/spec/classes/mod/ssl_spec.rb
@@ -136,6 +136,14 @@ describe 'apache::mod::ssl', :type => :class do
       it { is_expected.to contain_file('ssl.conf').with_content(/^  SSLPassPhraseDialog builtin$/)}
     end
 
+    context 'setting ssl_ca to a path' do
+      let :params do
+        {
+            :ssl_ca => '/etc/pki/some/path/ca.crt',
+        }
+      end
+      it { is_expected.to contain_file('ssl.conf').with_content(/^  SSLCACertificateFile/)}
+    end
     context "with Apache version < 2.4" do
       let :params do
         {

--- a/templates/mod/ssl.conf.erb
+++ b/templates/mod/ssl.conf.erb
@@ -20,6 +20,9 @@
   <%- end -%>
   SSLCryptoDevice <%= @ssl_cryptodevice %>
   SSLHonorCipherOrder <%= scope.function_bool2httpd([@_ssl_honorcipherorder]) %>
+  <%- if @ssl_ca -%>
+  SSLCACertificateFile    "<%= @ssl_ca %>"
+  <%- end -%>
 <% if scope.function_versioncmp([@_apache_version, '2.4']) >= 0 -%>
   SSLUseStapling <%= scope.function_bool2httpd([@ssl_stapling]) %>
   <%- if not @ssl_stapling_return_errors.nil? -%>


### PR DESCRIPTION
Instead of having to specify a CA file for each vhost, it's possible to
just specify it globally.