### PR TITLE
fixed apache group for SUSE/SLES Systems (checked for SLES11/12)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -477,7 +477,7 @@ class apache::params inherits ::apache::version {
     $access_log_file      = 'access.log'
   } elsif $::osfamily == 'Suse' {
     $user                = 'wwwrun'
-    $group               = 'wwwrun'
+    $group               = 'www'
     $root_group          = 'root'
     $apache_name         = 'apache2'
     $service_name        = 'apache2'


### PR DESCRIPTION
I checked SLES11 and SLES12 (and openSUSE 42.2) and the group for apache is "www" instead of "wwwrun" on all SUSE systems.

The user is wwwrun and the group www
`$ id wwwrun`
`uid=30(wwwrun) gid=8(www) groups=8(www)`