### PR TITLE
MODULES-4816 - new param for mod::security class

### DIFF
--- a/README.md
+++ b/README.md
@@ -1948,6 +1948,7 @@ Installs and configures Trustwave's [`mod_security`][]. It is enabled and runs b
 - `allowed_methods`: A space-separated list of allowed HTTP methods. Default: 'GET HEAD POST OPTIONS'.
 - `content_types`: A list of one or more allowed [MIME types][MIME `content-type`]. Default: 'application/x-www-form-urlencoded|multipart/form-data|text/xml|application/xml|application/x-amf'
 - `crs_package`: Names the package that installs CRS rules. Default: `modsec_crs_package` in [`apache::params`][].
+- `manage_security_crs` : Manage security_crs.conf rules file. Default: `true`.
 - `modsec_dir`: Defines the path where Puppet installs the modsec configuration and activated rules links. Default: 'On', set by `modsec_dir` in [`apache::params`][].
 ${modsec\_dir}/activated\_rules.
 - `modsec_secruleengine`: Configures the modsec rules engine. Valid options: 'On', 'Off', and 'DetectionOnly'. Default: `modsec_secruleengine` in [`apache::params`][].

--- a/manifests/mod/security.pp
+++ b/manifests/mod/security.pp
@@ -24,6 +24,7 @@ class apache::mod::security (
   $secrequestbodylimit         = '13107200',
   $secrequestbodynofileslimit  = '131072',
   $secrequestbodyinmemorylimit = '131072',
+  $manage_security_crs         = true,
 ) inherits ::apache::params {
   include ::apache
 
@@ -104,25 +105,27 @@ class apache::mod::security (
     notify  => Class['apache::service'],
   }
 
-  # Template uses:
-  # - $_secdefaultaction
-  # - $critical_anomaly_score
-  # - $error_anomaly_score
-  # - $warning_anomaly_score
-  # - $notice_anomaly_score
-  # - $inbound_anomaly_threshold
-  # - $outbound_anomaly_threshold
-  # - $anomaly_score_blocking
-  # - $allowed_methods
-  # - $content_types
-  # - $restricted_extensions
-  # - $restricted_headers
-  # - $secrequestmaxnumargs
-  file { "${modsec_dir}/security_crs.conf":
-    ensure  => file,
-    content => template('apache/mod/security_crs.conf.erb'),
-    require => File[$modsec_dir],
-    notify  => Class['apache::service'],
+  if $manage_security_crs {
+    # Template uses:
+    # - $_secdefaultaction
+    # - $critical_anomaly_score
+    # - $error_anomaly_score
+    # - $warning_anomaly_score
+    # - $notice_anomaly_score
+    # - $inbound_anomaly_threshold
+    # - $outbound_anomaly_threshold
+    # - $anomaly_score_blocking
+    # - $allowed_methods
+    # - $content_types
+    # - $restricted_extensions
+    # - $restricted_headers
+    # - $secrequestmaxnumargs
+    file { "${modsec_dir}/security_crs.conf":
+      ensure  => file,
+      content => template('apache/mod/security_crs.conf.erb'),
+      require => File[$modsec_dir],
+      notify  => Class['apache::service'],
+    }
   }
 
   unless $::operatingsystem == 'SLES' { apache::security::rule_link { $activated_rules: } }

--- a/spec/classes/mod/security_spec.rb
+++ b/spec/classes/mod/security_spec.rb
@@ -75,8 +75,15 @@ describe 'apache::mod::security', :type => :class do
         :target => '/tmp/foo/bar.conf',
       ) }
     end
+    describe 'with other modsec parameters' do
+      let :params do
+        {
+          :manage_security_crs => false
+        }
+      end
+      it { should_not contain_file('/etc/httpd/modsecurity.d/security_crs.conf') }
+    end
   end
-
   context "on Debian based systems" do
     let :facts do
       {


### PR DESCRIPTION
- New param `$deploy_security_crs` set to true by default so the default
  behaviour is unchanged.
- new rspec example so that the parameter is spec-tested