### PR TITLE
MODULES-4882 - Include missing "@" in template mod/cluster.conf.erb

### DIFF
--- a/templates/mod/cluster.conf.erb
+++ b/templates/mod/cluster.conf.erb
@@ -13,7 +13,7 @@ Listen <%= @ip %>:<%= @port %>
   ManagerBalancerName <%= @balancer_name %>
   ServerAdvertise <%= scope.function_bool2httpd([@server_advertise]) %>
   <%- if @server_advertise == true and @advertise_frequency != nil -%>
-  AdvertiseFrequency <%= advertise_frequency %>
+  AdvertiseFrequency <%= @advertise_frequency %>
   <%- end -%>
 
   <Location /mod_cluster_manager>


### PR DESCRIPTION
Corrects bad syntax included in [PR #1601](https://github.com/puppetlabs/puppetlabs-apache/pull/1601)