### PR TITLE
Explicitly disabled 3DES due to Sweet32 attack.

### DIFF
--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -4,7 +4,7 @@ class apache::mod::ssl (
   $ssl_options                = [ 'StdEnvVars' ],
   $ssl_openssl_conf_cmd       = undef,
   $ssl_ca                     = undef,
-  $ssl_cipher                 = 'HIGH:MEDIUM:!aNULL:!MD5:!RC4',
+  $ssl_cipher                 = 'HIGH:MEDIUM:!aNULL:!MD5:!RC4:!3DES',
   $ssl_honorcipherorder       = true,
   $ssl_protocol               = [ 'all', '-SSLv2', '-SSLv3' ],
   $ssl_proxy_protocol         = [],


### PR DESCRIPTION
https://sweet32.info/

The Sweet32 attack exploits DES or 3DES. 3DES is currently part of the "HIGH" cipher suite. This cipher suite is a default setting in the apache::mod::ssl , leaving any server using the default settings vulnerable. 

Fix: 
Change https://github.com/puppetlabs/puppetlabs-apache/blob/master/manifests/mod/ssl.pp#L7
Currently: 'HIGH:MEDIUM:!aNULL:!MD5:!RC4'
Should be: 'HIGH:MEDIUM:!aNULL:!MD5:!RC4:!3DES'

Note: Per https://httpd.apache.org/docs/2.4/mod/mod_ssl.html#sslciphersuite, DES (single DES) is not part of HIGH or MEDIUM, therefor is not enabled with the default settings from the module.