### PR TITLE
Migrate to puppet4 datatypes

### DIFF
--- a/manifests/custom_config.pp
+++ b/manifests/custom_config.pp
@@ -1,13 +1,13 @@
 # See README.md for usage information
 define apache::custom_config (
-  $ensure         = 'present',
-  $confdir        = $::apache::confd_dir,
-  $content        = undef,
-  $priority       = '25',
-  $source         = undef,
-  $verify_command = $::apache::params::verify_command,
-  $verify_config  = true,
-  $filename       = undef,
+  Enum['absent', 'present'] $ensure = 'present',
+  $confdir                          = $::apache::confd_dir,
+  $content                          = undef,
+  $priority                         = '25',
+  $source                           = undef,
+  $verify_command                   = $::apache::params::verify_command,
+  Boolean $verify_config            = true,
+  $filename                         = undef,
 ) {
 
   if $content and $source {
@@ -17,12 +17,6 @@ define apache::custom_config (
   if $ensure == 'present' and ! $content and ! $source {
     fail('One of $content and $source must be specified.')
   }
-
-  validate_re($ensure, '^(present|absent)$',
-  "${ensure} is not supported for ensure.
-  Allowed values are 'present' and 'absent'.")
-
-  validate_bool($verify_config)
 
   if $filename {
     $_filename = $filename

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -113,7 +113,7 @@ class apache (
   }
 
   if $mpm_module and $mpm_module != 'false' { # lint:ignore:quoted_booleans
-    validate_re($mpm_module, $valid_mpms_re)
+    assert_type(Pattern[$valid_mpms_re], $mpm_module)
   }
 
   # NOTE: on FreeBSD it's mpm module's responsibility to install httpd package.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,91 +13,83 @@
 # Sample Usage:
 #
 class apache (
-  $apache_name            = $::apache::params::apache_name,
-  $service_name           = $::apache::params::service_name,
-  $default_mods           = true,
-  $default_vhost          = true,
-  $default_charset        = undef,
-  $default_confd_files    = true,
-  $default_ssl_vhost      = false,
-  $default_ssl_cert       = $::apache::params::default_ssl_cert,
-  $default_ssl_key        = $::apache::params::default_ssl_key,
-  $default_ssl_chain      = undef,
-  $default_ssl_ca         = undef,
-  $default_ssl_crl_path   = undef,
-  $default_ssl_crl        = undef,
-  $default_ssl_crl_check  = undef,
-  $default_type           = 'none',
-  $dev_packages           = $::apache::params::dev_packages,
-  $ip                     = undef,
-  $service_enable         = true,
-  $service_manage         = true,
-  $service_ensure         = 'running',
-  $service_restart        = undef,
-  $purge_configs          = true,
-  $purge_vhost_dir        = undef,
-  $purge_vdir             = false,
-  $serveradmin            = 'root@localhost',
-  $sendfile               = 'On',
-  $error_documents        = false,
-  $timeout                = '120',
-  $httpd_dir              = $::apache::params::httpd_dir,
-  $server_root            = $::apache::params::server_root,
-  $conf_dir               = $::apache::params::conf_dir,
-  $confd_dir              = $::apache::params::confd_dir,
-  $vhost_dir              = $::apache::params::vhost_dir,
-  $vhost_enable_dir       = $::apache::params::vhost_enable_dir,
-  $vhost_include_pattern  = $::apache::params::vhost_include_pattern,
-  $mod_dir                = $::apache::params::mod_dir,
-  $mod_enable_dir         = $::apache::params::mod_enable_dir,
-  $mpm_module             = $::apache::params::mpm_module,
-  $lib_path               = $::apache::params::lib_path,
-  $conf_template          = $::apache::params::conf_template,
-  $servername             = $::apache::params::servername,
-  $pidfile                = $::apache::params::pidfile,
-  $rewrite_lock           = undef,
-  $manage_user            = true,
-  $manage_group           = true,
-  $user                   = $::apache::params::user,
-  $group                  = $::apache::params::group,
-  $http_protocol_options  = $::apache::params::http_protocol_options,
-  $supplementary_groups   = [],
-  $keepalive              = $::apache::params::keepalive,
-  $keepalive_timeout      = $::apache::params::keepalive_timeout,
-  $max_keepalive_requests = $::apache::params::max_keepalive_requests,
-  $limitreqfieldsize      = '8190',
-  $logroot                = $::apache::params::logroot,
-  $logroot_mode           = $::apache::params::logroot_mode,
-  $log_level              = $::apache::params::log_level,
-  $log_formats            = {},
-  $ssl_file               = undef,
-  $ports_file             = $::apache::params::ports_file,
-  $docroot                = $::apache::params::docroot,
-  $apache_version         = $::apache::version::default,
-  $server_tokens          = 'OS',
-  $server_signature       = 'On',
-  $trace_enable           = 'On',
-  $allow_encoded_slashes  = undef,
-  $file_e_tag             = undef,
-  $package_ensure         = 'installed',
-  $use_optional_includes  = $::apache::params::use_optional_includes,
-  $use_systemd            = $::apache::params::use_systemd,
-  $mime_types_additional  = $::apache::params::mime_types_additional,
-  $file_mode              = $::apache::params::file_mode,
-  $root_directory_options = $::apache::params::root_directory_options,
-  $root_directory_secured = false,
-  $error_log              = $::apache::params::error_log,
-  $scriptalias            = $::apache::params::scriptalias,
-  $access_log_file        = $::apache::params::access_log_file,
+  $apache_name                                                   = $::apache::params::apache_name,
+  $service_name                                                  = $::apache::params::service_name,
+  $default_mods                                                  = true,
+  Boolean $default_vhost                                         = true,
+  $default_charset                                               = undef,
+  Boolean $default_confd_files                                   = true,
+  Boolean $default_ssl_vhost                                     = false,
+  $default_ssl_cert                                              = $::apache::params::default_ssl_cert,
+  $default_ssl_key                                               = $::apache::params::default_ssl_key,
+  $default_ssl_chain                                             = undef,
+  $default_ssl_ca                                                = undef,
+  $default_ssl_crl_path                                          = undef,
+  $default_ssl_crl                                               = undef,
+  $default_ssl_crl_check                                         = undef,
+  $default_type                                                  = 'none',
+  $dev_packages                                                  = $::apache::params::dev_packages,
+  $ip                                                            = undef,
+  Boolean $service_enable                                        = true,
+  Boolean $service_manage                                        = true,
+  $service_ensure                                                = 'running',
+  $service_restart                                               = undef,
+  $purge_configs                                                 = true,
+  $purge_vhost_dir                                               = undef,
+  $purge_vdir                                                    = false,
+  $serveradmin                                                   = 'root@localhost',
+  $sendfile                                                      = 'On',
+  $error_documents                                               = false,
+  $timeout                                                       = '120',
+  $httpd_dir                                                     = $::apache::params::httpd_dir,
+  $server_root                                                   = $::apache::params::server_root,
+  $conf_dir                                                      = $::apache::params::conf_dir,
+  $confd_dir                                                     = $::apache::params::confd_dir,
+  $vhost_dir                                                     = $::apache::params::vhost_dir,
+  $vhost_enable_dir                                              = $::apache::params::vhost_enable_dir,
+  $vhost_include_pattern                                         = $::apache::params::vhost_include_pattern,
+  $mod_dir                                                       = $::apache::params::mod_dir,
+  $mod_enable_dir                                                = $::apache::params::mod_enable_dir,
+  $mpm_module                                                    = $::apache::params::mpm_module,
+  $lib_path                                                      = $::apache::params::lib_path,
+  $conf_template                                                 = $::apache::params::conf_template,
+  $servername                                                    = $::apache::params::servername,
+  $pidfile                                                       = $::apache::params::pidfile,
+  Optional[Stdlib::Absolutepath] $rewrite_lock                   = undef,
+  Boolean $manage_user                                           = true,
+  Boolean $manage_group                                          = true,
+  $user                                                          = $::apache::params::user,
+  $group                                                         = $::apache::params::group,
+  $http_protocol_options                                         = $::apache::params::http_protocol_options,
+  $supplementary_groups                                          = [],
+  $keepalive                                                     = $::apache::params::keepalive,
+  $keepalive_timeout                                             = $::apache::params::keepalive_timeout,
+  $max_keepalive_requests                                        = $::apache::params::max_keepalive_requests,
+  $limitreqfieldsize                                             = '8190',
+  $logroot                                                       = $::apache::params::logroot,
+  $logroot_mode                                                  = $::apache::params::logroot_mode,
+  $log_level                                                     = $::apache::params::log_level,
+  $log_formats                                                   = {},
+  $ssl_file                                                      = undef,
+  $ports_file                                                    = $::apache::params::ports_file,
+  $docroot                                                       = $::apache::params::docroot,
+  $apache_version                                                = $::apache::version::default,
+  $server_tokens                                                 = 'OS',
+  $server_signature                                              = 'On',
+  $trace_enable                                                  = 'On',
+  Optional[Enum['on', 'off', 'nodecode']] $allow_encoded_slashes = undef,
+  $file_e_tag                                                    = undef,
+  $package_ensure                                                = 'installed',
+  Boolean $use_optional_includes                                 = $::apache::params::use_optional_includes,
+  $use_systemd                                                   = $::apache::params::use_systemd,
+  $mime_types_additional                                         = $::apache::params::mime_types_additional,
+  $file_mode                                                     = $::apache::params::file_mode,
+  $root_directory_options                                        = $::apache::params::root_directory_options,
+  Boolean $root_directory_secured                                = false,
+  $error_log                                                     = $::apache::params::error_log,
+  $scriptalias                                                   = $::apache::params::scriptalias,
+  $access_log_file                                               = $::apache::params::access_log_file,
 ) inherits ::apache::params {
-  validate_bool($default_vhost)
-  validate_bool($default_ssl_vhost)
-  validate_bool($default_confd_files)
-  # true/false is sufficient for both ensure and enable
-  validate_bool($service_enable)
-  validate_bool($service_manage)
-  validate_bool($use_optional_includes)
-  validate_bool($root_directory_secured)
 
   $valid_mpms_re = $apache_version ? {
     '2.4'   => '(event|itk|peruser|prefork|worker)',
@@ -124,10 +116,6 @@ class apache (
     validate_re($mpm_module, $valid_mpms_re)
   }
 
-  if $allow_encoded_slashes {
-    validate_re($allow_encoded_slashes, '(^on$|^off$|^nodecode$)', "${allow_encoded_slashes} is not permitted for allow_encoded_slashes. Allowed values are 'on', 'off' or 'nodecode'.")
-  }
-
   # NOTE: on FreeBSD it's mpm module's responsibility to install httpd package.
   # NOTE: the same strategy may be introduced for other OSes. For this, you
   # should delete the 'if' block below and modify all MPM modules' manifests
@@ -144,7 +132,6 @@ class apache (
 
   # declare the web server user and group
   # Note: requiring the package means the package ought to create them and not puppet
-  validate_bool($manage_user)
   if $manage_user {
     user { $user:
       ensure  => present,
@@ -153,7 +140,6 @@ class apache (
       require => Package['httpd'],
     }
   }
-  validate_bool($manage_group)
   if $manage_group {
     group { $group:
       ensure  => present,
@@ -314,10 +300,6 @@ class apache (
     $apxs_workaround = $::osfamily ? {
       'freebsd' => true,
       default   => false
-    }
-
-    if $rewrite_lock {
-      validate_absolute_path($rewrite_lock)
     }
 
     # Template uses:

--- a/manifests/mod/auth_cas.pp
+++ b/manifests/mod/auth_cas.pp
@@ -1,7 +1,7 @@
 class apache::mod::auth_cas (
-  $cas_login_url,
-  $cas_validate_url,
-  $cas_cookie_path           = $::apache::params::cas_cookie_path,
+  String $cas_login_url,
+  String $cas_validate_url,
+  String $cas_cookie_path    = $::apache::params::cas_cookie_path,
   $cas_cookie_path_mode      = '0750',
   $cas_version               = 2,
   $cas_debug                 = 'Off',
@@ -24,8 +24,6 @@ class apache::mod::auth_cas (
   $cas_scrub_request_headers = undef,
   $suppress_warning          = false,
 ) inherits ::apache::params {
-
-  validate_string($cas_login_url, $cas_validate_url, $cas_cookie_path)
 
   if $::osfamily == 'RedHat' and ! $suppress_warning {
     warning('RedHat distributions do not have Apache mod_auth_cas in their default package repositories.')

--- a/manifests/mod/authnz_ldap.pp
+++ b/manifests/mod/authnz_ldap.pp
@@ -18,8 +18,6 @@ class apache::mod::authnz_ldap (
     $_verify_server_cert = $verify_server_cert
   }
 
-  validate_bool($_verify_server_cert)
-
   # Template uses:
   # - $_verify_server_cert
   file { 'authnz_ldap.conf':

--- a/manifests/mod/authnz_ldap.pp
+++ b/manifests/mod/authnz_ldap.pp
@@ -1,9 +1,10 @@
 # lint:ignore:variable_is_lowercase required for compatibility
 class apache::mod::authnz_ldap (
-  $verify_server_cert = true,
-  $verifyServerCert   = undef,
-  $package_name       = undef,
+  Boolean $verify_server_cert = true,
+  $verifyServerCert           = undef,
+  $package_name               = undef,
 ) {
+
   include ::apache
   include '::apache::mod::ldap'
   ::apache::mod { 'authnz_ldap':

--- a/manifests/mod/dir.pp
+++ b/manifests/mod/dir.pp
@@ -2,10 +2,10 @@
 # Parameters:
 # - $indexes provides a string for the DirectoryIndex directive http://httpd.apache.org/docs/current/mod/mod_dir.html#directoryindex
 class apache::mod::dir (
-  $dir     = 'public_html',
-  $indexes = ['index.html','index.html.var','index.cgi','index.pl','index.php','index.xhtml'],
+  $dir                   = 'public_html',
+  Array[String] $indexes = ['index.html','index.html.var','index.cgi','index.pl','index.php','index.xhtml'],
 ) {
-  validate_array($indexes)
+
   include ::apache
   ::apache::mod { 'dir': }
 

--- a/manifests/mod/dumpio.pp
+++ b/manifests/mod/dumpio.pp
@@ -1,10 +1,8 @@
 class apache::mod::dumpio(
-  $dump_io_input  = 'Off',
-  $dump_io_output = 'Off',
+  Enum['Off', 'On', 'off', 'on'] $dump_io_input  = 'Off',
+  Enum['Off', 'On', 'off', 'on'] $dump_io_output = 'Off',
 ) {
   include ::apache
-  validate_re(downcase($dump_io_input), '^(on|off)$', "${dump_io_input} is not supported for dump_io_input.  Allowed values are 'On' and 'Off'.")
-  validate_re(downcase($dump_io_output), '^(on|off)$', "${dump_io_output} is not supported for dump_io_output.  Allowed values are 'On' and 'Off'.")
 
   ::apache::mod { 'dumpio': }
   file{'dumpio.conf':

--- a/manifests/mod/ext_filter.pp
+++ b/manifests/mod/ext_filter.pp
@@ -1,10 +1,7 @@
 class apache::mod::ext_filter(
-  $ext_filter_define = undef
+  Optional[Hash] $ext_filter_define = undef
 ) {
   include ::apache
-  if $ext_filter_define {
-    validate_hash($ext_filter_define)
-  }
 
   ::apache::mod { 'ext_filter': }
 

--- a/manifests/mod/ldap.pp
+++ b/manifests/mod/ldap.pp
@@ -1,19 +1,17 @@
 class apache::mod::ldap (
-  $apache_version                = undef,
-  $package_name                  = undef,
-  $ldap_trusted_global_cert_file = undef,
-  $ldap_trusted_global_cert_type = 'CA_BASE64',
-  $ldap_shared_cache_size        = undef,
-  $ldap_cache_entries            = undef,
-  $ldap_cache_ttl                = undef,
-  $ldap_opcache_entries          = undef,
-  $ldap_opcache_ttl              = undef,
+  $apache_version                                  = undef,
+  $package_name                                    = undef,
+  $ldap_trusted_global_cert_file                   = undef,
+  Optional[String] $ldap_trusted_global_cert_type  = 'CA_BASE64',
+  $ldap_shared_cache_size                          = undef,
+  $ldap_cache_entries                              = undef,
+  $ldap_cache_ttl                                  = undef,
+  $ldap_opcache_entries                            = undef,
+  $ldap_opcache_ttl                                = undef,
 ){
+
   include ::apache
   $_apache_version = pick($apache_version, $apache::apache_version)
-  if ($ldap_trusted_global_cert_file) {
-    validate_string($ldap_trusted_global_cert_type)
-  }
   ::apache::mod { 'ldap':
     package => $package_name,
   }

--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -1,39 +1,37 @@
 class apache::mod::passenger (
-  $passenger_conf_file              = $::apache::params::passenger_conf_file,
-  $passenger_conf_package_file      = $::apache::params::passenger_conf_package_file,
-  $passenger_high_performance       = undef,
-  $passenger_pool_idle_time         = undef,
-  $passenger_max_request_queue_size = undef,
-  $passenger_max_requests           = undef,
-  $passenger_spawn_method           = undef,
-  $passenger_stat_throttle_rate     = undef,
-  $rack_autodetect                  = undef,
-  $rails_autodetect                 = undef,
-  $passenger_root                   = $::apache::params::passenger_root,
-  $passenger_ruby                   = $::apache::params::passenger_ruby,
-  $passenger_default_ruby           = $::apache::params::passenger_default_ruby,
-  $passenger_max_pool_size          = undef,
-  $passenger_min_instances          = undef,
-  $passenger_max_instances_per_app  = undef,
-  $passenger_use_global_queue       = undef,
-  $passenger_app_env                = undef,
-  $passenger_log_file               = undef,
-  $passenger_log_level              = undef,
-  $passenger_data_buffer_dir        = undef,
-  $manage_repo                      = true,
-  $mod_package                      = undef,
-  $mod_package_ensure               = undef,
-  $mod_lib                          = undef,
-  $mod_lib_path                     = undef,
-  $mod_id                           = undef,
-  $mod_path                         = undef,
+  $passenger_conf_file                                                                   = $::apache::params::passenger_conf_file,
+  $passenger_conf_package_file                                                           = $::apache::params::passenger_conf_package_file,
+  $passenger_high_performance                                                            = undef,
+  $passenger_pool_idle_time                                                              = undef,
+  $passenger_max_request_queue_size                                                      = undef,
+  $passenger_max_requests                                                                = undef,
+  Optional[Enum['smart', 'direct', 'smart-lv2', 'conservative']] $passenger_spawn_method = undef,
+  $passenger_stat_throttle_rate                                                          = undef,
+  $rack_autodetect                                                                       = undef,
+  $rails_autodetect                                                                      = undef,
+  $passenger_root                                                                        = $::apache::params::passenger_root,
+  $passenger_ruby                                                                        = $::apache::params::passenger_ruby,
+  $passenger_default_ruby                                                                = $::apache::params::passenger_default_ruby,
+  $passenger_max_pool_size                                                               = undef,
+  $passenger_min_instances                                                               = undef,
+  $passenger_max_instances_per_app                                                       = undef,
+  $passenger_use_global_queue                                                            = undef,
+  $passenger_app_env                                                                     = undef,
+  Optional[Stdlib::Absoluteppath] $passenger_log_file                                    = undef,
+  $passenger_log_level                                                                   = undef,
+  $passenger_data_buffer_dir                                                             = undef,
+  $manage_repo                                                                           = true,
+  $mod_package                                                                           = undef,
+  $mod_package_ensure                                                                    = undef,
+  $mod_lib                                                                               = undef,
+  $mod_lib_path                                                                          = undef,
+  $mod_id                                                                                = undef,
+  $mod_path                                                                              = undef,
 ) inherits ::apache::params {
+
   include ::apache
   if $passenger_spawn_method {
     validate_re($passenger_spawn_method, '(^smart$|^direct$|^smart-lv2$|^conservative$)', "${passenger_spawn_method} is not permitted for passenger_spawn_method. Allowed values are 'smart', 'direct', 'smart-lv2', or 'conservative'.")
-  }
-  if $passenger_log_file {
-    validate_absolute_path($passenger_log_file)
   }
 
   # Managed by the package, but declare it to avoid purging

--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -17,7 +17,7 @@ class apache::mod::passenger (
   $passenger_max_instances_per_app                                                       = undef,
   $passenger_use_global_queue                                                            = undef,
   $passenger_app_env                                                                     = undef,
-  Optional[Stdlib::Absoluteppath] $passenger_log_file                                    = undef,
+  Optional[Stdlib::Absolutepath] $passenger_log_file                                     = undef,
   $passenger_log_level                                                                   = undef,
   $passenger_data_buffer_dir                                                             = undef,
   $manage_repo                                                                           = true,
@@ -30,9 +30,6 @@ class apache::mod::passenger (
 ) inherits ::apache::params {
 
   include ::apache
-  if $passenger_spawn_method {
-    validate_re($passenger_spawn_method, '(^smart$|^direct$|^smart-lv2$|^conservative$)', "${passenger_spawn_method} is not permitted for passenger_spawn_method. Allowed values are 'smart', 'direct', 'smart-lv2', or 'conservative'.")
-  }
 
   # Managed by the package, but declare it to avoid purging
   if $passenger_conf_package_file {

--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -1,14 +1,15 @@
 class apache::mod::php (
-  $package_name   = undef,
-  $package_ensure = 'present',
-  $path           = undef,
-  $extensions     = ['.php'],
-  $content        = undef,
-  $template       = 'apache/mod/php.conf.erb',
-  $source         = undef,
-  $root_group     = $::apache::params::root_group,
-  $php_version    = $::apache::params::php_version,
+  $package_name     = undef,
+  $package_ensure   = 'present',
+  $path             = undef,
+  Array $extensions = ['.php'],
+  $content          = undef,
+  $template         = 'apache/mod/php.conf.erb',
+  $source           = undef,
+  $root_group       = $::apache::params::root_group,
+  $php_version      = $::apache::params::php_version,
 ) inherits apache::params {
+
   include ::apache
   $mod = "php${php_version}"
 
@@ -21,7 +22,6 @@ class apache::mod::php (
   else {
     fail('apache::mod::php requires apache::mod::prefork or apache::mod::itk; please enable mpm_module => \'prefork\' or mpm_module => \'itk\' on Class[\'apache\']')
   }
-  validate_array($extensions)
 
   if $source and ($content or $template != 'apache/mod/php.conf.erb') {
     warning('source and content or template parameters are provided. source parameter will be used')

--- a/manifests/mod/proxy_balancer.pp
+++ b/manifests/mod/proxy_balancer.pp
@@ -1,12 +1,9 @@
 class apache::mod::proxy_balancer(
-  $manager        = false,
-  $manager_path   = '/balancer-manager',
-  $allow_from     = ['127.0.0.1','::1'],
-  $apache_version = $::apache::apache_version,
+  Boolean $manager                   = false,
+  Stdlib::Absolutepath $manager_path = '/balancer-manager',
+  Array $allow_from                  = ['127.0.0.1','::1'],
+  $apache_version                    = $::apache::apache_version,
 ) {
-  validate_bool($manager)
-  validate_string($manager_path)
-  validate_array($allow_from)
 
   include ::apache::mod::proxy
   include ::apache::mod::proxy_http

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -1,23 +1,24 @@
 class apache::mod::ssl (
-  $ssl_compression            = false,
-  $ssl_cryptodevice           = 'builtin',
-  $ssl_options                = [ 'StdEnvVars' ],
-  $ssl_openssl_conf_cmd       = undef,
-  $ssl_ca                     = undef,
-  $ssl_cipher                 = 'HIGH:MEDIUM:!aNULL:!MD5:!RC4:!3DES',
-  $ssl_honorcipherorder       = true,
-  $ssl_protocol               = [ 'all', '-SSLv2', '-SSLv3' ],
-  $ssl_proxy_protocol         = [],
-  $ssl_pass_phrase_dialog     = 'builtin',
-  $ssl_random_seed_bytes      = '512',
-  $ssl_sessioncache           = $::apache::params::ssl_sessioncache,
-  $ssl_sessioncachetimeout    = '300',
-  $ssl_stapling               = false,
-  $ssl_stapling_return_errors = undef,
-  $ssl_mutex                  = undef,
-  $apache_version             = undef,
-  $package_name               = undef,
+  Boolean $ssl_compression                                  = false,
+  $ssl_cryptodevice                                         = 'builtin',
+  $ssl_options                                              = [ 'StdEnvVars' ],
+  $ssl_openssl_conf_cmd                                     = undef,
+  $ssl_ca                                                   = undef,
+  $ssl_cipher                                               = 'HIGH:MEDIUM:!aNULL:!MD5:!RC4:!3DES',
+  Variant[Boolean, Enum['on', 'off']] $ssl_honorcipherorder = true,
+  $ssl_protocol                                             = [ 'all', '-SSLv2', '-SSLv3' ],
+  Array $ssl_proxy_protocol                                 = [],
+  $ssl_pass_phrase_dialog                                   = 'builtin',
+  $ssl_random_seed_bytes                                    = '512',
+  String $ssl_sessioncache                                  = $::apache::params::ssl_sessioncache,
+  $ssl_sessioncachetimeout                                  = '300',
+  Boolean $ssl_stapling                                     = false,
+  Optional[Boolean] $ssl_stapling_return_errors             = undef,
+  $ssl_mutex                                                = undef,
+  $apache_version                                           = undef,
+  $package_name                                             = undef,
 ) inherits ::apache::params {
+
   include ::apache
   include ::apache::mod::mime
   $_apache_version = pick($apache_version, $apache::apache_version)
@@ -52,11 +53,6 @@ class apache::mod::ssl (
     }
   }
 
-  validate_bool($ssl_compression)
-
-  validate_array($ssl_proxy_protocol)
-  validate_string($ssl_sessioncache)
-
   if is_bool($ssl_honorcipherorder) {
     $_ssl_honorcipherorder = $ssl_honorcipherorder
   } else {
@@ -65,12 +61,6 @@ class apache::mod::ssl (
       'off'   => false,
       default => true,
     }
-  }
-
-  validate_bool($ssl_stapling)
-
-  if $ssl_stapling_return_errors != undef {
-    validate_bool($ssl_stapling_return_errors)
   }
 
   $stapling_cache = $::osfamily ? {

--- a/manifests/mod/status.pp
+++ b/manifests/mod/status.pp
@@ -26,14 +26,14 @@
 #  }
 #
 class apache::mod::status (
-  $allow_from      = ['127.0.0.1','::1'],
-  $extended_status = 'On',
-  $apache_version  = undef,
-  $status_path     = '/server-status',
+  Array $allow_from = ['127.0.0.1','::1'],
+  $extended_status  = 'On',
+  $apache_version   = undef,
+  $status_path      = '/server-status',
 ) inherits ::apache::params {
+
   include ::apache
   $_apache_version = pick($apache_version, $apache::apache_version)
-  validate_array($allow_from)
   validate_re(downcase($extended_status), '^(on|off)$', "${extended_status} is not supported for extended_status.  Allowed values are 'On' and 'Off'.")
   ::apache::mod { 'status': }
   # Template uses $allow_from, $extended_status, $_apache_version, $status_path

--- a/manifests/mod/status.pp
+++ b/manifests/mod/status.pp
@@ -26,15 +26,14 @@
 #  }
 #
 class apache::mod::status (
-  Array $allow_from = ['127.0.0.1','::1'],
-  $extended_status  = 'On',
-  $apache_version   = undef,
-  $status_path      = '/server-status',
+  Array $allow_from                               = ['127.0.0.1','::1'],
+  Enum['On', 'Off', 'on', 'off'] $extended_status = 'On',
+  $apache_version                                 = undef,
+  $status_path                                    = '/server-status',
 ) inherits ::apache::params {
 
   include ::apache
   $_apache_version = pick($apache_version, $apache::apache_version)
-  validate_re(downcase($extended_status), '^(on|off)$', "${extended_status} is not supported for extended_status.  Allowed values are 'On' and 'Off'.")
   ::apache::mod { 'status': }
   # Template uses $allow_from, $extended_status, $_apache_version, $status_path
   file { 'status.conf':

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -17,19 +17,17 @@
 #
 #
 class apache::service (
-  $service_name   = $::apache::params::service_name,
-  $service_enable = true,
-  $service_ensure = 'running',
-  $service_manage = true,
-  $service_restart = undef
+  $service_name           = $::apache::params::service_name,
+  Boolean $service_enable = true,
+  $service_ensure         = 'running',
+  Boolean $service_manage = true,
+  $service_restart        = undef
 ) {
+
   # The base class must be included first because parameter defaults depend on it
   if ! defined(Class['apache::params']) {
     fail('You must include the apache::params class before using any apache defined resources')
   }
-  validate_bool($service_enable)
-  validate_bool($service_manage)
-
   case $service_ensure {
     true, false, 'running', 'stopped': {
       $_service_ensure = $service_ensure

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1,179 +1,178 @@
 # See README.md for usage information
 define apache::vhost(
-  $docroot,
-  $manage_docroot              = true,
-  $virtual_docroot             = false,
-  $port                        = undef,
-  $ip                          = undef,
-  $ip_based                    = false,
-  $add_listen                  = true,
-  $docroot_owner               = 'root',
-  $docroot_group               = $::apache::params::root_group,
-  $docroot_mode                = undef,
-  $serveradmin                 = undef,
-  $ssl                         = false,
-  $ssl_cert                    = $::apache::default_ssl_cert,
-  $ssl_key                     = $::apache::default_ssl_key,
-  $ssl_chain                   = $::apache::default_ssl_chain,
-  $ssl_ca                      = $::apache::default_ssl_ca,
-  $ssl_crl_path                = $::apache::default_ssl_crl_path,
-  $ssl_crl                     = $::apache::default_ssl_crl,
-  $ssl_crl_check               = $::apache::default_ssl_crl_check,
-  $ssl_certs_dir               = $::apache::params::ssl_certs_dir,
-  $ssl_protocol                = undef,
-  $ssl_cipher                  = undef,
-  $ssl_honorcipherorder        = undef,
-  $ssl_verify_client           = undef,
-  $ssl_verify_depth            = undef,
-  $ssl_proxy_verify            = undef,
-  $ssl_proxy_verify_depth      = undef,
-  $ssl_proxy_ca_cert           = undef,
-  $ssl_proxy_check_peer_cn     = undef,
-  $ssl_proxy_check_peer_name   = undef,
-  $ssl_proxy_check_peer_expire = undef,
-  $ssl_proxy_machine_cert      = undef,
-  $ssl_proxy_protocol          = undef,
-  $ssl_options                 = undef,
-  $ssl_openssl_conf_cmd        = undef,
-  $ssl_proxyengine             = false,
-  $ssl_stapling                = undef,
-  $ssl_stapling_timeout        = undef,
-  $ssl_stapling_return_errors  = undef,
-  $priority                    = undef,
-  $default_vhost               = false,
-  $servername                  = $name,
-  $serveraliases               = [],
-  $options                     = ['Indexes','FollowSymLinks','MultiViews'],
-  $override                    = ['None'],
-  $directoryindex              = '',
-  $vhost_name                  = '*',
-  $logroot                     = $::apache::logroot,
-  $logroot_ensure              = 'directory',
-  $logroot_mode                = undef,
-  $logroot_owner               = undef,
-  $logroot_group               = undef,
-  $log_level                   = undef,
-  $access_log                  = true,
-  $access_log_file             = false,
-  $access_log_pipe             = false,
-  $access_log_syslog           = false,
-  $access_log_format           = false,
-  $access_log_env_var          = false,
-  $access_logs                 = undef,
-  $aliases                     = undef,
-  $directories                 = undef,
-  $error_log                   = true,
-  $error_log_file              = undef,
-  $error_log_pipe              = undef,
-  $error_log_syslog            = undef,
-  $http_protocol_options       = undef,
-  $modsec_audit_log            = undef,
-  $modsec_audit_log_file       = undef,
-  $modsec_audit_log_pipe       = undef,
-  $error_documents             = [],
-  $fallbackresource            = undef,
-  $scriptalias                 = undef,
-  $scriptaliases               = [],
-  $proxy_dest                  = undef,
-  $proxy_dest_match            = undef,
-  $proxy_dest_reverse_match    = undef,
-  $proxy_pass                  = undef,
-  $proxy_pass_match            = undef,
-  $suphp_addhandler            = $::apache::params::suphp_addhandler,
-  $suphp_engine                = $::apache::params::suphp_engine,
-  $suphp_configpath            = $::apache::params::suphp_configpath,
-  $php_flags                   = {},
-  $php_values                  = {},
-  $php_admin_flags             = {},
-  $php_admin_values            = {},
-  $no_proxy_uris               = [],
-  $no_proxy_uris_match         = [],
-  $proxy_preserve_host         = false,
-  $proxy_add_headers           = undef,
-  $proxy_error_override        = false,
-  $redirect_source             = '/',
-  $redirect_dest               = undef,
-  $redirect_status             = undef,
-  $redirectmatch_status        = undef,
-  $redirectmatch_regexp        = undef,
-  $redirectmatch_dest          = undef,
-  $rack_base_uris              = undef,
-  $passenger_base_uris         = undef,
-  $headers                     = undef,
-  $request_headers             = undef,
-  $filters                     = undef,
-  $rewrites                    = undef,
-  $rewrite_base                = undef,
-  $rewrite_rule                = undef,
-  $rewrite_cond                = undef,
-  $rewrite_inherit             = false,
-  $setenv                      = [],
-  $setenvif                    = [],
-  $setenvifnocase              = [],
-  $block                       = [],
-  $ensure                      = 'present',
-  $wsgi_application_group      = undef,
-  $wsgi_daemon_process         = undef,
-  $wsgi_daemon_process_options = undef,
-  $wsgi_import_script          = undef,
-  $wsgi_import_script_options  = undef,
-  $wsgi_process_group          = undef,
-  $wsgi_script_aliases_match   = undef,
-  $wsgi_script_aliases         = undef,
-  $wsgi_pass_authorization     = undef,
-  $wsgi_chunked_request        = undef,
-  $custom_fragment             = undef,
-  $itk                         = undef,
-  $action                      = undef,
-  $fastcgi_server              = undef,
-  $fastcgi_socket              = undef,
-  $fastcgi_dir                 = undef,
-  $fastcgi_idle_timeout        = undef,
-  $additional_includes         = [],
-  $use_optional_includes       = $::apache::use_optional_includes,
-  $apache_version              = $::apache::apache_version,
-  $allow_encoded_slashes       = undef,
-  $suexec_user_group           = undef,
-  $passenger_app_root          = undef,
-  $passenger_app_env           = undef,
-  $passenger_ruby              = undef,
-  $passenger_min_instances     = undef,
-  $passenger_start_timeout     = undef,
-  $passenger_pre_start         = undef,
-  $passenger_user              = undef,
-  $passenger_high_performance  = undef,
-  $passenger_nodejs            = undef,
-  $passenger_sticky_sessions   = undef,
-  $passenger_startup_file      = undef,
-  $add_default_charset         = undef,
-  $modsec_disable_vhost        = undef,
-  $modsec_disable_ids          = undef,
-  $modsec_disable_ips          = undef,
-  $modsec_disable_msgs         = undef,
-  $modsec_disable_tags         = undef,
-  $modsec_body_limit           = undef,
-  $jk_mounts                   = undef,
-  $auth_kerb                   = false,
-  $krb_method_negotiate        = 'on',
-  $krb_method_k5passwd         = 'on',
-  $krb_authoritative           = 'on',
-  $krb_auth_realms             = [],
-  $krb_5keytab                 = undef,
-  $krb_local_user_mapping      = undef,
-  $krb_verify_kdc              = 'on',
-  $krb_servicename             = 'HTTP',
-  $krb_save_credentials        = 'off',
-  $keepalive                   = undef,
-  $keepalive_timeout           = undef,
-  $max_keepalive_requests      = undef,
-  $cas_attribute_prefix        = undef,
-  $cas_attribute_delimiter     = undef,
-  $cas_scrub_request_headers   = undef,
-  $cas_sso_enabled             = undef,
-  $cas_login_url               = undef,
-  $cas_validate_url            = undef,
-  $cas_validate_saml           = undef,
+  Variant[Boolean,String] $docroot,
+  $manage_docroot                                                                   = true,
+  $virtual_docroot                                                                  = false,
+  $port                                                                             = undef,
+  $ip                                                                               = undef,
+  Boolean $ip_based                                                                 = false,
+  $add_listen                                                                       = true,
+  $docroot_owner                                                                    = 'root',
+  $docroot_group                                                                    = $::apache::params::root_group,
+  $docroot_mode                                                                     = undef,
+  $serveradmin                                                                      = undef,
+  Boolean $ssl                                                                      = false,
+  $ssl_cert                                                                         = $::apache::default_ssl_cert,
+  $ssl_key                                                                          = $::apache::default_ssl_key,
+  $ssl_chain                                                                        = $::apache::default_ssl_chain,
+  $ssl_ca                                                                           = $::apache::default_ssl_ca,
+  $ssl_crl_path                                                                     = $::apache::default_ssl_crl_path,
+  $ssl_crl                                                                          = $::apache::default_ssl_crl,
+  $ssl_crl_check                                                                    = $::apache::default_ssl_crl_check,
+  $ssl_certs_dir                                                                    = $::apache::params::ssl_certs_dir,
+  $ssl_protocol                                                                     = undef,
+  $ssl_cipher                                                                       = undef,
+  $ssl_honorcipherorder                                                             = undef,
+  $ssl_verify_client                                                                = undef,
+  $ssl_verify_depth                                                                 = undef,
+  Optional[Enum['none', 'optional', 'require', 'optional_no_ca']] $ssl_proxy_verify = undef,
+  $ssl_proxy_verify_depth                                                           = undef,
+  $ssl_proxy_ca_cert                                                                = undef,
+  Optional[Enum['on', 'off']] $ssl_proxy_check_peer_expire                          = undef,
+  $ssl_proxy_machine_cert                                                           = undef,
+  $ssl_proxy_protocol                                                               = undef,
+  $ssl_options                                                                      = undef,
+  $ssl_openssl_conf_cmd                                                             = undef,
+  Boolean $ssl_proxyengine                                                          = false,
+  Optional[Boolean] $ssl_stapling                                                   = undef,
+  $ssl_stapling_timeout                                                             = undef,
+  $ssl_stapling_return_errors                                                       = undef,
+  $priority                                                                         = undef,
+  Boolean $default_vhost                                                            = false,
+  $servername                                                                       = $name,
+  $serveraliases                                                                    = [],
+  $options                                                                          = ['Indexes','FollowSymLinks','MultiViews'],
+  $override                                                                         = ['None'],
+  $directoryindex                                                                   = '',
+  $vhost_name                                                                       = '*',
+  $logroot                                                                          = $::apache::logroot,
+  Enum['directory', 'absent'] $logroot_ensure                                       = 'directory',
+  $logroot_mode                                                                     = undef,
+  $logroot_owner                                                                    = undef,
+  $logroot_group                                                                    = undef,
+  $log_level                                                                        = undef,
+  Boolean $access_log                                                               = true,
+  $access_log_file                                                                  = false,
+  $access_log_pipe                                                                  = false,
+  $access_log_syslog                                                                = false,
+  $access_log_format                                                                = false,
+  $access_log_env_var                                                               = false,
+  $access_logs                                                                      = undef,
+  $aliases                                                                          = undef,
+  $directories                                                                      = undef,
+  Boolean $error_log                                                                = true,
+  $error_log_file                                                                   = undef,
+  $error_log_pipe                                                                   = undef,
+  $error_log_syslog                                                                 = undef,
+  $http_protocol_options                                                            = undef,
+  $modsec_audit_log                                                                 = undef,
+  $modsec_audit_log_file                                                            = undef,
+  $modsec_audit_log_pipe                                                            = undef,
+  $error_documents                                                                  = [],
+  Optional[Variant[Stdlib::Absolutepath, Enum['disabled']]] $fallbackresource       = undef,
+  $scriptalias                                                                      = undef,
+  $scriptaliases                                                                    = [],
+  $proxy_dest                                                                       = undef,
+  $proxy_dest_match                                                                 = undef,
+  $proxy_dest_reverse_match                                                         = undef,
+  $proxy_pass                                                                       = undef,
+  $proxy_pass_match                                                                 = undef,
+  $suphp_addhandler                                                                 = $::apache::params::suphp_addhandler,
+  Enum['on', 'off'] $suphp_engine                                                   = $::apache::params::suphp_engine,
+  $suphp_configpath                                                                 = $::apache::params::suphp_configpath,
+  $php_flags                                                                        = {},
+  $php_values                                                                       = {},
+  $php_admin_flags                                                                  = {},
+  $php_admin_values                                                                 = {},
+  $no_proxy_uris                                                                    = [],
+  $no_proxy_uris_match                                                              = [],
+  $proxy_preserve_host                                                              = false,
+  $proxy_add_headers                                                                = undef,
+  $proxy_error_override                                                             = false,
+  $redirect_source                                                                  = '/',
+  $redirect_dest                                                                    = undef,
+  $redirect_status                                                                  = undef,
+  $redirectmatch_status                                                             = undef,
+  $redirectmatch_regexp                                                             = undef,
+  $redirectmatch_dest                                                               = undef,
+  $rack_base_uris                                                                   = undef,
+  $passenger_base_uris                                                              = undef,
+  $headers                                                                          = undef,
+  $request_headers                                                                  = undef,
+  $filters                                                                          = undef,
+  Optional[Array] $rewrites                                                         = undef,
+  $rewrite_base                                                                     = undef,
+  $rewrite_rule                                                                     = undef,
+  $rewrite_cond                                                                     = undef,
+  $rewrite_inherit                                                                  = false,
+  $setenv                                                                           = [],
+  $setenvif                                                                         = [],
+  $setenvifnocase                                                                   = [],
+  $block                                                                            = [],
+  Enum['absent', 'present'] $ensure                                                 = 'present',
+  $wsgi_application_group                                                           = undef,
+  $wsgi_daemon_process                                                              = undef,
+  Optional[Hash] $wsgi_daemon_process_options                                       = undef,
+  $wsgi_import_script                                                               = undef,
+  Optional[Hash] $wsgi_import_script_options                                        = undef,
+  $wsgi_process_group                                                               = undef,
+  Optional[Hash] $wsgi_script_aliases_match                                         = undef,
+  Optional[Hash] $wsgi_script_aliases                                               = undef,
+  Optional[Enum['on', 'off', 'On', 'Off']] $wsgi_pass_authorization                 = undef,
+  $wsgi_chunked_request                                                             = undef,
+  Optional[String] $custom_fragment                                                 = undef,
+  Optional[Hash] $itk                                                               = undef,
+  $action                                                                           = undef,
+  $fastcgi_server                                                                   = undef,
+  $fastcgi_socket                                                                   = undef,
+  $fastcgi_dir                                                                      = undef,
+  $fastcgi_idle_timeout                                                             = undef,
+  $additional_includes                                                              = [],
+  $use_optional_includes                                                            = $::apache::use_optional_includes,
+  $apache_version                                                                   = $::apache::apache_version,
+  Optional[Enum['on', 'off', 'nodecode']] $allow_encoded_slashes                    = undef,
+  $suexec_user_group                                                                = undef,
+  $passenger_app_root                                                               = undef,
+  $passenger_app_env                                                                = undef,
+  $passenger_ruby                                                                   = undef,
+  $passenger_min_instances                                                          = undef,
+  $passenger_start_timeout                                                          = undef,
+  $passenger_pre_start                                                              = undef,
+  $passenger_user                                                                   = undef,
+  $passenger_high_performance                                                       = undef,
+  $passenger_nodejs                                                                 = undef,
+  Optional[Boolean] $passenger_sticky_sessions                                      = undef,
+  $passenger_startup_file                                                           = undef,
+  $add_default_charset                                                              = undef,
+  $modsec_disable_vhost                                                             = undef,
+  $modsec_disable_ids                                                               = undef,
+  $modsec_disable_ips                                                               = undef,
+  $modsec_disable_msgs                                                              = undef,
+  $modsec_disable_tags                                                              = undef,
+  $modsec_body_limit                                                                = undef,
+  $jk_mounts                                                                        = undef,
+  Boolean $auth_kerb                                                                = false,
+  $krb_method_negotiate                                                             = 'on',
+  $krb_method_k5passwd                                                              = 'on',
+  $krb_authoritative                                                                = 'on',
+  $krb_auth_realms                                                                  = [],
+  $krb_5keytab                                                                      = undef,
+  $krb_local_user_mapping                                                           = undef,
+  $krb_verify_kdc                                                                   = 'on',
+  $krb_servicename                                                                  = 'HTTP',
+  $krb_save_credentials                                                             = 'off',
+  Optional[Enum['on', 'off']] $keepalive                                            = undef,
+  $keepalive_timeout                                                                = undef,
+  $max_keepalive_requests                                                           = undef,
+  $cas_attribute_prefix                                                             = undef,
+  $cas_attribute_delimiter                                                          = undef,
+  $cas_scrub_request_headers                                                        = undef,
+  $cas_sso_enabled                                                                  = undef,
+  $cas_login_url                                                                    = undef,
+  $cas_validate_url                                                                 = undef,
+  $cas_validate_saml                                                                = undef,
 ) {
+
   # The base class must be included first because it is used by parameter defaults
   if ! defined(Class['apache']) {
     fail('You must include the apache base class before using any apache defined resources')
@@ -181,15 +180,6 @@ define apache::vhost(
 
   $apache_name = $::apache::apache_name
 
-  validate_re($ensure, '^(present|absent)$',
-  "${ensure} is not supported for ensure.
-  Allowed values are 'present' and 'absent'.")
-  validate_re($suphp_engine, '^(on|off)$',
-  "${suphp_engine} is not supported for suphp_engine.
-  Allowed values are 'on' and 'off'.")
-  validate_bool($ip_based)
-  validate_bool($access_log)
-  validate_bool($error_log)
   if $http_protocol_options != undef {
     validate_re($http_protocol_options, '^((Strict|Unsafe)?\s*(\b(RegisteredMethods|LenientMethods))?\s*(\b(Allow0\.9|Require1\.0))?)$',
     "${http_protocol_options} is not supported for http_protocol_options.
@@ -197,17 +187,7 @@ define apache::vhost(
     'Strict' or Unsafe, 'RegisteredMethods' or 'LenientMethods', and
     'Allow0.9' or 'Require1.0'.")
   }
-  if $modsec_audit_log != undef {
-    validate_bool($modsec_audit_log)
-  }
-  validate_bool($ssl)
-  validate_bool($default_vhost)
-  validate_bool($ssl_proxyengine)
-  if $ssl_stapling != undef {
-    validate_bool($ssl_stapling)
-  }
   if $rewrites {
-    validate_array($rewrites)
     unless empty($rewrites) {
       $rewrites_flattened = delete_undef_values(flatten([$rewrites]))
       validate_hash($rewrites_flattened[0])
@@ -221,18 +201,6 @@ define apache::vhost(
     "${suexec_user_group} is not supported for suexec_user_group.  Must be 'user group'.")
   }
 
-  if $wsgi_pass_authorization {
-    validate_re(downcase($wsgi_pass_authorization), '^(on|off)$',
-    "${wsgi_pass_authorization} is not supported for wsgi_pass_authorization.
-    Allowed values are 'on' and 'off'.")
-  }
-
-  if $wsgi_chunked_request {
-    validate_re(downcase($wsgi_chunked_request), '^(on|off)$',
-    "${wsgi_chunked_request} is not supported for wsgi_chunked_request.
-    Allowed values are 'on' and 'off'.")
-  }
-
   # Deprecated backwards-compatibility
   if $rewrite_base {
     warning('Apache::Vhost: parameter rewrite_base is deprecated in favor of rewrites')
@@ -243,26 +211,6 @@ define apache::vhost(
   if $rewrite_cond {
     warning('Apache::Vhost parameter rewrite_cond is deprecated in favor of rewrites')
   }
-
-  if $wsgi_script_aliases {
-    validate_hash($wsgi_script_aliases)
-  }
-  if $wsgi_script_aliases_match {
-    validate_hash($wsgi_script_aliases_match)
-  }
-  if $wsgi_daemon_process_options {
-    validate_hash($wsgi_daemon_process_options)
-  }
-  if $wsgi_import_script_options {
-    validate_hash($wsgi_import_script_options)
-  }
-  if $itk {
-    validate_hash($itk)
-  }
-
-  validate_re($logroot_ensure, '^(directory|absent)$',
-  "${logroot_ensure} is not supported for logroot_ensure.
-  Allowed values are 'directory' and 'absent'.")
 
   if $log_level {
     validate_apache_log_level($log_level)
@@ -280,51 +228,8 @@ define apache::vhost(
     fail("Apache::Vhost[${name}]: 'modsec_audit_log_file' and 'modsec_audit_log_pipe' cannot be defined at the same time")
   }
 
-  if $fallbackresource {
-    validate_re($fallbackresource, '^/|disabled', 'Please make sure fallbackresource starts with a / (or is "disabled")')
-  }
-
-  if $custom_fragment {
-    validate_string($custom_fragment)
-  }
-
-  if $allow_encoded_slashes {
-    validate_re($allow_encoded_slashes, '(^on$|^off$|^nodecode$)', "${allow_encoded_slashes} is not permitted for allow_encoded_slashes. Allowed values are 'on', 'off' or 'nodecode'.")
-  }
-
-  validate_bool($auth_kerb)
-
-  # Validate the docroot as a string if:
-  # - $manage_docroot is true
-  if $manage_docroot {
-    validate_string($docroot)
-  }
-
-  if $ssl_proxy_verify {
-    validate_re($ssl_proxy_verify,'^(none|optional|require|optional_no_ca)$',"${ssl_proxy_verify} is not permitted for ssl_proxy_verify. Allowed values are 'none', 'optional', 'require' or 'optional_no_ca'.")
-  }
-
   if $ssl_proxy_verify_depth {
     validate_integer($ssl_proxy_verify_depth)
-  }
-
-  if $ssl_proxy_check_peer_cn {
-    validate_re($ssl_proxy_check_peer_cn,'(^on$|^off$)',"${ssl_proxy_check_peer_cn} is not permitted for ssl_proxy_check_peer_cn. Allowed values are 'on' or 'off'.")
-  }
-  if $ssl_proxy_check_peer_name {
-    validate_re($ssl_proxy_check_peer_name,'(^on$|^off$)',"${ssl_proxy_check_peer_name} is not permitted for ssl_proxy_check_peer_name. Allowed values are 'on' or 'off'.")
-  }
-
-  if $ssl_proxy_check_peer_expire {
-    validate_re($ssl_proxy_check_peer_expire,'(^on$|^off$)',"${ssl_proxy_check_peer_expire} is not permitted for ssl_proxy_check_peer_expire. Allowed values are 'on' or 'off'.")
-  }
-
-  if $keepalive {
-    validate_re($keepalive,'(^on$|^off$)',"${keepalive} is not permitted for keepalive. Allowed values are 'on' or 'off'.")
-  }
-
-  if $passenger_sticky_sessions {
-    validate_bool($passenger_sticky_sessions)
   }
 
   # Input validation ends

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -201,17 +201,6 @@ define apache::vhost(
     "${suexec_user_group} is not supported for suexec_user_group.  Must be 'user group'.")
   }
 
-  # Deprecated backwards-compatibility
-  if $rewrite_base {
-    warning('Apache::Vhost: parameter rewrite_base is deprecated in favor of rewrites')
-  }
-  if $rewrite_rule {
-    warning('Apache::Vhost: parameter rewrite_rule is deprecated in favor of rewrites')
-  }
-  if $rewrite_cond {
-    warning('Apache::Vhost parameter rewrite_cond is deprecated in favor of rewrites')
-  }
-
   if $log_level {
     validate_apache_log_level($log_level)
   }

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -28,6 +28,8 @@ define apache::vhost(
   Optional[Enum['none', 'optional', 'require', 'optional_no_ca']] $ssl_proxy_verify = undef,
   $ssl_proxy_verify_depth                                                           = undef,
   $ssl_proxy_ca_cert                                                                = undef,
+  Optional[Enum['on', 'off']] $ssl_proxy_check_peer_cn                              = undef,
+  Optional[Enum['on', 'off']] $ssl_proxy_check_peer_name                            = undef,
   Optional[Enum['on', 'off']] $ssl_proxy_check_peer_expire                          = undef,
   $ssl_proxy_machine_cert                                                           = undef,
   $ssl_proxy_protocol                                                               = undef,

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.13.1 < 5.0.0"},
-    {"name":"puppetlabs/concat","version_requirement":">= 1.1.1 < 5.0.0"}
+    {"name":"puppetlabs/concat","version_requirement":">= 2.2.1 < 5.0.0"}
   ],
   "data_provider": null,
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/puppetlabs/puppetlabs-apache",
   "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.12.0 < 5.0.0"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.13.1 < 5.0.0"},
     {"name":"puppetlabs/concat","version_requirement":">= 1.1.1 < 5.0.0"}
   ],
   "data_provider": null,

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -563,12 +563,6 @@ describe 'apache', :type => :class do
         it { is_expected.not_to contain_class('apache::mod::peruser') }
         it { is_expected.not_to contain_class('apache::mod::prefork') }
       end
-      context "when declaring mpm_module => breakme" do
-        let :params do
-          { :mpm_module => 'breakme' }
-        end
-        it { expect { catalogue }.to raise_error Puppet::Error, /does not match/ }
-      end
     end
 
     describe "different templates for httpd.conf" do

--- a/spec/classes/mod/passenger_spec.rb
+++ b/spec/classes/mod/passenger_spec.rb
@@ -68,12 +68,6 @@ describe 'apache::mod::passenger', :type => :class do
       end
       it { is_expected.to contain_file('passenger.conf').with_content(/^  PassengerMaxRequests 20$/) }
     end
-    describe "with passenger_spawn_method => bogus" do
-      let :params do
-        { :passenger_spawn_method => 'bogus' }
-      end
-      it { is_expected.to raise_error(Puppet::Error, /not permitted for passenger_spawn_method/) }
-    end
     describe "with passenger_spawn_method => direct" do
       let :params do
         { :passenger_spawn_method => 'direct' }

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -53,22 +53,6 @@ describe 'apache::service', :type => :class do
       }
     end
 
-    context "$service_enable must be a bool" do
-      let (:params) {{ :service_enable => 'not-a-boolean' }}
-
-      it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /is not a boolean/)
-      end
-    end
-
-    context "$service_manage must be a bool" do
-      let (:params) {{ :service_manage => 'not-a-boolean' }}
-
-      it 'should fail' do
-        expect { catalogue }.to raise_error(Puppet::Error, /is not a boolean/)
-      end
-    end
-
     context "with $service_ensure => 'running'" do
       let (:params) {{ :service_ensure => 'running', }}
       it { is_expected.to contain_service("httpd").with(

--- a/spec/defines/custom_config_spec.rb
+++ b/spec/defines/custom_config_spec.rb
@@ -121,18 +121,5 @@ describe 'apache::custom_config', :type => :define do
         }.to raise_error(Puppet::Error, /One of \$content and \$source must be specified\./)
       end
     end
-    context 'bad ensure' do
-      let :params do
-        {
-          'content' => 'foo',
-          'ensure'  => 'foo',
-        }
-      end
-      it do
-        expect {
-          catalogue
-        }.to raise_error(Puppet::Error, /is not supported for ensure/)
-      end
-    end
   end
 end


### PR DESCRIPTION
goal of this is to get rid of all the legacy valida_* function calls, and not to provide perfect datatypes for all parameters.