### PR TITLE
[Modules 4746] Creates class for managing Apache mod_jk connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
 [`apache::mod::ext_filter`]: #class-apachemodext_filter
 [`apache::mod::geoip`]: #class-apachemodgeoip
 [`apache::mod::itk`]: #class-apachemoditk
+[`apache::mod::jk`]: #class-apachemodjk
 [`apache::mod::ldap`]: #class-apachemodldap
 [`apache::mod::passenger`]: #class-apachemodpassenger
 [`apache::mod::peruser`]: #class-apachemodperuser
@@ -1410,7 +1411,7 @@ The following Apache modules have supported classes, many of which allow for par
 * `info`\*
 * `intercept_form_submit`
 * `itk`
-* `jk` (see [`apache::mod::jk`][])
+* `jk` (see [`apache::mod::jk`])
 * `ldap` (see [`apache::mod::ldap`][])
 * `lookup_identity`
 * `mime`

--- a/README.md
+++ b/README.md
@@ -1791,7 +1791,7 @@ $workers_file_content = {
 
 **mount\_file\_content**
 
-Each directive has the format `<URI> = <Worker name>`. This maps as a hash of hashes, where the outer hash specifies workers, and each inner hash contains two items: uri_list - an Array with URIs to be mapped to the worker - and comment - an optional string with a comment for the worker.  
+Each directive has the format `<URI> = <Worker name>`. This maps as a hash of hashes, where the outer hash specifies workers, and each inner hash contains two items: uri_list - an array with URIs to be mapped to the worker - and comment - an optional string with a comment for the worker.  
 For example, the mount file below:
 
 ```

--- a/README.md
+++ b/README.md
@@ -1749,14 +1749,22 @@ class { '::apache::mod::jk':
 
 The best source for understanding the `mod_jk` parameters is the [official documentation](https://tomcat.apache.org/connectors-doc/reference/apache.html), except for \*file_content:
 
-**`workers_file_content`**
+**workers\_file\_content**
 
-Each directive has the format `worker.<Worker name>.<Property>=<Value>`. This maps as a hash of hashes, where the outer hash specifies workers, and each inner hash specifies each worker properties and values. For example, the workers file below:
+Each directive has the format `worker.<Worker name>.<Property>=<Value>`. This maps as a hash of hashes, where the outer hash specifies workers, and each inner hash specifies each worker properties and values.  
+Plus, there are two global directives, 'worker.list' and 'worker.mantain'  
+For example, the workers file below:
 
 ```
+worker.list = status
+worker.list = some_name,other_name
+
+worker.mantain = 60
+
 # Optional comment
 worker.some_name.type=ajp13
 worker.some_name.socket_keepalive=true
+
 # I just like comments
 worker.other_name.type=ajp12 (why would you?)
 worker.other_name.socket_keepalive=false
@@ -1766,12 +1774,14 @@ Should be parameterized as:
 
 ```
 $workers_file_content = {
-  some_name  => {
+  worker_lists   => ['status', 'some_name,other_name'],
+  worker_mantain => '60',
+  some_name      => {
     comment          => 'Optional comment',
     type             => 'ajp13',
     socket_keepalive => 'true',
   },
-  other_name => {
+  other_name     => {
     comment          => 'I just like comments',
     type             => 'ajp12',
     socket_keepalive => 'false',

--- a/README.md
+++ b/README.md
@@ -1789,6 +1789,37 @@ $workers_file_content = {
 }
 ```
 
+**mount\_file\_content**
+
+Each directive has the format `<URI> = <Worker name>`. This maps as a hash of hashes, where the outer hash specifies workers, and each inner hash contains two items: uri_list - an Array with URIs to be mapped to the worker - and comment - an optional string with a comment for the worker.  
+For example, the mount file below:
+
+```
+# Worker 1
+/context_1/ = worker_1
+/context_1/* = worker_1
+
+# Worker 2
+/ = worker_2
+/context_2/ = worker_2
+/context_2/* = worker_2
+```
+
+Should be parameterized as:
+
+```
+$mount_file_content = {
+  worker_1 => {
+    uri_list => ['/context_1/', '/context_1/*'],
+    comment  => 'Worker 1',
+  },
+  worker_2 => {
+    uri_list => ['/context_2/', '/context_2/*'],
+    comment  => 'Worker 2',
+  },
+},
+```
+
 ##### Class: `apache::mod::passenger`
 
 Installs and manages [`mod_passenger`][]. For RedHat based systems, please ensure that you meet the minimum requirements as described in the [passenger docs](https://www.phusionpassenger.com/library/install/apache/install/oss/el6/#step-1:-upgrade-your-kernel,-or-disable-selinux)

--- a/README.md
+++ b/README.md
@@ -1300,7 +1300,7 @@ If the string starts with / or | or syslog: the full path will be set. Otherwise
 
 ##### `scriptalias`
 
-Directory to use for global script alias 
+Directory to use for global script alias
 
 The default value is determined by your operating system:
 
@@ -1410,6 +1410,7 @@ The following Apache modules have supported classes, many of which allow for par
 * `info`\*
 * `intercept_form_submit`
 * `itk`
+* `jk` (see [`apache::mod::jk`][])
 * `ldap` (see [`apache::mod::ldap`][])
 * `lookup_identity`
 * `mime`
@@ -1724,6 +1725,58 @@ Installs and manages [`mod_info`][], which provides a comprehensive overview of 
 - `allow_from`: Whitelist of IPv4 or IPv6 addresses or ranges that can access `/server-info`. Valid options: One or more octets of an IPv4 address, an IPv6 address or range, or an array of either. Default: ['127.0.0.1','::1'].
 - `apache_version`: Apache's version number as a string, such as '2.2' or '2.4'. Default: the value of [`$::apache::apache_version`][`apache_version`].
 - `restrict_access`: Determines whether to enable access restrictions. If false, the `allow_from` whitelist is ignored and any IP address can access `/server-info`. Valid options: Boolean. Default: true.
+
+##### Class: `apache::mod::jk`
+
+Installs and manages `mod_jk`, a connector for Apache httpd redirection to old versions of TomCat and JBoss
+
+**Note**: There is no official package available for mod\_jk and thus it must be made available by means outside of the control of the apache module. Binaries can be found at [Apache Tomcat Connectors download page](https://tomcat.apache.org/download-connectors.cgi)
+
+``` puppet
+class { '::apache::mod::jk':
+  workers_file = 'conf/workers.properties',
+  mount_file   = 'conf/uriworkermap.properties',
+  shm_file     = 'run/jk.shm',
+  shm_size     = '50M',
+  $workers_file_content = {
+    <Content>
+  },
+}
+```
+
+**Parameters within `apache::mod::jk`**:
+
+The best source for understanding the `mod_jk` parameters is the [official documentation](https://tomcat.apache.org/connectors-doc/reference/apache.html), except for \*file_content:
+
+**`workers_file_content`**
+
+Each directive has the format `worker.<Worker name>.<Property>=<Value>`. This maps as a hash of hashes, where the outer hash specifies workers, and each inner hash specifies each worker properties and values. For example, the workers file below:
+
+```
+# Optional comment
+worker.some_name.type=ajp13
+worker.some_name.socket_keepalive=true
+# I just like comments
+worker.other_name.type=ajp12 (why would you?)
+worker.other_name.socket_keepalive=false
+```
+
+Should be parameterized as:
+
+```
+$workers_file_content = {
+  some_name  => {
+    comment          => 'Optional comment',
+    type             => 'ajp13',
+    socket_keepalive => 'true',
+  },
+  other_name => {
+    comment          => 'I just like comments',
+    type             => 'ajp12',
+    socket_keepalive => 'false',
+  },
+}
+```
 
 ##### Class: `apache::mod::passenger`
 

--- a/manifests/mod/jk.pp
+++ b/manifests/mod/jk.pp
@@ -11,7 +11,8 @@
 class apache::mod::jk (
   $workers_file          = undef,
   $worker_property       = {},
-  $shm_file              = "${::apache::logroot}/jk-runtime-status",
+  $logroot               = undef,
+  $shm_file              = 'jk-runtime-status',
   $shm_size              = undef,
   $mount_file            = undef,
   $mount_file_reload     = undef,
@@ -21,7 +22,7 @@ class apache::mod::jk (
   $mount_copy            = undef,
   $worker_indicator      = undef,
   $watchdog_interval     = undef,
-  $log_file              = "${::apache::logroot}/mod_jk.log",
+  $log_file              = 'mod_jk.log',
   $log_level             = undef,
   $log_stamp_format      = undef,
   $request_log_format    = undef,
@@ -68,6 +69,16 @@ class apache::mod::jk (
     notify  => Class['apache::service'],
   }
 
+  # Shared memory and log paths
+  if $logroot == undef {
+    $shm_path = ${::apache::logroot}/${shm_file}
+    $log_path = ${::apache::logroot}/${log_file}
+  }
+  else {
+    $shm_path = ${logroot}/${shm_file}
+    $log_path = ${logroot}/${log_file}
+  }
+
   # Main config file
   file {'jk.conf':
     path    => "${::apache::mod_dir}/jk.conf",
@@ -78,6 +89,7 @@ class apache::mod::jk (
     ],
   }
 
+  }
   # Workers file
   if $workers_file != undef {
     $workers_path = $workers_file ? {

--- a/manifests/mod/jk.pp
+++ b/manifests/mod/jk.pp
@@ -10,13 +10,13 @@
 #
 class apache::mod::jk (
   $workers_file          = undef,
-  $worker_property       = undef,
+  $worker_property       = {},
   $shm_file              = undef,
   $shm_size              = undef,
   $mount_file            = undef,
   $mount_file_reload     = undef,
-  $mount                 = undef,
-  $un_mount              = undef,
+  $mount                 = {},
+  $un_mount              = {},
   $auto_alias            = undef,
   $mount_copy            = undef,
   $worker_indicator      = undef,
@@ -42,8 +42,8 @@ class apache::mod::jk (
   $remote_port_indicator = undef,
   $remote_user_indicator = undef,
   $auth_type_indicator   = undef,
-  $options               = undef,
-  $env_var               = undef,
+  $options               = [],
+  $env_var               = {},
   $strip_session         = undef,
 ){
 

--- a/manifests/mod/jk.pp
+++ b/manifests/mod/jk.pp
@@ -46,6 +46,7 @@ class apache::mod::jk (
   $env_var               = {},
   $strip_session         = undef,
   # Workers file content
+  # See comments in template mod/jk/workers.properties.erb
   $workers_file_content  = [],
 ){
 

--- a/manifests/mod/jk.pp
+++ b/manifests/mod/jk.pp
@@ -11,7 +11,7 @@
 class apache::mod::jk (
   $workers_file          = undef,
   $worker_property       = {},
-  $logroot               = $::apache::logroot,
+  $logroot               = undef,
   $shm_file              = 'jk-runtime-status',
   $shm_size              = undef,
   $mount_file            = undef,
@@ -70,8 +70,14 @@ class apache::mod::jk (
   }
 
   # Shared memory and log paths
-  $shm_path = "${logroot}/${shm_file}"
-  $log_path = "${logroot}/${log_file}"
+  if $logroot == undef {
+    $shm_path = "${::apache::logroot}/${shm_file}"
+    $log_path = "${::apache::logroot}/${log_file}"
+  }
+  else {
+    $shm_path = "${logroot}/${shm_file}"
+    $log_path = "${logroot}/${log_file}"
+  }
 
   # Main config file
   file {'jk.conf':

--- a/manifests/mod/jk.pp
+++ b/manifests/mod/jk.pp
@@ -71,12 +71,12 @@ class apache::mod::jk (
 
   # Shared memory and log paths
   if $logroot == undef {
-    $shm_path = ${::apache::logroot}/${shm_file}
-    $log_path = ${::apache::logroot}/${log_file}
+    $shm_path = "${::apache::logroot}/${shm_file}"
+    $log_path = "${::apache::logroot}/${log_file}"
   }
   else {
-    $shm_path = ${logroot}/${shm_file}
-    $log_path = ${logroot}/${log_file}
+    $shm_path = "${logroot}/${shm_file}"
+    $log_path = "${logroot}/${log_file}"
   }
 
   # Main config file
@@ -89,7 +89,6 @@ class apache::mod::jk (
     ],
   }
 
-  }
   # Workers file
   if $workers_file != undef {
     $workers_path = $workers_file ? {

--- a/manifests/mod/jk.pp
+++ b/manifests/mod/jk.pp
@@ -45,6 +45,8 @@ class apache::mod::jk (
   $options               = [],
   $env_var               = {},
   $strip_session         = undef,
+  # Workers file content
+  $workers_file_content  = [],
 ){
 
   include ::apache
@@ -69,6 +71,18 @@ class apache::mod::jk (
       Exec["mkdir ${::apache::mod_dir}"],
       File[$::apache::mod_dir],
     ],
+  }
+
+  # Workers file
+  if $workers_file != undef {
+    $workers_path = $workers_file ? {
+      /^\//   => $workers_file,
+      default => "${apache::httpd_dir}/${workers_file}",
+    }
+    file { $workers_path:
+      content => template('apache/mod/jk/workers.properties.erb'),
+      require => Package['httpd'],
+    }
   }
 
 }

--- a/manifests/mod/jk.pp
+++ b/manifests/mod/jk.pp
@@ -48,6 +48,9 @@ class apache::mod::jk (
   # Workers file content
   # See comments in template mod/jk/workers.properties.erb
   $workers_file_content  = [],
+  # Mount file content
+  # See comments in template mod/jk/uriworkermap.properties.erb
+  $mount_file_content  = [],
 ){
 
   include ::apache
@@ -82,6 +85,18 @@ class apache::mod::jk (
     }
     file { $workers_path:
       content => template('apache/mod/jk/workers.properties.erb'),
+      require => Package['httpd'],
+    }
+  }
+
+  # Mount file
+  if $mount_file != undef {
+    $mount_path = $mount_file ? {
+      /^\//   => $mount_file,
+      default => "${apache::httpd_dir}/${mount_file}",
+    }
+    file { $mount_path:
+      content => template('apache/mod/jk/uriworkermap.properties.erb'),
       require => Package['httpd'],
     }
   }

--- a/manifests/mod/jk.pp
+++ b/manifests/mod/jk.pp
@@ -1,10 +1,50 @@
+# Class apache::mod::jk
+#
+# Manages mod_jk connector
+#
+# All parameters are optional. When undefined, some receive default values,
+# while others cause an optional directive to be absent
+#
+# For help on parameters, pls see official reference at:
+# https://tomcat.apache.org/connectors-doc/reference/apache.html
+#
 class apache::mod::jk (
-  $workers_file,
-  $jk_mount = undef,
-  $jk_mount_file = undef,
-  $log_file = undef,
-  $log_level = undef,
-  $log_stamp_format = undef,
+  $workers_file          = undef,
+  $worker_property       = undef,
+  $shm_file              = undef,
+  $shm_size              = undef,
+  $mount_file            = undef,
+  $mount_file_reload     = undef,
+  $mount                 = undef,
+  $un_mount              = undef,
+  $auto_alias            = undef,
+  $mount_copy            = undef,
+  $worker_indicator      = undef,
+  $watchdog_interval     = undef,
+  $log_file              = undef,
+  $log_level             = undef,
+  $log_stamp_format      = undef,
+  $request_log_format    = undef,
+  $extract_ssl           = undef,
+  $https_indicator       = undef,
+  $sslprotocol_indicator = undef,
+  $certs_indicator       = undef,
+  $cipher_indicator      = undef,
+  $certchain_prefix      = undef,
+  $session_indicator     = undef,
+  $keysize_indicator     = undef,
+  $local_name_indicator  = undef,
+  $ignore_cl_indicator   = undef,
+  $local_addr_indicator  = undef,
+  $local_port_indicator  = undef,
+  $remote_host_indicator = undef,
+  $remote_addr_indicator = undef,
+  $remote_port_indicator = undef,
+  $remote_user_indicator = undef,
+  $auth_type_indicator   = undef,
+  $options               = undef,
+  $env_var               = undef,
+  $strip_session         = undef,
 ){
 
   include ::apache

--- a/manifests/mod/jk.pp
+++ b/manifests/mod/jk.pp
@@ -45,6 +45,9 @@ class apache::mod::jk (
   $options               = [],
   $env_var               = {},
   $strip_session         = undef,
+  # Location list
+  # See comments in template mod/jk.conf.erb
+  $location_list         = [],
   # Workers file content
   # See comments in template mod/jk/workers.properties.erb
   $workers_file_content  = [],

--- a/manifests/mod/jk.pp
+++ b/manifests/mod/jk.pp
@@ -50,10 +50,10 @@ class apache::mod::jk (
   $location_list         = [],
   # Workers file content
   # See comments in template mod/jk/workers.properties.erb
-  $workers_file_content  = [],
+  $workers_file_content  = {},
   # Mount file content
   # See comments in template mod/jk/uriworkermap.properties.erb
-  $mount_file_content    = [],
+  $mount_file_content    = {},
 ){
 
   include ::apache

--- a/manifests/mod/jk.pp
+++ b/manifests/mod/jk.pp
@@ -4,4 +4,16 @@ class apache::mod::jk {
 
   ::apache::mod { 'jk': }
 
+  file {'jk.conf':
+    ensure  => file,
+    path    => "${::apache::mod_dir}/jk.conf",
+    mode    => $::apache::file_mode,
+    content => template('apache/mod/jk.conf.erb'),
+    require => [
+      Exec["mkdir ${::apache::mod_dir}"],
+      File[$::apache::mod_dir],
+    ],
+    notify  => Class['apache::service'],
+  }
+
 }

--- a/manifests/mod/jk.pp
+++ b/manifests/mod/jk.pp
@@ -11,7 +11,7 @@
 class apache::mod::jk (
   $workers_file          = undef,
   $worker_property       = {},
-  $shm_file              = undef,
+  $shm_file              = "${::apache::logroot}/jk-runtime-status",
   $shm_size              = undef,
   $mount_file            = undef,
   $mount_file_reload     = undef,
@@ -21,7 +21,7 @@ class apache::mod::jk (
   $mount_copy            = undef,
   $worker_indicator      = undef,
   $watchdog_interval     = undef,
-  $log_file              = undef,
+  $log_file              = "${::apache::logroot}/mod_jk.log",
   $log_level             = undef,
   $log_stamp_format      = undef,
   $request_log_format    = undef,

--- a/manifests/mod/jk.pp
+++ b/manifests/mod/jk.pp
@@ -53,7 +53,7 @@ class apache::mod::jk (
   $workers_file_content  = [],
   # Mount file content
   # See comments in template mod/jk/uriworkermap.properties.erb
-  $mount_file_content  = [],
+  $mount_file_content    = [],
 ){
 
   include ::apache

--- a/manifests/mod/jk.pp
+++ b/manifests/mod/jk.pp
@@ -11,7 +11,7 @@
 class apache::mod::jk (
   $workers_file          = undef,
   $worker_property       = {},
-  $logroot               = undef,
+  $logroot               = $::apache::logroot,
   $shm_file              = 'jk-runtime-status',
   $shm_size              = undef,
   $mount_file            = undef,
@@ -70,14 +70,8 @@ class apache::mod::jk (
   }
 
   # Shared memory and log paths
-  if $logroot == undef {
-    $shm_path = "${::apache::logroot}/${shm_file}"
-    $log_path = "${::apache::logroot}/${log_file}"
-  }
-  else {
-    $shm_path = "${logroot}/${shm_file}"
-    $log_path = "${logroot}/${log_file}"
-  }
+  $shm_path = "${logroot}/${shm_file}"
+  $log_path = "${logroot}/${log_file}"
 
   # Main config file
   file {'jk.conf':

--- a/manifests/mod/jk.pp
+++ b/manifests/mod/jk.pp
@@ -56,8 +56,6 @@ class apache::mod::jk (
   $mount_file_content    = {},
 ){
 
-  include ::apache
-
   # Provides important variables
   include ::apache
   # Manages basic module config

--- a/manifests/mod/jk.pp
+++ b/manifests/mod/jk.pp
@@ -54,17 +54,21 @@ class apache::mod::jk (
   # Manages basic module config
   ::apache::mod { 'jk': }
 
+  # File resource common parameters
+  File {
+    ensure  => file,
+    mode    => $::apache::file_mode,
+    notify  => Class['apache::service'],
+  }
+
   # Main config file
   file {'jk.conf':
-    ensure  => file,
     path    => "${::apache::mod_dir}/jk.conf",
-    mode    => $::apache::file_mode,
     content => template('apache/mod/jk.conf.erb'),
     require => [
       Exec["mkdir ${::apache::mod_dir}"],
       File[$::apache::mod_dir],
     ],
-    notify  => Class['apache::service'],
   }
 
 }

--- a/manifests/mod/jk.pp
+++ b/manifests/mod/jk.pp
@@ -1,0 +1,7 @@
+class apache::mod::jk {
+
+  include ::apache
+
+  ::apache::mod { 'jk': }
+
+}

--- a/manifests/mod/jk.pp
+++ b/manifests/mod/jk.pp
@@ -49,8 +49,12 @@ class apache::mod::jk (
 
   include ::apache
 
+  # Provides important variables
+  include ::apache
+  # Manages basic module config
   ::apache::mod { 'jk': }
 
+  # Main config file
   file {'jk.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/jk.conf",

--- a/manifests/mod/jk.pp
+++ b/manifests/mod/jk.pp
@@ -1,4 +1,11 @@
-class apache::mod::jk {
+class apache::mod::jk (
+  $workers_file,
+  $jk_mount = undef,
+  $jk_mount_file = undef,
+  $log_file = undef,
+  $log_level = undef,
+  $log_stamp_format = undef,
+){
 
   include ::apache
 

--- a/spec/classes/mod/jk_spec.rb
+++ b/spec/classes/mod/jk_spec.rb
@@ -10,7 +10,6 @@ describe 'apache::mod::jk', :type => :class do
     it { is_expected.to contain_class('apache') }
     it { is_expected.to contain_apache__mod('jk') }
     it { is_expected.to contain_file('jk.conf').that_notifies('Class[apache::service]') }
-    verify_contents(catalogue, 'jk.conf', ['<IfModule jk_module>', '</IfModule>'])
   end
 
   context "with only required facts and no parameters" do
@@ -24,6 +23,7 @@ describe 'apache::mod::jk', :type => :class do
     end
 
     it_behaves_like 'minimal resources'
+    verify_contents(catalogue, 'jk.conf', ['<IfModule jk_module>', '</IfModule>'])
 
   end
 

--- a/spec/classes/mod/jk_spec.rb
+++ b/spec/classes/mod/jk_spec.rb
@@ -18,7 +18,7 @@ describe 'apache::mod::jk', :type => :class do
     it { is_expected.to contain_class('apache') }
     it { is_expected.to contain_apache__mod('jk') }
     it { is_expected.to contain_file('jk.conf').that_notifies('Class[apache::service]').with(
-      :ensure  => file,
+      :ensure  => 'file',
       :content => /<IfModule jk_module>/,
       :content => /<\/IfModule>/,
     )}

--- a/spec/classes/mod/jk_spec.rb
+++ b/spec/classes/mod/jk_spec.rb
@@ -22,6 +22,13 @@ describe 'apache::mod::jk', :type => :class do
       }
     end
 
+    let :params do
+      {
+        :log_file => '/var/log/httpd/mod_jk.log',
+        :shm_file => '/var/log/httpd/jk-runtime-status',
+      }
+    end
+
     it_behaves_like 'minimal resources'
     it {
       verify_contents(catalogue, 'jk.conf', ['<IfModule jk_module>', '</IfModule>'])

--- a/spec/classes/mod/jk_spec.rb
+++ b/spec/classes/mod/jk_spec.rb
@@ -17,7 +17,11 @@ describe 'apache::mod::jk', :type => :class do
     it { is_expected.to create_class('apache::mod::jk') }
     it { is_expected.to contain_class('apache') }
     it { is_expected.to contain_apache__mod('jk') }
-    it { is_expected.to contain_file('jk.conf') }
+    it { is_expected.to contain_file('jk.conf').that_notifies('Class[apache::service]').with(
+      :ensure  => file,
+      :content => /<IfModule jk_module>/,
+      :content => /<\/IfModule>/,
+    )}
 
   end
 

--- a/spec/classes/mod/jk_spec.rb
+++ b/spec/classes/mod/jk_spec.rb
@@ -9,8 +9,8 @@ describe 'apache::mod::jk', :type => :class do
   it { is_expected.to contain_apache__mod('jk') }
   it { is_expected.to contain_file('jk.conf').that_notifies('Class[apache::service]').with(
     :ensure  => file,
-    :content => /<IfModule jk_module>/),
-    :content => /<\/IfModule>/),
-  }
+    :content => /<IfModule jk_module>/,
+    :content => /<\/IfModule>/,
+  )}
 
 end

--- a/spec/classes/mod/jk_spec.rb
+++ b/spec/classes/mod/jk_spec.rb
@@ -3,14 +3,26 @@ require 'spec_helper'
 describe 'apache::mod::jk', :type => :class do
   it_behaves_like 'a mod class, without including apache'
 
-  it { is_expected.to compile }
-  it { is_expected.to create_class('apache::mod::jk') }
-  it { is_expected.to contain_class('apache') }
-  it { is_expected.to contain_apache__mod('jk') }
-  it { is_expected.to contain_file('jk.conf').that_notifies('Class[apache::service]').with(
-    :ensure  => file,
-    :content => /<IfModule jk_module>/,
-    :content => /<\/IfModule>/,
-  )}
+  context "with only required facts and no parameters" do
+
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystem        => 'RedHat',
+        :operatingsystemrelease => '6',
+      }
+    end
+
+    it { is_expected.to compile }
+    it { is_expected.to create_class('apache::mod::jk') }
+    it { is_expected.to contain_class('apache') }
+    it { is_expected.to contain_apache__mod('jk') }
+    it { is_expected.to contain_file('jk.conf').that_notifies('Class[apache::service]').with(
+      :ensure  => file,
+      :content => /<IfModule jk_module>/,
+      :content => /<\/IfModule>/,
+    )}
+
+  end
 
 end

--- a/spec/classes/mod/jk_spec.rb
+++ b/spec/classes/mod/jk_spec.rb
@@ -12,7 +12,7 @@ describe 'apache::mod::jk', :type => :class do
     it { is_expected.to contain_file('jk.conf').that_notifies('Class[apache::service]') }
   end
 
-  context "with only required facts and no parameters" do
+  context "RHEL 6 with only required facts and no parameters" do
 
     let (:facts) do
       {
@@ -28,6 +28,31 @@ describe 'apache::mod::jk', :type => :class do
 
     let (:params) do
       { :logroot => '/var/log/httpd' }
+    end
+
+    it_behaves_like 'minimal resources'
+    it {
+      verify_contents(catalogue, 'jk.conf', ['<IfModule jk_module>', '</IfModule>'])
+    }
+
+  end
+
+  context "Debian 8 with only required facts and no parameters" do
+
+    let (:facts) do
+      {
+        :osfamily               => 'Debian',
+        :operatingsystem        => 'Debian',
+        :operatingsystemrelease => '8',
+      }
+    end
+
+    let (:pre_condition) do
+      'include apache'
+    end
+
+    let (:params) do
+      { :logroot => '/var/log/apache2' }
     end
 
     it_behaves_like 'minimal resources'

--- a/spec/classes/mod/jk_spec.rb
+++ b/spec/classes/mod/jk_spec.rb
@@ -17,11 +17,7 @@ describe 'apache::mod::jk', :type => :class do
     it { is_expected.to create_class('apache::mod::jk') }
     it { is_expected.to contain_class('apache') }
     it { is_expected.to contain_apache__mod('jk') }
-    it { is_expected.to contain_file('jk.conf').that_notifies('Class[apache::service]').with(
-      :ensure  => file,
-      :content => /<IfModule jk_module>/,
-      :content => /<\/IfModule>/,
-    )}
+    it { is_expected.to contain_file('jk.conf') }
 
   end
 

--- a/spec/classes/mod/jk_spec.rb
+++ b/spec/classes/mod/jk_spec.rb
@@ -23,7 +23,9 @@ describe 'apache::mod::jk', :type => :class do
     end
 
     it_behaves_like 'minimal resources'
-    verify_contents(catalogue, 'jk.conf', ['<IfModule jk_module>', '</IfModule>'])
+    it {
+      verify_contents(catalogue, 'jk.conf', ['<IfModule jk_module>', '</IfModule>'])
+    }
 
   end
 

--- a/spec/classes/mod/jk_spec.rb
+++ b/spec/classes/mod/jk_spec.rb
@@ -22,11 +22,8 @@ describe 'apache::mod::jk', :type => :class do
       }
     end
 
-    let :params do
-      {
-        :log_file => '/var/log/httpd/mod_jk.log',
-        :shm_file => '/var/log/httpd/jk-runtime-status',
-      }
+    let(:pre_condition) do
+      'include apache'
     end
 
     it_behaves_like 'minimal resources'

--- a/spec/classes/mod/jk_spec.rb
+++ b/spec/classes/mod/jk_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'apache::mod::jk', :type => :class do
+  it_behaves_like 'a mod class, without including apache'
+
+  it { is_expected.to compile }
+  it { is_expected.to create_class('apache::mod::jk') }
+  it { is_expected.to contain_class('apache') }
+  it { is_expected.to contain_apache__mod('jk') }
+  it { is_expected.to contain_file('jk.conf').that_notifies('Class[apache::service]').with(
+    :ensure  => file,
+    :content => /<IfModule jk_module>/),
+    :content => /<\/IfModule>/),
+  }
+
+end

--- a/spec/classes/mod/jk_spec.rb
+++ b/spec/classes/mod/jk_spec.rb
@@ -9,11 +9,8 @@ describe 'apache::mod::jk', :type => :class do
     it { is_expected.to create_class('apache::mod::jk') }
     it { is_expected.to contain_class('apache') }
     it { is_expected.to contain_apache__mod('jk') }
-    it { is_expected.to contain_file('jk.conf').that_notifies('Class[apache::service]').with(
-      :ensure  => 'file',
-      :content => /<IfModule jk_module>/,
-      :content => /<\/IfModule>/,
-    )}
+    it { is_expected.to contain_file('jk.conf').that_notifies('Class[apache::service]') }
+    verify_contents(catalogue, 'jk.conf', ['<IfModule jk_module>', '</IfModule>'])
   end
 
   context "with only required facts and no parameters" do

--- a/spec/classes/mod/jk_spec.rb
+++ b/spec/classes/mod/jk_spec.rb
@@ -27,7 +27,7 @@ describe 'apache::mod::jk', :type => :class do
     end
 
     let (:params) do
-      :logroot => '/var/log/httpd'
+      { :logroot => '/var/log/httpd' }
     end
 
     it_behaves_like 'minimal resources'

--- a/spec/classes/mod/jk_spec.rb
+++ b/spec/classes/mod/jk_spec.rb
@@ -14,7 +14,7 @@ describe 'apache::mod::jk', :type => :class do
 
   context "with only required facts and no parameters" do
 
-    let :facts do
+    let (:facts) do
       {
         :osfamily               => 'RedHat',
         :operatingsystem        => 'RedHat',

--- a/spec/classes/mod/jk_spec.rb
+++ b/spec/classes/mod/jk_spec.rb
@@ -3,6 +3,18 @@ require 'spec_helper'
 describe 'apache::mod::jk', :type => :class do
   it_behaves_like 'a mod class, without including apache'
 
+  shared_examples 'minimal resources' do
+    it { is_expected.to compile }
+    it { is_expected.to create_class('apache::mod::jk') }
+    it { is_expected.to contain_class('apache') }
+    it { is_expected.to contain_apache__mod('jk') }
+    it { is_expected.to contain_file('jk.conf').that_notifies('Class[apache::service]').with(
+      :ensure  => 'file',
+      :content => /<IfModule jk_module>/,
+      :content => /<\/IfModule>/,
+    )}
+  end
+
   context "with only required facts and no parameters" do
 
     let :facts do
@@ -13,15 +25,7 @@ describe 'apache::mod::jk', :type => :class do
       }
     end
 
-    it { is_expected.to compile }
-    it { is_expected.to create_class('apache::mod::jk') }
-    it { is_expected.to contain_class('apache') }
-    it { is_expected.to contain_apache__mod('jk') }
-    it { is_expected.to contain_file('jk.conf').that_notifies('Class[apache::service]').with(
-      :ensure  => 'file',
-      :content => /<IfModule jk_module>/,
-      :content => /<\/IfModule>/,
-    )}
+    it_behaves_like 'minimal resources'
 
   end
 

--- a/spec/classes/mod/jk_spec.rb
+++ b/spec/classes/mod/jk_spec.rb
@@ -22,8 +22,12 @@ describe 'apache::mod::jk', :type => :class do
       }
     end
 
-    let(:pre_condition) do
+    let (:pre_condition) do
       'include apache'
+    end
+
+    let (:params) do
+      :logroot => '/var/log/httpd'
     end
 
     it_behaves_like 'minimal resources'

--- a/spec/classes/mod/jk_spec.rb
+++ b/spec/classes/mod/jk_spec.rb
@@ -5,6 +5,7 @@ describe 'apache::mod::jk', :type => :class do
 
   shared_examples 'minimal resources' do
     it { is_expected.to compile }
+    it { is_expected.to compile.with_all_deps }
     it { is_expected.to create_class('apache::mod::jk') }
     it { is_expected.to contain_class('apache') }
     it { is_expected.to contain_apache__mod('jk') }

--- a/templates/mod/jk.conf.erb
+++ b/templates/mod/jk.conf.erb
@@ -22,10 +22,14 @@ JkMountFile <%= @mount_file %>
 JkMountFileReload <%= @mount_file_reload %>
 <% end -%>
 <% if @mount -%>
-JkMount <%= @mount %>
+<% @mount.sort.each do |url_prefix,worker_name| -%>
+JkMount <%= @url_prefix %> <%= @worker_name %>
+<% end -%>
 <% end -%>
 <% if @un_mount -%>
-JkUnMount <%= @un_mount %>
+<% @un_mount.sort.each do |url_prefix,worker_name| -%>
+JkUnMount <%= @url_prefix %> <%= @worker_name %>
+<% end -%>
 <% end -%>
 <% if @auto_alias -%>
 JkAutoAlias <%= @auto_alias %>
@@ -103,10 +107,14 @@ JkRemoteUserIndicator <%= @remote_user_indicator %>
 JkAuthTypeIndicator <%= @auth_type_indicator %>
 <% end -%>
 <% if @options -%>
-JkOptions <%= @options %>
+<% @options.sort.each do |fwd_option| -%>
+JkOptions <%= @fwd_option %>
+<% end -%>
 <% end -%>
 <% if @env_var -%>
-JkEnvVar <%= @env_var %>
+<% @env_var.sort.each do |variable,value| -%>
+JkEnvVar <%= @variable %><% if not @value.empty? -%> @value<% end -%>
+<% end -%>
 <% end -%>
 <% if @strip_session -%>
 JkStripSession <%= @strip_session %>

--- a/templates/mod/jk.conf.erb
+++ b/templates/mod/jk.conf.erb
@@ -2,3 +2,13 @@
 # Any manual changes will be overwritten
 
 JkWorkersFile <%= @workers_file %>
+
+<% if @log_file -%>
+JkLogFile <%= @log_file %>
+<% end -%>
+<% if @log_level -%>
+JkLogLevel <%= @log_level %>
+<% end -%>
+<% if @log_stamp_format -%>
+JkLogStampFormat <%= @log_stamp_format %>
+<% end -%>

--- a/templates/mod/jk.conf.erb
+++ b/templates/mod/jk.conf.erb
@@ -1,13 +1,42 @@
 # This file is generated automatically by Puppet - DO NOT EDIT
 # Any manual changes will be overwritten
 
+<% if @workers_file -%>
 JkWorkersFile <%= @workers_file %>
-<%# Define jk_mount_file if workers map should be global -%>
-<%# Otherwise, include JkMount directives in your vhosts -%>
-<% if @jk_mount_file -%>
-JkMountFile <%= @jk_mount_file %>
 <% end -%>
-
+<% if @worker_property -%>
+JkWorkerProperty <%= @worker_property %>
+<% end -%>
+<% if @shm_file -%>
+JkShmFile <%= @shm_file %>
+<% end -%>
+<% if @shm_size -%>
+JkShmSize <%= @shm_size %>
+<% end -%>
+<% if @mount_file -%>
+JkMountFile <%= @mount_file %>
+<% end -%>
+<% if @mount_file_reload -%>
+JkMountFileReload <%= @mount_file_reload %>
+<% end -%>
+<% if @mount -%>
+JkMount <%= @mount %>
+<% end -%>
+<% if @un_mount -%>
+JkUnMount <%= @un_mount %>
+<% end -%>
+<% if @auto_alias -%>
+JkAutoAlias <%= @auto_alias %>
+<% end -%>
+<% if @mount_copy -%>
+JkMountCopy <%= @mount_copy %>
+<% end -%>
+<% if @worker_indicator -%>
+JkWorkerIndicator <%= @worker_indicator %>
+<% end -%>
+<% if @watchdog_interval -%>
+JkWatchdogInterval <%= @watchdog_interval %>
+<% end -%>
 <% if @log_file -%>
 JkLogFile <%= @log_file %>
 <% end -%>
@@ -16,4 +45,67 @@ JkLogLevel <%= @log_level %>
 <% end -%>
 <% if @log_stamp_format -%>
 JkLogStampFormat <%= @log_stamp_format %>
+<% end -%>
+<% if @request_log_format -%>
+JkRequestLogFormat <%= @request_log_format %>
+<% end -%>
+<% if @extract_ssl -%>
+JkExtractSSL <%= @extract_ssl %>
+<% end -%>
+<% if @https_indicator -%>
+JkHTTPSIndicator <%= @https_indicator %>
+<% end -%>
+<% if @sslprotocol_indicator -%>
+JkSSLPROTOCOLIndicator <%= @sslprotocol_indicator %>
+<% end -%>
+<% if @certs_indicator -%>
+JkCERTSIndicator <%= @certs_indicator %>
+<% end -%>
+<% if @cipher_indicator -%>
+JkCIPHERIndicator <%= @cipher_indicator %>
+<% end -%>
+<% if @certchain_prefix -%>
+JkCERTCHAINPrefix <%= @certchain_prefix %>
+<% end -%>
+<% if @session_indicator -%>
+JkSESSIONIndicator <%= @session_indicator %>
+<% end -%>
+<% if @keysize_indicator -%>
+JkKEYSIZEIndicator <%= @keysize_indicator %>
+<% end -%>
+<% if @local_name_indicator -%>
+JkLocalNameIndicator <%= @local_name_indicator %>
+<% end -%>
+<% if @ignore_cl_indicator -%>
+JkIgnoreCLIndicator <%= @ignore_cl_indicator %>
+<% end -%>
+<% if @local_addr_indicator -%>
+JkLocalAddrIndicator <%= @local_addr_indicator %>
+<% end -%>
+<% if @local_port_indicator -%>
+JkLocalPortIndicator <%= @local_port_indicator %>
+<% end -%>
+<% if @remote_host_indicator -%>
+JkRemoteHostIndicator <%= @remote_host_indicator %>
+<% end -%>
+<% if @remote_addr_indicator -%>
+JkRemoteAddrIndicator <%= @remote_addr_indicator %>
+<% end -%>
+<% if @remote_port_indicator -%>
+JkRemotePortIndicator <%= @remote_port_indicator %>
+<% end -%>
+<% if @remote_user_indicator -%>
+JkRemoteUserIndicator <%= @remote_user_indicator %>
+<% end -%>
+<% if @auth_type_indicator -%>
+JkAuthTypeIndicator <%= @auth_type_indicator %>
+<% end -%>
+<% if @options -%>
+JkOptions <%= @options %>
+<% end -%>
+<% if @env_var -%>
+JkEnvVar <%= @env_var %>
+<% end -%>
+<% if @strip_session -%>
+JkStripSession <%= @strip_session %>
 <% end -%>

--- a/templates/mod/jk.conf.erb
+++ b/templates/mod/jk.conf.erb
@@ -10,8 +10,8 @@
   JkWorkerProperty <%= property %>=<%= value %>
   <%- end -%>
   <%- end -%>
-  <%- if @shm_file -%>
-  JkShmFile <%= @shm_file %>
+  <%- if @shm_path -%>
+  JkShmFile <%= @shm_path %>
   <%- end -%>
   <%- if @shm_size -%>
   JkShmSize <%= @shm_size %>
@@ -44,8 +44,8 @@
   <%- if @watchdog_interval -%>
   JkWatchdogInterval <%= @watchdog_interval %>
   <%- end -%>
-  <%- if @log_file -%>
-  JkLogFile <%= @log_file %>
+  <%- if @log_path -%>
+  JkLogFile <%= @log_path %>
   <%- end -%>
   <%- if @log_level -%>
   JkLogLevel <%= @log_level %>

--- a/templates/mod/jk.conf.erb
+++ b/templates/mod/jk.conf.erb
@@ -120,6 +120,35 @@
   <%- if @strip_session -%>
   JkStripSession <%= @strip_session %>
   <%- end -%>
+  <%# -%>
+  <%# Global locations for mod_jk are defined in array location_list -%>
+  <%# Each array item is a hash with quoted* property name as key -%>
+  <%# and value as value itself -%>
+  <%# You can define a comment in a special 'comment' key -%>
+  <%# -%>
+  <%# Example: -%>
+  <%# <Location /jkstatus/> -%>
+  <%#   # Configures jkstatus -%>
+  <%#   JkMount status -%>
+  <%#   Order deny,allow -%>
+  <%#   Deny from all -%>
+  <%#   Allow from 127.0.0.1 -%>
+  <%# </Location> -%>
+  <%# -%>
+  <%# Is defined as: -%>
+  <%# location_list = [ -%>
+  <%#   { -%>
+  <%#     'Location'   => '/jkstatus/', -%>
+  <%#     'Comment'    => 'Configures jkstatus', -%>
+  <%#     'JkMount'    => 'status', -%>
+  <%#     'Order'      => 'deny,allow', -%>
+  <%#     'Deny from'  => 'all', -%>
+  <%#     'Allow from' => '127.0.0.1', -%>
+  <%#   }, -%>
+  <%# ] -%>
+  <%# * Keys must be quoted to alow arbitrary case and/or multi-word keys -%>
+  <%# (BTW, note the case of 'Location' and 'Comment' keys) -%>
+  <%# -%>
   <%- if @location_list -%>
   <%- @location_list.each do |location_tag| -%>
 

--- a/templates/mod/jk.conf.erb
+++ b/templates/mod/jk.conf.erb
@@ -2,6 +2,11 @@
 # Any manual changes will be overwritten
 
 JkWorkersFile <%= @workers_file %>
+<%# Define jk_mount_file if workers map should be global -%>
+<%# Otherwise, include JkMount directives in your vhosts -%>
+<% if @jk_mount_file -%>
+JkMountFile <%= @jk_mount_file %>
+<% end -%>
 
 <% if @log_file -%>
 JkLogFile <%= @log_file %>

--- a/templates/mod/jk.conf.erb
+++ b/templates/mod/jk.conf.erb
@@ -120,4 +120,19 @@
   <%- if @strip_session -%>
   JkStripSession <%= @strip_session %>
   <%- end -%>
+  <%- if @location_list -%>
+  <%- @location_list.each do |location_tag| -%>
+
+  <Location <%= location_tag['Location'] %>>
+    <%- if location_tag.has_key?('Comment') -%>
+    # <%= location_tag['Comment'] %>
+    <%- end -%>
+    <%- location_tag.each do |property,value| -%>
+    <%- if property != 'Comment' and property != 'Location' -%>
+    <%= property %> <%= value %>
+    <%- end -%>
+    <%- end -%>
+  </Location>
+  <%- end -%>
+  <%- end -%>
 </IfModule>

--- a/templates/mod/jk.conf.erb
+++ b/templates/mod/jk.conf.erb
@@ -1,0 +1,2 @@
+# This file is generated automatically by Puppet - DO NOT EDIT
+# Any manual changes will be overwritten

--- a/templates/mod/jk.conf.erb
+++ b/templates/mod/jk.conf.erb
@@ -1,2 +1,4 @@
 # This file is generated automatically by Puppet - DO NOT EDIT
 # Any manual changes will be overwritten
+
+JkWorkersFile <%= @workers_file %>

--- a/templates/mod/jk.conf.erb
+++ b/templates/mod/jk.conf.erb
@@ -120,35 +120,35 @@
   <%- if @strip_session -%>
   JkStripSession <%= @strip_session %>
   <%- end -%>
-  <%# -%>
-  <%# Global locations for mod_jk are defined in array location_list -%>
-  <%# Each array item is a hash with quoted* property name as key -%>
-  <%# and value as value itself -%>
-  <%# You can define a comment in a special 'comment' key -%>
-  <%# -%>
-  <%# Example: -%>
-  <%# <Location /jkstatus/> -%>
-  <%#   # Configures jkstatus -%>
-  <%#   JkMount status -%>
-  <%#   Order deny,allow -%>
-  <%#   Deny from all -%>
-  <%#   Allow from 127.0.0.1 -%>
-  <%# </Location> -%>
-  <%# -%>
-  <%# Is defined as: -%>
-  <%# location_list = [ -%>
-  <%#   { -%>
-  <%#     'Location'   => '/jkstatus/', -%>
-  <%#     'Comment'    => 'Configures jkstatus', -%>
-  <%#     'JkMount'    => 'status', -%>
-  <%#     'Order'      => 'deny,allow', -%>
-  <%#     'Deny from'  => 'all', -%>
-  <%#     'Allow from' => '127.0.0.1', -%>
-  <%#   }, -%>
-  <%# ] -%>
-  <%# * Keys must be quoted to alow arbitrary case and/or multi-word keys -%>
-  <%# (BTW, note the case of 'Location' and 'Comment' keys) -%>
-  <%# -%>
+  <%-# -%>
+  <%-# Global locations for mod_jk are defined in array location_list -%>
+  <%-# Each array item is a hash with quoted* property name as key -%>
+  <%-# and value as value itself -%>
+  <%-# You can define a comment in a special 'comment' key -%>
+  <%-# -%>
+  <%-# Example: -%>
+  <%-# <Location /jkstatus/> -%>
+  <%-#   # Configures jkstatus -%>
+  <%-#   JkMount status -%>
+  <%-#   Order deny,allow -%>
+  <%-#   Deny from all -%>
+  <%-#   Allow from 127.0.0.1 -%>
+  <%-# </Location> -%>
+  <%-# -%>
+  <%-# Is defined as: -%>
+  <%-# location_list = [ -%>
+  <%-#   { -%>
+  <%-#     'Location'   => '/jkstatus/', -%>
+  <%-#     'Comment'    => 'Configures jkstatus', -%>
+  <%-#     'JkMount'    => 'status', -%>
+  <%-#     'Order'      => 'deny,allow', -%>
+  <%-#     'Deny from'  => 'all', -%>
+  <%-#     'Allow from' => '127.0.0.1', -%>
+  <%-#   }, -%>
+  <%-# ] -%>
+  <%-# * Keys must be quoted to allow arbitrary case and/or multi-word keys -%>
+  <%-# (BTW, note the case of 'Location' and 'Comment' keys) -%>
+  <%-# -%>
   <%- if @location_list -%>
   <%- @location_list.each do |location_tag| -%>
 

--- a/templates/mod/jk.conf.erb
+++ b/templates/mod/jk.conf.erb
@@ -5,7 +5,9 @@
 JkWorkersFile <%= @workers_file %>
 <% end -%>
 <% if @worker_property -%>
-JkWorkerProperty <%= @worker_property %>
+<% @worker_property.sort.each do |property,value| -%>
+JkWorkerProperty <%= @property %>=<%= @value %>
+<% end -%>
 <% end -%>
 <% if @shm_file -%>
 JkShmFile <%= @shm_file %>

--- a/templates/mod/jk.conf.erb
+++ b/templates/mod/jk.conf.erb
@@ -6,7 +6,7 @@ JkWorkersFile <%= @workers_file %>
 <% end -%>
 <% if @worker_property -%>
 <% @worker_property.sort.each do |property,value| -%>
-JkWorkerProperty <%= @property %>=<%= @value %>
+JkWorkerProperty <%= property %>=<%= value %>
 <% end -%>
 <% end -%>
 <% if @shm_file -%>
@@ -23,12 +23,12 @@ JkMountFileReload <%= @mount_file_reload %>
 <% end -%>
 <% if @mount -%>
 <% @mount.sort.each do |url_prefix,worker_name| -%>
-JkMount <%= @url_prefix %> <%= @worker_name %>
+JkMount <%= url_prefix %> <%= worker_name %>
 <% end -%>
 <% end -%>
 <% if @un_mount -%>
 <% @un_mount.sort.each do |url_prefix,worker_name| -%>
-JkUnMount <%= @url_prefix %> <%= @worker_name %>
+JkUnMount <%= url_prefix %> <%= worker_name %>
 <% end -%>
 <% end -%>
 <% if @auto_alias -%>
@@ -108,12 +108,12 @@ JkAuthTypeIndicator <%= @auth_type_indicator %>
 <% end -%>
 <% if @options -%>
 <% @options.sort.each do |fwd_option| -%>
-JkOptions <%= @fwd_option %>
+JkOptions <%= fwd_option %>
 <% end -%>
 <% end -%>
 <% if @env_var -%>
 <% @env_var.sort.each do |variable,value| -%>
-JkEnvVar <%= @variable %><% if not @value.empty? -%> @value<% end -%>
+JkEnvVar <%= variable %><% if not value.empty? -%> value<% end -%>
 <% end -%>
 <% end -%>
 <% if @strip_session -%>

--- a/templates/mod/jk.conf.erb
+++ b/templates/mod/jk.conf.erb
@@ -1,121 +1,123 @@
 # This file is generated automatically by Puppet - DO NOT EDIT
 # Any manual changes will be overwritten
 
-<% if @workers_file -%>
-JkWorkersFile <%= @workers_file %>
-<% end -%>
-<% if @worker_property -%>
-<% @worker_property.sort.each do |property,value| -%>
-JkWorkerProperty <%= property %>=<%= value %>
-<% end -%>
-<% end -%>
-<% if @shm_file -%>
-JkShmFile <%= @shm_file %>
-<% end -%>
-<% if @shm_size -%>
-JkShmSize <%= @shm_size %>
-<% end -%>
-<% if @mount_file -%>
-JkMountFile <%= @mount_file %>
-<% end -%>
-<% if @mount_file_reload -%>
-JkMountFileReload <%= @mount_file_reload %>
-<% end -%>
-<% if @mount -%>
-<% @mount.sort.each do |url_prefix,worker_name| -%>
-JkMount <%= url_prefix %> <%= worker_name %>
-<% end -%>
-<% end -%>
-<% if @un_mount -%>
-<% @un_mount.sort.each do |url_prefix,worker_name| -%>
-JkUnMount <%= url_prefix %> <%= worker_name %>
-<% end -%>
-<% end -%>
-<% if @auto_alias -%>
-JkAutoAlias <%= @auto_alias %>
-<% end -%>
-<% if @mount_copy -%>
-JkMountCopy <%= @mount_copy %>
-<% end -%>
-<% if @worker_indicator -%>
-JkWorkerIndicator <%= @worker_indicator %>
-<% end -%>
-<% if @watchdog_interval -%>
-JkWatchdogInterval <%= @watchdog_interval %>
-<% end -%>
-<% if @log_file -%>
-JkLogFile <%= @log_file %>
-<% end -%>
-<% if @log_level -%>
-JkLogLevel <%= @log_level %>
-<% end -%>
-<% if @log_stamp_format -%>
-JkLogStampFormat <%= @log_stamp_format %>
-<% end -%>
-<% if @request_log_format -%>
-JkRequestLogFormat <%= @request_log_format %>
-<% end -%>
-<% if @extract_ssl -%>
-JkExtractSSL <%= @extract_ssl %>
-<% end -%>
-<% if @https_indicator -%>
-JkHTTPSIndicator <%= @https_indicator %>
-<% end -%>
-<% if @sslprotocol_indicator -%>
-JkSSLPROTOCOLIndicator <%= @sslprotocol_indicator %>
-<% end -%>
-<% if @certs_indicator -%>
-JkCERTSIndicator <%= @certs_indicator %>
-<% end -%>
-<% if @cipher_indicator -%>
-JkCIPHERIndicator <%= @cipher_indicator %>
-<% end -%>
-<% if @certchain_prefix -%>
-JkCERTCHAINPrefix <%= @certchain_prefix %>
-<% end -%>
-<% if @session_indicator -%>
-JkSESSIONIndicator <%= @session_indicator %>
-<% end -%>
-<% if @keysize_indicator -%>
-JkKEYSIZEIndicator <%= @keysize_indicator %>
-<% end -%>
-<% if @local_name_indicator -%>
-JkLocalNameIndicator <%= @local_name_indicator %>
-<% end -%>
-<% if @ignore_cl_indicator -%>
-JkIgnoreCLIndicator <%= @ignore_cl_indicator %>
-<% end -%>
-<% if @local_addr_indicator -%>
-JkLocalAddrIndicator <%= @local_addr_indicator %>
-<% end -%>
-<% if @local_port_indicator -%>
-JkLocalPortIndicator <%= @local_port_indicator %>
-<% end -%>
-<% if @remote_host_indicator -%>
-JkRemoteHostIndicator <%= @remote_host_indicator %>
-<% end -%>
-<% if @remote_addr_indicator -%>
-JkRemoteAddrIndicator <%= @remote_addr_indicator %>
-<% end -%>
-<% if @remote_port_indicator -%>
-JkRemotePortIndicator <%= @remote_port_indicator %>
-<% end -%>
-<% if @remote_user_indicator -%>
-JkRemoteUserIndicator <%= @remote_user_indicator %>
-<% end -%>
-<% if @auth_type_indicator -%>
-JkAuthTypeIndicator <%= @auth_type_indicator %>
-<% end -%>
-<% if @options -%>
-<% @options.sort.each do |fwd_option| -%>
-JkOptions <%= fwd_option %>
-<% end -%>
-<% end -%>
-<% if @env_var -%>
-<% @env_var.sort.each do |variable,value| -%>
-JkEnvVar <%= variable %><% if not value.empty? -%> value<% end -%>
-<% end -%>
-<% end -%>
-<% if @strip_session -%>
-JkStripSession <%= @strip_session %>
-<% end -%>
+<IfModule jk_module>
+  <%- if @workers_file -%>
+  JkWorkersFile <%= @workers_file %>
+  <%- end -%>
+  <%- if @worker_property -%>
+  <%- @worker_property.sort.each do |property,value| -%>
+  JkWorkerProperty <%= property %>=<%= value %>
+  <%- end -%>
+  <%- end -%>
+  <%- if @shm_file -%>
+  JkShmFile <%= @shm_file %>
+  <%- end -%>
+  <%- if @shm_size -%>
+  JkShmSize <%= @shm_size %>
+  <%- end -%>
+  <%- if @mount_file -%>
+  JkMountFile <%= @mount_file %>
+  <%- end -%>
+  <%- if @mount_file_reload -%>
+  JkMountFileReload <%= @mount_file_reload %>
+  <%- end -%>
+  <%- if @mount -%>
+  <%- @mount.sort.each do |url_prefix,worker_name| -%>
+  JkMount <%= url_prefix %> <%= worker_name %>
+  <%- end -%>
+  <%- end -%>
+  <%- if @un_mount -%>
+  <%- @un_mount.sort.each do |url_prefix,worker_name| -%>
+  JkUnMount <%= url_prefix %> <%= worker_name %>
+  <%- end -%>
+  <%- end -%>
+  <%- if @auto_alias -%>
+  JkAutoAlias <%= @auto_alias %>
+  <%- end -%>
+  <%- if @mount_copy -%>
+  JkMountCopy <%= @mount_copy %>
+  <%- end -%>
+  <%- if @worker_indicator -%>
+  JkWorkerIndicator <%= @worker_indicator %>
+  <%- end -%>
+  <%- if @watchdog_interval -%>
+  JkWatchdogInterval <%= @watchdog_interval %>
+  <%- end -%>
+  <%- if @log_file -%>
+  JkLogFile <%= @log_file %>
+  <%- end -%>
+  <%- if @log_level -%>
+  JkLogLevel <%= @log_level %>
+  <%- end -%>
+  <%- if @log_stamp_format -%>
+  JkLogStampFormat <%= @log_stamp_format %>
+  <%- end -%>
+  <%- if @request_log_format -%>
+  JkRequestLogFormat <%= @request_log_format %>
+  <%- end -%>
+  <%- if @extract_ssl -%>
+  JkExtractSSL <%= @extract_ssl %>
+  <%- end -%>
+  <%- if @https_indicator -%>
+  JkHTTPSIndicator <%= @https_indicator %>
+  <%- end -%>
+  <%- if @sslprotocol_indicator -%>
+  JkSSLPROTOCOLIndicator <%= @sslprotocol_indicator %>
+  <%- end -%>
+  <%- if @certs_indicator -%>
+  JkCERTSIndicator <%= @certs_indicator %>
+  <%- end -%>
+  <%- if @cipher_indicator -%>
+  JkCIPHERIndicator <%= @cipher_indicator %>
+  <%- end -%>
+  <%- if @certchain_prefix -%>
+  JkCERTCHAINPrefix <%= @certchain_prefix %>
+  <%- end -%>
+  <%- if @session_indicator -%>
+  JkSESSIONIndicator <%= @session_indicator %>
+  <%- end -%>
+  <%- if @keysize_indicator -%>
+  JkKEYSIZEIndicator <%= @keysize_indicator %>
+  <%- end -%>
+  <%- if @local_name_indicator -%>
+  JkLocalNameIndicator <%= @local_name_indicator %>
+  <%- end -%>
+  <%- if @ignore_cl_indicator -%>
+  JkIgnoreCLIndicator <%= @ignore_cl_indicator %>
+  <%- end -%>
+  <%- if @local_addr_indicator -%>
+  JkLocalAddrIndicator <%= @local_addr_indicator %>
+  <%- end -%>
+  <%- if @local_port_indicator -%>
+  JkLocalPortIndicator <%= @local_port_indicator %>
+  <%- end -%>
+  <%- if @remote_host_indicator -%>
+  JkRemoteHostIndicator <%= @remote_host_indicator %>
+  <%- end -%>
+  <%- if @remote_addr_indicator -%>
+  JkRemoteAddrIndicator <%= @remote_addr_indicator %>
+  <%- end -%>
+  <%- if @remote_port_indicator -%>
+  JkRemotePortIndicator <%= @remote_port_indicator %>
+  <%- end -%>
+  <%- if @remote_user_indicator -%>
+  JkRemoteUserIndicator <%= @remote_user_indicator %>
+  <%- end -%>
+  <%- if @auth_type_indicator -%>
+  JkAuthTypeIndicator <%= @auth_type_indicator %>
+  <%- end -%>
+  <%- if @options -%>
+  <%- @options.sort.each do |fwd_option| -%>
+  JkOptions <%= fwd_option %>
+  <%- end -%>
+  <%- end -%>
+  <%- if @env_var -%>
+  <%- @env_var.sort.each do |variable,value| -%>
+  JkEnvVar <%= variable %><% if not value.empty? -%> value<% end -%>
+  <%- end -%>
+  <%- end -%>
+  <%- if @strip_session -%>
+  JkStripSession <%= @strip_session %>
+  <%- end -%>
+</IfModule>

--- a/templates/mod/jk/uriworkermap.properties.erb
+++ b/templates/mod/jk/uriworkermap.properties.erb
@@ -1,0 +1,12 @@
+# This file is generated automatically by Puppet - DO NOT EDIT
+# Any manual changes will be overwritten
+<% @mount_file_content.sort.each do |worker,directives| -%>
+
+<%# Places comment before worker mappings -%>
+<% if directives.has_key?('comment') -%>
+# <%= directives['comment'] %>
+<% end -%>
+<% directives['uri_list'].sort.each do |uri| -%>
+<%= uri %> = <%= worker %>
+<% end -%>
+<% end -%>

--- a/templates/mod/jk/uriworkermap.properties.erb
+++ b/templates/mod/jk/uriworkermap.properties.erb
@@ -1,5 +1,33 @@
 # This file is generated automatically by Puppet - DO NOT EDIT
 # Any manual changes will be overwritten
+<%# -%>
+<%# mount_file_content should be a hash which keys are workers names -%>
+<%# and values are new hashes with two items: -%>
+<%# uri_list - Array with URIs to be mapped to worker -%>
+<%# comment - Optional comment line -%>
+<%# -%>
+<%# Example: -%>
+<%# # Worker 1 -%>
+<%# /context_1/ = worker_1 -%>
+<%# /context_1/* = worker_1 -%>
+<%# -%>
+<%# # Worker 2 -%>
+<%# / = worker_2 -%>
+<%# /context_2/ = worker_2 -%>
+<%# /context_2/* = worker_2 -%>
+<%# -%>
+<%# should be parameterized as: -%>
+<%# $mount_file_content = { -%>
+<%#   worker_1 => { -%>
+<%#     uri_list => ['/context_1/', '/context_1/*'], -%>
+<%#     comment  => 'Worker 1', -%>
+<%#   }, -%>
+<%#   worker_2 => { -%>
+<%#     uri_list => ['/context_2/', '/context_2/*'], -%>
+<%#     comment  => 'Worker 2', -%>
+<%#   }, -%>
+<%# }, -%>
+<%# -%>
 <% @mount_file_content.sort.each do |worker,directives| -%>
 
 <%# Places comment before worker mappings -%>

--- a/templates/mod/jk/workers.properties.erb
+++ b/templates/mod/jk/workers.properties.erb
@@ -3,17 +3,26 @@
 <%# -%>
 <%# workers_file_content should be a hash which keys are workers names -%>
 <%# and values are new hashes with properties and values -%>
+<%# Two keys are special (and reserved!): -%>
+<%# worker_lists - Array of comma-separated worker names lists -%>
+<%# Each list is an item of the array and will be placed in one line -%>
+<%# worker_mantain - Numeric string -%>
 <%# -%>
 <%# Example: -%>
+<%# worker.list = status -%>
+<%# worker.list = some_name,other_name -%>
+<%# worker_mantain = 60 -%>
 <%# # Optional comment -%>
 <%# worker.some_name.type=ajp13 -%>
 <%# worker.some_name.socket_keepalive=true -%>
 <%# # I just like comments -%>
 <%# worker.other_name.type=ajp12 (why would you?) -%>
 <%# worker.other_name.socket_keepalive=false -%>
-<%# should be parameterized as: -%>
 <%# -%>
+<%# should be parameterized as: -%>
 <%# $workers_file_content = { -%>
+<%#   worker_lists => ['status', 'some_name,other_name'],
+<%#   worker_mantain => '60',
 <%#   some_name => { -%>
 <%#     type             => 'ajp13', -%>
 <%#     socket_keepalive => 'true', -%>

--- a/templates/mod/jk/workers.properties.erb
+++ b/templates/mod/jk/workers.properties.erb
@@ -36,7 +36,9 @@ worker.list = <%= list %>
 
 worker.maintain = <%= @workers_file_content['worker_mantain'] %>
 <% end -%>
-<% @workers_file_content.sort.each do |worker,directives| -%>
+<% @workers_file_content.sort.each do |name,directives| -%>
+<%# Skip hash items with the reserved keys -%>
+<% if not ['worker_lists', 'worker_mantain'].include?(name) -%>
 
 <%# Places comment before worker directives -%>
 <% if directives.has_key?('comment') -%>
@@ -44,7 +46,8 @@ worker.maintain = <%= @workers_file_content['worker_mantain'] %>
 <% end -%>
 <% directives.sort.each do |property,value| -%>
 <% if property != 'comment' -%>
-worker.<%= worker %>.<%= property %>=<%= value %>
+worker.<%= name %>.<%= property %>=<%= value %>
+<% end -%>
 <% end -%>
 <% end -%>
 <% end -%>

--- a/templates/mod/jk/workers.properties.erb
+++ b/templates/mod/jk/workers.properties.erb
@@ -2,7 +2,13 @@
 # Any manual changes will be overwritten
 <% @workers_file_content.sort.each do |worker,directives| -%>
 
+<%# Places comment before worker directives -%>
+<% if directives.has_key?('comment') -%>
+# <%= directives['comment'] %>
+<% end -%>
 <% directives.sort.each do |property,value| -%>
+<% if property != 'comment' -%>
 worker.<%= worker %>.<%= property %>=<%= value %>
+<% end -%>
 <% end -%>
 <% end -%>

--- a/templates/mod/jk/workers.properties.erb
+++ b/templates/mod/jk/workers.properties.erb
@@ -26,6 +26,16 @@
 <%#   }, -%>
 <%# }, -%>
 <%# -%>
+<% if @workers_file_content.has_key?('worker_lists') -%>
+
+<% @workers_file_content['worker_lists'].sort.each do |list| -%>
+worker.list = <%= list %>
+<% end -%>
+<% end -%>
+<% if @workers_file_content.has_key?('worker_mantain') -%>
+
+worker.maintain = <%= @workers_file_content['worker_mantain'] %>
+<% end -%>
 <% @workers_file_content.sort.each do |worker,directives| -%>
 
 <%# Places comment before worker directives -%>

--- a/templates/mod/jk/workers.properties.erb
+++ b/templates/mod/jk/workers.properties.erb
@@ -11,7 +11,7 @@
 <%# Example: -%>
 <%# worker.list = status -%>
 <%# worker.list = some_name,other_name -%>
-<%# worker_mantain = 60 -%>
+<%# worker.mantain = 60 -%>
 <%# # Optional comment -%>
 <%# worker.some_name.type=ajp13 -%>
 <%# worker.some_name.socket_keepalive=true -%>
@@ -21,8 +21,8 @@
 <%# -%>
 <%# should be parameterized as: -%>
 <%# $workers_file_content = { -%>
-<%#   worker_lists => ['status', 'some_name,other_name'],
-<%#   worker_mantain => '60',
+<%#   worker_lists => ['status', 'some_name,other_name'], -%>
+<%#   worker_mantain => '60', -%>
 <%#   some_name => { -%>
 <%#     type             => 'ajp13', -%>
 <%#     socket_keepalive => 'true', -%>

--- a/templates/mod/jk/workers.properties.erb
+++ b/templates/mod/jk/workers.properties.erb
@@ -1,5 +1,31 @@
 # This file is generated automatically by Puppet - DO NOT EDIT
 # Any manual changes will be overwritten
+<%# -%>
+<%# workers_file_content should be a hash which keys are workers names -%>
+<%# and values are new hashes with properties and values -%>
+<%# -%>
+<%# Example: -%>
+<%# # Optional comment -%>
+<%# worker.some_name.type=ajp13 -%>
+<%# worker.some_name.socket_keepalive=true -%>
+<%# # I just like comments -%>
+<%# worker.other_name.type=ajp12 (why would you?) -%>
+<%# worker.other_name.socket_keepalive=false -%>
+<%# should be parameterized as: -%>
+<%# -%>
+<%# $workers_file_content = { -%>
+<%#   some_name => { -%>
+<%#     type             => 'ajp13', -%>
+<%#     socket_keepalive => 'true', -%>
+<%#     comment          => 'Optional comment', -%>
+<%#   }, -%>
+<%#   other_name => { -%>
+<%#     type             => 'ajp12', -%>
+<%#     socket_keepalive => 'false', -%>
+<%#     comment          => 'I just like comments', -%>
+<%#   }, -%>
+<%# }, -%>
+<%# -%>
 <% @workers_file_content.sort.each do |worker,directives| -%>
 
 <%# Places comment before worker directives -%>

--- a/templates/mod/jk/workers.properties.erb
+++ b/templates/mod/jk/workers.properties.erb
@@ -1,0 +1,8 @@
+# This file is generated automatically by Puppet - DO NOT EDIT
+# Any manual changes will be overwritten
+<% @workers_file_content.sort.each do |worker,directives| -%>
+
+<% directives.sort.each do |property,value| -%>
+worker.<%= worker %>.<%= property %>=<%= value %>
+<% end -%>
+<% end -%>


### PR DESCRIPTION
Current state: includes `mod_jk` module, creates jk.load, jk.conf and worker properties files and adds some description in the README file.

Lacks (as far as my creativity goes): parameter validation, proper parsing of some parameters, worker map file management and tests.