### PR TITLE
MODULES-3838 Pass mod_packages through init.pp to allow overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1183,10 +1183,11 @@ Default: Depends on operating system.
 Allows the user to override default module package names.
 
 ```puppet
-class { '::apache':
-  mod_packages => merge($::apache::mod_params {
+include apache::params
+class { 'apache':
+  mod_packages => merge($::apache::params::mod_packages, {
     'auth_kerb' => 'httpd24-mod_auth_kerb',
-  }
+  })
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1178,6 +1178,20 @@ Default: Depends on operating system.
 - **Gentoo**: `/etc/apache2/modules.d`
 - **Red Hat**: `/etc/httpd/conf.d`
 
+##### `mod_packages`
+
+Allows the user to override default module package names.
+
+```puppet
+class { '::apache':
+  mod_packages => merge($::apache::mod_params {
+    'auth_kerb' => 'httpd24-mod_auth_kerb',
+  }
+}
+```
+
+Hash. Default: `$apache::params::mod_packages`
+
 ##### `mpm_module`
 
 Determines which [multi-processing module][] (MPM) is loaded and configured for the HTTPD process. Values: 'event', 'itk', 'peruser', 'prefork', 'worker', or `false`.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,6 +47,7 @@ class apache (
   $confd_dir                                                     = $::apache::params::confd_dir,
   $vhost_dir                                                     = $::apache::params::vhost_dir,
   $vhost_enable_dir                                              = $::apache::params::vhost_enable_dir,
+  $mod_packages                                                  = $::apache::params::mod_packages,
   $vhost_include_pattern                                         = $::apache::params::vhost_include_pattern,
   $mod_dir                                                       = $::apache::params::mod_dir,
   $mod_enable_dir                                                = $::apache::params::mod_enable_dir,

--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -46,7 +46,7 @@ define apache::mod (
   }
 
   # Determine if we have a package
-  $mod_packages = $::apache::params::mod_packages
+  $mod_packages = $::apache::mod_packages
   if $package {
     $_package = $package
   } elsif has_key($mod_packages, $mod) { # 2.6 compatibility hack

--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -38,7 +38,7 @@ class apache::mod::php (
   }
 
   # Determine if we have a package
-  $mod_packages = $::apache::params::mod_packages
+  $mod_packages = $::apache::mod_packages
   if $package_name {
     $_package_name = $package_name
   } elsif has_key($mod_packages, $mod) { # 2.6 compatibility hack

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -10,6 +10,7 @@ describe 'apache', :type => :class do
         :osfamily               => 'Debian',
         :operatingsystem        => 'Debian',
         :operatingsystemrelease => '6',
+        :operatingsystemmajrelease => '6',
         :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
         :concat_basedir         => '/dne',
         :is_pe                  => false,
@@ -124,6 +125,20 @@ describe 'apache', :type => :class do
       end
 
       it { is_expected.to contain_file("/etc/apache2/apache2.conf").with_content %r{^AddDefaultCharset none$} }
+    end
+
+    context "when overriding with mod_packages" do
+      let :params do
+        { :mod_packages => { 'dav_svn' => 'foobarbaz' } }
+      end
+      let :pre_condition do
+        "apache::mod { 'dav_svn': }"
+      end
+
+      it { is_expected.to contain_file("dav_svn.load") }
+      it { is_expected.to contain_package('foobarbaz') }
+      it { is_expected.to_not contain_file("fcgid.load") }
+      it { is_expected.to_not contain_package('libapache2-svn') }
     end
 
     # Assert that both load files and conf files are placed and symlinked for these mods
@@ -449,6 +464,20 @@ describe 'apache', :type => :class do
           }
         end
         it { is_expected.to contain_file("/etc/httpd/conf/httpd.conf").without_content %r{^RewriteLock [.]*$} }
+      end
+
+      context "when overriding with mod_packages" do
+        let :params do
+          { :mod_packages => { 'dav_svn' => 'foobarbaz' } }
+        end
+        let :pre_condition do
+          "apache::mod { 'dav_svn': }"
+        end
+
+        it { is_expected.to contain_file("dav_svn.load") }
+        it { is_expected.to contain_package('foobarbaz') }
+        it { is_expected.to_not contain_file("fcgid.load") }
+        it { is_expected.to_not contain_package('mod_dav_svn') }
       end
 
       context "when specifying slash encoding behaviour" do

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -10,7 +10,6 @@ describe 'apache', :type => :class do
         :osfamily               => 'Debian',
         :operatingsystem        => 'Debian',
         :operatingsystemrelease => '6',
-        :operatingsystemmajrelease => '6',
         :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
         :concat_basedir         => '/dne',
         :is_pe                  => false,
@@ -125,20 +124,6 @@ describe 'apache', :type => :class do
       end
 
       it { is_expected.to contain_file("/etc/apache2/apache2.conf").with_content %r{^AddDefaultCharset none$} }
-    end
-
-    context "when overriding with mod_packages" do
-      let :params do
-        { :mod_packages => { 'dav_svn' => 'foobarbaz' } }
-      end
-      let :pre_condition do
-        "apache::mod { 'dav_svn': }"
-      end
-
-      it { is_expected.to contain_file("dav_svn.load") }
-      it { is_expected.to contain_package('foobarbaz') }
-      it { is_expected.to_not contain_file("fcgid.load") }
-      it { is_expected.to_not contain_package('libapache2-svn') }
     end
 
     # Assert that both load files and conf files are placed and symlinked for these mods
@@ -464,20 +449,6 @@ describe 'apache', :type => :class do
           }
         end
         it { is_expected.to contain_file("/etc/httpd/conf/httpd.conf").without_content %r{^RewriteLock [.]*$} }
-      end
-
-      context "when overriding with mod_packages" do
-        let :params do
-          { :mod_packages => { 'dav_svn' => 'foobarbaz' } }
-        end
-        let :pre_condition do
-          "apache::mod { 'dav_svn': }"
-        end
-
-        it { is_expected.to contain_file("dav_svn.load") }
-        it { is_expected.to contain_package('foobarbaz') }
-        it { is_expected.to_not contain_file("fcgid.load") }
-        it { is_expected.to_not contain_package('mod_dav_svn') }
       end
 
       context "when specifying slash encoding behaviour" do

--- a/spec/classes/mod/auth_kerb_spec.rb
+++ b/spec/classes/mod/auth_kerb_spec.rb
@@ -74,4 +74,33 @@ describe 'apache::mod::auth_kerb', :type => :class do
       it { is_expected.to contain_package("www-apache/mod_auth_kerb") }
     end
   end
+  context "overriding mod_packages" do
+    context "on a RedHat OS", :compile do
+      let :facts do
+        {
+          :id                     => 'root',
+          :kernel                 => 'Linux',
+          :osfamily               => 'RedHat',
+          :operatingsystem        => 'RedHat',
+          :operatingsystemrelease => '6',
+          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :concat_basedir         => '/dne',
+          :is_pe                  => false,
+        }
+      end
+      let :pre_condition do
+        <<-EOS
+        include apache::params
+        class { 'apache':
+          mod_packages => merge($::apache::params::mod_packages, {
+            'auth_kerb' => 'httpd24-mod_auth_kerb',
+          })
+        }
+        EOS
+      end
+      it { is_expected.to contain_apache__mod("auth_kerb") }
+      it { is_expected.to contain_package("httpd24-mod_auth_kerb") }
+      it { is_expected.to_not contain_package("mod_auth_kerb") }
+    end
+  end
 end


### PR DESCRIPTION
When using the SCL packages on CentOS, package names have a prefix that needs to be overridden. With most other attributes in params.pp, this is possible by overriding variables passed to `Class['::apache']`, but in the case of `mod_packages` it's read directly from the params file on use. This is workaroundable by not using the `apache::mod::...` subclasses can calling `apache::mod { 'mod_name' }` directly, but there is a compounding problem.
The `apache::vhost::auth_kerb` parameter is used for for both including the `auth_kerb` modules (using class syntax rather than include, so cannot be duplicated), and for including config snippets in the generated vhost. It's not possible to make use of the config snippet whilst also needing to amend the package name.

This commit follows the existing style and passes `mod_packages` through `init.pp`, and updates all references of `apache::params::mod_packages` to `apache::mod_packages`. It's therefore possible to override the package names using something like:

```puppet
include ::apache::params
class { '::apache':
  mod_packages => merge($::apache::mod_params {
    'auth_kerb' => 'httpd24-mod_auth_kerb',
  }
}
```