### PR TITLE
(MODULES-4933) Enable support for a specific UserDir string

### DIFF
--- a/manifests/mod/userdir.pp
+++ b/manifests/mod/userdir.pp
@@ -3,6 +3,7 @@ class apache::mod::userdir (
   $dir = 'public_html',
   $disable_root = true,
   $apache_version = undef,
+  $userdir_str = undef,
   $overrides = [ 'FileInfo', 'AuthConfig', 'Limit', 'Indexes' ],
   $options = [ 'MultiViews', 'Indexes', 'SymLinksIfOwnerMatch', 'IncludesNoExec' ],
 ) {

--- a/templates/mod/userdir.conf.erb
+++ b/templates/mod/userdir.conf.erb
@@ -2,7 +2,11 @@
 <% if @disable_root -%>
   UserDir disabled root
 <% end -%>
+<%- if @userdir_str -%>
+  UserDir <%= @userdir_str %>
+<%- else -%>
   UserDir <%= @home %>/*/<%= @dir %>
+<% end -%>
 
   <Directory "<%= @home %>/*/<%= @dir %>">
     AllowOverride <%= @overrides.join(' ') %>


### PR DESCRIPTION
This small modification allows much more flexible UserDir settings to be used, for example specifying a relative path or URL rather than a absolute path. 