### PR TITLE
When absolute path is specified for access_log_file/error_log_file, don't prepend logbase

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -392,7 +392,12 @@ define apache::vhost(
 
   if $access_log and !$access_logs {
     if $access_log_file {
-      $_logs_dest = "${logroot}/${access_log_file}"
+      if $access_log_file =~ /^\// {
+        # Absolute path provided - don't prepend $logroot
+        $_logs_dest = $access_log_file
+      } else {
+        $_logs_dest = "${logroot}/${access_log_file}"
+      }
     } elsif $access_log_pipe {
       $_logs_dest = $access_log_pipe
     } elsif $access_log_syslog {
@@ -415,7 +420,12 @@ define apache::vhost(
   }
 
   if $error_log_file {
-    $error_log_destination = "${logroot}/${error_log_file}"
+    if $error_log_file =~ /^\// {
+        # Absolute path provided - don't prepend $logroot
+      $error_log_destination = $error_log_file
+    } else {
+      $error_log_destination = "${logroot}/${error_log_file}"
+    }
   } elsif $error_log_pipe {
     $error_log_destination = $error_log_pipe
   } elsif $error_log_syslog {

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -421,7 +421,7 @@ define apache::vhost(
 
   if $error_log_file {
     if $error_log_file =~ /^\// {
-        # Absolute path provided - don't prepend $logroot
+      # Absolute path provided - don't prepend $logroot
       $error_log_destination = $error_log_file
     } else {
       $error_log_destination = "${logroot}/${error_log_file}"


### PR DESCRIPTION
It might sometimes be desirable to have access and error logs in different folders. This isn't possible at the moment as the `access_log_file`/`error_log_file` is treated as a path relative to `logbase`. This pull request changes the behaviour so that if absolute path is detected, `logbase` is not prepended.