### PR TITLE
Add passenger_spawn_method to vhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -3780,6 +3780,10 @@ Sets the overrides for the specified virtual host. Accepts an array of [AllowOve
 
 Default: '[none]'.
 
+##### `passenger_spawn_method`
+
+Sets [PassengerSpawnMethod](https://www.phusionpassenger.com/library/config/apache/reference/#passengerspawnmethod), whether Passenger spawns applications directly, or using a prefork copy-on-write mechanism.
+
 ##### `passenger_app_root`
 
 Sets [PassengerRoot](https://www.phusionpassenger.com/library/config/apache/reference/#passengerapproot), the location of the Passenger application root if different from the DocumentRoot.

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -134,6 +134,7 @@ define apache::vhost(
   $apache_version                                                                   = $::apache::apache_version,
   Optional[Enum['on', 'off', 'nodecode']] $allow_encoded_slashes                    = undef,
   Optional[Pattern[/^[\w-]+ [\w-]+$/]] $suexec_user_group                           = undef,
+  $passenger_spawn_method                                                           = undef,
   $passenger_app_root                                                               = undef,
   $passenger_app_env                                                                = undef,
   $passenger_ruby                                                                   = undef,
@@ -232,7 +233,7 @@ define apache::vhost(
     include ::apache::mod::suexec
   }
 
-  if $passenger_app_root or $passenger_app_env or $passenger_ruby or $passenger_min_instances or $passenger_max_requests or $passenger_start_timeout or $passenger_pre_start or $passenger_user or $passenger_high_performance or $passenger_nodejs or $passenger_sticky_sessions or $passenger_startup_file {
+  if $passenger_spawn_method or $passenger_app_root or $passenger_app_env or $passenger_ruby or $passenger_min_instances or $passenger_max_requests or $passenger_start_timeout or $passenger_pre_start or $passenger_user or $passenger_high_performance or $passenger_nodejs or $passenger_sticky_sessions or $passenger_startup_file {
     include ::apache::mod::passenger
   }
 
@@ -968,6 +969,7 @@ define apache::vhost(
   }
 
   # Template uses:
+  # - $passenger_spawn_method
   # - $passenger_app_root
   # - $passenger_app_env
   # - $passenger_ruby
@@ -979,7 +981,7 @@ define apache::vhost(
   # - $passenger_nodejs
   # - $passenger_sticky_sessions
   # - $passenger_startup_file
-  if $passenger_app_root or $passenger_app_env or $passenger_ruby or $passenger_min_instances or $passenger_start_timeout or $passenger_pre_start or $passenger_user or $passenger_nodejs or $passenger_sticky_sessions or $passenger_startup_file{
+  if $passenger_spawn_method or $passenger_app_root or $passenger_app_env or $passenger_ruby or $passenger_min_instances or $passenger_start_timeout or $passenger_pre_start or $passenger_user or $passenger_nodejs or $passenger_sticky_sessions or $passenger_startup_file{
     concat::fragment { "${name}-passenger":
       target  => "${priority_real}${filename}.conf",
       order   => 300,

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -392,6 +392,7 @@ describe 'apache::vhost', :type => :define do
           'use_optional_includes'       => true,
           'suexec_user_group'           => 'root root',
           'allow_encoded_slashes'       => 'nodecode',
+          'passenger_spawn_method'      => 'direct',
           'passenger_app_root'          => '/usr/share/myapp',
           'passenger_app_env'           => 'test',
           'passenger_ruby'              => '/usr/bin/ruby1.9.1',

--- a/templates/vhost/_passenger.erb
+++ b/templates/vhost/_passenger.erb
@@ -1,3 +1,6 @@
+<% if @passenger_spawn_method -%>
+  PassengerSpawnMethod <%= @passenger_spawn_method %>
+<% end -%>
 <% if @passenger_app_root -%>
   PassengerAppRoot <%= @passenger_app_root %>
 <% end -%>


### PR DESCRIPTION
Currently, you can set this globally, but not per vhost...
It is supported in vhost context by passenger: https://www.phusionpassenger.com/library/config/apache/reference/#passengerspawnmethod