### PR TITLE
(#5121) Clobber mod_ssl RPM package path for ssl.conf file on RHEL7

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,7 +69,6 @@ class apache (
   $logroot_mode           = $::apache::params::logroot_mode,
   $log_level              = $::apache::params::log_level,
   $log_formats            = {},
-  $ssl_file               = $::apache::params::ssl_file,
   $ports_file             = $::apache::params::ports_file,
   $docroot                = $::apache::params::docroot,
   $apache_version         = $::apache::version::default,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,6 +69,7 @@ class apache (
   $logroot_mode           = $::apache::params::logroot_mode,
   $log_level              = $::apache::params::log_level,
   $log_formats            = {},
+  $ssl_conf_clobber       = $::apache::params::ssl_conf_clobber,
   $ports_file             = $::apache::params::ports_file,
   $docroot                = $::apache::params::docroot,
   $apache_version         = $::apache::version::default,

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -118,7 +118,7 @@ class apache::mod::ssl (
   # $_apache_version
   file { 'ssl.conf':
     ensure  => file,
-    path    => $::apache::ssl_file,
+    path    => "${::apache::mod_dir}/ssl.conf",
     mode    => $::apache::file_mode,
     content => template('apache/mod/ssl.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -125,4 +125,11 @@ class apache::mod::ssl (
     before  => File[$::apache::mod_dir],
     notify  => Class['apache::service'],
   }
+
+  if $::apache::ssl_conf_clobber and $apache::ssl_conf_clobber != "${::apache::mod_dir}/ssl.conf" {
+    file{$::apache::ssl_conf_clobber:
+      ensure  => file,
+      content => '# puppet overwriting unwanted mod_ssl configuration file from package',
+    }
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -74,7 +74,6 @@ class apache::params inherits ::apache::version {
     $vhost_dir            = "${httpd_dir}/conf.d"
     $vhost_enable_dir     = undef
     $conf_file            = 'httpd.conf'
-    $ssl_file             = "${confd_dir}/ssl.conf"
     $ports_file           = "${conf_dir}/ports.conf"
     $pidfile              = 'run/httpd.pid'
     $logroot              = '/var/log/httpd'
@@ -215,7 +214,6 @@ class apache::params inherits ::apache::version {
     $vhost_dir           = "${httpd_dir}/sites-available"
     $vhost_enable_dir    = "${httpd_dir}/sites-enabled"
     $conf_file           = 'apache2.conf'
-    $ssl_file             = "${mod_dir}/ssl.conf"
     $ports_file          = "${conf_dir}/ports.conf"
     $pidfile             = "\${APACHE_PID_FILE}"
     $logroot             = '/var/log/apache2'
@@ -356,7 +354,6 @@ class apache::params inherits ::apache::version {
     $vhost_dir        = "${httpd_dir}/Vhosts"
     $vhost_enable_dir = undef
     $conf_file        = 'httpd.conf'
-    $ssl_file         = "${mod_dir}/ssl.conf"
     $ports_file       = "${conf_dir}/ports.conf"
     $pidfile          = '/var/run/httpd.pid'
     $logroot          = '/var/log/apache24'
@@ -427,7 +424,6 @@ class apache::params inherits ::apache::version {
     $vhost_dir        = "${httpd_dir}/vhosts.d"
     $vhost_enable_dir = undef
     $conf_file        = 'httpd.conf'
-    $ssl_file         = "${mod_dir}/ssl.conf"
     $ports_file       = "${conf_dir}/ports.conf"
     $logroot          = '/var/log/apache2'
     $logroot_mode     = undef
@@ -496,7 +492,6 @@ class apache::params inherits ::apache::version {
     $vhost_dir           = "${httpd_dir}/sites-available"
     $vhost_enable_dir    = "${httpd_dir}/sites-enabled"
     $conf_file           = 'httpd.conf'
-    $ssl_file            = "${mod_dir}/ssl.conf"
     $ports_file          = "${conf_dir}/ports.conf"
     $pidfile             = '/var/run/httpd2.pid'
     $logroot             = '/var/log/apache2'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -74,6 +74,7 @@ class apache::params inherits ::apache::version {
     $vhost_dir            = "${httpd_dir}/conf.d"
     $vhost_enable_dir     = undef
     $conf_file            = 'httpd.conf'
+    $ssl_conf_clobber     = '/etc/httpd/conf.d/ssl.conf'
     $ports_file           = "${conf_dir}/ports.conf"
     $pidfile              = 'run/httpd.pid'
     $logroot              = '/var/log/httpd'
@@ -214,6 +215,7 @@ class apache::params inherits ::apache::version {
     $vhost_dir           = "${httpd_dir}/sites-available"
     $vhost_enable_dir    = "${httpd_dir}/sites-enabled"
     $conf_file           = 'apache2.conf'
+    $ssl_conf_clobber    = undef
     $ports_file          = "${conf_dir}/ports.conf"
     $pidfile             = "\${APACHE_PID_FILE}"
     $logroot             = '/var/log/apache2'
@@ -354,6 +356,7 @@ class apache::params inherits ::apache::version {
     $vhost_dir        = "${httpd_dir}/Vhosts"
     $vhost_enable_dir = undef
     $conf_file        = 'httpd.conf'
+    $ssl_conf_clobber = undef
     $ports_file       = "${conf_dir}/ports.conf"
     $pidfile          = '/var/run/httpd.pid'
     $logroot          = '/var/log/apache24'
@@ -424,6 +427,7 @@ class apache::params inherits ::apache::version {
     $vhost_dir        = "${httpd_dir}/vhosts.d"
     $vhost_enable_dir = undef
     $conf_file        = 'httpd.conf'
+    $ssl_conf_clobber = undef
     $ports_file       = "${conf_dir}/ports.conf"
     $logroot          = '/var/log/apache2'
     $logroot_mode     = undef
@@ -492,6 +496,7 @@ class apache::params inherits ::apache::version {
     $vhost_dir           = "${httpd_dir}/sites-available"
     $vhost_enable_dir    = "${httpd_dir}/sites-enabled"
     $conf_file           = 'httpd.conf'
+    $ssl_conf_clobber    = undef
     $ports_file          = "${conf_dir}/ports.conf"
     $pidfile             = '/var/run/httpd2.pid'
     $logroot             = '/var/log/apache2'

--- a/spec/classes/mod/ssl_spec.rb
+++ b/spec/classes/mod/ssl_spec.rb
@@ -61,6 +61,8 @@ describe 'apache::mod::ssl', :type => :class do
       }
     end
     it { is_expected.to contain_file('ssl.conf').with_path('/etc/httpd/conf.modules.d/ssl.conf')}
+    it { is_expected.to contain_file('ssl.conf').with_content(%r{^  SSLSessionCache "shmcb:/var/cache/mod_ssl/scache\(512000\)"$})}
+    it { is_expected.to contain_file('/etc/httpd/conf.d/ssl.conf').with_content(%r{^.*unwanted mod_ssl configuration.*$})}
   end
 
   context 'on a Debian OS' do

--- a/spec/classes/mod/ssl_spec.rb
+++ b/spec/classes/mod/ssl_spec.rb
@@ -18,7 +18,7 @@ describe 'apache::mod::ssl', :type => :class do
     it { expect { catalogue }.to raise_error(Puppet::Error, /Unsupported osfamily:/) }
   end
 
-  context 'on a RedHat OS' do
+  context 'on a RedHat 6 OS' do
     let :facts do
       {
         :osfamily               => 'RedHat',
@@ -43,7 +43,24 @@ describe 'apache::mod::ssl', :type => :class do
       it { is_expected.to contain_package('httpd24-mod_ssl') }
       it { is_expected.not_to contain_package('mod_ssl') }
       it { is_expected.to contain_file('ssl.conf').with_content(%r{^  SSLSessionCache "shmcb:/var/cache/mod_ssl/scache\(512000\)"$})}
+      it { is_expected.to contain_file('ssl.conf').with_path('/etc/httpd/conf.d/ssl.conf')}
     end
+  end
+
+  context 'on a RedHat 7 OS' do
+    let :facts do
+      {
+        :osfamily               => 'RedHat',
+        :operatingsystemrelease => '7',
+        :concat_basedir         => '/dne',
+        :operatingsystem        => 'RedHat',
+        :id                     => 'root',
+        :kernel                 => 'Linux',
+        :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :is_pe                  => false,
+      }
+    end
+    it { is_expected.to contain_file('ssl.conf').with_path('/etc/httpd/conf.modules.d/ssl.conf')}
   end
 
   context 'on a Debian OS' do
@@ -260,6 +277,18 @@ describe 'apache::mod::ssl', :type => :class do
         }
       end
       it { is_expected.to contain_file('ssl.conf').with_content(%r{^  SSLProxyProtocol -ALL \+TLSv1$})}
+    end
+    context 'setting apache mod_dir' do
+      let :pre_condition do
+        [
+         '
+           class{"apache":
+             mod_dir  => "/tmp/junk/conf.modules.puppet.d",
+           }
+         ',
+        ]
+      end
+      it { is_expected.to contain_file('ssl.conf').with_path('/tmp/junk/conf.modules.puppet.d/ssl.conf')}
     end
   end
 end


### PR DESCRIPTION
https://tickets.puppetlabs.com/browse/MODULES-5121

This reverts bf9f0d04bb48649c3f5b32a1a7da0ecf89960999 and allows mod::ssl to behave
like other modules again. In paticular with a configuration.

```puppet
class{'apache':
    class { '::apache':
    confd_dir           => '/etc/httpd/conf.puppet.d',
    default_confd_files => false,
    default_mods        => false,
    default_vhost       => false,
    mod_dir             => '/etc/httpd/conf.modules.puppet.d',
    vhost_dir           => '/etc/httpd/conf.puppet.d',
}
class{'apache::mod::ssl':}

```
The ssl.conf location will still respect `mod_dir` parameter above.

In addition there are a couple of extra tests to catch this test case.


