### PR TITLE
(MODULES-5121) Allow ssl.conf to have better defaults

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,7 +69,7 @@ class apache (
   $logroot_mode           = $::apache::params::logroot_mode,
   $log_level              = $::apache::params::log_level,
   $log_formats            = {},
-  $ssl_file               = $::apache::params::ssl_file,
+  $ssl_file               = undef,
   $ports_file             = $::apache::params::ports_file,
   $docroot                = $::apache::params::docroot,
   $apache_version         = $::apache::version::default,
@@ -101,6 +101,22 @@ class apache (
   $valid_mpms_re = $apache_version ? {
     '2.4'   => '(event|itk|peruser|prefork|worker)',
     default => '(event|itk|prefork|worker)'
+  }
+
+  if $::osfamily == 'RedHat' and $::apache::version::distrelease == '7' {
+    # On redhat 7 the ssl.conf lives in /etc/httpd/conf.d (the confd_dir)
+    # when all other module configs live in /etc/httpd/conf.modules.d (the
+    # mod_dir). On all other platforms and versions, ssl.conf lives in the
+    # mod_dir. This should maintain the expected location of ssl.conf
+    $_ssl_file = $ssl_file ? {
+      undef   => "${apache::confd_dir}/ssl.conf",
+      default =>  $ssl_file
+    }
+  } else {
+    $_ssl_file = $ssl_file ? {
+      undef   => "${apache::mod_dir}/ssl.conf",
+      default =>  $ssl_file
+    }
   }
 
   if $mpm_module and $mpm_module != 'false' { # lint:ignore:quoted_booleans

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -118,7 +118,7 @@ class apache::mod::ssl (
   # $_apache_version
   file { 'ssl.conf':
     ensure  => file,
-    path    => $::apache::ssl_file,
+    path    => $::apache::_ssl_file,
     mode    => $::apache::file_mode,
     content => template('apache/mod/ssl.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -74,7 +74,6 @@ class apache::params inherits ::apache::version {
     $vhost_dir            = "${httpd_dir}/conf.d"
     $vhost_enable_dir     = undef
     $conf_file            = 'httpd.conf'
-    $ssl_file             = "${confd_dir}/ssl.conf"
     $ports_file           = "${conf_dir}/ports.conf"
     $pidfile              = 'run/httpd.pid'
     $logroot              = '/var/log/httpd'
@@ -215,7 +214,6 @@ class apache::params inherits ::apache::version {
     $vhost_dir           = "${httpd_dir}/sites-available"
     $vhost_enable_dir    = "${httpd_dir}/sites-enabled"
     $conf_file           = 'apache2.conf'
-    $ssl_file             = "${mod_dir}/ssl.conf"
     $ports_file          = "${conf_dir}/ports.conf"
     $pidfile             = "\${APACHE_PID_FILE}"
     $logroot             = '/var/log/apache2'
@@ -356,7 +354,6 @@ class apache::params inherits ::apache::version {
     $vhost_dir        = "${httpd_dir}/Vhosts"
     $vhost_enable_dir = undef
     $conf_file        = 'httpd.conf'
-    $ssl_file         = "${mod_dir}/ssl.conf"
     $ports_file       = "${conf_dir}/ports.conf"
     $pidfile          = '/var/run/httpd.pid'
     $logroot          = '/var/log/apache24'
@@ -427,7 +424,6 @@ class apache::params inherits ::apache::version {
     $vhost_dir        = "${httpd_dir}/vhosts.d"
     $vhost_enable_dir = undef
     $conf_file        = 'httpd.conf'
-    $ssl_file         = "${mod_dir}/ssl.conf"
     $ports_file       = "${conf_dir}/ports.conf"
     $logroot          = '/var/log/apache2'
     $logroot_mode     = undef
@@ -496,7 +492,6 @@ class apache::params inherits ::apache::version {
     $vhost_dir           = "${httpd_dir}/sites-available"
     $vhost_enable_dir    = "${httpd_dir}/sites-enabled"
     $conf_file           = 'httpd.conf'
-    $ssl_file            = "${mod_dir}/ssl.conf"
     $ports_file          = "${conf_dir}/ports.conf"
     $pidfile             = '/var/run/httpd2.pid'
     $logroot             = '/var/log/apache2'


### PR DESCRIPTION
ssl.conf location must be maintained to avoid duplicate ssl.confs being
created in both mod_dir and confd_dir on rhel7 package updates, and must
also be based on the parameter values passed into the base apache class
for custom directories.

Closes #1635