### PR TITLE
Ensure that ProxyPreserveHost is set even when ProxyPass (etc) are not.

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -750,7 +750,7 @@ define apache::vhost(
   # - $proxy_preserve_host
   # - $proxy_add_headers
   # - $no_proxy_uris
-  if $proxy_dest or $proxy_pass or $proxy_pass_match or $proxy_dest_match {
+  if $proxy_dest or $proxy_pass or $proxy_pass_match or $proxy_dest_match or $proxy_preserve_host {
     concat::fragment { "${name}-proxy":
       target  => "${priority_real}${filename}.conf",
       order   => 160,


### PR DESCRIPTION
Proxying can be enabled when the [P] flag is given to a RewriteRule, not only when ProxyPass is used. In that instance, we may want to be able to set ProxyPreserveHost.