### PR TITLE
Don't install proxy_html package in ubuntu xenial

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -231,34 +231,58 @@ class apache::params inherits ::apache::version {
     if ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') < 0) or ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '9') < 0) {
       # Only the major version is used here
       $php_version = '5'
+      $mod_packages = {
+        'auth_cas'              => 'libapache2-mod-auth-cas',
+        'auth_kerb'             => 'libapache2-mod-auth-kerb',
+        'auth_mellon'           => 'libapache2-mod-auth-mellon',
+        'authnz_pam'            => 'libapache2-mod-authnz-pam',
+        'dav_svn'               => 'libapache2-svn',
+        'fastcgi'               => 'libapache2-mod-fastcgi',
+        'fcgid'                 => 'libapache2-mod-fcgid',
+        'geoip'                 => 'libapache2-mod-geoip',
+        'intercept_form_submit' => 'libapache2-mod-intercept-form-submit',
+        'lookup_identity'       => 'libapache2-mod-lookup-identity',
+        'nss'                   => 'libapache2-mod-nss',
+        'pagespeed'             => 'mod-pagespeed-stable',
+        'passenger'             => 'libapache2-mod-passenger',
+        'perl'                  => 'libapache2-mod-perl2',
+        'phpXXX'                => 'libapache2-mod-phpXXX',
+        'proxy_html'            => 'libapache2-mod-proxy-html',
+        'python'                => 'libapache2-mod-python',
+        'rpaf'                  => 'libapache2-mod-rpaf',
+        'security'              => 'libapache2-modsecurity',
+        'shib2'                 => 'libapache2-mod-shib2',
+        'suphp'                 => 'libapache2-mod-suphp',
+        'wsgi'                  => 'libapache2-mod-wsgi',
+        'xsendfile'             => 'libapache2-mod-xsendfile',
+      }
     } else {
       # major.minor version used since Debian stretch and Ubuntu Xenial
       $php_version = '7.0'
-    }
-    $mod_packages        = {
-      'auth_cas'              => 'libapache2-mod-auth-cas',
-      'auth_kerb'             => 'libapache2-mod-auth-kerb',
-      'auth_mellon'           => 'libapache2-mod-auth-mellon',
-      'authnz_pam'            => 'libapache2-mod-authnz-pam',
-      'dav_svn'               => 'libapache2-svn',
-      'fastcgi'               => 'libapache2-mod-fastcgi',
-      'fcgid'                 => 'libapache2-mod-fcgid',
-      'geoip'                 => 'libapache2-mod-geoip',
-      'intercept_form_submit' => 'libapache2-mod-intercept-form-submit',
-      'lookup_identity'       => 'libapache2-mod-lookup-identity',
-      'nss'                   => 'libapache2-mod-nss',
-      'pagespeed'             => 'mod-pagespeed-stable',
-      'passenger'             => 'libapache2-mod-passenger',
-      'perl'                  => 'libapache2-mod-perl2',
-      'phpXXX'                => 'libapache2-mod-phpXXX',
-      'proxy_html'            => 'libapache2-mod-proxy-html',
-      'python'                => 'libapache2-mod-python',
-      'rpaf'                  => 'libapache2-mod-rpaf',
-      'security'              => 'libapache2-modsecurity',
-      'shib2'                 => 'libapache2-mod-shib2',
-      'suphp'                 => 'libapache2-mod-suphp',
-      'wsgi'                  => 'libapache2-mod-wsgi',
-      'xsendfile'             => 'libapache2-mod-xsendfile',
+      $mod_packages = {
+        'auth_cas'              => 'libapache2-mod-auth-cas',
+        'auth_kerb'             => 'libapache2-mod-auth-kerb',
+        'auth_mellon'           => 'libapache2-mod-auth-mellon',
+        'authnz_pam'            => 'libapache2-mod-authnz-pam',
+        'dav_svn'               => 'libapache2-svn',
+        'fastcgi'               => 'libapache2-mod-fastcgi',
+        'fcgid'                 => 'libapache2-mod-fcgid',
+        'geoip'                 => 'libapache2-mod-geoip',
+        'intercept_form_submit' => 'libapache2-mod-intercept-form-submit',
+        'lookup_identity'       => 'libapache2-mod-lookup-identity',
+        'nss'                   => 'libapache2-mod-nss',
+        'pagespeed'             => 'mod-pagespeed-stable',
+        'passenger'             => 'libapache2-mod-passenger',
+        'perl'                  => 'libapache2-mod-perl2',
+        'phpXXX'                => 'libapache2-mod-phpXXX',
+        'python'                => 'libapache2-mod-python',
+        'rpaf'                  => 'libapache2-mod-rpaf',
+        'security'              => 'libapache2-modsecurity',
+        'shib2'                 => 'libapache2-mod-shib2',
+        'suphp'                 => 'libapache2-mod-suphp',
+        'wsgi'                  => 'libapache2-mod-wsgi',
+        'xsendfile'             => 'libapache2-mod-xsendfile',
+      }
     }
     $error_log           = 'error.log'
     $scriptalias         = '/usr/lib/cgi-bin'


### PR DESCRIPTION
In Ubuntu Xenial, proxy_html module is include in apache standard
packages, so don't try to install it