### PR TITLE
Use puppet 4 types to avoid deprecation warnings

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -271,7 +271,7 @@ class apache (
   if $::apache::conf_dir and $::apache::params::conf_file {
     if $::osfamily == 'gentoo' {
       $error_documents_path = '/usr/share/apache2/error'
-      if is_array($default_mods) {
+      if $default_mods =~ Array {
         if versioncmp($apache_version, '2.4') >= 0 {
           if defined('apache::mod::ssl') {
             ::portage::makeconf { 'apache2_modules':
@@ -336,7 +336,7 @@ class apache (
 
     # preserve back-wards compatibility to the times when default_mods was
     # only a boolean value. Now it can be an array (too)
-    if is_array($default_mods) {
+    if $default_mods =~ Array {
       class { '::apache::default_mods':
         all  => false,
         mods => $default_mods,

--- a/manifests/mod/authnz_ldap.pp
+++ b/manifests/mod/authnz_ldap.pp
@@ -1,4 +1,3 @@
-# lint:ignore:variable_is_lowercase required for compatibility
 class apache::mod::authnz_ldap (
   Boolean $verify_server_cert = true,
   $package_name               = undef,
@@ -22,4 +21,3 @@ class apache::mod::authnz_ldap (
     notify  => Class['apache::service'],
   }
 }
-# lint:endignore

--- a/manifests/mod/negotiation.pp
+++ b/manifests/mod/negotiation.pp
@@ -1,17 +1,11 @@
 class apache::mod::negotiation (
-  $force_language_priority = 'Prefer Fallback',
-  $language_priority = [ 'en', 'ca', 'cs', 'da', 'de', 'el', 'eo', 'es', 'et',
+  Variant[Array[String], String] $force_language_priority = 'Prefer Fallback',
+  Variant[Array[String], String] $language_priority = [ 'en', 'ca', 'cs', 'da', 'de', 'el', 'eo', 'es', 'et',
                         'fr', 'he', 'hr', 'it', 'ja', 'ko', 'ltz', 'nl', 'nn',
                         'no', 'pl', 'pt', 'pt-BR', 'ru', 'sv', 'zh-CN',
                         'zh-TW' ],
 ) {
   include ::apache
-  if !is_array($force_language_priority) and !is_string($force_language_priority) {
-    fail('force_languague_priority must be a string or array of strings')
-  }
-  if !is_array($language_priority) and !is_string($language_priority) {
-    fail('force_languague_priority must be a string or array of strings')
-  }
 
   ::apache::mod { 'negotiation': }
   # Template uses no variables

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -53,7 +53,7 @@ class apache::mod::ssl (
     }
   }
 
-  if is_bool($ssl_honorcipherorder) {
+  if $ssl_honorcipherorder =~ Boolean {
     $_ssl_honorcipherorder = $ssl_honorcipherorder
   } else {
     $_ssl_honorcipherorder = $ssl_honorcipherorder ? {

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -59,7 +59,7 @@ define apache::vhost(
   $access_log_syslog                                                                = false,
   $access_log_format                                                                = false,
   $access_log_env_var                                                               = false,
-  $access_logs                                                                      = undef,
+  Optional[Array] $access_logs                                                      = undef,
   $aliases                                                                          = undef,
   $directories                                                                      = undef,
   Boolean $error_log                                                                = true,
@@ -324,9 +324,6 @@ define apache::vhost(
       'env'         => $access_log_env_var
     }]
   } elsif $access_logs {
-    if !is_array($access_logs) {
-      fail("Apache::Vhost[${name}]: access_logs must be an array of hashes")
-    }
     $_access_logs = $access_logs
   }
 


### PR DESCRIPTION
This completes the work https://github.com/puppetlabs/puppetlabs-apache/pull/1621 started. I think this covers all deprecation warnings.

Also makes puppet-lint a bit happier