### PR TITLE
(maint) require base64

### DIFF
--- a/lib/puppet/parser/functions/apache_pw_hash.rb
+++ b/lib/puppet/parser/functions/apache_pw_hash.rb
@@ -1,3 +1,5 @@
+require 'base64'
+
 Puppet::Parser::Functions::newfunction(:apache_pw_hash, :type => :rvalue, :doc => <<-EOS
 Hashes a password in a format suitable for htpasswd files read by apache.
 


### PR DESCRIPTION
the apache_pw_hash function tests fail on puppet 4.7.1 because of 'uninitialized constant Base64'. Base64 is ruby stdlib, not core, so this requires it defensively.