### PR TITLE
Expose loadfile_name option to mod::python class

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@
 [`apache::mod::proxy_balancer`]: #class-apachemodproxybalancer
 [`apache::mod::proxy_fcgi`]: #class-apachemodproxy_fcgi
 [`apache::mod::proxy_html`]: #class-apachemodproxy_html
+[`apache::mod::python`]: #class-apachemodpython
 [`apache::mod::security`]: #class-apachemodsecurity
 [`apache::mod::shib`]: #class-apachemodshib
 [`apache::mod::ssl`]: #class-apachemodssl
@@ -187,6 +188,7 @@
 [`mod_proxy`]: https://httpd.apache.org/docs/current/mod/mod_proxy.html
 [`mod_proxy_balancer`]: https://httpd.apache.org/docs/current/mod/mod_proxy_balancer.html
 [`mod_reqtimeout`]: https://httpd.apache.org/docs/current/mod/mod_reqtimeout.html
+[`mod_python`]: http://modpython.org/
 [`mod_rewrite`]: https://httpd.apache.org/docs/current/mod/mod_rewrite.html
 [`mod_security`]: https://www.modsecurity.org/
 [`mod_ssl`]: https://httpd.apache.org/docs/current/mod/mod_ssl.html
@@ -1611,7 +1613,7 @@ The following Apache modules have supported classes, many of which allow for par
 * `proxy_balancer`
 * `proxy_html` (see [`apache::mod::proxy_html`][])
 * `proxy_http`
-* `python`
+* `python` (see [`apache::mod::python`][])
 * `reqtimeout`
 * `remoteip`\*
 * `rewrite`
@@ -2476,6 +2478,14 @@ Default values for these parameters depend on your operating system. Most of thi
 ##### Class: `apache::mod::proxy_html`
 
 **Note**: There is no official package available for `mod_proxy_html`, so you must make it available outside of the apache module.
+
+##### Class: `apache::mod::python`
+
+Installs and configures [`mod_python`][].
+
+**Parameters**
+
+* `loadfile_name`: Sets the name of the configuration file that is used to load the python module.
 
 ##### Class: `apache::mod::reqtimeout`
 

--- a/manifests/mod/python.pp
+++ b/manifests/mod/python.pp
@@ -1,6 +1,10 @@
-class apache::mod::python {
+class apache::mod::python (
+  Optional[String] $loadfile_name = undef,
+) {
   include ::apache
-  ::apache::mod { 'python': }
+  ::apache::mod { 'python':
+    loadfile_name => $loadfile_name,
+  }
 }
 
 

--- a/spec/classes/mod/python_spec.rb
+++ b/spec/classes/mod/python_spec.rb
@@ -37,6 +37,14 @@ describe 'apache::mod::python', :type => :class do
     it { is_expected.to contain_class("apache::params") }
     it { is_expected.to contain_apache__mod("python") }
     it { is_expected.to contain_package("mod_python") }
+    it { is_expected.to contain_file("python.load").with_path('/etc/httpd/conf.d/python.load') }
+
+    describe "with loadfile_name specified" do
+      let :params do
+        { :loadfile_name => 'FooBar' }
+      end
+      it { is_expected.to contain_file("FooBar").with_path('/etc/httpd/conf.d/FooBar') }
+    end
   end
   context "on a FreeBSD OS" do
     let :facts do


### PR DESCRIPTION
This is a work around to a particular clash between these
two lines.

```puppet
class{'apache::mod::python':}
class{'collectd::plugin::python':}
```

Both classes create a file resource `file{'python.load':}`

This patch allows the resource name to be configured for
`apache::mod::python` setup.

There is an altenative more perfect solution to use a better
more unique name space by default e.g `file{"apache_${_loadfile_name}:` but this
would touch so many test files....

This change is fully backwards compatible.

* [collectd::plugin::python](https://github.com/voxpupuli/puppet-collectd/blob/master/manifests/plugin.pp#L16)