### PR TITLE
MODULES-5426 : Add support for all mod_passenger server config settings	

### DIFF
--- a/README.md
+++ b/README.md
@@ -2242,109 +2242,102 @@ $mount_file_content = {
 
 Installs and manages [`mod_passenger`][]. For Red Hat-based systems, ensure that you meet the minimum requirements described in the [passenger docs](https://www.phusionpassenger.com/library/install/apache/install/oss/el6/#step-1:-upgrade-your-kernel,-or-disable-selinux).
 
-The current set of server configurations settings were taking directly from the [`Passenger Reference`](https://www.phusionpassenger.com/library/config/apache/reference/). Deprecation warning and removal failure messages can be enabled by setting the passenger_installed_version to
+The current set of server configurations settings were taking directly from the [Passenger Reference](https://www.phusionpassenger.com/library/config/apache/reference/). Deprecation warning and removal failure messages can be enabled by setting the `passenger_installed_version` to
 the version number installed on the server.
 
 **Parameters**:
 
-|parameter|default value|passenger config setting|notes|
-|---------|-------------|------------------------|-----|
-|manage_repo|true|n/a||
-|mod_id|undef|n/a||
-|mod_lib|undef|n/a||
-|mod_lib_path|undef|n/a||
-|mod_package|undef|n/a||
-|mod_package_ensure|undef|n/a||
-|mod_path|undef|n/a||
-|passenger_allow_encoded_slashes|undef|[`PassengerAllowEncodedSlashes`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerAllowEncodedSlashes)||
-|passenger_app_env|undef|[`PassengerAppEnv`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerAppEnv)||
-|passenger_app_group_name|undef|[`PassengerAppGroupName`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerAppGroupName)||
-|passenger_app_root|undef|[`PassengerAppRoot`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerAppRoot)||
-|passenger_app_type|undef|[`PassengerAppType`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerAppType)||
-|passenger_base_uri|undef|[`PassengerBaseURI`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerBaseURI)||
-|passenger_buffer_response|undef|[`PassengerBufferResponse`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerBufferResponse)||
-|passenger_buffer_upload|undef|[`PassengerBufferUpload`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerBufferUpload)||
-|passenger_concurrency_model|undef|[`PassengerConcurrencyModel`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerConcurrencyModel)||
-|passenger_conf_file|$::apache::params::passenger_conf_file|n/a||
-|passenger_conf_package_file|$::apache::params::passenger_conf_package_file|n/a||
-|passenger_data_buffer_dir|undef|[`PassengerDataBufferDir`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerDataBufferDir)||
-|passenger_debug_log_file|undef|PassengerDebugLogFile|This option has been renamed in version 5.0.5 to PassengerLogFile.|
-|passenger_debugger|undef|[`PassengerDebugger`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerDebugger)||
-|passenger_default_group|undef|[`PassengerDefaultGroup`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerDefaultGroup)||
-|passenger_default_ruby|$::apache::params::passenger_default_ruby|[`PassengerDefaultRuby`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerDefaultRuby)||
-|passenger_default_user|undef|[`PassengerDefaultUser`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerDefaultUser)||
-|passenger_disable_security_update_check|undef|[`PassengerDisableSecurityUpdateCheck`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerDisableSecurityUpdateCheck)||
-|passenger_enabled|undef|[`PassengerEnabled`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerEnabled)||
-|passenger_error_override|undef|[`PassengerErrorOverride`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerErrorOverride)||
-|passenger_file_descriptor_log_file|undef|[`PassengerFileDescriptorLogFile`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerFileDescriptorLogFile)||
-|passenger_fly_with|undef|[`PassengerFlyWith`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerFlyWith)||
-|passenger_force_max_concurrent_requests_per_process|undef|[`PassengerForceMaxConcurrentRequestsPerProcess`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerForceMaxConcurrentRequestsPerProcess)||
-|passenger_friendly_error_pages|undef|[`PassengerFriendlyErrorPages`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerFriendlyErrorPages)||
-|passenger_group|undef|[`PassengerGroup`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerGroup)||
-|passenger_high_performance|undef|[`PassengerHighPerformance`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerHighPerformance)||
-|passenger_installed_version|undef|n/a|When set, puppet will issue warnings and failures for deprecated and removed passenger configuration options|
-|passenger_instance_registry_dir|undef|[`PassengerInstanceRegistryDir`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerInstanceRegistryDir)||
-|passenger_load_shell_envvars|undef|[`PassengerLoadShellEnvvars`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerLoadShellEnvvars)||
-|passenger_log_file|undef|[`PassengerLogFile`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerLogFile)||
-|passenger_log_level|undef|[`PassengerLogLevel`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerLogLevel)||
-|passenger_lve_min_uid|undef|[`PassengerLveMinUid`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerLveMinUid)||
-|passenger_max_instances|undef|[`PassengerMaxInstances`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxInstances)||
-|passenger_max_instances_per_app|undef|[`PassengerMaxInstancesPerApp`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxInstancesPerApp)||
-|passenger_max_pool_size|undef|[`PassengerMaxPoolSize`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxPoolSize)||
-|passenger_max_preloader_idle_time|undef|[`PassengerMaxPreloaderIdleTime`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxPreloaderIdleTime)||
-|passenger_max_request_queue_size|undef|[`PassengerMaxRequestQueueSize`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxRequestQueueSize)||
-|passenger_max_request_time|undef|[`PassengerMaxRequestTime`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxRequestTime)||
-|passenger_max_requests|undef|[`PassengerMaxRequests`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxRequests)||
-|passenger_memory_limit|undef|[`PassengerMemoryLimit`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMemoryLimit)||
-|passenger_meteor_app_settings|undef|[`PassengerMeteorAppSettings`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMeteorAppSettings)||
-|passenger_min_instances|undef|[`PassengerMinInstances`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMinInstances)||
-|passenger_nodejs|undef|[`PassengerNodejs`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerNodejs)||
-|passenger_pool_idle_time|undef|[`PassengerPoolIdleTime`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerPoolIdleTime)||
-|passenger_pre_start|undef|[`PassengerPreStart`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerPreStart)||
-|passenger_python|undef|[`PassengerPython`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerPython)||
-|passenger_resist_deployment_errors|undef|[`PassengerResistDeploymentErrors`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerResistDeploymentErrors)||
-|passenger_resolve_symlinks_in_document_root|undef|[`PassengerResolveSymlinksInDocumentRoot`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerResolveSymlinksInDocumentRoot)||
-|passenger_response_buffer_high_watermark|undef|[`PassengerResponseBufferHighWatermark`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerResponseBufferHighWatermark)||
-|passenger_restart_dir|undef|[`PassengerRestartDir`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerRestartDir)||
-|passenger_rolling_restarts|undef|[`PassengerRollingRestarts`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerRollingRestarts)||
-|passenger_root|$::apache::params::passenger_root|[`PassengerRoot`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerRoot)||
-|passenger_ruby|$::apache::params::passenger_ruby|[`PassengerRuby`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerRuby)||
-|passenger_security_update_check_proxy|undef|[`PassengerSecurityUpdateCheckProxy`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerSecurityUpdateCheckProxy)||
-|passenger_show_version_in_header|undef|[`PassengerShowVersionInHeader`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerShowVersionInHeader)||
-|passenger_socket_backlog|undef|[`PassengerSocketBacklog`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerSocketBacklog)||
-|passenger_spawn_method|undef|[`PassengerSpawnMethod`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerSpawnMethod)||
-|passenger_start_timeout|undef|[`PassengerStartTimeout`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerStartTimeout)||
-|passenger_startup_file|undef|[`PassengerStartupFile`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerStartupFile)||
-|passenger_stat_throttle_rate|undef|[`PassengerStatThrottleRate`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerStatThrottleRate)||
-|passenger_sticky_sessions|undef|[`PassengerStickySessions`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerStickySessions)||
-|passenger_sticky_sessions_cookie_name|undef|[`PassengerStickySessionsCookieName`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerStickySessionsCookieName)||
-|passenger_thread_count|undef|[`PassengerThreadCount`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerThreadCount)||
-|passenger_use_global_queue|undef|PassengerUseGlobalQueue||
-|passenger_user|undef|[`PassengerUser`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerUser)||
-|passenger_user_switching|undef|[`PassengerUserSwitching`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerUserSwitching)||
-|rack_auto_detect|undef|RackAutoDetect|These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.|
-|rack_autodetect|undef|n/a|see rack_auto_detect|
-|rack_base_uri|undef|RackBaseURI|Deprecated in 3.0.0 in favor of PassengerBaseURI.|
-|rack_env|undef|[`RackEnv`](https://www.phusionpassenger.com/library/config/apache/reference/#RackEnv)||
-|rails_allow_mod_rewrite|undef|RailsAllowModRewrite|This option doesn't do anything anymore in since version 4.0.0.|
-|rails_app_spawner_idle_time|undef|RailsAppSpawnerIdleTime|This option has been removed in version 4.0.0, and replaced with PassengerMaxPreloaderIdleTime.|
-|rails_auto_detect|undef|RailsAutoDetect|These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.|
-|rails_autodetect|undef|n/a|see rails_auto_detect|
-|rails_base_uri|undef|RailsBaseURI|Deprecated in 3.0.0 in favor of PassengerBaseURI.|
-|rails_default_user|undef|RailsDefaultUser|Deprecated in 3.0.0 in favor of PassengerDefaultUser.|
-|rails_env|undef|[`RailsEnv`](https://www.phusionpassenger.com/library/config/apache/reference/#RailsEnv)||
-|rails_framework_spawner_idle_time|undef|RailsFrameworkSpawnerIdleTime|This option is no longer available in version 4.0.0. There is no alternative because framework spawning has been removed altogether. You should use smart spawning instead.|
-|rails_ruby|undef|RailsRuby|Deprecated in 3.0.0 in favor of PassengerRuby.|
-|rails_spawn_method|undef|RailsSpawnMethod|Deprecated in 3.0.0 in favor of PassengerSpawnMethod.|
-|rails_user_switching|undef|RailsUserSwitching|Deprecated in 3.0.0 in favor of PassengerUserSwitching.|
-|union_station_filter|undef|[`UnionStationFilter`](https://www.phusionpassenger.com/library/config/apache/reference/#UnionStationFilter)||
-|union_station_gateway_address|undef|[`UnionStationGatewayAddress`](https://www.phusionpassenger.com/library/config/apache/reference/#UnionStationGatewayAddress)||
-|union_station_gateway_cert|undef|[`UnionStationGatewayCert`](https://www.phusionpassenger.com/library/config/apache/reference/#UnionStationGatewayCert)||
-|union_station_gateway_port|undef|[`UnionStationGatewayPort`](https://www.phusionpassenger.com/library/config/apache/reference/#UnionStationGatewayPort)||
-|union_station_key|undef|[`UnionStationKey`](https://www.phusionpassenger.com/library/config/apache/reference/#UnionStationKey)||
-|union_station_proxy_address|undef|[`UnionStationProxyAddress`](https://www.phusionpassenger.com/library/config/apache/reference/#UnionStationProxyAddress)||
-|union_station_support|undef|[`UnionStationSupport`](https://www.phusionpassenger.com/library/config/apache/reference/#UnionStationSupport)||
-|wsgi_auto_detect|undef|WsgiAutoDetect|These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.|
+|parameter|default value|passenger config setting|context|notes|
+|---------|-------------|------------------------|-------|-----|
+|manage_repo|true|n/a|||
+|mod_id|undef|n/a|||
+|mod_lib|undef|n/a|||
+|mod_lib_path|undef|n/a|||
+|mod_package|undef|n/a|||
+|mod_package_ensure|undef|n/a|||
+|mod_path|undef|n/a|||
+|passenger_allow_encoded_slashes|undef|[`PassengerAllowEncodedSlashes`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerAllowEncodedSlashes)|server-config virutal-host htaccess directory ||
+|passenger_app_env|undef|[`PassengerAppEnv`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerAppEnv)|server-config virutal-host htaccess directory ||
+|passenger_app_group_name|undef|[`PassengerAppGroupName`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerAppGroupName)|server-config virutal-host htaccess directory ||
+|passenger_app_root|undef|[`PassengerAppRoot`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerAppRoot)|server-config virutal-host htaccess directory ||
+|passenger_app_type|undef|[`PassengerAppType`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerAppType)|server-config virutal-host htaccess directory ||
+|passenger_base_uri|undef|[`PassengerBaseURI`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerBaseURI)|server-config virutal-host htaccess directory ||
+|passenger_buffer_response|undef|[`PassengerBufferResponse`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerBufferResponse)|server-config virutal-host htaccess directory ||
+|passenger_buffer_upload|undef|[`PassengerBufferUpload`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerBufferUpload)|server-config virutal-host htaccess directory ||
+|passenger_concurrency_model|undef|[`PassengerConcurrencyModel`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerConcurrencyModel)|server-config virutal-host htaccess directory ||
+|passenger_conf_file|$::apache::params::passenger_conf_file|n/a|||
+|passenger_conf_package_file|$::apache::params::passenger_conf_package_file|n/a|||
+|passenger_data_buffer_dir|undef|[`PassengerDataBufferDir`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerDataBufferDir)|server-config ||
+|passenger_debug_log_file|undef|PassengerDebugLogFile|server-config |This option has been renamed in version 5.0.5 to PassengerLogFile.|
+|passenger_debugger|undef|[`PassengerDebugger`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerDebugger)|server-config virutal-host htaccess directory ||
+|passenger_default_group|undef|[`PassengerDefaultGroup`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerDefaultGroup)|server-config ||
+|passenger_default_ruby|$::apache::params::passenger_default_ruby|[`PassengerDefaultRuby`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerDefaultRuby)|server-config ||
+|passenger_default_user|undef|[`PassengerDefaultUser`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerDefaultUser)|server-config ||
+|passenger_disable_security_update_check|undef|[`PassengerDisableSecurityUpdateCheck`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerDisableSecurityUpdateCheck)|server-config ||
+|passenger_enabled|undef|[`PassengerEnabled`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerEnabled)|server-config virutal-host htaccess directory ||
+|passenger_error_override|undef|[`PassengerErrorOverride`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerErrorOverride)|server-config virutal-host htaccess directory ||
+|passenger_file_descriptor_log_file|undef|[`PassengerFileDescriptorLogFile`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerFileDescriptorLogFile)|server-config ||
+|passenger_fly_with|undef|[`PassengerFlyWith`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerFlyWith)|server-config ||
+|passenger_force_max_concurrent_requests_per_process|undef|[`PassengerForceMaxConcurrentRequestsPerProcess`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerForceMaxConcurrentRequestsPerProcess)|server-config virutal-host htaccess directory ||
+|passenger_friendly_error_pages|undef|[`PassengerFriendlyErrorPages`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerFriendlyErrorPages)|server-config virutal-host htaccess directory ||
+|passenger_group|undef|[`PassengerGroup`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerGroup)|server-config virutal-host directory ||
+|passenger_high_performance|undef|[`PassengerHighPerformance`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerHighPerformance)|server-config virutal-host htaccess directory ||
+|passenger_installed_version|undef|n/a| |If set, will enable version checking of the passenger options against the value set.|
+|passenger_instance_registry_dir|undef|[`PassengerInstanceRegistryDir`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerInstanceRegistryDir)|server-config ||
+|passenger_load_shell_envvars|undef|[`PassengerLoadShellEnvvars`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerLoadShellEnvvars)|server-config virutal-host htaccess directory ||
+|passenger_log_file|undef|[`PassengerLogFile`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerLogFile)|server-config ||
+|passenger_log_level|undef|[`PassengerLogLevel`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerLogLevel)|server-config ||
+|passenger_lve_min_uid|undef|[`PassengerLveMinUid`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerLveMinUid)|server-config virutal-host ||
+|passenger_max_instances|undef|[`PassengerMaxInstances`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxInstances)|server-config virutal-host htaccess directory ||
+|passenger_max_instances_per_app|undef|[`PassengerMaxInstancesPerApp`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxInstancesPerApp)|server-config ||
+|passenger_max_pool_size|undef|[`PassengerMaxPoolSize`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxPoolSize)|server-config ||
+|passenger_max_preloader_idle_time|undef|[`PassengerMaxPreloaderIdleTime`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxPreloaderIdleTime)|server-config virutal-host ||
+|passenger_max_request_queue_size|undef|[`PassengerMaxRequestQueueSize`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxRequestQueueSize)|server-config virutal-host htaccess directory ||
+|passenger_max_request_time|undef|[`PassengerMaxRequestTime`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxRequestTime)|server-config virutal-host htaccess directory ||
+|passenger_max_requests|undef|[`PassengerMaxRequests`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxRequests)|server-config virutal-host htaccess directory ||
+|passenger_memory_limit|undef|[`PassengerMemoryLimit`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMemoryLimit)|server-config virutal-host htaccess directory ||
+|passenger_meteor_app_settings|undef|[`PassengerMeteorAppSettings`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMeteorAppSettings)|server-config virutal-host htaccess directory ||
+|passenger_min_instances|undef|[`PassengerMinInstances`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMinInstances)|server-config virutal-host htaccess directory ||
+|passenger_nodejs|undef|[`PassengerNodejs`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerNodejs)|server-config virutal-host htaccess directory ||
+|passenger_pool_idle_time|undef|[`PassengerPoolIdleTime`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerPoolIdleTime)|server-config ||
+|passenger_pre_start|undef|[`PassengerPreStart`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerPreStart)|server-config virutal-host ||
+|passenger_python|undef|[`PassengerPython`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerPython)|server-config virutal-host htaccess directory ||
+|passenger_resist_deployment_errors|undef|[`PassengerResistDeploymentErrors`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerResistDeploymentErrors)|server-config virutal-host htaccess directory ||
+|passenger_resolve_symlinks_in_document_root|undef|[`PassengerResolveSymlinksInDocumentRoot`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerResolveSymlinksInDocumentRoot)|server-config virutal-host htaccess directory ||
+|passenger_response_buffer_high_watermark|undef|[`PassengerResponseBufferHighWatermark`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerResponseBufferHighWatermark)|server-config ||
+|passenger_restart_dir|undef|[`PassengerRestartDir`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerRestartDir)|server-config virutal-host htaccess directory ||
+|passenger_rolling_restarts|undef|[`PassengerRollingRestarts`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerRollingRestarts)|server-config virutal-host htaccess directory ||
+|passenger_root|$::apache::params::passenger_root|[`PassengerRoot`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerRoot)|server-config ||
+|passenger_ruby|$::apache::params::passenger_ruby|[`PassengerRuby`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerRuby)|server-config virutal-host htaccess directory ||
+|passenger_security_update_check_proxy|undef|[`PassengerSecurityUpdateCheckProxy`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerSecurityUpdateCheckProxy)|server-config ||
+|passenger_show_version_in_header|undef|[`PassengerShowVersionInHeader`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerShowVersionInHeader)|server-config ||
+|passenger_socket_backlog|undef|[`PassengerSocketBacklog`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerSocketBacklog)|server-config ||
+|passenger_spawn_method|undef|[`PassengerSpawnMethod`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerSpawnMethod)|server-config virutal-host ||
+|passenger_start_timeout|undef|[`PassengerStartTimeout`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerStartTimeout)|server-config virutal-host htaccess directory ||
+|passenger_startup_file|undef|[`PassengerStartupFile`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerStartupFile)|server-config virutal-host htaccess directory ||
+|passenger_stat_throttle_rate|undef|[`PassengerStatThrottleRate`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerStatThrottleRate)|server-config ||
+|passenger_sticky_sessions|undef|[`PassengerStickySessions`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerStickySessions)|server-config virutal-host htaccess directory ||
+|passenger_sticky_sessions_cookie_name|undef|[`PassengerStickySessionsCookieName`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerStickySessionsCookieName)|server-config virutal-host htaccess directory ||
+|passenger_thread_count|undef|[`PassengerThreadCount`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerThreadCount)|server-config virutal-host htaccess directory ||
+|passenger_use_global_queue|undef|PassengerUseGlobalQueue|server-config ||
+|passenger_user|undef|[`PassengerUser`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerUser)|server-config virutal-host directory ||
+|passenger_user_switching|undef|[`PassengerUserSwitching`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerUserSwitching)|server-config ||
+|rack_auto_detect|undef|RackAutoDetect|server-config |These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.|
+|rack_autodetect|undef|n/a|||
+|rack_base_uri|undef|RackBaseURI|server-config |Deprecated in 3.0.0 in favor of PassengerBaseURI.|
+|rack_env|undef|[`RackEnv`](https://www.phusionpassenger.com/library/config/apache/reference/#RackEnv)|server-config virutal-host htaccess directory ||
+|rails_allow_mod_rewrite|undef|RailsAllowModRewrite|server-config |This option doesn't do anything anymore in since version 4.0.0.|
+|rails_app_spawner_idle_time|undef|RailsAppSpawnerIdleTime|server-config |This option has been removed in version 4.0.0, and replaced with PassengerMaxPreloaderIdleTime.|
+|rails_auto_detect|undef|RailsAutoDetect|server-config |These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.|
+|rails_autodetect|undef|n/a|||
+|rails_base_uri|undef|RailsBaseURI|server-config |Deprecated in 3.0.0 in favor of PassengerBaseURI.|
+|rails_default_user|undef|RailsDefaultUser|server-config |Deprecated in 3.0.0 in favor of PassengerDefaultUser.|
+|rails_env|undef|[`RailsEnv`](https://www.phusionpassenger.com/library/config/apache/reference/#RailsEnv)|server-config virutal-host htaccess directory ||
+|rails_framework_spawner_idle_time|undef|RailsFrameworkSpawnerIdleTime|server-config |This option is no longer available in version 4.0.0. There is no alternative because framework spawning has been removed altogether. You should use smart spawning instead.|
+|rails_ruby|undef|RailsRuby|server-config |Deprecated in 3.0.0 in favor of PassengerRuby.|
+|rails_spawn_method|undef|RailsSpawnMethod|server-config |Deprecated in 3.0.0 in favor of PassengerSpawnMethod.|
+|rails_user_switching|undef|RailsUserSwitching|server-config |Deprecated in 3.0.0 in favor of PassengerUserSwitching.|
+|wsgi_auto_detect|undef|WsgiAutoDetect|server-config |These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.|
 
 
 ##### Class: `apache::mod::ldap`

--- a/README.md
+++ b/README.md
@@ -2242,8 +2242,7 @@ $mount_file_content = {
 
 Installs and manages [`mod_passenger`][]. For Red Hat-based systems, ensure that you meet the minimum requirements described in the [passenger docs](https://www.phusionpassenger.com/library/install/apache/install/oss/el6/#step-1:-upgrade-your-kernel,-or-disable-selinux).
 
-The current set of server configurations settings were taking directly from the [Passenger Reference](https://www.phusionpassenger.com/library/config/apache/reference/). Deprecation warning and removal failure messages can be enabled by setting the `passenger_installed_version` to
-the version number installed on the server.
+The current set of server configurations settings were taken directly from the [Passenger Reference](https://www.phusionpassenger.com/library/config/apache/reference/). To enable deprecation warnings and removal failure messages, set the `passenger_installed_version` to the version number installed on the server.
 
 **Parameters**:
 

--- a/README.md
+++ b/README.md
@@ -2242,33 +2242,110 @@ $mount_file_content = {
 
 Installs and manages [`mod_passenger`][]. For Red Hat-based systems, ensure that you meet the minimum requirements described in the [passenger docs](https://www.phusionpassenger.com/library/install/apache/install/oss/el6/#step-1:-upgrade-your-kernel,-or-disable-selinux).
 
+The current set of server configurations settings were taking directly from the [`Passenger Reference`](https://www.phusionpassenger.com/library/config/apache/reference/). Deprecation warning and removal failure messages can be enabled by setting the passenger_installed_version to
+the version number installed on the server.
+
 **Parameters**:
 
-* `passenger_high_performance`: Sets the [`PassengerHighPerformance`](https://www.phusionpassenger.com/library/config/apache/reference/#passengerhighperformance).
+|parameter|default value|passenger config setting|notes|
+|---------|-------------|------------------------|-----|
+|manage_repo|true|n/a||
+|mod_id|undef|n/a||
+|mod_lib|undef|n/a||
+|mod_lib_path|undef|n/a||
+|mod_package|undef|n/a||
+|mod_package_ensure|undef|n/a||
+|mod_path|undef|n/a||
+|passenger_allow_encoded_slashes|undef|[`PassengerAllowEncodedSlashes`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerAllowEncodedSlashes)||
+|passenger_app_env|undef|[`PassengerAppEnv`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerAppEnv)||
+|passenger_app_group_name|undef|[`PassengerAppGroupName`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerAppGroupName)||
+|passenger_app_root|undef|[`PassengerAppRoot`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerAppRoot)||
+|passenger_app_type|undef|[`PassengerAppType`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerAppType)||
+|passenger_base_uri|undef|[`PassengerBaseURI`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerBaseURI)||
+|passenger_buffer_response|undef|[`PassengerBufferResponse`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerBufferResponse)||
+|passenger_buffer_upload|undef|[`PassengerBufferUpload`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerBufferUpload)||
+|passenger_concurrency_model|undef|[`PassengerConcurrencyModel`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerConcurrencyModel)||
+|passenger_conf_file|$::apache::params::passenger_conf_file|n/a||
+|passenger_conf_package_file|$::apache::params::passenger_conf_package_file|n/a||
+|passenger_data_buffer_dir|undef|[`PassengerDataBufferDir`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerDataBufferDir)||
+|passenger_debug_log_file|undef|PassengerDebugLogFile|This option has been renamed in version 5.0.5 to PassengerLogFile.|
+|passenger_debugger|undef|[`PassengerDebugger`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerDebugger)||
+|passenger_default_group|undef|[`PassengerDefaultGroup`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerDefaultGroup)||
+|passenger_default_ruby|$::apache::params::passenger_default_ruby|[`PassengerDefaultRuby`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerDefaultRuby)||
+|passenger_default_user|undef|[`PassengerDefaultUser`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerDefaultUser)||
+|passenger_disable_security_update_check|undef|[`PassengerDisableSecurityUpdateCheck`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerDisableSecurityUpdateCheck)||
+|passenger_enabled|undef|[`PassengerEnabled`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerEnabled)||
+|passenger_error_override|undef|[`PassengerErrorOverride`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerErrorOverride)||
+|passenger_file_descriptor_log_file|undef|[`PassengerFileDescriptorLogFile`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerFileDescriptorLogFile)||
+|passenger_fly_with|undef|[`PassengerFlyWith`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerFlyWith)||
+|passenger_force_max_concurrent_requests_per_process|undef|[`PassengerForceMaxConcurrentRequestsPerProcess`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerForceMaxConcurrentRequestsPerProcess)||
+|passenger_friendly_error_pages|undef|[`PassengerFriendlyErrorPages`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerFriendlyErrorPages)||
+|passenger_group|undef|[`PassengerGroup`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerGroup)||
+|passenger_high_performance|undef|[`PassengerHighPerformance`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerHighPerformance)||
+|passenger_installed_version|undef|n/a|When set, puppet will issue warnings and failures for deprecated and removed passenger configuration options|
+|passenger_instance_registry_dir|undef|[`PassengerInstanceRegistryDir`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerInstanceRegistryDir)||
+|passenger_load_shell_envvars|undef|[`PassengerLoadShellEnvvars`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerLoadShellEnvvars)||
+|passenger_log_file|undef|[`PassengerLogFile`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerLogFile)||
+|passenger_log_level|undef|[`PassengerLogLevel`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerLogLevel)||
+|passenger_lve_min_uid|undef|[`PassengerLveMinUid`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerLveMinUid)||
+|passenger_max_instances|undef|[`PassengerMaxInstances`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxInstances)||
+|passenger_max_instances_per_app|undef|[`PassengerMaxInstancesPerApp`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxInstancesPerApp)||
+|passenger_max_pool_size|undef|[`PassengerMaxPoolSize`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxPoolSize)||
+|passenger_max_preloader_idle_time|undef|[`PassengerMaxPreloaderIdleTime`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxPreloaderIdleTime)||
+|passenger_max_request_queue_size|undef|[`PassengerMaxRequestQueueSize`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxRequestQueueSize)||
+|passenger_max_request_time|undef|[`PassengerMaxRequestTime`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxRequestTime)||
+|passenger_max_requests|undef|[`PassengerMaxRequests`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxRequests)||
+|passenger_memory_limit|undef|[`PassengerMemoryLimit`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMemoryLimit)||
+|passenger_meteor_app_settings|undef|[`PassengerMeteorAppSettings`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMeteorAppSettings)||
+|passenger_min_instances|undef|[`PassengerMinInstances`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMinInstances)||
+|passenger_nodejs|undef|[`PassengerNodejs`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerNodejs)||
+|passenger_pool_idle_time|undef|[`PassengerPoolIdleTime`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerPoolIdleTime)||
+|passenger_pre_start|undef|[`PassengerPreStart`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerPreStart)||
+|passenger_python|undef|[`PassengerPython`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerPython)||
+|passenger_resist_deployment_errors|undef|[`PassengerResistDeploymentErrors`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerResistDeploymentErrors)||
+|passenger_resolve_symlinks_in_document_root|undef|[`PassengerResolveSymlinksInDocumentRoot`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerResolveSymlinksInDocumentRoot)||
+|passenger_response_buffer_high_watermark|undef|[`PassengerResponseBufferHighWatermark`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerResponseBufferHighWatermark)||
+|passenger_restart_dir|undef|[`PassengerRestartDir`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerRestartDir)||
+|passenger_rolling_restarts|undef|[`PassengerRollingRestarts`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerRollingRestarts)||
+|passenger_root|$::apache::params::passenger_root|[`PassengerRoot`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerRoot)||
+|passenger_ruby|$::apache::params::passenger_ruby|[`PassengerRuby`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerRuby)||
+|passenger_security_update_check_proxy|undef|[`PassengerSecurityUpdateCheckProxy`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerSecurityUpdateCheckProxy)||
+|passenger_show_version_in_header|undef|[`PassengerShowVersionInHeader`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerShowVersionInHeader)||
+|passenger_socket_backlog|undef|[`PassengerSocketBacklog`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerSocketBacklog)||
+|passenger_spawn_method|undef|[`PassengerSpawnMethod`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerSpawnMethod)||
+|passenger_start_timeout|undef|[`PassengerStartTimeout`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerStartTimeout)||
+|passenger_startup_file|undef|[`PassengerStartupFile`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerStartupFile)||
+|passenger_stat_throttle_rate|undef|[`PassengerStatThrottleRate`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerStatThrottleRate)||
+|passenger_sticky_sessions|undef|[`PassengerStickySessions`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerStickySessions)||
+|passenger_sticky_sessions_cookie_name|undef|[`PassengerStickySessionsCookieName`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerStickySessionsCookieName)||
+|passenger_thread_count|undef|[`PassengerThreadCount`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerThreadCount)||
+|passenger_use_global_queue|undef|PassengerUseGlobalQueue||
+|passenger_user|undef|[`PassengerUser`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerUser)||
+|passenger_user_switching|undef|[`PassengerUserSwitching`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerUserSwitching)||
+|rack_auto_detect|undef|RackAutoDetect|These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.|
+|rack_autodetect|undef|n/a|see rack_auto_detect|
+|rack_base_uri|undef|RackBaseURI|Deprecated in 3.0.0 in favor of PassengerBaseURI.|
+|rack_env|undef|[`RackEnv`](https://www.phusionpassenger.com/library/config/apache/reference/#RackEnv)||
+|rails_allow_mod_rewrite|undef|RailsAllowModRewrite|This option doesn't do anything anymore in since version 4.0.0.|
+|rails_app_spawner_idle_time|undef|RailsAppSpawnerIdleTime|This option has been removed in version 4.0.0, and replaced with PassengerMaxPreloaderIdleTime.|
+|rails_auto_detect|undef|RailsAutoDetect|These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.|
+|rails_autodetect|undef|n/a|see rails_auto_detect|
+|rails_base_uri|undef|RailsBaseURI|Deprecated in 3.0.0 in favor of PassengerBaseURI.|
+|rails_default_user|undef|RailsDefaultUser|Deprecated in 3.0.0 in favor of PassengerDefaultUser.|
+|rails_env|undef|[`RailsEnv`](https://www.phusionpassenger.com/library/config/apache/reference/#RailsEnv)||
+|rails_framework_spawner_idle_time|undef|RailsFrameworkSpawnerIdleTime|This option is no longer available in version 4.0.0. There is no alternative because framework spawning has been removed altogether. You should use smart spawning instead.|
+|rails_ruby|undef|RailsRuby|Deprecated in 3.0.0 in favor of PassengerRuby.|
+|rails_spawn_method|undef|RailsSpawnMethod|Deprecated in 3.0.0 in favor of PassengerSpawnMethod.|
+|rails_user_switching|undef|RailsUserSwitching|Deprecated in 3.0.0 in favor of PassengerUserSwitching.|
+|union_station_filter|undef|[`UnionStationFilter`](https://www.phusionpassenger.com/library/config/apache/reference/#UnionStationFilter)||
+|union_station_gateway_address|undef|[`UnionStationGatewayAddress`](https://www.phusionpassenger.com/library/config/apache/reference/#UnionStationGatewayAddress)||
+|union_station_gateway_cert|undef|[`UnionStationGatewayCert`](https://www.phusionpassenger.com/library/config/apache/reference/#UnionStationGatewayCert)||
+|union_station_gateway_port|undef|[`UnionStationGatewayPort`](https://www.phusionpassenger.com/library/config/apache/reference/#UnionStationGatewayPort)||
+|union_station_key|undef|[`UnionStationKey`](https://www.phusionpassenger.com/library/config/apache/reference/#UnionStationKey)||
+|union_station_proxy_address|undef|[`UnionStationProxyAddress`](https://www.phusionpassenger.com/library/config/apache/reference/#UnionStationProxyAddress)||
+|union_station_support|undef|[`UnionStationSupport`](https://www.phusionpassenger.com/library/config/apache/reference/#UnionStationSupport)||
+|wsgi_auto_detect|undef|WsgiAutoDetect|These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.|
 
-  Values: 'On', 'Off'.
-
-  Default: `undef`.
-
-* `passenger_pool_idle_time`: Sets the [`PassengerPoolIdleTime`](https://www.phusionpassenger.com/library/config/apache/reference/#passengerpoolidletime).
-
-  Default: `undef`.
-
-* `passenger_max_pool_size`: Sets the [`PassengerMaxPoolSize`](https://www.phusionpassenger.com/library/config/apache/reference/#passengermaxpoolsize).
-
-  Default: `undef`.
-
-* `passenger_max_request_queue_size`: Sets the [`PassengerMaxRequestQueueSize`](https://www.phusionpassenger.com/library/config/apache/reference/#passengermaxrequestqueuesize).
-
-  Default: `undef`.
-
-* `passenger_max_requests`: Sets the [`PassengerMaxRequests`](https://www.phusionpassenger.com/library/config/apache/reference/#passengermaxrequests).
-
-  Default: `undef`.
-
-* `passenger_data_buffer_dir`: Sets the [`PassengerDataBufferDir`](https://www.phusionpassenger.com/library/config/apache/reference/#passengerdatabufferdir).
-
-  Default: `undef`.
 
 ##### Class: `apache::mod::ldap`
 

--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -73,7 +73,6 @@ class apache::mod::passenger (
   $passenger_user                                                                            = undef,
   $passenger_user_switching                                                                  = undef,
   $rack_auto_detect                                                                          = undef,
-  $rack_autodectect                                                                          = undef,
   $rack_autodetect                                                                           = undef,
   $rack_base_uri                                                                             = undef,
   $rack_env                                                                                  = undef,
@@ -152,7 +151,7 @@ class apache::mod::passenger (
     }
     if $passenger_debug_log_file {
       if (versioncmp($passenger_installed_version, '5.0.5') > 0) {
-        warning("DEPRECATED PASSENGER OPTION :: passenger_debug_log_file :: This option has been renamed in version 5.0.5 to PassengerLogFile.")
+        warning('DEPRECATED PASSENGER OPTION :: passenger_debug_log_file :: This option has been renamed in version 5.0.5 to PassengerLogFile.')
       }
       if (versioncmp($passenger_installed_version, '5.0.5') < 0) {
         fail("Passenger config option :: passenger_debug_log_file is not introduced until version 5.0.5 :: ${passenger_installed_version} is the version reported")
@@ -405,9 +404,9 @@ class apache::mod::passenger (
     }
     if $passenger_use_global_queue {
       if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
-        fail("REMOVED PASSENGER OPTION :: passenger_use_global_queue ::  ")
+        fail('REMOVED PASSENGER OPTION :: passenger_use_global_queue :: no longer used after version 4.0.0 and is on by default')
       }
-      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+      if (versioncmp($passenger_installed_version, '2.0.4') < 0) {
         fail("Passenger config option :: passenger_use_global_queue is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
       }
     }
@@ -421,9 +420,9 @@ class apache::mod::passenger (
         fail("Passenger config option :: passenger_user_switching is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
       }
     }
-    if $rack_auto_detect {
+    if ($rack_auto_detect or $rack_autodetect) {
       if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
-        fail("REMOVED PASSENGER OPTION :: rack_auto_detect ::  These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.")
+        fail('REMOVED PASSENGER OPTION :: rack_auto_detect ::  These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.')
       }
       if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
         fail("Passenger config option :: rack_auto_detect is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
@@ -431,7 +430,7 @@ class apache::mod::passenger (
     }
     if $rack_base_uri {
       if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
-        warning("DEPRECATED PASSENGER OPTION :: rack_base_uri :: Deprecated in 3.0.0 in favor of PassengerBaseURI.")
+        warning('DEPRECATED PASSENGER OPTION :: rack_base_uri :: Deprecated in 3.0.0 in favor of PassengerBaseURI.')
       }
       if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
         fail("Passenger config option :: rack_base_uri is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
@@ -452,15 +451,15 @@ class apache::mod::passenger (
     }
     if $rails_app_spawner_idle_time {
       if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
-        fail("REMOVED PASSENGER OPTION :: rails_app_spawner_idle_time ::  This option has been removed in version 4.0.0, and replaced with PassengerMaxPreloaderIdleTime.")
+        fail('REMOVED PASSENGER OPTION :: rails_app_spawner_idle_time ::  This option has been removed in version 4.0.0, and replaced with PassengerMaxPreloaderIdleTime.')
       }
       if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
         fail("Passenger config option :: rails_app_spawner_idle_time is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
       }
     }
-    if $rails_auto_detect {
+    if ($rails_auto_detect or $rails_autodetect) {
       if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
-        fail("REMOVED PASSENGER OPTION :: rails_auto_detect ::  These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.")
+        fail('REMOVED PASSENGER OPTION :: rails_auto_detect ::  These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.')
       }
       if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
         fail("Passenger config option :: rails_auto_detect is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
@@ -468,7 +467,7 @@ class apache::mod::passenger (
     }
     if $rails_base_uri {
       if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
-        warning("DEPRECATED PASSENGER OPTION :: rails_base_uri :: Deprecated in 3.0.0 in favor of PassengerBaseURI.")
+        warning('DEPRECATED PASSENGER OPTION :: rails_base_uri :: Deprecated in 3.0.0 in favor of PassengerBaseURI.')
       }
       if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
         fail("Passenger config option :: rails_base_uri is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
@@ -476,7 +475,7 @@ class apache::mod::passenger (
     }
     if $rails_default_user {
       if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
-        warning("DEPRECATED PASSENGER OPTION :: rails_default_user :: Deprecated in 3.0.0 in favor of PassengerDefaultUser.")
+        warning('DEPRECATED PASSENGER OPTION :: rails_default_user :: Deprecated in 3.0.0 in favor of PassengerDefaultUser.')
       }
       if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
         fail("Passenger config option :: rails_default_user is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
@@ -489,7 +488,7 @@ class apache::mod::passenger (
     }
     if $rails_framework_spawner_idle_time {
       if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
-        fail("REMOVED PASSENGER OPTION :: rails_framework_spawner_idle_time ::  This option is no longer available in version 4.0.0. There is no alternative because framework spawning has been removed altogether. You should use smart spawning instead.")
+        fail('REMOVED PASSENGER OPTION :: rails_framework_spawner_idle_time ::  This option is no longer available in version 4.0.0. There is no alternative because framework spawning has been removed altogether. You should use smart spawning instead.')
       }
       if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
         fail("Passenger config option :: rails_framework_spawner_idle_time is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
@@ -497,7 +496,7 @@ class apache::mod::passenger (
     }
     if $rails_ruby {
       if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
-        warning("DEPRECATED PASSENGER OPTION :: rails_ruby :: Deprecated in 3.0.0 in favor of PassengerRuby.")
+        warning('DEPRECATED PASSENGER OPTION :: rails_ruby :: Deprecated in 3.0.0 in favor of PassengerRuby.')
       }
       if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
         fail("Passenger config option :: rails_ruby is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
@@ -505,7 +504,7 @@ class apache::mod::passenger (
     }
     if $rails_spawn_method {
       if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
-        warning("DEPRECATED PASSENGER OPTION :: rails_spawn_method :: Deprecated in 3.0.0 in favor of PassengerSpawnMethod.")
+        warning('DEPRECATED PASSENGER OPTION :: rails_spawn_method :: Deprecated in 3.0.0 in favor of PassengerSpawnMethod.')
       }
       if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
         fail("Passenger config option :: rails_spawn_method is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
@@ -513,7 +512,7 @@ class apache::mod::passenger (
     }
     if $rails_user_switching {
       if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
-        warning("DEPRECATED PASSENGER OPTION :: rails_user_switching :: Deprecated in 3.0.0 in favor of PassengerUserSwitching.")
+        warning('DEPRECATED PASSENGER OPTION :: rails_user_switching :: Deprecated in 3.0.0 in favor of PassengerUserSwitching.')
       }
       if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
         fail("Passenger config option :: rails_user_switching is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
@@ -556,7 +555,7 @@ class apache::mod::passenger (
     }
     if $wsgi_auto_detect {
       if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
-        fail("REMOVED PASSENGER OPTION :: wsgi_auto_detect ::  These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.")
+        fail('REMOVED PASSENGER OPTION :: wsgi_auto_detect ::  These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.')
       }
       if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
         fail("Passenger config option :: wsgi_auto_detect is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")

--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -1,35 +1,568 @@
 class apache::mod::passenger (
-  $passenger_conf_file                                                                   = $::apache::params::passenger_conf_file,
-  $passenger_conf_package_file                                                           = $::apache::params::passenger_conf_package_file,
-  $passenger_high_performance                                                            = undef,
-  $passenger_pool_idle_time                                                              = undef,
-  $passenger_max_request_queue_size                                                      = undef,
-  $passenger_max_requests                                                                = undef,
-  Optional[Enum['smart', 'direct', 'smart-lv2', 'conservative']] $passenger_spawn_method = undef,
-  $passenger_stat_throttle_rate                                                          = undef,
-  $rack_autodetect                                                                       = undef,
-  $rails_autodetect                                                                      = undef,
-  $passenger_root                                                                        = $::apache::params::passenger_root,
-  $passenger_ruby                                                                        = $::apache::params::passenger_ruby,
-  $passenger_default_ruby                                                                = $::apache::params::passenger_default_ruby,
-  $passenger_max_pool_size                                                               = undef,
-  $passenger_min_instances                                                               = undef,
-  $passenger_max_instances_per_app                                                       = undef,
-  $passenger_use_global_queue                                                            = undef,
-  $passenger_app_env                                                                     = undef,
-  Optional[Stdlib::Absolutepath] $passenger_log_file                                     = undef,
-  $passenger_log_level                                                                   = undef,
-  $passenger_data_buffer_dir                                                             = undef,
-  $manage_repo                                                                           = true,
-  $mod_package                                                                           = undef,
-  $mod_package_ensure                                                                    = undef,
-  $mod_lib                                                                               = undef,
-  $mod_lib_path                                                                          = undef,
-  $mod_id                                                                                = undef,
-  $mod_path                                                                              = undef,
+  $manage_repo                                                                               = true,
+  $mod_id                                                                                    = undef,
+  $mod_lib                                                                                   = undef,
+  $mod_lib_path                                                                              = undef,
+  $mod_package                                                                               = undef,
+  $mod_package_ensure                                                                        = undef,
+  $mod_path                                                                                  = undef,
+  $passenger_allow_encoded_slashes                                                           = undef,
+  $passenger_app_env                                                                         = undef,
+  $passenger_app_group_name                                                                  = undef,
+  $passenger_app_root                                                                        = undef,
+  $passenger_app_type                                                                        = undef,
+  $passenger_base_uri                                                                        = undef,
+  $passenger_buffer_response                                                                 = undef,
+  $passenger_buffer_upload                                                                   = undef,
+  $passenger_concurrency_model                                                               = undef,
+  $passenger_conf_file                                                                       = $::apache::params::passenger_conf_file,
+  $passenger_conf_package_file                                                               = $::apache::params::passenger_conf_package_file,
+  $passenger_data_buffer_dir                                                                 = undef,
+  $passenger_debug_log_file                                                                  = undef,
+  $passenger_debugger                                                                        = undef,
+  $passenger_default_group                                                                   = undef,
+  $passenger_default_ruby                                                                    = $::apache::params::passenger_default_ruby,
+  $passenger_default_user                                                                    = undef,
+  $passenger_disable_security_update_check                                                   = undef,
+  $passenger_enabled                                                                         = undef,
+  $passenger_error_override                                                                  = undef,
+  $passenger_file_descriptor_log_file                                                        = undef,
+  $passenger_fly_with                                                                        = undef,
+  $passenger_force_max_concurrent_requests_per_process                                       = undef,
+  $passenger_friendly_error_pages                                                            = undef,
+  $passenger_group                                                                           = undef,
+  $passenger_high_performance                                                                = undef,
+  $passenger_installed_version                                                               = undef,
+  $passenger_instance_registry_dir                                                           = undef,
+  $passenger_load_shell_envvars                                                              = undef,
+  Optional[Stdlib::Absolutepath] $passenger_log_file                                         = undef,
+  $passenger_log_level                                                                       = undef,
+  $passenger_lve_min_uid                                                                     = undef,
+  $passenger_max_instances                                                                   = undef,
+  $passenger_max_instances_per_app                                                           = undef,
+  $passenger_max_pool_size                                                                   = undef,
+  $passenger_max_preloader_idle_time                                                         = undef,
+  $passenger_max_request_queue_size                                                          = undef,
+  $passenger_max_request_time                                                                = undef,
+  $passenger_max_requests                                                                    = undef,
+  $passenger_memory_limit                                                                    = undef,
+  $passenger_meteor_app_settings                                                             = undef,
+  $passenger_min_instances                                                                   = undef,
+  $passenger_nodejs                                                                          = undef,
+  $passenger_pool_idle_time                                                                  = undef,
+  $passenger_pre_start                                                                       = undef,
+  $passenger_python                                                                          = undef,
+  $passenger_resist_deployment_errors                                                        = undef,
+  $passenger_resolve_symlinks_in_document_root                                               = undef,
+  $passenger_response_buffer_high_watermark                                                  = undef,
+  $passenger_restart_dir                                                                     = undef,
+  $passenger_rolling_restarts                                                                = undef,
+  $passenger_root                                                                            = $::apache::params::passenger_root,
+  $passenger_ruby                                                                            = $::apache::params::passenger_ruby,
+  $passenger_security_update_check_proxy                                                     = undef,
+  $passenger_show_version_in_header                                                          = undef,
+  $passenger_socket_backlog                                                                  = undef,
+  Optional[Enum['smart', 'direct', 'smart-lv2', 'conservative']] $passenger_spawn_method     = undef,
+  $passenger_start_timeout                                                                   = undef,
+  $passenger_startup_file                                                                    = undef,
+  $passenger_stat_throttle_rate                                                              = undef,
+  $passenger_sticky_sessions                                                                 = undef,
+  $passenger_sticky_sessions_cookie_name                                                     = undef,
+  $passenger_thread_count                                                                    = undef,
+  $passenger_use_global_queue                                                                = undef,
+  $passenger_user                                                                            = undef,
+  $passenger_user_switching                                                                  = undef,
+  $rack_auto_detect                                                                          = undef,
+  $rack_autodectect                                                                          = undef,
+  $rack_autodetect                                                                           = undef,
+  $rack_base_uri                                                                             = undef,
+  $rack_env                                                                                  = undef,
+  $rails_allow_mod_rewrite                                                                   = undef,
+  $rails_app_spawner_idle_time                                                               = undef,
+  $rails_auto_detect                                                                         = undef,
+  $rails_autodetect                                                                          = undef,
+  $rails_base_uri                                                                            = undef,
+  $rails_default_user                                                                        = undef,
+  $rails_env                                                                                 = undef,
+  $rails_framework_spawner_idle_time                                                         = undef,
+  $rails_ruby                                                                                = undef,
+  $rails_spawn_method                                                                        = undef,
+  $rails_user_switching                                                                      = undef,
+  $union_station_filter                                                                      = undef,
+  $union_station_gateway_address                                                             = undef,
+  $union_station_gateway_cert                                                                = undef,
+  $union_station_gateway_port                                                                = undef,
+  $union_station_key                                                                         = undef,
+  $union_station_proxy_address                                                               = undef,
+  $union_station_support                                                                     = undef,
+  $wsgi_auto_detect                                                                          = undef,
 ) inherits ::apache::params {
-
   include ::apache
+  # Checking version support
+  if $passenger_installed_version {
+    if $passenger_allow_encoded_slashes {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_allow_encoded_slashes is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_app_env {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_app_env is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_app_group_name {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_app_group_name is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_app_root {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_app_root is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_app_type {
+      if (versioncmp($passenger_installed_version, '4.0.25') < 0) {
+        fail("Passenger config option :: passenger_app_type is not introduced until version 4.0.25 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_base_uri {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_base_uri is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_buffer_response {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_buffer_response is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_buffer_upload {
+      if (versioncmp($passenger_installed_version, '4.0.26') < 0) {
+        fail("Passenger config option :: passenger_buffer_upload is not introduced until version 4.0.26 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_concurrency_model {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_concurrency_model is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_data_buffer_dir {
+      if (versioncmp($passenger_installed_version, '5.0.0') < 0) {
+        fail("Passenger config option :: passenger_data_buffer_dir is not introduced until version 5.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_debug_log_file {
+      if (versioncmp($passenger_installed_version, '5.0.5') > 0) {
+        warning("DEPRECATED PASSENGER OPTION :: passenger_debug_log_file :: This option has been renamed in version 5.0.5 to PassengerLogFile.")
+      }
+      if (versioncmp($passenger_installed_version, '5.0.5') < 0) {
+        fail("Passenger config option :: passenger_debug_log_file is not introduced until version 5.0.5 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_debugger {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_debugger is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_default_group {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_default_group is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_default_ruby {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_default_ruby is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_default_user {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_default_user is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_disable_security_update_check {
+      if (versioncmp($passenger_installed_version, '5.1.0') < 0) {
+        fail("Passenger config option :: passenger_disable_security_update_check is not introduced until version 5.1.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_enabled {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_enabled is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_error_override {
+      if (versioncmp($passenger_installed_version, '4.0.24') < 0) {
+        fail("Passenger config option :: passenger_error_override is not introduced until version 4.0.24 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_file_descriptor_log_file {
+      if (versioncmp($passenger_installed_version, '5.0.5') < 0) {
+        fail("Passenger config option :: passenger_file_descriptor_log_file is not introduced until version 5.0.5 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_fly_with {
+      if (versioncmp($passenger_installed_version, '4.0.45') < 0) {
+        fail("Passenger config option :: passenger_fly_with is not introduced until version 4.0.45 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_force_max_concurrent_requests_per_process {
+      if (versioncmp($passenger_installed_version, '5.0.22') < 0) {
+        fail("Passenger config option :: passenger_force_max_concurrent_requests_per_process is not introduced until version 5.0.22 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_friendly_error_pages {
+      if (versioncmp($passenger_installed_version, '4.0.42') < 0) {
+        fail("Passenger config option :: passenger_friendly_error_pages is not introduced until version 4.0.42 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_group {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_group is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_high_performance {
+      if (versioncmp($passenger_installed_version, '2.0.0') < 0) {
+        fail("Passenger config option :: passenger_high_performance is not introduced until version 2.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_instance_registry_dir {
+      if (versioncmp($passenger_installed_version, '5.0.0') < 0) {
+        fail("Passenger config option :: passenger_instance_registry_dir is not introduced until version 5.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_load_shell_envvars {
+      if (versioncmp($passenger_installed_version, '4.0.20') < 0) {
+        fail("Passenger config option :: passenger_load_shell_envvars is not introduced until version 4.0.20 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_log_file {
+      if (versioncmp($passenger_installed_version, '5.0.5') < 0) {
+        fail("Passenger config option :: passenger_log_file is not introduced until version 5.0.5 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_log_level {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_log_level is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_lve_min_uid {
+      if (versioncmp($passenger_installed_version, '5.0.28') < 0) {
+        fail("Passenger config option :: passenger_lve_min_uid is not introduced until version 5.0.28 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_max_instances {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_max_instances is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_max_instances_per_app {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_max_instances_per_app is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_max_pool_size {
+      if (versioncmp($passenger_installed_version, '1.0.0') < 0) {
+        fail("Passenger config option :: passenger_max_pool_size is not introduced until version 1.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_max_preloader_idle_time {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_max_preloader_idle_time is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_max_request_queue_size {
+      if (versioncmp($passenger_installed_version, '4.0.15') < 0) {
+        fail("Passenger config option :: passenger_max_request_queue_size is not introduced until version 4.0.15 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_max_request_time {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_max_request_time is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_max_requests {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_max_requests is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_memory_limit {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_memory_limit is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_meteor_app_settings {
+      if (versioncmp($passenger_installed_version, '5.0.7') < 0) {
+        fail("Passenger config option :: passenger_meteor_app_settings is not introduced until version 5.0.7 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_min_instances {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_min_instances is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_nodejs {
+      if (versioncmp($passenger_installed_version, '4.0.24') < 0) {
+        fail("Passenger config option :: passenger_nodejs is not introduced until version 4.0.24 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_pool_idle_time {
+      if (versioncmp($passenger_installed_version, '1.0.0') < 0) {
+        fail("Passenger config option :: passenger_pool_idle_time is not introduced until version 1.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_pre_start {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_pre_start is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_python {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_python is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_resist_deployment_errors {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_resist_deployment_errors is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_resolve_symlinks_in_document_root {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_resolve_symlinks_in_document_root is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_response_buffer_high_watermark {
+      if (versioncmp($passenger_installed_version, '5.0.0') < 0) {
+        fail("Passenger config option :: passenger_response_buffer_high_watermark is not introduced until version 5.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_restart_dir {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_restart_dir is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_rolling_restarts {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_rolling_restarts is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_root {
+      if (versioncmp($passenger_installed_version, '1.0.0') < 0) {
+        fail("Passenger config option :: passenger_root is not introduced until version 1.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_ruby {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_ruby is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_security_update_check_proxy {
+      if (versioncmp($passenger_installed_version, '5.1.0') < 0) {
+        fail("Passenger config option :: passenger_security_update_check_proxy is not introduced until version 5.1.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_show_version_in_header {
+      if (versioncmp($passenger_installed_version, '5.1.0') < 0) {
+        fail("Passenger config option :: passenger_show_version_in_header is not introduced until version 5.1.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_socket_backlog {
+      if (versioncmp($passenger_installed_version, '5.0.24') < 0) {
+        fail("Passenger config option :: passenger_socket_backlog is not introduced until version 5.0.24 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_spawn_method {
+      if (versioncmp($passenger_installed_version, '2.0.0') < 0) {
+        fail("Passenger config option :: passenger_spawn_method is not introduced until version 2.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_start_timeout {
+      if (versioncmp($passenger_installed_version, '4.0.15') < 0) {
+        fail("Passenger config option :: passenger_start_timeout is not introduced until version 4.0.15 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_startup_file {
+      if (versioncmp($passenger_installed_version, '4.0.25') < 0) {
+        fail("Passenger config option :: passenger_startup_file is not introduced until version 4.0.25 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_stat_throttle_rate {
+      if (versioncmp($passenger_installed_version, '2.2.0') < 0) {
+        fail("Passenger config option :: passenger_stat_throttle_rate is not introduced until version 2.2.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_sticky_sessions {
+      if (versioncmp($passenger_installed_version, '4.0.45') < 0) {
+        fail("Passenger config option :: passenger_sticky_sessions is not introduced until version 4.0.45 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_sticky_sessions_cookie_name {
+      if (versioncmp($passenger_installed_version, '4.0.45') < 0) {
+        fail("Passenger config option :: passenger_sticky_sessions_cookie_name is not introduced until version 4.0.45 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_thread_count {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_thread_count is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_use_global_queue {
+      if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
+        fail("REMOVED PASSENGER OPTION :: passenger_use_global_queue ::  ")
+      }
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_use_global_queue is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_user {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_user is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_user_switching {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_user_switching is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $rack_auto_detect {
+      if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
+        fail("REMOVED PASSENGER OPTION :: rack_auto_detect ::  These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.")
+      }
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: rack_auto_detect is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $rack_base_uri {
+      if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
+        warning("DEPRECATED PASSENGER OPTION :: rack_base_uri :: Deprecated in 3.0.0 in favor of PassengerBaseURI.")
+      }
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: rack_base_uri is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $rack_env {
+      if (versioncmp($passenger_installed_version, '2.0.0') < 0) {
+        fail("Passenger config option :: rack_env is not introduced until version 2.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $rails_allow_mod_rewrite {
+      if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
+        warning("DEPRECATED PASSENGER OPTION :: rails_allow_mod_rewrite :: This option doesn't do anything anymore in since version 4.0.0.")
+      }
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: rails_allow_mod_rewrite is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $rails_app_spawner_idle_time {
+      if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
+        fail("REMOVED PASSENGER OPTION :: rails_app_spawner_idle_time ::  This option has been removed in version 4.0.0, and replaced with PassengerMaxPreloaderIdleTime.")
+      }
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: rails_app_spawner_idle_time is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $rails_auto_detect {
+      if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
+        fail("REMOVED PASSENGER OPTION :: rails_auto_detect ::  These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.")
+      }
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: rails_auto_detect is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $rails_base_uri {
+      if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
+        warning("DEPRECATED PASSENGER OPTION :: rails_base_uri :: Deprecated in 3.0.0 in favor of PassengerBaseURI.")
+      }
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: rails_base_uri is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $rails_default_user {
+      if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
+        warning("DEPRECATED PASSENGER OPTION :: rails_default_user :: Deprecated in 3.0.0 in favor of PassengerDefaultUser.")
+      }
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: rails_default_user is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $rails_env {
+      if (versioncmp($passenger_installed_version, '2.0.0') < 0) {
+        fail("Passenger config option :: rails_env is not introduced until version 2.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $rails_framework_spawner_idle_time {
+      if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
+        fail("REMOVED PASSENGER OPTION :: rails_framework_spawner_idle_time ::  This option is no longer available in version 4.0.0. There is no alternative because framework spawning has been removed altogether. You should use smart spawning instead.")
+      }
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: rails_framework_spawner_idle_time is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $rails_ruby {
+      if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
+        warning("DEPRECATED PASSENGER OPTION :: rails_ruby :: Deprecated in 3.0.0 in favor of PassengerRuby.")
+      }
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: rails_ruby is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $rails_spawn_method {
+      if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
+        warning("DEPRECATED PASSENGER OPTION :: rails_spawn_method :: Deprecated in 3.0.0 in favor of PassengerSpawnMethod.")
+      }
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: rails_spawn_method is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $rails_user_switching {
+      if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
+        warning("DEPRECATED PASSENGER OPTION :: rails_user_switching :: Deprecated in 3.0.0 in favor of PassengerUserSwitching.")
+      }
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: rails_user_switching is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $union_station_filter {
+      if (versioncmp($passenger_installed_version, '3.0.5') < 0) {
+        fail("Passenger config option :: union_station_filter is not introduced until version 3.0.5 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $union_station_gateway_address {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: union_station_gateway_address is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $union_station_gateway_cert {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: union_station_gateway_cert is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $union_station_gateway_port {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: union_station_gateway_port is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $union_station_key {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: union_station_key is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $union_station_proxy_address {
+      if (versioncmp($passenger_installed_version, '3.0.11') < 0) {
+        fail("Passenger config option :: union_station_proxy_address is not introduced until version 3.0.11 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $union_station_support {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: union_station_support is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $wsgi_auto_detect {
+      if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
+        fail("REMOVED PASSENGER OPTION :: wsgi_auto_detect ::  These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.")
+      }
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: wsgi_auto_detect is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+  }
 
   # Managed by the package, but declare it to avoid purging
   if $passenger_conf_package_file {
@@ -85,25 +618,93 @@ class apache::mod::passenger (
       loadfile_name  => 'zpassenger.load',
     }
   }
-
   # Template uses:
-  # - $passenger_root
-  # - $passenger_ruby
-  # - $passenger_default_ruby
-  # - $passenger_max_pool_size
-  # - $passenger_min_instances
-  # - $passenger_max_instances_per_app
-  # - $passenger_high_performance
-  # - $passenger_max_requests
-  # - $passenger_spawn_method
-  # - $passenger_stat_throttle_rate
-  # - $passenger_use_global_queue
-  # - $passenger_log_file
-  # - $passenger_log_level
-  # - $passenger_app_env
-  # - $passenger_data_buffer_dir
-  # - $rack_autodetect
-  # - $rails_autodetect
+  # - $passenger_allow_encoded_slashes : since 4.0.0
+  # - $passenger_app_env : since 4.0.0
+  # - $passenger_app_group_name : since 4.0.0
+  # - $passenger_app_root : since 4.0.0
+  # - $passenger_app_type : since 4.0.25
+  # - $passenger_base_uri : since 4.0.0
+  # - $passenger_buffer_response : since 4.0.0
+  # - $passenger_buffer_upload : since 4.0.26
+  # - $passenger_concurrency_model : since 4.0.0
+  # - $passenger_data_buffer_dir : since 5.0.0
+  # - $passenger_debug_log_file : since 5.0.5
+  # - $passenger_debugger : since 3.0.0
+  # - $passenger_default_group : since 3.0.0
+  # - $passenger_default_ruby : since 4.0.0
+  # - $passenger_default_user : since 3.0.0
+  # - $passenger_disable_security_update_check : since 5.1.0
+  # - $passenger_enabled : since 4.0.0
+  # - $passenger_error_override : since 4.0.24
+  # - $passenger_file_descriptor_log_file : since 5.0.5
+  # - $passenger_fly_with : since 4.0.45
+  # - $passenger_force_max_concurrent_requests_per_process : since 5.0.22
+  # - $passenger_friendly_error_pages : since 4.0.42
+  # - $passenger_group : since 4.0.0
+  # - $passenger_high_performance : since 2.0.0
+  # - $passenger_instance_registry_dir : since 5.0.0
+  # - $passenger_load_shell_envvars : since 4.0.20
+  # - $passenger_log_file : since 5.0.5
+  # - $passenger_log_level : since 3.0.0
+  # - $passenger_lve_min_uid : since 5.0.28
+  # - $passenger_max_instances : since 3.0.0
+  # - $passenger_max_instances_per_app : since 3.0.0
+  # - $passenger_max_pool_size : since 1.0.0
+  # - $passenger_max_preloader_idle_time : since 4.0.0
+  # - $passenger_max_request_queue_size : since 4.0.15
+  # - $passenger_max_request_time : since 3.0.0
+  # - $passenger_max_requests : since 3.0.0
+  # - $passenger_memory_limit : since 3.0.0
+  # - $passenger_meteor_app_settings : since 5.0.7
+  # - $passenger_min_instances : since 3.0.0
+  # - $passenger_nodejs : since 4.0.24
+  # - $passenger_pool_idle_time : since 1.0.0
+  # - $passenger_pre_start : since 3.0.0
+  # - $passenger_python : since 4.0.0
+  # - $passenger_resist_deployment_errors : since 3.0.0
+  # - $passenger_resolve_symlinks_in_document_root : since 3.0.0
+  # - $passenger_response_buffer_high_watermark : since 5.0.0
+  # - $passenger_restart_dir : since 3.0.0
+  # - $passenger_rolling_restarts : since 3.0.0
+  # - $passenger_root : since 1.0.0
+  # - $passenger_ruby : since 4.0.0
+  # - $passenger_security_update_check_proxy : since 5.1.0
+  # - $passenger_show_version_in_header : since 5.1.0
+  # - $passenger_socket_backlog : since 5.0.24
+  # - $passenger_spawn_method : since 2.0.0
+  # - $passenger_start_timeout : since 4.0.15
+  # - $passenger_startup_file : since 4.0.25
+  # - $passenger_stat_throttle_rate : since 2.2.0
+  # - $passenger_sticky_sessions : since 4.0.45
+  # - $passenger_sticky_sessions_cookie_name : since 4.0.45
+  # - $passenger_thread_count : since 4.0.0
+  # - $passenger_use_global_queue : since 4.0.0
+  # - $passenger_user : since 4.0.0
+  # - $passenger_user_switching : since 3.0.0
+  # - $rack_auto_detect : since 4.0.0
+  # - $rack_base_uri : since 3.0.0
+  # - $rack_env : since 2.0.0
+  # - $rails_allow_mod_rewrite : since 4.0.0
+  # - $rails_app_spawner_idle_time : since 4.0.0
+  # - $rails_auto_detect : since 4.0.0
+  # - $rails_base_uri : since 3.0.0
+  # - $rails_default_user : since 3.0.0
+  # - $rails_env : since 2.0.0
+  # - $rails_framework_spawner_idle_time : since 4.0.0
+  # - $rails_ruby : since 3.0.0
+  # - $rails_spawn_method : since 3.0.0
+  # - $rails_user_switching : since 3.0.0
+  # - $union_station_filter : since 3.0.5
+  # - $union_station_gateway_address : since 3.0.0
+  # - $union_station_gateway_cert : since 3.0.0
+  # - $union_station_gateway_port : since 3.0.0
+  # - $union_station_key : since 3.0.0
+  # - $union_station_proxy_address : since 3.0.11
+  # - $union_station_support : since 3.0.0
+  # - $wsgi_auto_detect : since 4.0.0
+  # - $rails_autodetect : this options is only for backward compatiblity with older versions of this class
+  # - $rack_autodectect : this options is only for backward compatiblity with older versions of this class
   file { 'passenger.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/${passenger_conf_file}",

--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -587,7 +587,7 @@ class apache::mod::passenger (
   # - $passenger_buffer_upload : since 4.0.26
   # - $passenger_concurrency_model : since 4.0.0
   # - $passenger_data_buffer_dir : since 5.0.0
-  # - $passenger_debug_log_file : since 5.0.5
+  # - $passenger_debug_log_file : since unkown, probably deprecated
   # - $passenger_debugger : since 3.0.0
   # - $passenger_default_group : since 3.0.0
   # - $passenger_default_ruby : since 4.0.0
@@ -637,22 +637,22 @@ class apache::mod::passenger (
   # - $passenger_sticky_sessions : since 4.0.45
   # - $passenger_sticky_sessions_cookie_name : since 4.0.45
   # - $passenger_thread_count : since 4.0.0
-  # - $passenger_use_global_queue : since 4.0.0
+  # - $passenger_use_global_queue : since 2.0.4
   # - $passenger_user : since 4.0.0
   # - $passenger_user_switching : since 3.0.0
-  # - $rack_auto_detect : since 4.0.0
-  # - $rack_base_uri : since 3.0.0
+  # - $rack_auto_detect : since unkown, probably deprecated
+  # - $rack_base_uri : since unkown, probably deprecated
   # - $rack_env : since 2.0.0
-  # - $rails_allow_mod_rewrite : since 4.0.0
-  # - $rails_app_spawner_idle_time : since 4.0.0
-  # - $rails_auto_detect : since 4.0.0
-  # - $rails_base_uri : since 3.0.0
-  # - $rails_default_user : since 3.0.0
+  # - $rails_allow_mod_rewrite : since unkown, probably deprecated
+  # - $rails_app_spawner_idle_time : since unkown, probably deprecated
+  # - $rails_auto_detect : since unkown, probably deprecated
+  # - $rails_base_uri : since unkown, probably deprecated
+  # - $rails_default_user : since unkown, probably deprecated
   # - $rails_env : since 2.0.0
-  # - $rails_framework_spawner_idle_time : since 4.0.0
-  # - $rails_ruby : since 3.0.0
-  # - $rails_spawn_method : since 3.0.0
-  # - $rails_user_switching : since 3.0.0
+  # - $rails_framework_spawner_idle_time : since unkown, probably deprecated
+  # - $rails_ruby : since unkown, probably deprecated
+  # - $rails_spawn_method : since unkown, probably deprecated
+  # - $rails_user_switching : since unkown, probably deprecated
   # - $union_station_filter : since 3.0.5
   # - $union_station_gateway_address : since 3.0.0
   # - $union_station_gateway_cert : since 3.0.0
@@ -660,9 +660,9 @@ class apache::mod::passenger (
   # - $union_station_key : since 3.0.0
   # - $union_station_proxy_address : since 3.0.11
   # - $union_station_support : since 3.0.0
-  # - $wsgi_auto_detect : since 4.0.0
+  # - $wsgi_auto_detect : since unkown, probably deprecated
   # - $rails_autodetect : this options is only for backward compatiblity with older versions of this class
-  # - $rack_autodectect : this options is only for backward compatiblity with older versions of this class
+  # - $rack_autodetect : this options is only for backward compatiblity with older versions of this class
   file { 'passenger.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/${passenger_conf_file}",

--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -416,7 +416,7 @@ class apache::mod::passenger (
         fail("Passenger config option :: passenger_user_switching is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
       }
     }
-    if $rack_auto_detect {
+    if ($rack_auto_detect or $rack_autodetect) {
       if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
         fail('REMOVED PASSENGER OPTION :: rack_auto_detect ::  These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.')
       }
@@ -441,7 +441,7 @@ class apache::mod::passenger (
         fail('REMOVED PASSENGER OPTION :: rails_app_spawner_idle_time ::  This option has been removed in version 4.0.0, and replaced with PassengerMaxPreloaderIdleTime.')
       }
     }
-    if $rails_auto_detect {
+    if ($rails_auto_detect or $rails_autodetect) {
       if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
         fail('REMOVED PASSENGER OPTION :: rails_auto_detect ::  These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.')
       }

--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -1,3 +1,17 @@
+# Manages the settings for the mod_passenger
+# The result is the /etc/mods-available/mod_passenger.conf file
+#
+# Where do we get these settings?
+#   Settings are dervied from https://www.phusionpassenger.com/library/config/apache/reference
+#   Also in passenger source code you can strip out what are all the available options by looking in
+#     * src/apache2_module/Configuration.cpp
+#     * src/apache2_module/ConfigurationCommands.cpp
+#   Note: in the src there are several undocumented settings.
+#
+# Change Log:
+#   * As of 08/13/2017 there are 84 available/deprecated/removed settings.
+#   * Around 08/20/2017 UnionStation was discontinued options were removed.
+#   * As of 08/20/2017 there are 77 available/deprecated/removed settings.
 class apache::mod::passenger (
   $manage_repo                                                                               = true,
   $mod_id                                                                                    = undef,
@@ -87,13 +101,6 @@ class apache::mod::passenger (
   $rails_ruby                                                                                = undef,
   $rails_spawn_method                                                                        = undef,
   $rails_user_switching                                                                      = undef,
-  $union_station_filter                                                                      = undef,
-  $union_station_gateway_address                                                             = undef,
-  $union_station_gateway_cert                                                                = undef,
-  $union_station_gateway_port                                                                = undef,
-  $union_station_key                                                                         = undef,
-  $union_station_proxy_address                                                               = undef,
-  $union_station_support                                                                     = undef,
   $wsgi_auto_detect                                                                          = undef,
 ) inherits ::apache::params {
   include ::apache
@@ -481,41 +488,6 @@ class apache::mod::passenger (
         warning('DEPRECATED PASSENGER OPTION :: rails_user_switching :: Deprecated in 3.0.0 in favor of PassengerUserSwitching.')
       }
     }
-    if $union_station_filter {
-      if (versioncmp($passenger_installed_version, '3.0.5') < 0) {
-        fail("Passenger config option :: union_station_filter is not introduced until version 3.0.5 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $union_station_gateway_address {
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: union_station_gateway_address is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $union_station_gateway_cert {
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: union_station_gateway_cert is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $union_station_gateway_port {
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: union_station_gateway_port is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $union_station_key {
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: union_station_key is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $union_station_proxy_address {
-      if (versioncmp($passenger_installed_version, '3.0.11') < 0) {
-        fail("Passenger config option :: union_station_proxy_address is not introduced until version 3.0.11 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $union_station_support {
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: union_station_support is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
     if $wsgi_auto_detect {
       if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
         fail('REMOVED PASSENGER OPTION :: wsgi_auto_detect ::  These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.')
@@ -576,91 +548,85 @@ class apache::mod::passenger (
       loadfile_name  => 'zpassenger.load',
     }
   }
+
   # Template uses:
-  # - $passenger_allow_encoded_slashes : since 4.0.0
-  # - $passenger_app_env : since 4.0.0
-  # - $passenger_app_group_name : since 4.0.0
-  # - $passenger_app_root : since 4.0.0
-  # - $passenger_app_type : since 4.0.25
-  # - $passenger_base_uri : since 4.0.0
-  # - $passenger_buffer_response : since 4.0.0
-  # - $passenger_buffer_upload : since 4.0.26
-  # - $passenger_concurrency_model : since 4.0.0
-  # - $passenger_data_buffer_dir : since 5.0.0
-  # - $passenger_debug_log_file : since unkown, probably deprecated
-  # - $passenger_debugger : since 3.0.0
-  # - $passenger_default_group : since 3.0.0
-  # - $passenger_default_ruby : since 4.0.0
-  # - $passenger_default_user : since 3.0.0
-  # - $passenger_disable_security_update_check : since 5.1.0
-  # - $passenger_enabled : since 4.0.0
-  # - $passenger_error_override : since 4.0.24
-  # - $passenger_file_descriptor_log_file : since 5.0.5
-  # - $passenger_fly_with : since 4.0.45
-  # - $passenger_force_max_concurrent_requests_per_process : since 5.0.22
-  # - $passenger_friendly_error_pages : since 4.0.42
-  # - $passenger_group : since 4.0.0
-  # - $passenger_high_performance : since 2.0.0
-  # - $passenger_instance_registry_dir : since 5.0.0
-  # - $passenger_load_shell_envvars : since 4.0.20
-  # - $passenger_log_file : since 5.0.5
-  # - $passenger_log_level : since 3.0.0
-  # - $passenger_lve_min_uid : since 5.0.28
-  # - $passenger_max_instances : since 3.0.0
-  # - $passenger_max_instances_per_app : since 3.0.0
-  # - $passenger_max_pool_size : since 1.0.0
-  # - $passenger_max_preloader_idle_time : since 4.0.0
-  # - $passenger_max_request_queue_size : since 4.0.15
-  # - $passenger_max_request_time : since 3.0.0
-  # - $passenger_max_requests : since 3.0.0
-  # - $passenger_memory_limit : since 3.0.0
-  # - $passenger_meteor_app_settings : since 5.0.7
-  # - $passenger_min_instances : since 3.0.0
-  # - $passenger_nodejs : since 4.0.24
-  # - $passenger_pool_idle_time : since 1.0.0
-  # - $passenger_pre_start : since 3.0.0
-  # - $passenger_python : since 4.0.0
-  # - $passenger_resist_deployment_errors : since 3.0.0
-  # - $passenger_resolve_symlinks_in_document_root : since 3.0.0
-  # - $passenger_response_buffer_high_watermark : since 5.0.0
-  # - $passenger_restart_dir : since 3.0.0
-  # - $passenger_rolling_restarts : since 3.0.0
-  # - $passenger_root : since 1.0.0
-  # - $passenger_ruby : since 4.0.0
-  # - $passenger_security_update_check_proxy : since 5.1.0
-  # - $passenger_show_version_in_header : since 5.1.0
-  # - $passenger_socket_backlog : since 5.0.24
-  # - $passenger_spawn_method : since 2.0.0
-  # - $passenger_start_timeout : since 4.0.15
-  # - $passenger_startup_file : since 4.0.25
-  # - $passenger_stat_throttle_rate : since 2.2.0
-  # - $passenger_sticky_sessions : since 4.0.45
-  # - $passenger_sticky_sessions_cookie_name : since 4.0.45
-  # - $passenger_thread_count : since 4.0.0
-  # - $passenger_use_global_queue : since 2.0.4
-  # - $passenger_user : since 4.0.0
-  # - $passenger_user_switching : since 3.0.0
-  # - $rack_auto_detect : since unkown, probably deprecated
-  # - $rack_base_uri : since unkown, probably deprecated
-  # - $rack_env : since 2.0.0
-  # - $rails_allow_mod_rewrite : since unkown, probably deprecated
-  # - $rails_app_spawner_idle_time : since unkown, probably deprecated
-  # - $rails_auto_detect : since unkown, probably deprecated
-  # - $rails_base_uri : since unkown, probably deprecated
-  # - $rails_default_user : since unkown, probably deprecated
-  # - $rails_env : since 2.0.0
-  # - $rails_framework_spawner_idle_time : since unkown, probably deprecated
-  # - $rails_ruby : since unkown, probably deprecated
-  # - $rails_spawn_method : since unkown, probably deprecated
-  # - $rails_user_switching : since unkown, probably deprecated
-  # - $union_station_filter : since 3.0.5
-  # - $union_station_gateway_address : since 3.0.0
-  # - $union_station_gateway_cert : since 3.0.0
-  # - $union_station_gateway_port : since 3.0.0
-  # - $union_station_key : since 3.0.0
-  # - $union_station_proxy_address : since 3.0.11
-  # - $union_station_support : since 3.0.0
-  # - $wsgi_auto_detect : since unkown, probably deprecated
+  # - $passenger_allow_encoded_slashes : since 4.0.0.
+  # - $passenger_app_env : since 4.0.0.
+  # - $passenger_app_group_name : since 4.0.0.
+  # - $passenger_app_root : since 4.0.0.
+  # - $passenger_app_type : since 4.0.25.
+  # - $passenger_base_uri : since 4.0.0.
+  # - $passenger_buffer_response : since 4.0.0.
+  # - $passenger_buffer_upload : since 4.0.26.
+  # - $passenger_concurrency_model : since 4.0.0.
+  # - $passenger_data_buffer_dir : since 5.0.0.
+  # - $passenger_debug_log_file : since unkown. Deprecated in 5.0.5.
+  # - $passenger_debugger : since 3.0.0.
+  # - $passenger_default_group : since 3.0.0.
+  # - $passenger_default_ruby : since 4.0.0.
+  # - $passenger_default_user : since 3.0.0.
+  # - $passenger_disable_security_update_check : since 5.1.0.
+  # - $passenger_enabled : since 4.0.0.
+  # - $passenger_error_override : since 4.0.24.
+  # - $passenger_file_descriptor_log_file : since 5.0.5.
+  # - $passenger_fly_with : since 4.0.45.
+  # - $passenger_force_max_concurrent_requests_per_process : since 5.0.22.
+  # - $passenger_friendly_error_pages : since 4.0.42.
+  # - $passenger_group : since 4.0.0.
+  # - $passenger_high_performance : since 2.0.0.
+  # - $passenger_instance_registry_dir : since 5.0.0.
+  # - $passenger_load_shell_envvars : since 4.0.20.
+  # - $passenger_log_file : since 5.0.5.
+  # - $passenger_log_level : since 3.0.0.
+  # - $passenger_lve_min_uid : since 5.0.28.
+  # - $passenger_max_instances : since 3.0.0.
+  # - $passenger_max_instances_per_app : since 3.0.0.
+  # - $passenger_max_pool_size : since 1.0.0.
+  # - $passenger_max_preloader_idle_time : since 4.0.0.
+  # - $passenger_max_request_queue_size : since 4.0.15.
+  # - $passenger_max_request_time : since 3.0.0.
+  # - $passenger_max_requests : since 3.0.0.
+  # - $passenger_memory_limit : since 3.0.0.
+  # - $passenger_meteor_app_settings : since 5.0.7.
+  # - $passenger_min_instances : since 3.0.0.
+  # - $passenger_nodejs : since 4.0.24.
+  # - $passenger_pool_idle_time : since 1.0.0.
+  # - $passenger_pre_start : since 3.0.0.
+  # - $passenger_python : since 4.0.0.
+  # - $passenger_resist_deployment_errors : since 3.0.0.
+  # - $passenger_resolve_symlinks_in_document_root : since 3.0.0.
+  # - $passenger_response_buffer_high_watermark : since 5.0.0.
+  # - $passenger_restart_dir : since 3.0.0.
+  # - $passenger_rolling_restarts : since 3.0.0.
+  # - $passenger_root : since 1.0.0.
+  # - $passenger_ruby : since 4.0.0.
+  # - $passenger_security_update_check_proxy : since 5.1.0.
+  # - $passenger_show_version_in_header : since 5.1.0.
+  # - $passenger_socket_backlog : since 5.0.24.
+  # - $passenger_spawn_method : since 2.0.0.
+  # - $passenger_start_timeout : since 4.0.15.
+  # - $passenger_startup_file : since 4.0.25.
+  # - $passenger_stat_throttle_rate : since 2.2.0.
+  # - $passenger_sticky_sessions : since 4.0.45.
+  # - $passenger_sticky_sessions_cookie_name : since 4.0.45.
+  # - $passenger_thread_count : since 4.0.0.
+  # - $passenger_use_global_queue : since 2.0.4.Deprecated in 4.0.0.
+  # - $passenger_user : since 4.0.0.
+  # - $passenger_user_switching : since 3.0.0.
+  # - $rack_auto_detect : since unkown. Deprecated in 4.0.0.
+  # - $rack_base_uri : since unkown. Deprecated in 3.0.0.
+  # - $rack_env : since 2.0.0.
+  # - $rails_allow_mod_rewrite : since unkown. Deprecated in 4.0.0.
+  # - $rails_app_spawner_idle_time : since unkown. Deprecated in 4.0.0.
+  # - $rails_auto_detect : since unkown. Deprecated in 4.0.0.
+  # - $rails_base_uri : since unkown. Deprecated in 3.0.0.
+  # - $rails_default_user : since unkown. Deprecated in 3.0.0.
+  # - $rails_env : since 2.0.0.
+  # - $rails_framework_spawner_idle_time : since unkown. Deprecated in 4.0.0.
+  # - $rails_ruby : since unkown. Deprecated in 3.0.0.
+  # - $rails_spawn_method : since unkown. Deprecated in 3.0.0.
+  # - $rails_user_switching : since unkown. Deprecated in 3.0.0.
+  # - $wsgi_auto_detect : since unkown. Deprecated in 4.0.0.
   # - $rails_autodetect : this options is only for backward compatiblity with older versions of this class
   # - $rack_autodetect : this options is only for backward compatiblity with older versions of this class
   file { 'passenger.conf':

--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -97,7 +97,6 @@ class apache::mod::passenger (
   $wsgi_auto_detect                                                                          = undef,
 ) inherits ::apache::params {
   include ::apache
-  # Checking version support
   if $passenger_installed_version {
     if $passenger_allow_encoded_slashes {
       if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
@@ -152,9 +151,6 @@ class apache::mod::passenger (
     if $passenger_debug_log_file {
       if (versioncmp($passenger_installed_version, '5.0.5') > 0) {
         warning('DEPRECATED PASSENGER OPTION :: passenger_debug_log_file :: This option has been renamed in version 5.0.5 to PassengerLogFile.')
-      }
-      if (versioncmp($passenger_installed_version, '5.0.5') < 0) {
-        fail("Passenger config option :: passenger_debug_log_file is not introduced until version 5.0.5 :: ${passenger_installed_version} is the version reported")
       }
     }
     if $passenger_debugger {
@@ -404,10 +400,10 @@ class apache::mod::passenger (
     }
     if $passenger_use_global_queue {
       if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
-        fail('REMOVED PASSENGER OPTION :: passenger_use_global_queue :: no longer used after version 4.0.0 and is on by default')
+        fail('REMOVED PASSENGER OPTION :: passenger_use_global_queue :: -- no message on the current passenger reference webpage -- ')
       }
       if (versioncmp($passenger_installed_version, '2.0.4') < 0) {
-        fail("Passenger config option :: passenger_use_global_queue is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+        fail('Passenger config option :: passenger_use_global_queue is not introduced until version 2.0.4 :: ${passenger_installed_version} is the version reported')
       }
     }
     if $passenger_user {
@@ -420,20 +416,14 @@ class apache::mod::passenger (
         fail("Passenger config option :: passenger_user_switching is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
       }
     }
-    if ($rack_auto_detect or $rack_autodetect) {
+    if $rack_auto_detect {
       if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
         fail('REMOVED PASSENGER OPTION :: rack_auto_detect ::  These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.')
-      }
-      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
-        fail("Passenger config option :: rack_auto_detect is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
       }
     }
     if $rack_base_uri {
       if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
         warning('DEPRECATED PASSENGER OPTION :: rack_base_uri :: Deprecated in 3.0.0 in favor of PassengerBaseURI.')
-      }
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: rack_base_uri is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
       }
     }
     if $rack_env {
@@ -445,40 +435,25 @@ class apache::mod::passenger (
       if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
         warning("DEPRECATED PASSENGER OPTION :: rails_allow_mod_rewrite :: This option doesn't do anything anymore in since version 4.0.0.")
       }
-      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
-        fail("Passenger config option :: rails_allow_mod_rewrite is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
-      }
     }
     if $rails_app_spawner_idle_time {
       if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
         fail('REMOVED PASSENGER OPTION :: rails_app_spawner_idle_time ::  This option has been removed in version 4.0.0, and replaced with PassengerMaxPreloaderIdleTime.')
       }
-      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
-        fail("Passenger config option :: rails_app_spawner_idle_time is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
-      }
     }
-    if ($rails_auto_detect or $rails_autodetect) {
+    if $rails_auto_detect {
       if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
         fail('REMOVED PASSENGER OPTION :: rails_auto_detect ::  These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.')
-      }
-      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
-        fail("Passenger config option :: rails_auto_detect is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
       }
     }
     if $rails_base_uri {
       if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
         warning('DEPRECATED PASSENGER OPTION :: rails_base_uri :: Deprecated in 3.0.0 in favor of PassengerBaseURI.')
       }
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: rails_base_uri is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
-      }
     }
     if $rails_default_user {
       if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
         warning('DEPRECATED PASSENGER OPTION :: rails_default_user :: Deprecated in 3.0.0 in favor of PassengerDefaultUser.')
-      }
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: rails_default_user is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
       }
     }
     if $rails_env {
@@ -490,32 +465,20 @@ class apache::mod::passenger (
       if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
         fail('REMOVED PASSENGER OPTION :: rails_framework_spawner_idle_time ::  This option is no longer available in version 4.0.0. There is no alternative because framework spawning has been removed altogether. You should use smart spawning instead.')
       }
-      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
-        fail("Passenger config option :: rails_framework_spawner_idle_time is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
-      }
     }
     if $rails_ruby {
       if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
         warning('DEPRECATED PASSENGER OPTION :: rails_ruby :: Deprecated in 3.0.0 in favor of PassengerRuby.')
-      }
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: rails_ruby is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
       }
     }
     if $rails_spawn_method {
       if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
         warning('DEPRECATED PASSENGER OPTION :: rails_spawn_method :: Deprecated in 3.0.0 in favor of PassengerSpawnMethod.')
       }
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: rails_spawn_method is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
-      }
     }
     if $rails_user_switching {
       if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
         warning('DEPRECATED PASSENGER OPTION :: rails_user_switching :: Deprecated in 3.0.0 in favor of PassengerUserSwitching.')
-      }
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: rails_user_switching is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
       }
     }
     if $union_station_filter {
@@ -557,12 +520,8 @@ class apache::mod::passenger (
       if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
         fail('REMOVED PASSENGER OPTION :: wsgi_auto_detect ::  These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.')
       }
-      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
-        fail("Passenger config option :: wsgi_auto_detect is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
-      }
     }
   }
-
   # Managed by the package, but declare it to avoid purging
   if $passenger_conf_package_file {
     file { 'passenger_package.conf':

--- a/spec/acceptance/mod_passenger_spec.rb
+++ b/spec/acceptance/mod_passenger_spec.rb
@@ -83,45 +83,45 @@ describe 'apache::mod::passenger class' do
   EOS
 
   case fact('osfamily')
-    when 'Debian'
-      context 'passenger config with passenger_installed_version set' do
-        it 'should fail when an option is not valid for $passenger_installed_version' do
-          pp = <<-EOS
+  when 'Debian'
+    context 'passenger config with passenger_installed_version set' do
+      it 'should fail when an option is not valid for $passenger_installed_version' do
+        pp = <<-EOS
           class { 'apache': }
           class { 'apache::mod::passenger':
             passenger_installed_version     => '4.0.0',
             passenger_instance_registry_dir => '/some/path/to/nowhere'
           }
-          EOS
-          apply_manifest(pp, :expect_failures => true) do |r|
-            expect(r.stderr).to match(/passenger_instance_registry_dir is not introduced until version 5.0.0/)
-          end
+        EOS
+        apply_manifest(pp, :expect_failures => true) do |r|
+          expect(r.stderr).to match(/passenger_instance_registry_dir is not introduced until version 5.0.0/)
         end
-        it 'should fail when an option is removed' do
-          pp = <<-EOS
+      end
+      it 'should fail when an option is removed' do
+        pp = <<-EOS
           class { 'apache': }
           class { 'apache::mod::passenger':
             passenger_installed_version => '5.0.0',
             rails_autodetect            => 'on'
           }
-          EOS
-          apply_manifest(pp, :expect_failures => true) do |r|
-            expect(r.stderr).to match(/REMOVED PASSENGER OPTION/)
-          end
+        EOS
+        apply_manifest(pp, :expect_failures => true) do |r|
+          expect(r.stderr).to match(/REMOVED PASSENGER OPTION/)
         end
-        it 'should warn when an option is deprecated' do
-          pp = <<-EOS
+      end
+      it 'should warn when an option is deprecated' do
+        pp = <<-EOS
           class { 'apache': }
           class { 'apache::mod::passenger':
             passenger_installed_version => '5.0.0',
             rails_ruby                  => '/some/path/to/ruby'
           }
-          EOS
-          apply_manifest(pp, :catch_failures => true) do |r|
-            expect(r.stderr).to match(/DEPRECATED PASSENGER OPTION/)
-          end
+        EOS
+        apply_manifest(pp, :catch_failures => true) do |r|
+          expect(r.stderr).to match(/DEPRECATED PASSENGER OPTION/)
         end
       end
+    end
       context "default passenger config" do
         it 'succeeds in puppeting passenger' do
           pp = <<-EOS
@@ -129,115 +129,115 @@ describe 'apache::mod::passenger class' do
           class { 'apache': }
           class { 'apache::mod::passenger': }
           #{pp_rackapp}
-          EOS
-          apply_manifest(pp, :catch_failures => true)
-        end
-
-        describe service($service_name) do
-          if (fact('operatingsystem') == 'Debian' && fact('operatingsystemmajrelease') == '8')
-            pending 'Should be enabled - Bug 760616 on Debian 8'
-          else
-            it { should be_enabled }
-          end
-          it { is_expected.to be_running }
-        end
-
-        describe file(conf_file) do
-          it { is_expected.to contain "PassengerRoot \"#{passenger_root}\"" }
-
-          case fact('operatingsystem')
-            when 'Ubuntu'
-              case fact('lsbdistrelease')
-                when '10.04'
-                  it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
-                  it { is_expected.not_to contain "/PassengerDefaultRuby/" }
-                when '12.04'
-                  it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
-                  it { is_expected.not_to contain "/PassengerDefaultRuby/" }
-                when '14.04'
-                  it { is_expected.to contain "PassengerDefaultRuby \"#{passenger_ruby}\"" }
-                  it { is_expected.not_to contain "/PassengerRuby/" }
-                when '16.04'
-                  it { is_expected.to contain "PassengerDefaultRuby \"#{passenger_ruby}\"" }
-                  it { is_expected.not_to contain "/PassengerRuby/" }
-                else
-                  # This may or may not work on Ubuntu releases other than the above
-                  it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
-                  it { is_expected.not_to contain "/PassengerDefaultRuby/" }
-              end
-            when 'Debian'
-              case fact('lsbdistcodename')
-                when 'wheezy'
-                  it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
-                  it { is_expected.not_to contain "/PassengerDefaultRuby/" }
-                when 'jessie'
-                  it { is_expected.to contain "PassengerDefaultRuby \"#{passenger_ruby}\"" }
-                  it { is_expected.not_to contain "/PassengerRuby/" }
-                else
-                  # This may or may not work on Debian releases other than the above
-                  it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
-                  it { is_expected.not_to contain "/PassengerDefaultRuby/" }
-              end
-          end
-        end
-
-        describe file(load_file) do
-          it { is_expected.to contain "LoadModule passenger_module #{passenger_module_path}" }
-        end
-
-        it 'should output status via passenger-memory-stats' do
-          shell("PATH=/usr/bin:$PATH /usr/sbin/passenger-memory-stats") do |r|
-            expect(r.stdout).to match(/Apache processes/)
-            expect(r.stdout).to match(/Nginx processes/)
-            expect(r.stdout).to match(/Passenger processes/)
-
-            # passenger-memory-stats output on newer Debian/Ubuntu verions do not contain
-            # these two lines
-            unless ((fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '14.04') or
-                (fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '16.04') or
-                (fact('operatingsystem') == 'Debian' && fact('operatingsystemmajrelease') == '8'))
-              expect(r.stdout).to match(/### Processes: [0-9]+/)
-              expect(r.stdout).to match(/### Total private dirty RSS: [0-9\.]+ MB/)
-            end
-
-            expect(r.exit_code).to eq(0)
-          end
-        end
-
-        # passenger-status fails under stock ubuntu-server-12042-x64 + mod_passenger,
-        # even when the passenger process is successfully installed and running
-        unless fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '12.04'
-          it 'should output status via passenger-status' do
-            # xml output not available on ubunutu <= 10.04, so sticking with default pool output
-            shell("PATH=/usr/bin:$PATH /usr/sbin/passenger-status") do |r|
-              # spacing may vary
-              expect(r.stdout).to match(/[\-]+ General information [\-]+/)
-              if fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '14.04' or
-                  (fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '16.04') or
-                  fact('operatingsystem') == 'Debian' && fact('operatingsystemmajrelease') == '8'
-                expect(r.stdout).to match(/Max pool size[ ]+: [0-9]+/)
-                expect(r.stdout).to match(/Processes[ ]+: [0-9]+/)
-                expect(r.stdout).to match(/Requests in top-level queue[ ]+: [0-9]+/)
-              else
-                expect(r.stdout).to match(/max[ ]+= [0-9]+/)
-                expect(r.stdout).to match(/count[ ]+= [0-9]+/)
-                expect(r.stdout).to match(/active[ ]+= [0-9]+/)
-                expect(r.stdout).to match(/inactive[ ]+= [0-9]+/)
-                expect(r.stdout).to match(/Waiting on global queue: [0-9]+/)
-              end
-
-              expect(r.exit_code).to eq(0)
-            end
-          end
-        end
-
-        it 'should answer to passenger.example.com' do
-          shell("/usr/bin/curl passenger.example.com:80") do |r|
-            expect(r.stdout).to match(/^hello <b>world<\/b>$/)
-            expect(r.exit_code).to eq(0)
-          end
-        end
-
+        EOS
+        apply_manifest(pp, :catch_failures => true)
       end
+
+      describe service($service_name) do
+        if (fact('operatingsystem') == 'Debian' && fact('operatingsystemmajrelease') == '8')
+          pending 'Should be enabled - Bug 760616 on Debian 8'
+        else
+          it { should be_enabled }
+        end
+        it { is_expected.to be_running }
+      end
+
+      describe file(conf_file) do
+        it { is_expected.to contain "PassengerRoot \"#{passenger_root}\"" }
+
+        case fact('operatingsystem')
+        when 'Ubuntu'
+          case fact('lsbdistrelease')
+          when '10.04'
+            it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
+            it { is_expected.not_to contain "/PassengerDefaultRuby/" }
+          when '12.04'
+            it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
+            it { is_expected.not_to contain "/PassengerDefaultRuby/" }
+          when '14.04'
+            it { is_expected.to contain "PassengerDefaultRuby \"#{passenger_ruby}\"" }
+            it { is_expected.not_to contain "/PassengerRuby/" }
+          when '16.04'
+            it { is_expected.to contain "PassengerDefaultRuby \"#{passenger_ruby}\"" }
+            it { is_expected.not_to contain "/PassengerRuby/" }
+          else
+            # This may or may not work on Ubuntu releases other than the above
+            it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
+            it { is_expected.not_to contain "/PassengerDefaultRuby/" }
+          end
+        when 'Debian'
+          case fact('lsbdistcodename')
+          when 'wheezy'
+            it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
+            it { is_expected.not_to contain "/PassengerDefaultRuby/" }
+          when 'jessie'
+            it { is_expected.to contain "PassengerDefaultRuby \"#{passenger_ruby}\"" }
+            it { is_expected.not_to contain "/PassengerRuby/" }
+          else
+            # This may or may not work on Debian releases other than the above
+            it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
+            it { is_expected.not_to contain "/PassengerDefaultRuby/" }
+          end
+        end
+      end
+
+      describe file(load_file) do
+        it { is_expected.to contain "LoadModule passenger_module #{passenger_module_path}" }
+      end
+
+      it 'should output status via passenger-memory-stats' do
+        shell("PATH=/usr/bin:$PATH /usr/sbin/passenger-memory-stats") do |r|
+          expect(r.stdout).to match(/Apache processes/)
+          expect(r.stdout).to match(/Nginx processes/)
+          expect(r.stdout).to match(/Passenger processes/)
+
+          # passenger-memory-stats output on newer Debian/Ubuntu verions do not contain
+          # these two lines
+          unless ((fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '14.04') or
+                 (fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '16.04') or
+                 (fact('operatingsystem') == 'Debian' && fact('operatingsystemmajrelease') == '8'))
+            expect(r.stdout).to match(/### Processes: [0-9]+/)
+            expect(r.stdout).to match(/### Total private dirty RSS: [0-9\.]+ MB/)
+          end
+
+          expect(r.exit_code).to eq(0)
+        end
+      end
+
+      # passenger-status fails under stock ubuntu-server-12042-x64 + mod_passenger,
+      # even when the passenger process is successfully installed and running
+      unless fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '12.04'
+        it 'should output status via passenger-status' do
+          # xml output not available on ubunutu <= 10.04, so sticking with default pool output
+          shell("PATH=/usr/bin:$PATH /usr/sbin/passenger-status") do |r|
+            # spacing may vary
+            expect(r.stdout).to match(/[\-]+ General information [\-]+/)
+            if fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '14.04' or
+               (fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '16.04') or
+               fact('operatingsystem') == 'Debian' && fact('operatingsystemmajrelease') == '8'
+              expect(r.stdout).to match(/Max pool size[ ]+: [0-9]+/)
+              expect(r.stdout).to match(/Processes[ ]+: [0-9]+/)
+              expect(r.stdout).to match(/Requests in top-level queue[ ]+: [0-9]+/)
+            else
+              expect(r.stdout).to match(/max[ ]+= [0-9]+/)
+              expect(r.stdout).to match(/count[ ]+= [0-9]+/)
+              expect(r.stdout).to match(/active[ ]+= [0-9]+/)
+              expect(r.stdout).to match(/inactive[ ]+= [0-9]+/)
+              expect(r.stdout).to match(/Waiting on global queue: [0-9]+/)
+            end
+
+            expect(r.exit_code).to eq(0)
+          end
+        end
+      end
+
+      it 'should answer to passenger.example.com' do
+        shell("/usr/bin/curl passenger.example.com:80") do |r|
+          expect(r.stdout).to match(/^hello <b>world<\/b>$/)
+          expect(r.exit_code).to eq(0)
+        end
+      end
+
+    end
   end
 end

--- a/spec/acceptance/mod_passenger_spec.rb
+++ b/spec/acceptance/mod_passenger_spec.rb
@@ -83,123 +83,161 @@ describe 'apache::mod::passenger class' do
   EOS
 
   case fact('osfamily')
-  when 'Debian'
-    context "default passenger config" do
-      it 'succeeds in puppeting passenger' do
-        pp = <<-EOS
+    when 'Debian'
+      context 'passenger config with passenger_installed_version set' do
+        it 'should fail when an option is not valid for $passenger_installed_version' do
+          pp = <<-EOS
+          class { 'apache': }
+          class { 'apache::mod::passenger':
+            passenger_installed_version     => '4.0.0',
+            passenger_instance_registry_dir => '/some/path/to/nowhere'
+          }
+          EOS
+          apply_manifest(pp, :expect_failures => true) do |r|
+            expect(r.stderr).to match(/passenger_instance_registry_dir is not introduced until version 5.0.0/)
+          end
+        end
+        it 'should fail when an option is removed' do
+          pp = <<-EOS
+          class { 'apache': }
+          class { 'apache::mod::passenger':
+            passenger_installed_version => '5.0.0',
+            rails_autodetect            => 'on'
+          }
+          EOS
+          apply_manifest(pp, :expect_failures => true) do |r|
+            expect(r.stderr).to match(/REMOVED PASSENGER OPTION/)
+          end
+        end
+        it 'should warn when an option is deprecated' do
+          pp = <<-EOS
+          class { 'apache': }
+          class { 'apache::mod::passenger':
+            passenger_installed_version => '5.0.0',
+            rails_ruby                  => '/some/path/to/ruby'
+          }
+          EOS
+          apply_manifest(pp, :catch_failures => true) do |r|
+            expect(r.stderr).to match(/DEPRECATED PASSENGER OPTION/)
+          end
+        end
+      end
+      context "default passenger config" do
+        it 'succeeds in puppeting passenger' do
+          pp = <<-EOS
           /* stock apache and mod_passenger */
           class { 'apache': }
           class { 'apache::mod::passenger': }
           #{pp_rackapp}
-        EOS
-        apply_manifest(pp, :catch_failures => true)
-      end
-
-      describe service($service_name) do
-        if (fact('operatingsystem') == 'Debian' && fact('operatingsystemmajrelease') == '8')
-          pending 'Should be enabled - Bug 760616 on Debian 8'
-        else
-          it { should be_enabled }
+          EOS
+          apply_manifest(pp, :catch_failures => true)
         end
-        it { is_expected.to be_running }
-      end
 
-      describe file(conf_file) do
-        it { is_expected.to contain "PassengerRoot \"#{passenger_root}\"" }
-
-        case fact('operatingsystem')
-        when 'Ubuntu'
-          case fact('lsbdistrelease')
-          when '10.04'
-            it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
-            it { is_expected.not_to contain "/PassengerDefaultRuby/" }
-          when '12.04'
-            it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
-            it { is_expected.not_to contain "/PassengerDefaultRuby/" }
-          when '14.04'
-            it { is_expected.to contain "PassengerDefaultRuby \"#{passenger_ruby}\"" }
-            it { is_expected.not_to contain "/PassengerRuby/" }
-          when '16.04'
-            it { is_expected.to contain "PassengerDefaultRuby \"#{passenger_ruby}\"" }
-            it { is_expected.not_to contain "/PassengerRuby/" }
+        describe service($service_name) do
+          if (fact('operatingsystem') == 'Debian' && fact('operatingsystemmajrelease') == '8')
+            pending 'Should be enabled - Bug 760616 on Debian 8'
           else
-            # This may or may not work on Ubuntu releases other than the above
-            it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
-            it { is_expected.not_to contain "/PassengerDefaultRuby/" }
+            it { should be_enabled }
           end
-        when 'Debian'
-          case fact('lsbdistcodename')
-          when 'wheezy'
-            it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
-            it { is_expected.not_to contain "/PassengerDefaultRuby/" }
-          when 'jessie'
-            it { is_expected.to contain "PassengerDefaultRuby \"#{passenger_ruby}\"" }
-            it { is_expected.not_to contain "/PassengerRuby/" }
-          else
-            # This may or may not work on Debian releases other than the above
-            it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
-            it { is_expected.not_to contain "/PassengerDefaultRuby/" }
+          it { is_expected.to be_running }
+        end
+
+        describe file(conf_file) do
+          it { is_expected.to contain "PassengerRoot \"#{passenger_root}\"" }
+
+          case fact('operatingsystem')
+            when 'Ubuntu'
+              case fact('lsbdistrelease')
+                when '10.04'
+                  it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
+                  it { is_expected.not_to contain "/PassengerDefaultRuby/" }
+                when '12.04'
+                  it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
+                  it { is_expected.not_to contain "/PassengerDefaultRuby/" }
+                when '14.04'
+                  it { is_expected.to contain "PassengerDefaultRuby \"#{passenger_ruby}\"" }
+                  it { is_expected.not_to contain "/PassengerRuby/" }
+                when '16.04'
+                  it { is_expected.to contain "PassengerDefaultRuby \"#{passenger_ruby}\"" }
+                  it { is_expected.not_to contain "/PassengerRuby/" }
+                else
+                  # This may or may not work on Ubuntu releases other than the above
+                  it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
+                  it { is_expected.not_to contain "/PassengerDefaultRuby/" }
+              end
+            when 'Debian'
+              case fact('lsbdistcodename')
+                when 'wheezy'
+                  it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
+                  it { is_expected.not_to contain "/PassengerDefaultRuby/" }
+                when 'jessie'
+                  it { is_expected.to contain "PassengerDefaultRuby \"#{passenger_ruby}\"" }
+                  it { is_expected.not_to contain "/PassengerRuby/" }
+                else
+                  # This may or may not work on Debian releases other than the above
+                  it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
+                  it { is_expected.not_to contain "/PassengerDefaultRuby/" }
+              end
           end
         end
-      end
 
-      describe file(load_file) do
-        it { is_expected.to contain "LoadModule passenger_module #{passenger_module_path}" }
-      end
-
-      it 'should output status via passenger-memory-stats' do
-        shell("PATH=/usr/bin:$PATH /usr/sbin/passenger-memory-stats") do |r|
-          expect(r.stdout).to match(/Apache processes/)
-          expect(r.stdout).to match(/Nginx processes/)
-          expect(r.stdout).to match(/Passenger processes/)
-
-          # passenger-memory-stats output on newer Debian/Ubuntu verions do not contain
-          # these two lines
-          unless ((fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '14.04') or
-                 (fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '16.04') or
-                 (fact('operatingsystem') == 'Debian' && fact('operatingsystemmajrelease') == '8'))
-            expect(r.stdout).to match(/### Processes: [0-9]+/)
-            expect(r.stdout).to match(/### Total private dirty RSS: [0-9\.]+ MB/)
-          end
-
-          expect(r.exit_code).to eq(0)
+        describe file(load_file) do
+          it { is_expected.to contain "LoadModule passenger_module #{passenger_module_path}" }
         end
-      end
 
-      # passenger-status fails under stock ubuntu-server-12042-x64 + mod_passenger,
-      # even when the passenger process is successfully installed and running
-      unless fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '12.04'
-        it 'should output status via passenger-status' do
-          # xml output not available on ubunutu <= 10.04, so sticking with default pool output
-          shell("PATH=/usr/bin:$PATH /usr/sbin/passenger-status") do |r|
-            # spacing may vary
-            expect(r.stdout).to match(/[\-]+ General information [\-]+/)
-            if fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '14.04' or
-               (fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '16.04') or
-               fact('operatingsystem') == 'Debian' && fact('operatingsystemmajrelease') == '8'
-              expect(r.stdout).to match(/Max pool size[ ]+: [0-9]+/)
-              expect(r.stdout).to match(/Processes[ ]+: [0-9]+/)
-              expect(r.stdout).to match(/Requests in top-level queue[ ]+: [0-9]+/)
-            else
-              expect(r.stdout).to match(/max[ ]+= [0-9]+/)
-              expect(r.stdout).to match(/count[ ]+= [0-9]+/)
-              expect(r.stdout).to match(/active[ ]+= [0-9]+/)
-              expect(r.stdout).to match(/inactive[ ]+= [0-9]+/)
-              expect(r.stdout).to match(/Waiting on global queue: [0-9]+/)
+        it 'should output status via passenger-memory-stats' do
+          shell("PATH=/usr/bin:$PATH /usr/sbin/passenger-memory-stats") do |r|
+            expect(r.stdout).to match(/Apache processes/)
+            expect(r.stdout).to match(/Nginx processes/)
+            expect(r.stdout).to match(/Passenger processes/)
+
+            # passenger-memory-stats output on newer Debian/Ubuntu verions do not contain
+            # these two lines
+            unless ((fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '14.04') or
+                (fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '16.04') or
+                (fact('operatingsystem') == 'Debian' && fact('operatingsystemmajrelease') == '8'))
+              expect(r.stdout).to match(/### Processes: [0-9]+/)
+              expect(r.stdout).to match(/### Total private dirty RSS: [0-9\.]+ MB/)
             end
 
             expect(r.exit_code).to eq(0)
           end
         end
-      end
 
-      it 'should answer to passenger.example.com' do
-        shell("/usr/bin/curl passenger.example.com:80") do |r|
-          expect(r.stdout).to match(/^hello <b>world<\/b>$/)
-          expect(r.exit_code).to eq(0)
+        # passenger-status fails under stock ubuntu-server-12042-x64 + mod_passenger,
+        # even when the passenger process is successfully installed and running
+        unless fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '12.04'
+          it 'should output status via passenger-status' do
+            # xml output not available on ubunutu <= 10.04, so sticking with default pool output
+            shell("PATH=/usr/bin:$PATH /usr/sbin/passenger-status") do |r|
+              # spacing may vary
+              expect(r.stdout).to match(/[\-]+ General information [\-]+/)
+              if fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '14.04' or
+                  (fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '16.04') or
+                  fact('operatingsystem') == 'Debian' && fact('operatingsystemmajrelease') == '8'
+                expect(r.stdout).to match(/Max pool size[ ]+: [0-9]+/)
+                expect(r.stdout).to match(/Processes[ ]+: [0-9]+/)
+                expect(r.stdout).to match(/Requests in top-level queue[ ]+: [0-9]+/)
+              else
+                expect(r.stdout).to match(/max[ ]+= [0-9]+/)
+                expect(r.stdout).to match(/count[ ]+= [0-9]+/)
+                expect(r.stdout).to match(/active[ ]+= [0-9]+/)
+                expect(r.stdout).to match(/inactive[ ]+= [0-9]+/)
+                expect(r.stdout).to match(/Waiting on global queue: [0-9]+/)
+              end
+
+              expect(r.exit_code).to eq(0)
+            end
+          end
         end
-      end
 
-    end
+        it 'should answer to passenger.example.com' do
+          shell("/usr/bin/curl passenger.example.com:80") do |r|
+            expect(r.stdout).to match(/^hello <b>world<\/b>$/)
+            expect(r.exit_code).to eq(0)
+          end
+        end
+
+      end
   end
 end

--- a/spec/acceptance/mod_passenger_spec.rb
+++ b/spec/acceptance/mod_passenger_spec.rb
@@ -2,9 +2,6 @@ require 'spec_helper_acceptance'
 require_relative './version.rb'
 
 describe 'apache::mod::passenger class' do
-  pending 'This cannot run in the same test run as apache::vhost with passenger
-  as the passenger.conf file is not yet managed by puppet and will be wiped out
-  between tests and not replaced'
   case fact('osfamily')
   when 'Debian'
     conf_file = "#{$mod_dir}/passenger.conf"

--- a/spec/classes/mod/passenger_spec.rb
+++ b/spec/classes/mod/passenger_spec.rb
@@ -2,6 +2,185 @@ require 'spec_helper'
 
 describe 'apache::mod::passenger', :type => :class do
   it_behaves_like "a mod class, without including apache"
+  context "validating all passenger params - using Debian" do
+    let :facts do
+      {
+          :osfamily               => 'Debian',
+          :operatingsystemrelease => '6',
+          :kernel                 => 'Linux',
+          :concat_basedir         => '/dne',
+          :lsbdistcodename        => 'squeeze',
+          :operatingsystem        => 'Debian',
+          :id                     => 'root',
+          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :is_pe                  => false,
+      }
+    end
+    it { is_expected.to contain_class("apache::params") }
+    it { is_expected.to contain_apache__mod('passenger') }
+    it { is_expected.to contain_package("libapache2-mod-passenger") }
+    it { is_expected.to contain_file('zpassenger.load').with({
+                                                                 'path' => '/etc/apache2/mods-available/zpassenger.load',
+                                                             }) }
+    it { is_expected.to contain_file('passenger.conf').with({
+                                                                'path' => '/etc/apache2/mods-available/passenger.conf',
+                                                            }) }
+
+    passenger_config_options = {
+        'passenger_allow_encoded_slashes' => {Type: 'OnOff', PassOpt: :PassengerAllowEncodedSlashes},
+        'passenger_app_env' => {Type: 'String', PassOpt: :PassengerAppEnv},
+        'passenger_app_group_name' => {Type: 'String', PassOpt: :PassengerAppGroupName},
+        'passenger_app_root' => {Type: 'FullPath', PassOpt: :PassengerAppRoot},
+        'passenger_app_type' => {Type: 'String', PassOpt: :PassengerAppType},
+        'passenger_base_uri' => {Type: 'URI', PassOpt: :PassengerBaseURI},
+        'passenger_buffer_response' => {Type: 'OnOff', PassOpt: :PassengerBufferResponse},
+        'passenger_buffer_upload' => {Type: 'OnOff', PassOpt: :PassengerBufferUpload},
+        'passenger_concurrency_model' => {Type: ["process", "thread"], PassOpt: :PassengerConcurrencyModel},
+        'passenger_data_buffer_dir' => {Type: 'FullPath', PassOpt: :PassengerDataBufferDir},
+        'passenger_debug_log_file' => {Type: 'String', PassOpt: :PassengerDebugLogFile},
+        'passenger_debugger' => {Type: 'OnOff', PassOpt: :PassengerDebugger},
+        'passenger_default_group' => {Type: 'String', PassOpt: :PassengerDefaultGroup},
+        'passenger_default_ruby' => {Type: 'FullPath', PassOpt: :PassengerDefaultRuby},
+        'passenger_default_user' => {Type: 'String', PassOpt: :PassengerDefaultUser},
+        'passenger_disable_security_update_check' => {Type: 'OnOff', PassOpt: :PassengerDisableSecurityUpdateCheck},
+        'passenger_enabled' => {Type: 'OnOff', PassOpt: :PassengerEnabled},
+        'passenger_error_override' => {Type: 'OnOff', PassOpt: :PassengerErrorOverride},
+        'passenger_file_descriptor_log_file' => {Type: 'FullPath', PassOpt: :PassengerFileDescriptorLogFile},
+        'passenger_fly_with' => {Type: 'FullPath', PassOpt: :PassengerFlyWith},
+        'passenger_force_max_concurrent_requests_per_process' => {Type: 'Integer', PassOpt: :PassengerForceMaxConcurrentRequestsPerProcess},
+        'passenger_friendly_error_pages' => {Type: 'OnOff', PassOpt: :PassengerFriendlyErrorPages},
+        'passenger_group' => {Type: 'String', PassOpt: :PassengerGroup},
+        'passenger_high_performance' => {Type: 'OnOff', PassOpt: :PassengerHighPerformance},
+        'passenger_instance_registry_dir' => {Type: 'FullPath', PassOpt: :PassengerInstanceRegistryDir},
+        'passenger_load_shell_envvars' => {Type: 'OnOff', PassOpt: :PassengerLoadShellEnvvars},
+        'passenger_log_file' => {Type: 'FullPath', PassOpt: :PassengerLogFile},
+        'passenger_log_level' => {Type: 'Integer', PassOpt: :PassengerLogLevel},
+        'passenger_lve_min_uid' => {Type: 'Integer', PassOpt: :PassengerLveMinUid},
+        'passenger_max_instances' => {Type: 'Integer', PassOpt: :PassengerMaxInstances},
+        'passenger_max_instances_per_app' => {Type: 'Integer', PassOpt: :PassengerMaxInstancesPerApp},
+        'passenger_max_pool_size' => {Type: 'Integer', PassOpt: :PassengerMaxPoolSize},
+        'passenger_max_preloader_idle_time' => {Type: 'Integer', PassOpt: :PassengerMaxPreloaderIdleTime},
+        'passenger_max_request_queue_size' => {Type: 'Integer', PassOpt: :PassengerMaxRequestQueueSize},
+        'passenger_max_request_time' => {Type: 'Integer', PassOpt: :PassengerMaxRequestTime},
+        'passenger_max_requests' => {Type: 'Integer', PassOpt: :PassengerMaxRequests},
+        'passenger_memory_limit' => {Type: 'Integer', PassOpt: :PassengerMemoryLimit},
+        'passenger_meteor_app_settings' => {Type: 'FullPath', PassOpt: :PassengerMeteorAppSettings},
+        'passenger_min_instances' => {Type: 'Integer', PassOpt: :PassengerMinInstances},
+        'passenger_nodejs' => {Type: 'FullPath', PassOpt: :PassengerNodejs},
+        'passenger_pool_idle_time' => {Type: 'Integer', PassOpt: :PassengerPoolIdleTime},
+        'passenger_pre_start' => {Type: 'URI', PassOpt: :PassengerPreStart},
+        'passenger_python' => {Type: 'FullPath', PassOpt: :PassengerPython},
+        'passenger_resist_deployment_errors' => {Type: 'OnOff', PassOpt: :PassengerResistDeploymentErrors},
+        'passenger_resolve_symlinks_in_document_root' => {Type: 'OnOff', PassOpt: :PassengerResolveSymlinksInDocumentRoot},
+        'passenger_response_buffer_high_watermark' => {Type: 'Integer', PassOpt: :PassengerResponseBufferHighWatermark},
+        'passenger_restart_dir' => {Type: 'Path', PassOpt: :PassengerRestartDir},
+        'passenger_rolling_restarts' => {Type: 'OnOff', PassOpt: :PassengerRollingRestarts},
+        'passenger_root' => {Type: 'FullPath', PassOpt: :PassengerRoot},
+        'passenger_ruby' => {Type: 'FullPath', PassOpt: :PassengerRuby},
+        'passenger_security_update_check_proxy' => {Type: 'URI', PassOpt: :PassengerSecurityUpdateCheckProxy},
+        'passenger_show_version_in_header' => {Type: 'OnOff', PassOpt: :PassengerShowVersionInHeader},
+        'passenger_socket_backlog' => {Type: 'Integer', PassOpt: :PassengerSocketBacklog},
+        'passenger_spawn_method' => {Type: ["smart", "direct"], PassOpt: :PassengerSpawnMethod},
+        'passenger_start_timeout' => {Type: 'Integer', PassOpt: :PassengerStartTimeout},
+        'passenger_startup_file' => {Type: 'RelPath', PassOpt: :PassengerStartupFile},
+        'passenger_stat_throttle_rate' => {Type: 'Integer', PassOpt: :PassengerStatThrottleRate},
+        'passenger_sticky_sessions' => {Type: 'OnOff', PassOpt: :PassengerStickySessions},
+        'passenger_sticky_sessions_cookie_name' => {Type: 'String', PassOpt: :PassengerStickySessionsCookieName},
+        'passenger_thread_count' => {Type: 'Integer', PassOpt: :PassengerThreadCount},
+        'passenger_use_global_queue' => {Type: 'String', PassOpt: :PassengerUseGlobalQueue},
+        'passenger_user' => {Type: 'String', PassOpt: :PassengerUser},
+        'passenger_user_switching' => {Type: 'OnOff', PassOpt: :PassengerUserSwitching},
+        'rack_auto_detect' => {Type: 'String', PassOpt: :RackAutoDetect},
+        'rack_base_uri' => {Type: 'String', PassOpt: :RackBaseURI},
+        'rack_env' => {Type: 'String', PassOpt: :RackEnv},
+        'rails_allow_mod_rewrite' => {Type: 'String', PassOpt: :RailsAllowModRewrite},
+        'rails_app_spawner_idle_time' => {Type: 'String', PassOpt: :RailsAppSpawnerIdleTime},
+        'rails_auto_detect' => {Type: 'String', PassOpt: :RailsAutoDetect},
+        'rails_base_uri' => {Type: 'String', PassOpt: :RailsBaseURI},
+        'rails_default_user' => {Type: 'String', PassOpt: :RailsDefaultUser},
+        'rails_env' => {Type: 'String', PassOpt: :RailsEnv},
+        'rails_framework_spawner_idle_time' => {Type: 'String', PassOpt: :RailsFrameworkSpawnerIdleTime},
+        'rails_ruby' => {Type: 'String', PassOpt: :RailsRuby},
+        'rails_spawn_method' => {Type: 'String', PassOpt: :RailsSpawnMethod},
+        'rails_user_switching' => {Type: 'String', PassOpt: :RailsUserSwitching},
+        'union_station_filter' => {Type: 'QuotedString', PassOpt: :UnionStationFilter},
+        'union_station_gateway_address' => {Type: 'URI', PassOpt: :UnionStationGatewayAddress},
+        'union_station_gateway_cert' => {Type: 'FullPath', PassOpt: :UnionStationGatewayCert},
+        'union_station_gateway_port' => {Type: 'Integer', PassOpt: :UnionStationGatewayPort},
+        'union_station_key' => {Type: 'String', PassOpt: :UnionStationKey},
+        'union_station_proxy_address' => {Type: 'URI', PassOpt: :UnionStationProxyAddress},
+        'union_station_support' => {Type: 'OnOff', PassOpt: :UnionStationSupport},
+        'wsgi_auto_detect' => {Type: 'String', PassOpt: :WsgiAutoDetect},
+        'rails_autodetect' => {Type: 'OnOff', PassOpt: :RailsAutoDetect},
+        'rack_autodetect' => {Type: 'OnOff', PassOpt: :RackAutoDetect},
+    }
+    passenger_config_options.each do |config_option, config_hash|
+      puppetized_config_option = config_option
+      valid_config_values = []
+      case config_hash[:Type]
+        when 'QuotedString'
+          valid_config_values = ['"a quoted string"']
+          valid_config_values.each do |valid_value|
+            describe "with #{puppetized_config_option} => '#{valid_value.gsub(/\"/, '')}'" do
+              let :params do
+                { puppetized_config_option.to_sym => valid_value }
+              end
+              it { is_expected.to contain_file('passenger.conf').with_content(/^  #{config_hash[:PassOpt]} "#{valid_value}"$/) }
+            end
+          end
+        when 'FullPath', 'RelPath', 'Path'
+          valid_config_values = ['/some/path/to/somewhere']
+          valid_config_values.each do |valid_value|
+            describe "with #{puppetized_config_option} => #{valid_value}" do
+              let :params do
+                { puppetized_config_option.to_sym => valid_value }
+              end
+              it { is_expected.to contain_file('passenger.conf').with_content(/^  #{config_hash[:PassOpt]} "#{valid_value}"$/) }
+            end
+          end
+        when 'URI', 'String'
+          valid_config_values = ['some_string_for_you']
+          valid_config_values.each do |valid_value|
+            describe "with #{puppetized_config_option} => #{valid_value}" do
+              let :params do
+                { puppetized_config_option.to_sym => valid_value }
+              end
+              it { is_expected.to contain_file('passenger.conf').with_content(/^  #{config_hash[:PassOpt]} #{valid_value}$/) }
+            end
+          end
+        when 'Integer'
+          valid_config_values = [100]
+          valid_config_values.each do |valid_value|
+            describe "with #{puppetized_config_option} => #{valid_value}" do
+              let :params do
+                { puppetized_config_option.to_sym => valid_value }
+              end
+              it { is_expected.to contain_file('passenger.conf').with_content(/^  #{config_hash[:PassOpt]} #{valid_value}$/) }
+            end
+          end
+        when 'OnOff'
+          valid_config_values = ['on', 'off']
+          valid_config_values.each do |valid_value|
+            describe "with #{puppetized_config_option} => '#{valid_value}'" do
+              let :params do
+                { puppetized_config_option.to_sym => valid_value }
+              end
+              it { is_expected.to contain_file('passenger.conf').with_content(/^  #{config_hash[:PassOpt]} #{valid_value}$/) }
+            end
+          end
+        else
+          valid_config_values = config_hash[:Type]
+          valid_config_values.each do |valid_value|
+            describe "with #{puppetized_config_option} => '#{valid_value}'" do
+              let :params do
+                { puppetized_config_option.to_sym => valid_value }
+              end
+              it { is_expected.to contain_file('passenger.conf').with_content(/^  #{config_hash[:PassOpt]} #{valid_value}$/) }
+            end
+          end
+      end
+    end
+  end
   context "on a Debian OS" do
     let :facts do
       {
@@ -25,7 +204,7 @@ describe 'apache::mod::passenger', :type => :class do
     it { is_expected.to contain_file('passenger.conf').with({
       'path' => '/etc/apache2/mods-available/passenger.conf',
     }) }
-    describe "with passenger_root => '/usr/lib/example'" do
+     describe "with passenger_root => '/usr/lib/example'" do
       let :params do
         { :passenger_root => '/usr/lib/example' }
       end
@@ -122,11 +301,17 @@ describe 'apache::mod::passenger', :type => :class do
       end
       it { is_expected.to contain_file('passenger.conf').with_content(/^  PassengerAppEnv foo$/) }
     end
+    describe "with passenger_instance_registry_dir => '/var/run/passenger-instreg'" do
+      let :params do
+        { :passenger_instance_registry_dir => '/var/run/passenger-instreg' }
+      end
+      it { is_expected.to contain_file('passenger.conf').with_content(%r{^  PassengerInstanceRegistryDir "/var/run/passenger-instreg"$}) }
+    end
     describe "with passenger_log_file => '/var/log/apache2/passenger.log'" do
       let :params do
         { :passenger_log_file => '/var/log/apache2/passenger.log' }
       end
-      it { is_expected.to contain_file('passenger.conf').with_content(%r{^  PassengerLogFile /var/log/apache2/passenger.log$}) }
+      it { is_expected.to contain_file('passenger.conf').with_content(%r{^  PassengerLogFile "/var/log/apache2/passenger.log"$}) }
     end
     describe "with passenger_log_level => 3" do
       let :params do
@@ -162,15 +347,15 @@ describe 'apache::mod::passenger', :type => :class do
     context "with Ubuntu 12.04 defaults" do
       let :facts do
         {
-          :osfamily               => 'Debian',
-          :operatingsystemrelease => '12.04',
-          :kernel                 => 'Linux',
-          :operatingsystem        => 'Ubuntu',
-          :lsbdistrelease         => '12.04',
-          :concat_basedir         => '/dne',
-          :id                     => 'root',
-          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          :is_pe                  => false,
+            :osfamily               => 'Debian',
+            :operatingsystemrelease => '12.04',
+            :kernel                 => 'Linux',
+            :operatingsystem        => 'Ubuntu',
+            :lsbdistrelease         => '12.04',
+            :concat_basedir         => '/dne',
+            :id                     => 'root',
+            :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+            :is_pe                  => false,
         }
       end
 
@@ -182,15 +367,15 @@ describe 'apache::mod::passenger', :type => :class do
     context "with Ubuntu 14.04 defaults" do
       let :facts do
         {
-          :osfamily               => 'Debian',
-          :operatingsystemrelease => '14.04',
-          :operatingsystem        => 'Ubuntu',
-          :kernel                 => 'Linux',
-          :lsbdistrelease         => '14.04',
-          :concat_basedir         => '/dne',
-          :id                     => 'root',
-          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          :is_pe                  => false,
+            :osfamily               => 'Debian',
+            :operatingsystemrelease => '14.04',
+            :operatingsystem        => 'Ubuntu',
+            :kernel                 => 'Linux',
+            :lsbdistrelease         => '14.04',
+            :concat_basedir         => '/dne',
+            :id                     => 'root',
+            :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+            :is_pe                  => false,
         }
       end
 
@@ -202,15 +387,15 @@ describe 'apache::mod::passenger', :type => :class do
     context "with Debian 7 defaults" do
       let :facts do
         {
-          :osfamily               => 'Debian',
-          :operatingsystemrelease => '7.3',
-          :operatingsystem        => 'Debian',
-          :kernel                 => 'Linux',
-          :lsbdistcodename        => 'wheezy',
-          :concat_basedir         => '/dne',
-          :id                     => 'root',
-          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          :is_pe                  => false,
+            :osfamily               => 'Debian',
+            :operatingsystemrelease => '7.3',
+            :operatingsystem        => 'Debian',
+            :kernel                 => 'Linux',
+            :lsbdistcodename        => 'wheezy',
+            :concat_basedir         => '/dne',
+            :id                     => 'root',
+            :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+            :is_pe                  => false,
         }
       end
 
@@ -222,15 +407,15 @@ describe 'apache::mod::passenger', :type => :class do
     context "with Debian 8 defaults" do
       let :facts do
         {
-          :osfamily               => 'Debian',
-          :operatingsystemrelease => '8.0',
-          :operatingsystem        => 'Debian',
-          :kernel                 => 'Linux',
-          :lsbdistcodename        => 'jessie',
-          :concat_basedir         => '/dne',
-          :id                     => 'root',
-          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          :is_pe                  => false,
+            :osfamily               => 'Debian',
+            :operatingsystemrelease => '8.0',
+            :operatingsystem        => 'Debian',
+            :kernel                 => 'Linux',
+            :lsbdistcodename        => 'jessie',
+            :concat_basedir         => '/dne',
+            :id                     => 'root',
+            :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+            :is_pe                  => false,
         }
       end
 
@@ -243,13 +428,13 @@ describe 'apache::mod::passenger', :type => :class do
   context "on a RedHat OS" do
     let :rh_facts do
       {
-        :osfamily               => 'RedHat',
-        :concat_basedir         => '/dne',
-        :operatingsystem        => 'RedHat',
-        :id                     => 'root',
-        :kernel                 => 'Linux',
-        :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        :is_pe                  => false,
+          :osfamily               => 'RedHat',
+          :concat_basedir         => '/dne',
+          :operatingsystem        => 'RedHat',
+          :id                     => 'root',
+          :kernel                 => 'Linux',
+          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :is_pe                  => false,
       }
     end
 
@@ -260,13 +445,13 @@ describe 'apache::mod::passenger', :type => :class do
       it { is_expected.to contain_apache__mod('passenger') }
       it { is_expected.to contain_package("mod_passenger") }
       it { is_expected.to contain_file('passenger_package.conf').with({
-        'path' => '/etc/httpd/conf.d/passenger.conf',
-      }) }
+                                                                          'path' => '/etc/httpd/conf.d/passenger.conf',
+                                                                      }) }
       it { is_expected.to contain_file('passenger_package.conf').without_content }
       it { is_expected.to contain_file('passenger_package.conf').without_source }
       it { is_expected.to contain_file('zpassenger.load').with({
-        'path' => '/etc/httpd/conf.d/zpassenger.load',
-      }) }
+                                                                   'path' => '/etc/httpd/conf.d/zpassenger.load',
+                                                               }) }
       it { is_expected.to contain_file('passenger.conf').without_content(/PassengerRoot/) }
       it { is_expected.to contain_file('passenger.conf').without_content(/PassengerRuby/) }
       describe "with passenger_root => '/usr/lib/example'" do
@@ -287,24 +472,24 @@ describe 'apache::mod::passenger', :type => :class do
       let(:facts) { rh_facts.merge(:operatingsystemrelease => '7') }
 
       it { is_expected.to contain_file('passenger_package.conf').with({
-        'path' => '/etc/httpd/conf.d/passenger.conf',
-      }) }
+                                                                          'path' => '/etc/httpd/conf.d/passenger.conf',
+                                                                      }) }
       it { is_expected.to contain_file('zpassenger.load').with({
-        'path' => '/etc/httpd/conf.modules.d/zpassenger.load',
-      }) }
+                                                                   'path' => '/etc/httpd/conf.modules.d/zpassenger.load',
+                                                               }) }
     end
   end
   context "on a FreeBSD OS" do
     let :facts do
       {
-        :osfamily               => 'FreeBSD',
-        :operatingsystemrelease => '9',
-        :concat_basedir         => '/dne',
-        :operatingsystem        => 'FreeBSD',
-        :id                     => 'root',
-        :kernel                 => 'FreeBSD',
-        :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        :is_pe                  => false,
+          :osfamily               => 'FreeBSD',
+          :operatingsystemrelease => '9',
+          :concat_basedir         => '/dne',
+          :operatingsystem        => 'FreeBSD',
+          :id                     => 'root',
+          :kernel                 => 'FreeBSD',
+          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :is_pe                  => false,
       }
     end
     it { is_expected.to contain_class("apache::params") }
@@ -314,14 +499,14 @@ describe 'apache::mod::passenger', :type => :class do
   context "on a Gentoo OS" do
     let :facts do
       {
-        :osfamily               => 'Gentoo',
-        :operatingsystem        => 'Gentoo',
-        :operatingsystemrelease => '3.16.1-gentoo',
-        :concat_basedir         => '/dne',
-        :id                     => 'root',
-        :kernel                 => 'Linux',
-        :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
-        :is_pe                  => false,
+          :osfamily               => 'Gentoo',
+          :operatingsystem        => 'Gentoo',
+          :operatingsystemrelease => '3.16.1-gentoo',
+          :concat_basedir         => '/dne',
+          :id                     => 'root',
+          :kernel                 => 'Linux',
+          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
+          :is_pe                  => false,
       }
     end
     it { is_expected.to contain_class("apache::params") }

--- a/spec/classes/mod/passenger_spec.rb
+++ b/spec/classes/mod/passenger_spec.rb
@@ -27,97 +27,91 @@ describe 'apache::mod::passenger', :type => :class do
                                                             }) }
 
     passenger_config_options = {
-        'passenger_allow_encoded_slashes' => {Type: 'OnOff', PassOpt: :PassengerAllowEncodedSlashes},
-        'passenger_app_env' => {Type: 'String', PassOpt: :PassengerAppEnv},
-        'passenger_app_group_name' => {Type: 'String', PassOpt: :PassengerAppGroupName},
-        'passenger_app_root' => {Type: 'FullPath', PassOpt: :PassengerAppRoot},
-        'passenger_app_type' => {Type: 'String', PassOpt: :PassengerAppType},
-        'passenger_base_uri' => {Type: 'URI', PassOpt: :PassengerBaseURI},
-        'passenger_buffer_response' => {Type: 'OnOff', PassOpt: :PassengerBufferResponse},
-        'passenger_buffer_upload' => {Type: 'OnOff', PassOpt: :PassengerBufferUpload},
-        'passenger_concurrency_model' => {Type: ["process", "thread"], PassOpt: :PassengerConcurrencyModel},
-        'passenger_data_buffer_dir' => {Type: 'FullPath', PassOpt: :PassengerDataBufferDir},
-        'passenger_debug_log_file' => {Type: 'String', PassOpt: :PassengerDebugLogFile},
-        'passenger_debugger' => {Type: 'OnOff', PassOpt: :PassengerDebugger},
-        'passenger_default_group' => {Type: 'String', PassOpt: :PassengerDefaultGroup},
-        'passenger_default_ruby' => {Type: 'FullPath', PassOpt: :PassengerDefaultRuby},
-        'passenger_default_user' => {Type: 'String', PassOpt: :PassengerDefaultUser},
-        'passenger_disable_security_update_check' => {Type: 'OnOff', PassOpt: :PassengerDisableSecurityUpdateCheck},
-        'passenger_enabled' => {Type: 'OnOff', PassOpt: :PassengerEnabled},
-        'passenger_error_override' => {Type: 'OnOff', PassOpt: :PassengerErrorOverride},
-        'passenger_file_descriptor_log_file' => {Type: 'FullPath', PassOpt: :PassengerFileDescriptorLogFile},
-        'passenger_fly_with' => {Type: 'FullPath', PassOpt: :PassengerFlyWith},
-        'passenger_force_max_concurrent_requests_per_process' => {Type: 'Integer', PassOpt: :PassengerForceMaxConcurrentRequestsPerProcess},
-        'passenger_friendly_error_pages' => {Type: 'OnOff', PassOpt: :PassengerFriendlyErrorPages},
-        'passenger_group' => {Type: 'String', PassOpt: :PassengerGroup},
-        'passenger_high_performance' => {Type: 'OnOff', PassOpt: :PassengerHighPerformance},
-        'passenger_instance_registry_dir' => {Type: 'FullPath', PassOpt: :PassengerInstanceRegistryDir},
-        'passenger_load_shell_envvars' => {Type: 'OnOff', PassOpt: :PassengerLoadShellEnvvars},
-        'passenger_log_file' => {Type: 'FullPath', PassOpt: :PassengerLogFile},
-        'passenger_log_level' => {Type: 'Integer', PassOpt: :PassengerLogLevel},
-        'passenger_lve_min_uid' => {Type: 'Integer', PassOpt: :PassengerLveMinUid},
-        'passenger_max_instances' => {Type: 'Integer', PassOpt: :PassengerMaxInstances},
-        'passenger_max_instances_per_app' => {Type: 'Integer', PassOpt: :PassengerMaxInstancesPerApp},
-        'passenger_max_pool_size' => {Type: 'Integer', PassOpt: :PassengerMaxPoolSize},
-        'passenger_max_preloader_idle_time' => {Type: 'Integer', PassOpt: :PassengerMaxPreloaderIdleTime},
-        'passenger_max_request_queue_size' => {Type: 'Integer', PassOpt: :PassengerMaxRequestQueueSize},
-        'passenger_max_request_time' => {Type: 'Integer', PassOpt: :PassengerMaxRequestTime},
-        'passenger_max_requests' => {Type: 'Integer', PassOpt: :PassengerMaxRequests},
-        'passenger_memory_limit' => {Type: 'Integer', PassOpt: :PassengerMemoryLimit},
-        'passenger_meteor_app_settings' => {Type: 'FullPath', PassOpt: :PassengerMeteorAppSettings},
-        'passenger_min_instances' => {Type: 'Integer', PassOpt: :PassengerMinInstances},
-        'passenger_nodejs' => {Type: 'FullPath', PassOpt: :PassengerNodejs},
-        'passenger_pool_idle_time' => {Type: 'Integer', PassOpt: :PassengerPoolIdleTime},
-        'passenger_pre_start' => {Type: 'URI', PassOpt: :PassengerPreStart},
-        'passenger_python' => {Type: 'FullPath', PassOpt: :PassengerPython},
-        'passenger_resist_deployment_errors' => {Type: 'OnOff', PassOpt: :PassengerResistDeploymentErrors},
-        'passenger_resolve_symlinks_in_document_root' => {Type: 'OnOff', PassOpt: :PassengerResolveSymlinksInDocumentRoot},
-        'passenger_response_buffer_high_watermark' => {Type: 'Integer', PassOpt: :PassengerResponseBufferHighWatermark},
-        'passenger_restart_dir' => {Type: 'Path', PassOpt: :PassengerRestartDir},
-        'passenger_rolling_restarts' => {Type: 'OnOff', PassOpt: :PassengerRollingRestarts},
-        'passenger_root' => {Type: 'FullPath', PassOpt: :PassengerRoot},
-        'passenger_ruby' => {Type: 'FullPath', PassOpt: :PassengerRuby},
-        'passenger_security_update_check_proxy' => {Type: 'URI', PassOpt: :PassengerSecurityUpdateCheckProxy},
-        'passenger_show_version_in_header' => {Type: 'OnOff', PassOpt: :PassengerShowVersionInHeader},
-        'passenger_socket_backlog' => {Type: 'Integer', PassOpt: :PassengerSocketBacklog},
-        'passenger_spawn_method' => {Type: ["smart", "direct"], PassOpt: :PassengerSpawnMethod},
-        'passenger_start_timeout' => {Type: 'Integer', PassOpt: :PassengerStartTimeout},
-        'passenger_startup_file' => {Type: 'RelPath', PassOpt: :PassengerStartupFile},
-        'passenger_stat_throttle_rate' => {Type: 'Integer', PassOpt: :PassengerStatThrottleRate},
-        'passenger_sticky_sessions' => {Type: 'OnOff', PassOpt: :PassengerStickySessions},
-        'passenger_sticky_sessions_cookie_name' => {Type: 'String', PassOpt: :PassengerStickySessionsCookieName},
-        'passenger_thread_count' => {Type: 'Integer', PassOpt: :PassengerThreadCount},
-        'passenger_use_global_queue' => {Type: 'String', PassOpt: :PassengerUseGlobalQueue},
-        'passenger_user' => {Type: 'String', PassOpt: :PassengerUser},
-        'passenger_user_switching' => {Type: 'OnOff', PassOpt: :PassengerUserSwitching},
-        'rack_auto_detect' => {Type: 'String', PassOpt: :RackAutoDetect},
-        'rack_base_uri' => {Type: 'String', PassOpt: :RackBaseURI},
-        'rack_env' => {Type: 'String', PassOpt: :RackEnv},
-        'rails_allow_mod_rewrite' => {Type: 'String', PassOpt: :RailsAllowModRewrite},
-        'rails_app_spawner_idle_time' => {Type: 'String', PassOpt: :RailsAppSpawnerIdleTime},
-        'rails_auto_detect' => {Type: 'String', PassOpt: :RailsAutoDetect},
-        'rails_base_uri' => {Type: 'String', PassOpt: :RailsBaseURI},
-        'rails_default_user' => {Type: 'String', PassOpt: :RailsDefaultUser},
-        'rails_env' => {Type: 'String', PassOpt: :RailsEnv},
-        'rails_framework_spawner_idle_time' => {Type: 'String', PassOpt: :RailsFrameworkSpawnerIdleTime},
-        'rails_ruby' => {Type: 'String', PassOpt: :RailsRuby},
-        'rails_spawn_method' => {Type: 'String', PassOpt: :RailsSpawnMethod},
-        'rails_user_switching' => {Type: 'String', PassOpt: :RailsUserSwitching},
-        'union_station_filter' => {Type: 'QuotedString', PassOpt: :UnionStationFilter},
-        'union_station_gateway_address' => {Type: 'URI', PassOpt: :UnionStationGatewayAddress},
-        'union_station_gateway_cert' => {Type: 'FullPath', PassOpt: :UnionStationGatewayCert},
-        'union_station_gateway_port' => {Type: 'Integer', PassOpt: :UnionStationGatewayPort},
-        'union_station_key' => {Type: 'String', PassOpt: :UnionStationKey},
-        'union_station_proxy_address' => {Type: 'URI', PassOpt: :UnionStationProxyAddress},
-        'union_station_support' => {Type: 'OnOff', PassOpt: :UnionStationSupport},
-        'wsgi_auto_detect' => {Type: 'String', PassOpt: :WsgiAutoDetect},
-        'rails_autodetect' => {Type: 'OnOff', PassOpt: :RailsAutoDetect},
-        'rack_autodetect' => {Type: 'OnOff', PassOpt: :RackAutoDetect},
+        'passenger_allow_encoded_slashes' => {type: 'OnOff', pass_opt: :PassengerAllowEncodedSlashes},
+        'passenger_app_env' => {type: 'String', pass_opt: :PassengerAppEnv},
+        'passenger_app_group_name' => {type: 'String', pass_opt: :PassengerAppGroupName},
+        'passenger_app_root' => {type: 'FullPath', pass_opt: :PassengerAppRoot},
+        'passenger_app_type' => {type: 'String', pass_opt: :PassengerAppType},
+        'passenger_base_uri' => {type: 'URI', pass_opt: :PassengerBaseURI},
+        'passenger_buffer_response' => {type: 'OnOff', pass_opt: :PassengerBufferResponse},
+        'passenger_buffer_upload' => {type: 'OnOff', pass_opt: :PassengerBufferUpload},
+        'passenger_concurrency_model' => {type: ["process", "thread"], pass_opt: :PassengerConcurrencyModel},
+        'passenger_data_buffer_dir' => {type: 'FullPath', pass_opt: :PassengerDataBufferDir},
+        'passenger_debug_log_file' => {type: 'String', pass_opt: :PassengerDebugLogFile},
+        'passenger_debugger' => {type: 'OnOff', pass_opt: :PassengerDebugger},
+        'passenger_default_group' => {type: 'String', pass_opt: :PassengerDefaultGroup},
+        'passenger_default_ruby' => {type: 'FullPath', pass_opt: :PassengerDefaultRuby},
+        'passenger_default_user' => {type: 'String', pass_opt: :PassengerDefaultUser},
+        'passenger_disable_security_update_check' => {type: 'OnOff', pass_opt: :PassengerDisableSecurityUpdateCheck},
+        'passenger_enabled' => {type: 'OnOff', pass_opt: :PassengerEnabled},
+        'passenger_error_override' => {type: 'OnOff', pass_opt: :PassengerErrorOverride},
+        'passenger_file_descriptor_log_file' => {type: 'FullPath', pass_opt: :PassengerFileDescriptorLogFile},
+        'passenger_fly_with' => {type: 'FullPath', pass_opt: :PassengerFlyWith},
+        'passenger_force_max_concurrent_requests_per_process' => {type: 'Integer', pass_opt: :PassengerForceMaxConcurrentRequestsPerProcess},
+        'passenger_friendly_error_pages' => {type: 'OnOff', pass_opt: :PassengerFriendlyErrorPages},
+        'passenger_group' => {type: 'String', pass_opt: :PassengerGroup},
+        'passenger_high_performance' => {type: 'OnOff', pass_opt: :PassengerHighPerformance},
+        'passenger_instance_registry_dir' => {type: 'FullPath', pass_opt: :PassengerInstanceRegistryDir},
+        'passenger_load_shell_envvars' => {type: 'OnOff', pass_opt: :PassengerLoadShellEnvvars},
+        'passenger_log_file' => {type: 'FullPath', pass_opt: :PassengerLogFile},
+        'passenger_log_level' => {type: 'Integer', pass_opt: :PassengerLogLevel},
+        'passenger_lve_min_uid' => {type: 'Integer', pass_opt: :PassengerLveMinUid},
+        'passenger_max_instances' => {type: 'Integer', pass_opt: :PassengerMaxInstances},
+        'passenger_max_instances_per_app' => {type: 'Integer', pass_opt: :PassengerMaxInstancesPerApp},
+        'passenger_max_pool_size' => {type: 'Integer', pass_opt: :PassengerMaxPoolSize},
+        'passenger_max_preloader_idle_time' => {type: 'Integer', pass_opt: :PassengerMaxPreloaderIdleTime},
+        'passenger_max_request_queue_size' => {type: 'Integer', pass_opt: :PassengerMaxRequestQueueSize},
+        'passenger_max_request_time' => {type: 'Integer', pass_opt: :PassengerMaxRequestTime},
+        'passenger_max_requests' => {type: 'Integer', pass_opt: :PassengerMaxRequests},
+        'passenger_memory_limit' => {type: 'Integer', pass_opt: :PassengerMemoryLimit},
+        'passenger_meteor_app_settings' => {type: 'FullPath', pass_opt: :PassengerMeteorAppSettings},
+        'passenger_min_instances' => {type: 'Integer', pass_opt: :PassengerMinInstances},
+        'passenger_nodejs' => {type: 'FullPath', pass_opt: :PassengerNodejs},
+        'passenger_pool_idle_time' => {type: 'Integer', pass_opt: :PassengerPoolIdleTime},
+        'passenger_pre_start' => {type: 'URI', pass_opt: :PassengerPreStart},
+        'passenger_python' => {type: 'FullPath', pass_opt: :PassengerPython},
+        'passenger_resist_deployment_errors' => {type: 'OnOff', pass_opt: :PassengerResistDeploymentErrors},
+        'passenger_resolve_symlinks_in_document_root' => {type: 'OnOff', pass_opt: :PassengerResolveSymlinksInDocumentRoot},
+        'passenger_response_buffer_high_watermark' => {type: 'Integer', pass_opt: :PassengerResponseBufferHighWatermark},
+        'passenger_restart_dir' => {type: 'Path', pass_opt: :PassengerRestartDir},
+        'passenger_rolling_restarts' => {type: 'OnOff', pass_opt: :PassengerRollingRestarts},
+        'passenger_root' => {type: 'FullPath', pass_opt: :PassengerRoot},
+        'passenger_ruby' => {type: 'FullPath', pass_opt: :PassengerRuby},
+        'passenger_security_update_check_proxy' => {type: 'URI', pass_opt: :PassengerSecurityUpdateCheckProxy},
+        'passenger_show_version_in_header' => {type: 'OnOff', pass_opt: :PassengerShowVersionInHeader},
+        'passenger_socket_backlog' => {type: 'Integer', pass_opt: :PassengerSocketBacklog},
+        'passenger_spawn_method' => {type: ["smart", "direct"], pass_opt: :PassengerSpawnMethod},
+        'passenger_start_timeout' => {type: 'Integer', pass_opt: :PassengerStartTimeout},
+        'passenger_startup_file' => {type: 'RelPath', pass_opt: :PassengerStartupFile},
+        'passenger_stat_throttle_rate' => {type: 'Integer', pass_opt: :PassengerStatThrottleRate},
+        'passenger_sticky_sessions' => {type: 'OnOff', pass_opt: :PassengerStickySessions},
+        'passenger_sticky_sessions_cookie_name' => {type: 'String', pass_opt: :PassengerStickySessionsCookieName},
+        'passenger_thread_count' => {type: 'Integer', pass_opt: :PassengerThreadCount},
+        'passenger_use_global_queue' => {type: 'String', pass_opt: :PassengerUseGlobalQueue},
+        'passenger_user' => {type: 'String', pass_opt: :PassengerUser},
+        'passenger_user_switching' => {type: 'OnOff', pass_opt: :PassengerUserSwitching},
+        'rack_auto_detect' => {type: 'String', pass_opt: :RackAutoDetect},
+        'rack_autodetect' => {type: 'String', pass_opt: :RackAutoDetect},
+        'rack_base_uri' => {type: 'String', pass_opt: :RackBaseURI},
+        'rack_env' => {type: 'String', pass_opt: :RackEnv},
+        'rails_allow_mod_rewrite' => {type: 'String', pass_opt: :RailsAllowModRewrite},
+        'rails_app_spawner_idle_time' => {type: 'String', pass_opt: :RailsAppSpawnerIdleTime},
+        'rails_auto_detect' => {type: 'String', pass_opt: :RailsAutoDetect},
+        'rails_autodetect' => {type: 'String', pass_opt: :RailsAutoDetect},
+        'rails_base_uri' => {type: 'String', pass_opt: :RailsBaseURI},
+        'rails_default_user' => {type: 'String', pass_opt: :RailsDefaultUser},
+        'rails_env' => {type: 'String', pass_opt: :RailsEnv},
+        'rails_framework_spawner_idle_time' => {type: 'String', pass_opt: :RailsFrameworkSpawnerIdleTime},
+        'rails_ruby' => {type: 'String', pass_opt: :RailsRuby},
+        'rails_spawn_method' => {type: 'String', pass_opt: :RailsSpawnMethod},
+        'rails_user_switching' => {type: 'String', pass_opt: :RailsUserSwitching},
+        'wsgi_auto_detect' => {type: 'String', pass_opt: :WsgiAutoDetect},
     }
     passenger_config_options.each do |config_option, config_hash|
       puppetized_config_option = config_option
       valid_config_values = []
-      case config_hash[:Type]
+      case config_hash[:type]
+        # UnionStationFilter values are quoted strings
         when 'QuotedString'
           valid_config_values = ['"a quoted string"']
           valid_config_values.each do |valid_value|
@@ -125,7 +119,7 @@ describe 'apache::mod::passenger', :type => :class do
               let :params do
                 { puppetized_config_option.to_sym => valid_value }
               end
-              it { is_expected.to contain_file('passenger.conf').with_content(/^  #{config_hash[:PassOpt]} "#{valid_value}"$/) }
+              it { is_expected.to contain_file('passenger.conf').with_content(/^  #{config_hash[:pass_opt]} "#{valid_value}"$/) }
             end
           end
         when 'FullPath', 'RelPath', 'Path'
@@ -135,47 +129,37 @@ describe 'apache::mod::passenger', :type => :class do
               let :params do
                 { puppetized_config_option.to_sym => valid_value }
               end
-              it { is_expected.to contain_file('passenger.conf').with_content(/^  #{config_hash[:PassOpt]} "#{valid_value}"$/) }
+              it { is_expected.to contain_file('passenger.conf').with_content(/^  #{config_hash[:pass_opt]} "#{valid_value}"$/) }
             end
           end
-        when 'URI', 'String'
-          valid_config_values = ['some_string_for_you']
+        when 'URI', 'String', 'Integer'
+          valid_config_values = ['some_value_for_you']
           valid_config_values.each do |valid_value|
             describe "with #{puppetized_config_option} => #{valid_value}" do
               let :params do
                 { puppetized_config_option.to_sym => valid_value }
               end
-              it { is_expected.to contain_file('passenger.conf').with_content(/^  #{config_hash[:PassOpt]} #{valid_value}$/) }
+              it { is_expected.to contain_file('passenger.conf').with_content(/^  #{config_hash[:pass_opt]} #{valid_value}$/) }
             end
           end
-        when 'Integer'
-          valid_config_values = [100]
-          valid_config_values.each do |valid_value|
-            describe "with #{puppetized_config_option} => #{valid_value}" do
-              let :params do
-                { puppetized_config_option.to_sym => valid_value }
-              end
-              it { is_expected.to contain_file('passenger.conf').with_content(/^  #{config_hash[:PassOpt]} #{valid_value}$/) }
-            end
-          end
-        when 'OnOff'
+       when 'OnOff'
           valid_config_values = ['on', 'off']
           valid_config_values.each do |valid_value|
             describe "with #{puppetized_config_option} => '#{valid_value}'" do
               let :params do
                 { puppetized_config_option.to_sym => valid_value }
               end
-              it { is_expected.to contain_file('passenger.conf').with_content(/^  #{config_hash[:PassOpt]} #{valid_value}$/) }
+              it { is_expected.to contain_file('passenger.conf').with_content(/^  #{config_hash[:pass_opt]} #{valid_value}$/) }
             end
           end
         else
-          valid_config_values = config_hash[:Type]
+          valid_config_values = config_hash[:type]
           valid_config_values.each do |valid_value|
             describe "with #{puppetized_config_option} => '#{valid_value}'" do
               let :params do
                 { puppetized_config_option.to_sym => valid_value }
               end
-              it { is_expected.to contain_file('passenger.conf').with_content(/^  #{config_hash[:PassOpt]} #{valid_value}$/) }
+              it { is_expected.to contain_file('passenger.conf').with_content(/^  #{config_hash[:pass_opt]} #{valid_value}$/) }
             end
           end
       end
@@ -204,7 +188,7 @@ describe 'apache::mod::passenger', :type => :class do
     it { is_expected.to contain_file('passenger.conf').with({
       'path' => '/etc/apache2/mods-available/passenger.conf',
     }) }
-     describe "with passenger_root => '/usr/lib/example'" do
+    describe "with passenger_root => '/usr/lib/example'" do
       let :params do
         { :passenger_root => '/usr/lib/example' }
       end
@@ -301,12 +285,6 @@ describe 'apache::mod::passenger', :type => :class do
       end
       it { is_expected.to contain_file('passenger.conf').with_content(/^  PassengerAppEnv foo$/) }
     end
-    describe "with passenger_instance_registry_dir => '/var/run/passenger-instreg'" do
-      let :params do
-        { :passenger_instance_registry_dir => '/var/run/passenger-instreg' }
-      end
-      it { is_expected.to contain_file('passenger.conf').with_content(%r{^  PassengerInstanceRegistryDir "/var/run/passenger-instreg"$}) }
-    end
     describe "with passenger_log_file => '/var/log/apache2/passenger.log'" do
       let :params do
         { :passenger_log_file => '/var/log/apache2/passenger.log' }
@@ -347,15 +325,15 @@ describe 'apache::mod::passenger', :type => :class do
     context "with Ubuntu 12.04 defaults" do
       let :facts do
         {
-            :osfamily               => 'Debian',
-            :operatingsystemrelease => '12.04',
-            :kernel                 => 'Linux',
-            :operatingsystem        => 'Ubuntu',
-            :lsbdistrelease         => '12.04',
-            :concat_basedir         => '/dne',
-            :id                     => 'root',
-            :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-            :is_pe                  => false,
+          :osfamily               => 'Debian',
+          :operatingsystemrelease => '12.04',
+          :kernel                 => 'Linux',
+          :operatingsystem        => 'Ubuntu',
+          :lsbdistrelease         => '12.04',
+          :concat_basedir         => '/dne',
+          :id                     => 'root',
+          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :is_pe                  => false,
         }
       end
 
@@ -367,15 +345,15 @@ describe 'apache::mod::passenger', :type => :class do
     context "with Ubuntu 14.04 defaults" do
       let :facts do
         {
-            :osfamily               => 'Debian',
-            :operatingsystemrelease => '14.04',
-            :operatingsystem        => 'Ubuntu',
-            :kernel                 => 'Linux',
-            :lsbdistrelease         => '14.04',
-            :concat_basedir         => '/dne',
-            :id                     => 'root',
-            :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-            :is_pe                  => false,
+          :osfamily               => 'Debian',
+          :operatingsystemrelease => '14.04',
+          :operatingsystem        => 'Ubuntu',
+          :kernel                 => 'Linux',
+          :lsbdistrelease         => '14.04',
+          :concat_basedir         => '/dne',
+          :id                     => 'root',
+          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :is_pe                  => false,
         }
       end
 
@@ -387,15 +365,15 @@ describe 'apache::mod::passenger', :type => :class do
     context "with Debian 7 defaults" do
       let :facts do
         {
-            :osfamily               => 'Debian',
-            :operatingsystemrelease => '7.3',
-            :operatingsystem        => 'Debian',
-            :kernel                 => 'Linux',
-            :lsbdistcodename        => 'wheezy',
-            :concat_basedir         => '/dne',
-            :id                     => 'root',
-            :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-            :is_pe                  => false,
+          :osfamily               => 'Debian',
+          :operatingsystemrelease => '7.3',
+          :operatingsystem        => 'Debian',
+          :kernel                 => 'Linux',
+          :lsbdistcodename        => 'wheezy',
+          :concat_basedir         => '/dne',
+          :id                     => 'root',
+          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :is_pe                  => false,
         }
       end
 
@@ -407,15 +385,15 @@ describe 'apache::mod::passenger', :type => :class do
     context "with Debian 8 defaults" do
       let :facts do
         {
-            :osfamily               => 'Debian',
-            :operatingsystemrelease => '8.0',
-            :operatingsystem        => 'Debian',
-            :kernel                 => 'Linux',
-            :lsbdistcodename        => 'jessie',
-            :concat_basedir         => '/dne',
-            :id                     => 'root',
-            :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-            :is_pe                  => false,
+          :osfamily               => 'Debian',
+          :operatingsystemrelease => '8.0',
+          :operatingsystem        => 'Debian',
+          :kernel                 => 'Linux',
+          :lsbdistcodename        => 'jessie',
+          :concat_basedir         => '/dne',
+          :id                     => 'root',
+          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :is_pe                  => false,
         }
       end
 
@@ -428,13 +406,13 @@ describe 'apache::mod::passenger', :type => :class do
   context "on a RedHat OS" do
     let :rh_facts do
       {
-          :osfamily               => 'RedHat',
-          :concat_basedir         => '/dne',
-          :operatingsystem        => 'RedHat',
-          :id                     => 'root',
-          :kernel                 => 'Linux',
-          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          :is_pe                  => false,
+        :osfamily               => 'RedHat',
+        :concat_basedir         => '/dne',
+        :operatingsystem        => 'RedHat',
+        :id                     => 'root',
+        :kernel                 => 'Linux',
+        :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :is_pe                  => false,
       }
     end
 
@@ -445,13 +423,13 @@ describe 'apache::mod::passenger', :type => :class do
       it { is_expected.to contain_apache__mod('passenger') }
       it { is_expected.to contain_package("mod_passenger") }
       it { is_expected.to contain_file('passenger_package.conf').with({
-                                                                          'path' => '/etc/httpd/conf.d/passenger.conf',
-                                                                      }) }
+        'path' => '/etc/httpd/conf.d/passenger.conf',
+      }) }
       it { is_expected.to contain_file('passenger_package.conf').without_content }
       it { is_expected.to contain_file('passenger_package.conf').without_source }
       it { is_expected.to contain_file('zpassenger.load').with({
-                                                                   'path' => '/etc/httpd/conf.d/zpassenger.load',
-                                                               }) }
+        'path' => '/etc/httpd/conf.d/zpassenger.load',
+      }) }
       it { is_expected.to contain_file('passenger.conf').without_content(/PassengerRoot/) }
       it { is_expected.to contain_file('passenger.conf').without_content(/PassengerRuby/) }
       describe "with passenger_root => '/usr/lib/example'" do
@@ -472,24 +450,24 @@ describe 'apache::mod::passenger', :type => :class do
       let(:facts) { rh_facts.merge(:operatingsystemrelease => '7') }
 
       it { is_expected.to contain_file('passenger_package.conf').with({
-                                                                          'path' => '/etc/httpd/conf.d/passenger.conf',
-                                                                      }) }
+        'path' => '/etc/httpd/conf.d/passenger.conf',
+      }) }
       it { is_expected.to contain_file('zpassenger.load').with({
-                                                                   'path' => '/etc/httpd/conf.modules.d/zpassenger.load',
-                                                               }) }
+        'path' => '/etc/httpd/conf.modules.d/zpassenger.load',
+      }) }
     end
   end
   context "on a FreeBSD OS" do
     let :facts do
       {
-          :osfamily               => 'FreeBSD',
-          :operatingsystemrelease => '9',
-          :concat_basedir         => '/dne',
-          :operatingsystem        => 'FreeBSD',
-          :id                     => 'root',
-          :kernel                 => 'FreeBSD',
-          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          :is_pe                  => false,
+        :osfamily               => 'FreeBSD',
+        :operatingsystemrelease => '9',
+        :concat_basedir         => '/dne',
+        :operatingsystem        => 'FreeBSD',
+        :id                     => 'root',
+        :kernel                 => 'FreeBSD',
+        :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :is_pe                  => false,
       }
     end
     it { is_expected.to contain_class("apache::params") }
@@ -499,14 +477,14 @@ describe 'apache::mod::passenger', :type => :class do
   context "on a Gentoo OS" do
     let :facts do
       {
-          :osfamily               => 'Gentoo',
-          :operatingsystem        => 'Gentoo',
-          :operatingsystemrelease => '3.16.1-gentoo',
-          :concat_basedir         => '/dne',
-          :id                     => 'root',
-          :kernel                 => 'Linux',
-          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
-          :is_pe                  => false,
+        :osfamily               => 'Gentoo',
+        :operatingsystem        => 'Gentoo',
+        :operatingsystemrelease => '3.16.1-gentoo',
+        :concat_basedir         => '/dne',
+        :id                     => 'root',
+        :kernel                 => 'Linux',
+        :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
+        :is_pe                  => false,
       }
     end
     it { is_expected.to contain_class("apache::params") }

--- a/templates/mod/passenger.conf.erb
+++ b/templates/mod/passenger.conf.erb
@@ -1,61 +1,263 @@
+<!--@formatter:off-->
 # The Passenger Apache module configuration file is being
 # managed by Puppet and changes will be overwritten.
 <IfModule mod_passenger.c>
+  <%- if @passenger_allow_encoded_slashes -%>
+  PassengerAllowEncodedSlashes <%= @passenger_allow_encoded_slashes %>
+  <%- end -%>
+  <%- if @passenger_app_env -%>
+  PassengerAppEnv <%= @passenger_app_env %>
+  <%- end -%>
+  <%- if @passenger_app_group_name -%>
+  PassengerAppGroupName <%= @passenger_app_group_name %>
+  <%- end -%>
+  <%- if @passenger_app_root -%>
+  PassengerAppRoot "<%= @passenger_app_root %>"
+  <%- end -%>
+  <%- if @passenger_app_type -%>
+  PassengerAppType <%= @passenger_app_type %>
+  <%- end -%>
+  <%- if @passenger_base_uri -%>
+  PassengerBaseURI <%= @passenger_base_uri %>
+  <%- end -%>
+  <%- if @passenger_buffer_response -%>
+  PassengerBufferResponse <%= @passenger_buffer_response %>
+  <%- end -%>
+  <%- if @passenger_buffer_upload -%>
+  PassengerBufferUpload <%= @passenger_buffer_upload %>
+  <%- end -%>
+  <%- if @passenger_concurrency_model -%>
+  PassengerConcurrencyModel <%= @passenger_concurrency_model %>
+  <%- end -%>
+  <%- if @passenger_data_buffer_dir -%>
+  PassengerDataBufferDir "<%= @passenger_data_buffer_dir %>"
+  <%- end -%>
+  <%- if @passenger_debug_log_file -%>
+  PassengerDebugLogFile <%= @passenger_debug_log_file %>
+  <%- end -%>
+  <%- if @passenger_debugger -%>
+  PassengerDebugger <%= @passenger_debugger %>
+  <%- end -%>
+  <%- if @passenger_default_group -%>
+  PassengerDefaultGroup <%= @passenger_default_group %>
+  <%- end -%>
+  <%- if @passenger_default_ruby -%>
+  PassengerDefaultRuby "<%= @passenger_default_ruby %>"
+  <%- end -%>
+  <%- if @passenger_default_user -%>
+  PassengerDefaultUser <%= @passenger_default_user %>
+  <%- end -%>
+  <%- if @passenger_disable_security_update_check -%>
+  PassengerDisableSecurityUpdateCheck <%= @passenger_disable_security_update_check %>
+  <%- end -%>
+  <%- if @passenger_enabled -%>
+  PassengerEnabled <%= @passenger_enabled %>
+  <%- end -%>
+  <%- if @passenger_error_override -%>
+  PassengerErrorOverride <%= @passenger_error_override %>
+  <%- end -%>
+  <%- if @passenger_file_descriptor_log_file -%>
+  PassengerFileDescriptorLogFile "<%= @passenger_file_descriptor_log_file %>"
+  <%- end -%>
+  <%- if @passenger_fly_with -%>
+  PassengerFlyWith "<%= @passenger_fly_with %>"
+  <%- end -%>
+  <%- if @passenger_force_max_concurrent_requests_per_process -%>
+  PassengerForceMaxConcurrentRequestsPerProcess <%= @passenger_force_max_concurrent_requests_per_process %>
+  <%- end -%>
+  <%- if @passenger_friendly_error_pages -%>
+  PassengerFriendlyErrorPages <%= @passenger_friendly_error_pages %>
+  <%- end -%>
+  <%- if @passenger_group -%>
+  PassengerGroup <%= @passenger_group %>
+  <%- end -%>
+  <%- if @passenger_high_performance -%>
+  PassengerHighPerformance <%= @passenger_high_performance %>
+  <%- end -%>
+  <%- if @passenger_instance_registry_dir -%>
+  PassengerInstanceRegistryDir "<%= @passenger_instance_registry_dir %>"
+  <%- end -%>
+  <%- if @passenger_load_shell_envvars -%>
+  PassengerLoadShellEnvvars <%= @passenger_load_shell_envvars %>
+  <%- end -%>
+  <%- if @passenger_log_file -%>
+  PassengerLogFile "<%= @passenger_log_file %>"
+  <%- end -%>
+  <%- if @passenger_log_level -%>
+  PassengerLogLevel <%= @passenger_log_level %>
+  <%- end -%>
+  <%- if @passenger_lve_min_uid -%>
+  PassengerLveMinUid <%= @passenger_lve_min_uid %>
+  <%- end -%>
+  <%- if @passenger_max_instances -%>
+  PassengerMaxInstances <%= @passenger_max_instances %>
+  <%- end -%>
+  <%- if @passenger_max_instances_per_app -%>
+  PassengerMaxInstancesPerApp <%= @passenger_max_instances_per_app %>
+  <%- end -%>
+  <%- if @passenger_max_pool_size -%>
+  PassengerMaxPoolSize <%= @passenger_max_pool_size %>
+  <%- end -%>
+  <%- if @passenger_max_preloader_idle_time -%>
+  PassengerMaxPreloaderIdleTime <%= @passenger_max_preloader_idle_time %>
+  <%- end -%>
+  <%- if @passenger_max_request_queue_size -%>
+  PassengerMaxRequestQueueSize <%= @passenger_max_request_queue_size %>
+  <%- end -%>
+  <%- if @passenger_max_request_time -%>
+  PassengerMaxRequestTime <%= @passenger_max_request_time %>
+  <%- end -%>
+  <%- if @passenger_max_requests -%>
+  PassengerMaxRequests <%= @passenger_max_requests %>
+  <%- end -%>
+  <%- if @passenger_memory_limit -%>
+  PassengerMemoryLimit <%= @passenger_memory_limit %>
+  <%- end -%>
+  <%- if @passenger_meteor_app_settings -%>
+  PassengerMeteorAppSettings "<%= @passenger_meteor_app_settings %>"
+  <%- end -%>
+  <%- if @passenger_min_instances -%>
+  PassengerMinInstances <%= @passenger_min_instances %>
+  <%- end -%>
+  <%- if @passenger_nodejs -%>
+  PassengerNodejs "<%= @passenger_nodejs %>"
+  <%- end -%>
+  <%- if @passenger_pool_idle_time -%>
+  PassengerPoolIdleTime <%= @passenger_pool_idle_time %>
+  <%- end -%>
+  <%- if @passenger_pre_start -%>
+  PassengerPreStart <%= @passenger_pre_start %>
+  <%- end -%>
+  <%- if @passenger_python -%>
+  PassengerPython "<%= @passenger_python %>"
+  <%- end -%>
+  <%- if @passenger_resist_deployment_errors -%>
+  PassengerResistDeploymentErrors <%= @passenger_resist_deployment_errors %>
+  <%- end -%>
+  <%- if @passenger_resolve_symlinks_in_document_root -%>
+  PassengerResolveSymlinksInDocumentRoot <%= @passenger_resolve_symlinks_in_document_root %>
+  <%- end -%>
+  <%- if @passenger_response_buffer_high_watermark -%>
+  PassengerResponseBufferHighWatermark <%= @passenger_response_buffer_high_watermark %>
+  <%- end -%>
+  <%- if @passenger_restart_dir -%>
+  PassengerRestartDir "<%= @passenger_restart_dir %>"
+  <%- end -%>
+  <%- if @passenger_rolling_restarts -%>
+  PassengerRollingRestarts <%= @passenger_rolling_restarts %>
+  <%- end -%>
   <%- if @passenger_root -%>
   PassengerRoot "<%= @passenger_root %>"
   <%- end -%>
   <%- if @passenger_ruby -%>
   PassengerRuby "<%= @passenger_ruby %>"
   <%- end -%>
-  <%- if @passenger_default_ruby -%>
-  PassengerDefaultRuby "<%= @passenger_default_ruby %>"
+  <%- if @passenger_security_update_check_proxy -%>
+  PassengerSecurityUpdateCheckProxy <%= @passenger_security_update_check_proxy %>
   <%- end -%>
-  <%- if @passenger_high_performance -%>
-  PassengerHighPerformance <%= @passenger_high_performance %>
+  <%- if @passenger_show_version_in_header -%>
+  PassengerShowVersionInHeader <%= @passenger_show_version_in_header %>
   <%- end -%>
-  <%- if @passenger_max_pool_size -%>
-  PassengerMaxPoolSize <%= @passenger_max_pool_size %>
-  <%- end -%>
-  <%- if @passenger_min_instances -%>
-  PassengerMinInstances <%= @passenger_min_instances %>
-  <%- end -%>
-  <%- if @passenger_max_instances_per_app -%>
-  PassengerMaxInstancesPerApp <%= @passenger_max_instances_per_app %>
-  <%- end -%>
-  <%- if @passenger_pool_idle_time -%>
-  PassengerPoolIdleTime <%= @passenger_pool_idle_time %>
-  <%- end -%>
-  <%- if @passenger_max_request_queue_size -%>
-  PassengerMaxRequestQueueSize <%= @passenger_max_request_queue_size %>
-  <%- end -%>
-  <%- if @passenger_max_requests -%>
-  PassengerMaxRequests <%= @passenger_max_requests %>
+  <%- if @passenger_socket_backlog -%>
+  PassengerSocketBacklog <%= @passenger_socket_backlog %>
   <%- end -%>
   <%- if @passenger_spawn_method -%>
   PassengerSpawnMethod <%= @passenger_spawn_method %>
   <%- end -%>
+  <%- if @passenger_start_timeout -%>
+  PassengerStartTimeout <%= @passenger_start_timeout %>
+  <%- end -%>
+  <%- if @passenger_startup_file -%>
+  PassengerStartupFile "<%= @passenger_startup_file %>"
+  <%- end -%>
   <%- if @passenger_stat_throttle_rate -%>
   PassengerStatThrottleRate <%= @passenger_stat_throttle_rate %>
   <%- end -%>
-  <%- if @rack_autodetect -%>
-  RackAutoDetect <%= @rack_autodetect %>
+  <%- if @passenger_sticky_sessions -%>
+  PassengerStickySessions <%= @passenger_sticky_sessions %>
   <%- end -%>
-  <%- if @rails_autodetect -%>
-  RailsAutoDetect <%= @rails_autodetect %>
+  <%- if @passenger_sticky_sessions_cookie_name -%>
+  PassengerStickySessionsCookieName <%= @passenger_sticky_sessions_cookie_name %>
+  <%- end -%>
+  <%- if @passenger_thread_count -%>
+  PassengerThreadCount <%= @passenger_thread_count %>
   <%- end -%>
   <%- if @passenger_use_global_queue -%>
   PassengerUseGlobalQueue <%= @passenger_use_global_queue %>
   <%- end -%>
-  <%- if @passenger_app_env -%>
-  PassengerAppEnv <%= @passenger_app_env %>
+  <%- if @passenger_user -%>
+  PassengerUser <%= @passenger_user %>
   <%- end -%>
-  <%- if @passenger_log_file -%>
-  PassengerLogFile <%= @passenger_log_file %>
+  <%- if @passenger_user_switching -%>
+  PassengerUserSwitching <%= @passenger_user_switching %>
   <%- end -%>
-  <%- if @passenger_log_level -%>
-  PassengerLogLevel <%= @passenger_log_level %>
+  <%- if @rack_auto_detect -%>
+  RackAutoDetect <%= @rack_auto_detect %>
   <%- end -%>
-  <%- if @passenger_data_buffer_dir -%>
-  PassengerDataBufferDir <%= @passenger_data_buffer_dir %>
+  <%- if @rack_base_uri -%>
+  RackBaseURI <%= @rack_base_uri %>
+  <%- end -%>
+  <%- if @rack_env -%>
+  RackEnv <%= @rack_env %>
+  <%- end -%>
+  <%- if @rails_allow_mod_rewrite -%>
+  RailsAllowModRewrite <%= @rails_allow_mod_rewrite %>
+  <%- end -%>
+  <%- if @rails_app_spawner_idle_time -%>
+  RailsAppSpawnerIdleTime <%= @rails_app_spawner_idle_time %>
+  <%- end -%>
+  <%- if @rails_auto_detect -%>
+  RailsAutoDetect <%= @rails_auto_detect %>
+  <%- end -%>
+  <%- if @rails_base_uri -%>
+  RailsBaseURI <%= @rails_base_uri %>
+  <%- end -%>
+  <%- if @rails_default_user -%>
+  RailsDefaultUser <%= @rails_default_user %>
+  <%- end -%>
+  <%- if @rails_env -%>
+  RailsEnv <%= @rails_env %>
+  <%- end -%>
+  <%- if @rails_framework_spawner_idle_time -%>
+  RailsFrameworkSpawnerIdleTime <%= @rails_framework_spawner_idle_time %>
+  <%- end -%>
+  <%- if @rails_ruby -%>
+  RailsRuby <%= @rails_ruby %>
+  <%- end -%>
+  <%- if @rails_spawn_method -%>
+  RailsSpawnMethod <%= @rails_spawn_method %>
+  <%- end -%>
+  <%- if @rails_user_switching -%>
+  RailsUserSwitching <%= @rails_user_switching %>
+  <%- end -%>
+  <%- if @union_station_filter -%>
+  UnionStationFilter "<%= @union_station_filter %>"
+  <%- end -%>
+  <%- if @union_station_gateway_address -%>
+  UnionStationGatewayAddress <%= @union_station_gateway_address %>
+  <%- end -%>
+  <%- if @union_station_gateway_cert -%>
+  UnionStationGatewayCert "<%= @union_station_gateway_cert %>"
+  <%- end -%>
+  <%- if @union_station_gateway_port -%>
+  UnionStationGatewayPort <%= @union_station_gateway_port %>
+  <%- end -%>
+  <%- if @union_station_key -%>
+  UnionStationKey <%= @union_station_key %>
+  <%- end -%>
+  <%- if @union_station_proxy_address -%>
+  UnionStationProxyAddress <%= @union_station_proxy_address %>
+  <%- end -%>
+  <%- if @union_station_support -%>
+  UnionStationSupport <%= @union_station_support %>
+  <%- end -%>
+  <%- if @wsgi_auto_detect -%>
+  WsgiAutoDetect <%= @wsgi_auto_detect %>
+  <%- end -%>
+  <%- if @rails_autodetect -%>
+  RailsAutoDetect <%= @rails_autodetect %>
+  <%- end -%>
+  <%- if @rack_autodetect -%>
+  RackAutoDetect <%= @rack_autodetect %>
   <%- end -%>
 </IfModule>

--- a/templates/mod/passenger.conf.erb
+++ b/templates/mod/passenger.conf.erb
@@ -1,4 +1,3 @@
-<!--@formatter:off-->
 # The Passenger Apache module configuration file is being
 # managed by Puppet and changes will be overwritten.
 <IfModule mod_passenger.c>

--- a/templates/mod/passenger.conf.erb
+++ b/templates/mod/passenger.conf.erb
@@ -229,27 +229,6 @@
   <%- if @rails_user_switching -%>
   RailsUserSwitching <%= @rails_user_switching %>
   <%- end -%>
-  <%- if @union_station_filter -%>
-  UnionStationFilter "<%= @union_station_filter %>"
-  <%- end -%>
-  <%- if @union_station_gateway_address -%>
-  UnionStationGatewayAddress <%= @union_station_gateway_address %>
-  <%- end -%>
-  <%- if @union_station_gateway_cert -%>
-  UnionStationGatewayCert "<%= @union_station_gateway_cert %>"
-  <%- end -%>
-  <%- if @union_station_gateway_port -%>
-  UnionStationGatewayPort <%= @union_station_gateway_port %>
-  <%- end -%>
-  <%- if @union_station_key -%>
-  UnionStationKey <%= @union_station_key %>
-  <%- end -%>
-  <%- if @union_station_proxy_address -%>
-  UnionStationProxyAddress <%= @union_station_proxy_address %>
-  <%- end -%>
-  <%- if @union_station_support -%>
-  UnionStationSupport <%= @union_station_support %>
-  <%- end -%>
   <%- if @wsgi_auto_detect -%>
   WsgiAutoDetect <%= @wsgi_auto_detect %>
   <%- end -%>
@@ -259,4 +238,5 @@
   <%- if @rack_autodetect -%>
   RackAutoDetect <%= @rack_autodetect %>
   <%- end -%>
+
 </IfModule>


### PR DESCRIPTION
Support for the available server configuration settings is currently incomplete.  The changes I've will:

- Add support for all currently documented server config settings
- Maintain support for the current set of apache::mod::passenger settings
- Check if the user provided version of passenger supports, deprecated or removed the server config setting, Note: only works if passenger_installed_version is set.
- Add basic rspec tests for the changes
- Add basic acceptances tests to validate the support, deprecated, and removed functionality

Items from the guidlines for contributing:
- [X] Acceptance tests pass
- [X] Rspec tests pass
- [x] Documentation updated

