### PR TITLE
MODULES-5428 : Add passenger setting support inside Directory directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -920,6 +920,7 @@ worker/prefork
 * f672e46 a2mod fix
 * 8a56ee9 add pthon support to apache
 
+[2.3.0]:https://github.com/puppetlabs/puppetlabs-apache/compare/2.2.0...2.3.0
 [2.2.0]:https://github.com/puppetlabs/puppetlabs-apache/compare/2.1.0...2.2.0
 [2.1.0]:https://github.com/puppetlabs/puppetlabs-apache/compare/2.0.0...2.1.0
 [2.0.0]:https://github.com/puppetlabs/puppetlabs-apache/compare/1.11.0...2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org).
 
+## Supported Release [2.3.0]
+### Summary
+This is a feature release. It includes a task that will reload the apache service.
+
+#### Added
+- Add a task that allows the reloading of the Apache service.
+
 ## Supported Release [2.2.0]
 ### Summary
 This is a maintainence and feature release. It will include updates to translations in Japanese, some maintainence and adding `PassengerSpawnMethod` to vhost.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org).
 
+## Supported Release [2.2.0]
+### Summary
+This is a maintainence and feature release. It will include updates to translations in Japanese, some maintainence and adding `PassengerSpawnMethod` to vhost.
+
+#### Added
+- `PassengerSpawnMethod` added to `vhost`.
+
+#### Changed
+- Improve version match fact for `apache_version`
+- Update to prefork.conf params for Apache 2.4
+- Updates to `CONTRIBUTING.md`
+- Do not install mod_fastcgi on el7
+- Include mod_wsgi when using wsgi options
+
 ## Supported Release [2.1.0]
 ### Summary
 This is a feature release including a security patch (CVE-2017-2299)
@@ -899,6 +913,7 @@ worker/prefork
 * f672e46 a2mod fix
 * 8a56ee9 add pthon support to apache
 
+[2.2.0]:https://github.com/puppetlabs/puppetlabs-apache/compare/2.1.0...2.2.0
 [2.1.0]:https://github.com/puppetlabs/puppetlabs-apache/compare/2.0.0...2.1.0
 [2.0.0]:https://github.com/puppetlabs/puppetlabs-apache/compare/1.11.0...2.0.0
 [1.11.1]:https://github.com/puppetlabs/puppetlabs-apache/compare/1.11.0...1.11.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org).
 
+## Supported Release [2.1.0]
+### Summary
+This is a feature release including a security patch (CVE-2017-2299)
+
+#### Added
+- `apache::mod::jk` class for managing the mod_jk connector
+- `apache_pw_hash` function
+- the ProxyPass directive in location contexts
+- more Puppet 4 type validation
+- `apache::mod::macro` class for managing mod_macro
+
+#### Changed
+- $ssl_certs_dir default to `undef` for all platorms
+- $ssl_verify_client must now be set to use any of the following: `$ssl_certs_dir`, `$ssl_ca`, `$ssl_crl_path`, `$ssl_crl`, `$ssl_verify_depth`, `$ssl_crl_check`
+
+#### Fixed
+- issue where mod_alias was not being loaded when RedirectMatch* directives were being used ([MODULES-3942](https://tickets.puppet.com/browse/MODULES-3942))
+- issue with `$directories` parameter in `apache::vhost`
+- issue in UserDir template where the UserDir path did not match the Directory path
+- **Issue where the $ssl_certs_dir default set Apache to implicitly trust all client certificates that were issued by any CA in that directory**
+
+#### Removed
+- support for EOL platforms: Ubuntu 10.04, 12.04 and Debian 6 (Squeeze)
+
 ## Supported Release [2.0.0]
 ### Summary
 Major release **removing Puppet 3 support** and other backwards-incompatible changes.
@@ -46,6 +70,17 @@ Major release **removing Puppet 3 support** and other backwards-incompatible cha
 - mod::cgi ordering for FreeBSD
 - issue where ProxyPreserveHost could not be set without other Proxy* directives
 - the module attempting to install proxy_html on Ubuntu Xenial and Debian Stretch
+
+## Supported Release [1.11.1]
+#### Summary
+This is a security patch release (CVE-2017-2299). These changes are also in version 2.1.0 and higher.
+
+#### Changed
+- $ssl_certs_dir default to `undef` for all platorms
+- $ssl_verify_client must now be set to use any of the following: `$ssl_certs_dir`, `$ssl_ca`, `$ssl_crl_path`, `$ssl_crl`, `$ssl_verify_depth`, `$ssl_crl_check`
+
+#### Fixed
+- **Issue where the $ssl_certs_dir default set Apache to implicitly trust all client certificates that were issued by any CA in that directory** ([MODULES-5471](https://tickets.puppet.com/browse/MODULES-5471))
 
 ## Supported Release [1.11.0]
 ### Summary
@@ -864,7 +899,9 @@ worker/prefork
 * f672e46 a2mod fix
 * 8a56ee9 add pthon support to apache
 
+[2.1.0]:https://github.com/puppetlabs/puppetlabs-apache/compare/2.0.0...2.1.0
 [2.0.0]:https://github.com/puppetlabs/puppetlabs-apache/compare/1.11.0...2.0.0
+[1.11.1]:https://github.com/puppetlabs/puppetlabs-apache/compare/1.11.0...1.11.1
 [1.11.0]:https://github.com/puppetlabs/puppetlabs-apache/compare/1.10.0...1.11.0
 [1.10.0]:https://github.com/puppetlabs/puppetlabs-apache/compare/1.9.0...1.10.0
 [1.9.0]:https://github.com/puppetlabs/puppetlabs-apache/compare/1.8.1...1.9.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,63 +1,75 @@
-Checklist (and a short version for the impatient)
-=================================================
+# Contributing to Puppet modules
 
-  * Commits:
+So you want to contribute to a Puppet module: Great! Below are some instructions to get you started doing
+that very thing while setting expectations around code quality as well as a few tips for making the
+process as easy as possible. 
 
-    - Make commits of logical units.
+### Table of Contents
 
-    - Check for unnecessary whitespace with "git diff --check" before
-      committing.
+1. [Getting Started](#getting-started)
+1. [Commit Checklist](#commit-checklist)
+1. [Submission](#submission)
+1. [More about commits](#more-about-commits)
+1. [Testing](#testing)
+    - [Running Tests](#running-tests)
+    - [Writing Tests](#writing-tests)
+1. [Get Help](#get-help)
 
-    - Commit using Unix line endings (check the settings around "crlf" in
-      git-config(1)).
+## Getting Started
 
-    - Do not check in commented out code or unneeded files.
+- Fork the module repository on GitHub and clone to your workspace
 
-    - The first line of the commit message should be a short
-      description (50 characters is the soft limit, excluding ticket
-      number(s)), and should skip the full stop.
+- Make your changes!
 
-    - Associate the issue in the message. The first line should include
-      the issue number in the form "(#XXXX) Rest of message".
+## Commit Checklist
 
-    - The body should provide a meaningful commit message, which:
+### The Basics
 
-      - uses the imperative, present tense: "change", not "changed" or
-        "changes".
+- [x] my commit is a single logical unit of work
 
-      - includes motivation for the change, and contrasts its
-        implementation with the previous behavior.
+- [x] I have checked for unnecessary whitespace with "git diff --check" 
 
-    - Make sure that you have tests for the bug you are fixing, or
-      feature you are adding.
+- [x] my commit does not include commented out code or unneeded files
 
-    - Make sure the test suites passes after your commit:
-      `bundle exec rspec spec/acceptance` More information on [testing](#Testing) below
+### The Content
 
-    - When introducing a new feature, make sure it is properly
-      documented in the README.md
+- [x] my commit includes tests for the bug I fixed or feature I added
 
-  * Submission:
+- [x] my commit includes appropriate documentation changes if it is introducing a new feature or changing existing functionality
+    
+- [x] my code passes existing test suites
 
-    * Pre-requisites:
+### The Commit Message
 
-      - Make sure you have a [GitHub account](https://github.com/join)
+- [x] the first line of my commit message includes:
 
-      - [Create a ticket](https://tickets.puppet.com/secure/CreateIssue!default.jspa), or [watch the ticket](https://tickets.puppet.com/browse/) you are patching for.
+  - [x] an issue number (if applicable), e.g. "(MODULES-xxxx) This is the first line" 
+  
+  - [x] a short description (50 characters is the soft limit, excluding ticket number(s))
 
-    * Preferred method:
+- [x] the body of my commit message:
 
-      - Fork the repository on GitHub.
+  - [x] is meaningful
 
-      - Push your changes to a topic branch in your fork of the
-        repository. (the format ticket/1234-short_description_of_change is
-        usually preferred for this project).
+  - [x] uses the imperative, present tense: "change", not "changed" or "changes"
 
-      - Submit a pull request to the repository in the puppetlabs
-        organization.
+  - [x] includes motivation for the change, and contrasts its implementation with the previous behavior
 
-The long version
-================
+## Submission
+
+### Pre-requisites
+
+- Make sure you have a [GitHub account](https://github.com/join)
+
+- [Create a ticket](https://tickets.puppet.com/secure/CreateIssue!default.jspa), or [watch the ticket](https://tickets.puppet.com/browse/) you are patching for.
+
+### Push and PR
+
+- Push your changes to your fork
+
+- [Open a Pull Request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/) against the repository in the puppetlabs organization
+
+## More about commits 
 
   1.  Make separate commits for logically separate changes.
 
@@ -104,37 +116,32 @@ The long version
       GitHub has some pretty good
       [general documentation](http://help.github.com/) on using
       their site.  They also have documentation on
-      [creating pull requests](http://help.github.com/send-pull-requests/).
+      [creating pull requests](https://help.github.com/articles/creating-a-pull-request-from-a-fork/).
 
       In general, after pushing your topic branch up to your
       repository on GitHub, you can switch to the branch in the
       GitHub UI and click "Pull Request" towards the top of the page
       in order to open a pull request.
 
+  3.  Update the related JIRA issue.
 
-  3.  Update the related GitHub issue.
-
-      If there is a GitHub issue associated with the change you
+      If there is a JIRA issue associated with the change you
       submitted, then you should update the ticket to include the
       location of your branch, along with any other commentary you
       may wish to make.
 
-Testing
-=======
+# Testing
 
-Getting Started
----------------
+## Getting Started
 
-Our puppet modules provide [`Gemfile`](./Gemfile)s which can tell a ruby
-package manager such as [bundler](http://bundler.io/) what Ruby packages,
+Our Puppet modules provide [`Gemfile`](./Gemfile)s, which can tell a Ruby package manager such as [bundler](http://bundler.io/) what Ruby packages,
 or Gems, are required to build, develop, and test this software.
 
-Please make sure you have [bundler installed](http://bundler.io/#getting-started)
-on your system, then use it to install all dependencies needed for this project,
-by running
+Please make sure you have [bundler installed](http://bundler.io/#getting-started) on your system, and then use it to 
+install all dependencies needed for this project in the project root by running
 
 ```shell
-% bundle install
+% bundle install --path .bundle/gems
 Fetching gem metadata from https://rubygems.org/........
 Fetching gem metadata from https://rubygems.org/..
 Using rake (10.1.0)
@@ -148,7 +155,7 @@ Your bundle is complete!
 Use `bundle show [gemname]` to see where a bundled gem is installed.
 ```
 
-NOTE some systems may require you to run this command with sudo.
+NOTE: some systems may require you to run this command with sudo.
 
 If you already have those gems installed, make sure they are up-to-date:
 
@@ -156,26 +163,27 @@ If you already have those gems installed, make sure they are up-to-date:
 % bundle update
 ```
 
-With all dependencies in place and up-to-date we can now run the tests:
+## Running Tests
+
+With all dependencies in place and up-to-date, run the tests:
+
+### Unit Tests
 
 ```shell
 % bundle exec rake spec
 ```
 
-This will execute all the [rspec tests](http://rspec-puppet.com/) tests
-under [spec/defines](./spec/defines), [spec/classes](./spec/classes),
-and so on. rspec tests may have the same kind of dependencies as the
-module they are testing. While the module defines in its [Modulefile](./Modulefile),
+This executes all the [rspec tests](http://rspec-puppet.com/) in the directories defined [here](https://github.com/puppetlabs/puppetlabs_spec_helper/blob/699d9fbca1d2489bff1736bb254bb7b7edb32c74/lib/puppetlabs_spec_helper/rake_tasks.rb#L17) and so on. 
+rspec tests may have the same kind of dependencies as the module they are testing. Although the module defines these dependencies in its [metadata.json](./metadata.json),
 rspec tests define them in [.fixtures.yml](./fixtures.yml).
 
-Some puppet modules also come with [beaker](https://github.com/puppetlabs/beaker)
-tests. These tests spin up a virtual machine under
-[VirtualBox](https://www.virtualbox.org/)) with, controlling it with
-[Vagrant](http://www.vagrantup.com/) to actually simulate scripted test
-scenarios. In order to run these, you will need both of those tools
-installed on your system.
+### Acceptance Tests
 
-You can run them by issuing the following command
+Some Puppet modules also come with acceptance tests, which use [beaker][]. These tests spin up a virtual machine under
+[VirtualBox](https://www.virtualbox.org/), controlled with [Vagrant](http://www.vagrantup.com/), to simulate scripted test
+scenarios. In order to run these, you need both Virtualbox and Vagrant installed on your system.
+
+Run the tests by issuing the following command
 
 ```shell
 % bundle exec rake spec_clean
@@ -183,35 +191,81 @@ You can run them by issuing the following command
 ```
 
 This will now download a pre-fabricated image configured in the [default node-set](./spec/acceptance/nodesets/default.yml),
-install puppet, copy this module and install its dependencies per [spec/spec_helper_acceptance.rb](./spec/spec_helper_acceptance.rb)
+install Puppet, copy this module, and install its dependencies per [spec/spec_helper_acceptance.rb](./spec/spec_helper_acceptance.rb)
 and then run all the tests under [spec/acceptance](./spec/acceptance).
 
-Writing Tests
--------------
+## Writing Tests
 
-XXX getting started writing tests.
+### Unit Tests
 
-If you have commit access to the repository
-===========================================
+When writing unit tests for Puppet, [rspec-puppet][] is your best friend. It provides tons of helper methods for testing your manifests against a 
+catalog (e.g. contain_file, contain_package, with_params, etc). It would be ridiculous to try and top rspec-puppet's [documentation][rspec-puppet_docs] 
+but here's a tiny sample:
 
-Even if you have commit access to the repository, you will still need to
-go through the process above, and have someone else review and merge
-in your changes.  The rule is that all changes must be reviewed by a
-developer on the project (that did not write the code) to ensure that
-all changes go through a code review process.
+Sample manifest:
 
-Having someone other than the author of the topic branch recorded as
-performing the merge is the record that they performed the code
-review.
+```puppet
+file { "a test file":
+  ensure => present,
+  path   => "/etc/sample",
+}
+```
 
+Sample test:
 
-Additional Resources
-====================
+```ruby
+it 'does a thing' do
+  expect(subject).to contain_file("a test file").with({:path => "/etc/sample"})
+end
+```
 
-* [Getting additional help](http://puppet.com/community/get-help)
+### Acceptance Tests
 
+Writing acceptance tests for Puppet involves [beaker][] and its cousin [beaker-rspec][]. A common pattern for acceptance tests is to create a test manifest, apply it
+twice to check for idempotency or errors, then run expectations.
+
+```ruby
+it 'does an end-to-end thing' do
+  pp = <<-EOF
+    file { 'a test file': 
+      ensure  => present,
+      path    => "/etc/sample",
+      content => "test string",
+    }
+    
+  apply_manifest(pp, :catch_failures => true)
+  apply_manifest(pp, :catch_changes => true)
+  
+end
+
+describe file("/etc/sample") do
+  it { is_expected.to contain "test string" }
+end
+
+```
+
+# If you have commit access to the repository
+
+Even if you have commit access to the repository, you still need to go through the process above, and have someone else review and merge
+in your changes.  The rule is that **all changes must be reviewed by a project developer that did not write the code to ensure that
+all changes go through a code review process.**
+
+The record of someone performing the merge is the record that they performed the code review. Again, this should be someone other than the author of the topic branch.
+
+# Get Help
+
+### On the web
+* [Puppet help messageboard](http://puppet.com/community/get-help)
 * [Writing tests](https://docs.puppet.com/guides/module_guides/bgtm.html#step-three-module-testing)
-
 * [General GitHub documentation](http://help.github.com/)
-
 * [GitHub pull request documentation](http://help.github.com/send-pull-requests/)
+
+### On chat
+* Slack (slack.puppet.com) #forge-modules, #puppet-dev, #windows, #voxpupuli
+* IRC (freenode) #puppet-dev, #voxpupuli
+
+
+[rspec-puppet]: http://rspec-puppet.com/
+[rspec-puppet_docs]: http://rspec-puppet.com/documentation/
+[beaker]: https://github.com/puppetlabs/beaker
+[beaker-rspec]: https://github.com/puppetlabs/beaker-rspec

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 [Public defined types]: #public-defined-types
 [Private defined types]: #private-defined-types
 [Templates]: #templates
+[Tasks]: #tasks
 
 [Limitations]: #limitations
 
@@ -287,6 +288,7 @@
     - [Public defined types][]
     - [Private defined types][]
     - [Templates][]
+    - [Tasks][]
 5. [Limitations - OS compatibility, etc.][Limitations]
 6. [Development - Guide for contributing to the module][Development]
     - [Contributing to the apache module][Contributing]
@@ -814,6 +816,7 @@ Load balancing scheduler algorithms (`lbmethod`) are listed [in mod_proxy_balanc
     - [Defined type: apache::peruser::processor](#defined-type-apacheperuserprocessor)
     - [Defined type: apache::security::file_link](#defined-type-apachesecurityfile_link)
 - [**Templates**](#templates)
+- [**Tasks**](#tasks)
 
 ### Public Classes
 
@@ -5398,6 +5401,10 @@ Links the `activated_rules` from [`apache::mod::security`][] to the respective C
 ### Templates
 
 The Apache module relies heavily on templates to enable the [`apache::vhost`][] and [`apache::mod`][] defined types. These templates are built based on [Facter][] facts specific to your operating system. Unless explicitly called out, most templates are not meant for configuration.
+
+### Tasks
+
+The Apache module has a task that allows a user to reload the Apache config without restarting the service. Please refer to to the [PE documentation](https://puppet.com/docs/pe/2017.3/orchestrator/running_tasks.html) or [Bolt documentation](https://puppet.com/docs/bolt/latest/bolt.html) on how to execute a task.
 
 ### Functions
 #### apache_pw_hash

--- a/README.md
+++ b/README.md
@@ -3454,7 +3454,7 @@ Sets the [FallbackResource](https://httpd.apache.org/docs/current/mod/mod_dir.ht
 
 Default: `undef`.
 
-#####`fastcgi_idle_timeout`
+##### `fastcgi_idle_timeout`
 
 If using fastcgi, this option sets the timeout for the server to respond.
 
@@ -4031,7 +4031,7 @@ Specifies the resource identifiers for a rack configuration. The file paths spec
 
 Default: `undef`.
 
-#####`passenger_base_uris`
+##### `passenger_base_uris`
 
 Used to specify that the given URI is a Phusion Passenger-served application. The file paths specified are listed as passenger application roots for [Phusion Passenger](https://www.phusionpassenger.com/documentation/Users%20guide%20Apache.html#PassengerBaseURI) in the _passenger_base_uris.erb template.
 

--- a/README.md
+++ b/README.md
@@ -1437,7 +1437,7 @@ Defines the pattern for files included from the `vhost_dir`.
 
 If set to a value like `[^.#]\*.conf[^~]` to make sure that files accidentally created in this directory (such as files created by version control systems or editor backups) are *not* included in your server configuration.
 
-Default: '*', also for BC with previous versions of this module. TODO: what does "also for BC" mean?
+Default: '*'.
 
 Some operating systems use a value of `*.conf`. By default, this module creates configuration files ending in `.conf`.
 
@@ -2450,7 +2450,7 @@ Installs and configures `mod_passenger`.
 
 >**Note**: The passenger module isn't available on RH/CentOS without providing the dependency packages provided by EPEL and the `mod_passengers` custom repository. See the `manage_repo` parameter above and [https://www.phusionpassenger.com/library/install/apache/install/oss/el7/]()
 
-**Parameters**: [TODO: parameters were not listed (except `manage_repo`), so I pulled them out of the manifest. I need to know what these parameters do and what their values can be OR a link that points external documentation for the parameter mapping (as with mod_pagespeed above) <!--see also MODULES-4745-->]
+**Parameters**:
 
 * `passenger_conf_file`: `$::apache::params::passenger_conf_file`
 * `passenger_conf_package_file: `$::apache::params::passenger_conf_package_file`
@@ -2486,8 +2486,6 @@ Installs and configures `mod_passenger`.
 Installs `mod_proxy` and uses the `proxy.conf.erb` template to generate its configuration.
 
 **Parameters within `apache::mod::proxy`**:
-
-TODO: What do these parameters do?
 
 - `allow_from`: Default: `undef`.
 - `apache_version`: Default: `undef`.
@@ -2952,7 +2950,7 @@ Default: '25'.
 
 ##### `source`
 
-Points to the configuration file's source. The [`content`][] and `source` parameters are exclusive of each other. TODO: is this required or does it have a default value?
+Points to the configuration file's source. The [`content`][] and `source` parameters are exclusive of each other.
 
 Default: `undef`
 

--- a/README.md
+++ b/README.md
@@ -1595,6 +1595,7 @@ The following Apache modules have supported classes, many of which allow for par
 * `jk` (see [`apache::mod::jk`])
 * `ldap` (see [`apache::mod::ldap`][])
 * `lookup_identity`
+* `macro` (see [`apache:mod:macro`][])
 * `mime`
 * `mime_magic`\*
 * `negotiation`

--- a/README.md
+++ b/README.md
@@ -3778,6 +3778,10 @@ Sets the overrides for the specified virtual host. Accepts an array of [AllowOve
 
 Default: '[none]'.
 
+##### `passenger_spawn_method`
+
+Sets [PassengerSpawnMethod](https://www.phusionpassenger.com/library/config/apache/reference/#passengerspawnmethod), whether Passenger spawns applications directly, or using a prefork copy-on-write mechanism.
+
 ##### `passenger_app_root`
 
 Sets [PassengerRoot](https://www.phusionpassenger.com/library/config/apache/reference/#passengerapproot), the location of the Passenger application root if different from the DocumentRoot.

--- a/README.md
+++ b/README.md
@@ -2154,6 +2154,7 @@ Installs and manages `mod_jk`, a connector for Apache httpd redirection to old v
 
 ``` puppet
 class { '::apache::mod::jk':
+  ip           = '192.168.2.15',
   workers_file = 'conf/workers.properties',
   mount_file   = 'conf/uriworkermap.properties',
   shm_file     = 'run/jk.shm',
@@ -2166,7 +2167,31 @@ class { '::apache::mod::jk':
 
 **Parameters within `apache::mod::jk`**:
 
-The best source for understanding the `mod_jk` parameters is the [official documentation](https://tomcat.apache.org/connectors-doc/reference/apache.html), except for \*file_content:
+The best source for understanding the `mod_jk` parameters is the [official documentation](https://tomcat.apache.org/connectors-doc/reference/apache.html), except for:
+
+**add_listen**
+
+Defines if a `Listen` directive according to parameters `ip` and `port` (see below), so that Apache listens to the IP/port combination and redirect to `mod_jk`.
+Useful when another `Listen` directive, like `Listen *:<Port>` or `Listen <Port>`, can conflict with the one necessary for `mod_jk` binding.
+
+Type: Boolean
+Default: true
+
+**ip**
+
+IP for binding to `mod_jk`.
+Useful when the binding address is not the primary network interface IP.
+
+Type: String
+Default: `$facts['ipaddress']`
+
+**port**
+
+Port for binding to `mod_jk`.
+Useful when something else, like a reverse proxy or cache, is receiving requests at port 80, then needs to forward them to Apache at a different port.
+
+Type: String (numerical)
+Default: '80'
 
 **workers\_file\_content**
 

--- a/README.md
+++ b/README.md
@@ -3029,6 +3029,15 @@ The `apache::vhost` defined type uses `concat::fragment` to build the configurat
 
 For the custom fragment's `order` parameter, the `apache::vhost` defined type uses multiples of 10, so any `order` that isn't a multiple of 10 should work.
 
+> **Note:** When creating an `apache::vhost`, it cannot be named `default` or `default-ssl`, because vhosts with these titles are always managed by the module. This means that you cannot override `Apache::Vhost['default']`  or `Apache::Vhost['default-ssl]` resources. An optional workaround is to create a vhost named something else, such as `my default`, and ensure that the `default` and `default_ssl` vhosts are set to `false`:
+
+```
+class { 'apache':
+  default_vhost     => false
+  default_ssl_vhost => false,
+}
+```
+
 **Parameters**:
 
 ##### `access_log`

--- a/README.md
+++ b/README.md
@@ -3782,6 +3782,10 @@ Default: '[none]'.
 
 Sets [PassengerSpawnMethod](https://www.phusionpassenger.com/library/config/apache/reference/#passengerspawnmethod), whether Passenger spawns applications directly, or using a prefork copy-on-write mechanism.
 
+Valid options: `smart` or `direct`.
+
+Default: `undef`.
+
 ##### `passenger_app_root`
 
 Sets [PassengerRoot](https://www.phusionpassenger.com/library/config/apache/reference/#passengerapproot), the location of the Passenger application root if different from the DocumentRoot.

--- a/README.md
+++ b/README.md
@@ -2238,6 +2238,38 @@ $mount_file_content = {
 },
 ```
 
+**shm\_file and log\_file**
+
+Depending on how these files are specified, the class creates their final path differently:
+- Relative path: prepends supplied path with `logroot` (see below)
+- Absolute path or pipe: uses supplied path as-is
+
+Examples (RHEL 6):
+
+```
+shm_file => 'shm_file'
+# Ends up in
+$shm_path = '/var/log/httpd/shm_file'
+```
+```
+shm_file => '/run/shm_file'
+# Ends up in
+$shm_path = '/run/shm_file'
+```
+```
+shm_file => '"|rotatelogs /var/log/httpd/mod_jk.log.%Y%m%d 86400 -180"'
+# Ends up in
+$shm_path = '"|rotatelogs /var/log/httpd/mod_jk.log.%Y%m%d 86400 -180"'
+```
+
+> The default logroot is sane enough. Therefore, it is not recommended to specify absolute paths.
+
+**logroot**
+
+The base directory for `shm_file` and `log_file` is determined by the `logroot` parameter. If unspecified, defaults to `apache::params::logroot`.
+
+> The default logroot is sane enough. Therefore, it is not recommended to override it.
+
 ##### Class: `apache::mod::passenger`
 
 Installs and manages [`mod_passenger`][]. For Red Hat-based systems, ensure that you meet the minimum requirements described in the [passenger docs](https://www.phusionpassenger.com/library/install/apache/install/oss/el6/#step-1:-upgrade-your-kernel,-or-disable-selinux).

--- a/README.md
+++ b/README.md
@@ -1369,7 +1369,7 @@ Default: `undef`.
 
 ##### `ssl_ca`
 
-Specifies the SSL certificate authority. [SSLCACertificateFile](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcacertificatefile).
+Specifies the SSL certificate authority. [SSLCACertificateFile](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcacertificatefile) to use to verify certificate used in ssl client authentication.
 
 It is possible to override this on a vhost level.
 
@@ -4971,7 +4971,7 @@ Default: `false`.
 
 ##### `ssl_ca`
 
-Specifies the SSL certificate authority.
+Specifies the SSL certificate authority to be used to verify client certificates used for authentication. You must also set `ssl_verify_client` to use this.
 
 Default: `undef`.
 
@@ -5008,14 +5008,9 @@ Default: `true`.
 
 ##### `ssl_certs_dir`
 
-Specifies the location of the SSL certification directory.
+Specifies the location of the SSL certification directory to verify client certs. Will not be used unless `ssl_verify_client` is also set (see below).
 
-Default: Depends on operating system.
-
-- Debian: '/etc/ssl/certs'
-- Red Hat: '/etc/pki/tls/certs'
-- FreeBSD: `undef`
-- Gentoo: '/etc/ssl/apache2'
+Default: undef
 
 ##### `ssl_chain`
 
@@ -5031,13 +5026,13 @@ Default: `undef`.
 
 ##### `ssl_crl_path`
 
-Specifies the location of the certificate revocation list. (This default works out of the box but must be updated in the base `apache` class with your specific certificate information before being used in production.)
+Specifies the location of the certificate revocation list to verify certificates for client authentication with. (This default works out of the box but must be updated in the base `apache` class with your specific certificate information before being used in production.)
 
 Default: `undef`.
 
 ##### `ssl_crl_check`
 
-Sets the certificate revocation check level via the [SSLCARevocationCheck directive](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcarevocationcheck). The default works out of the box but must be specified when using CRLs in production. Only applicable to Apache 2.4 or higher; the value is ignored on older versions.
+Sets the certificate revocation check level via the [SSLCARevocationCheck directive] for ssl client authentication (https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcarevocationcheck). The default works out of the box but must be specified when using CRLs in production. Only applicable to Apache 2.4 or higher; the value is ignored on older versions.
 
 Default: `undef`.
 
@@ -5070,11 +5065,12 @@ Default: `undef`.
 
 ##### `ssl_verify_depth`
 
-Sets the [SSLVerifyDepth](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslverifydepth) directive, which specifies the maximum depth of CA certificates in client certificate verification.
+Sets the [SSLVerifyDepth](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslverifydepth) directive, which specifies the maximum depth of CA certificates in client certificate verification. You must set `ssl_verify_client` for it to take effect.
 
 ``` puppet
 apache::vhost { 'sample.example.net':
   …
+  ssl_verify_client => 'require',
   ssl_verify_depth => 1,
 }
 ```

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@
 
 [Development]: #development
 [Contributing]: #contributing
-[Testing]: #testing
 
 [`AddDefaultCharset`]: https://httpd.apache.org/docs/current/mod/core.html#adddefaultcharset
 [`add_listen`]: #add_listen
@@ -90,6 +89,7 @@
 [common gateway interface]: https://httpd.apache.org/docs/current/howto/cgi.html
 [`confd_dir`]: #confd_dir
 [`content`]: #content
+[CONTRIBUTING.md]: CONTRIBUTING.md
 [custom error documents]: https://httpd.apache.org/docs/current/custom-error.html
 [`custom_fragment`]: #custom_fragment
 
@@ -5377,26 +5377,4 @@ The [`apache::mod::suphp`][] class is untested since repositories are missing co
 
 We want to make it as easy as possible to contribute changes so our modules work in your environment, but we also need contributors to follow a few guidelines to help us maintain and improve the modules' quality.
 
-For more information, please read the complete [module contribution guide][].
-
-### Testing
-
-This project contains tests for both [rspec-puppet][] and [beaker-rspec][] to verify functionality. For detailed information on using these tools, please see their respective documentation.
-
-#### Testing quickstart: Ruby > 1.8.7
-
-```
-gem install bundler
-bundle install
-bundle exec rake spec
-bundle exec rspec spec/acceptance
-RS_DEBUG=yes bundle exec rspec spec/acceptance
-```
-
-#### Testing quickstart: Ruby = 1.8.7
-
-```
-gem install bundler
-bundle install --without system_tests
-bundle exec rake spec
-```
+For more information, please read the complete [module contribution guide][] and check out [CONTRIBUTING.md][].

--- a/README.md
+++ b/README.md
@@ -2300,33 +2300,102 @@ The base directory for `shm_file` and `log_file` is determined by the `logroot` 
 
 Installs and manages [`mod_passenger`][]. For Red Hat-based systems, ensure that you meet the minimum requirements described in the [passenger docs](https://www.phusionpassenger.com/library/install/apache/install/oss/el6/#step-1:-upgrade-your-kernel,-or-disable-selinux).
 
+The current set of server configurations settings were taken directly from the [Passenger Reference](https://www.phusionpassenger.com/library/config/apache/reference/). To enable deprecation warnings and removal failure messages, set the `passenger_installed_version` to the version number installed on the server.
+
 **Parameters**:
 
-* `passenger_high_performance`: Sets the [`PassengerHighPerformance`](https://www.phusionpassenger.com/library/config/apache/reference/#passengerhighperformance).
+|parameter|default value|passenger config setting|context|notes|
+|---------|-------------|------------------------|-------|-----|
+|manage_repo|true|n/a|||
+|mod_id|undef|n/a|||
+|mod_lib|undef|n/a|||
+|mod_lib_path|undef|n/a|||
+|mod_package|undef|n/a|||
+|mod_package_ensure|undef|n/a|||
+|mod_path|undef|n/a|||
+|passenger_allow_encoded_slashes|undef|[`PassengerAllowEncodedSlashes`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerAllowEncodedSlashes)|server-config virutal-host htaccess directory ||
+|passenger_app_env|undef|[`PassengerAppEnv`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerAppEnv)|server-config virutal-host htaccess directory ||
+|passenger_app_group_name|undef|[`PassengerAppGroupName`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerAppGroupName)|server-config virutal-host htaccess directory ||
+|passenger_app_root|undef|[`PassengerAppRoot`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerAppRoot)|server-config virutal-host htaccess directory ||
+|passenger_app_type|undef|[`PassengerAppType`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerAppType)|server-config virutal-host htaccess directory ||
+|passenger_base_uri|undef|[`PassengerBaseURI`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerBaseURI)|server-config virutal-host htaccess directory ||
+|passenger_buffer_response|undef|[`PassengerBufferResponse`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerBufferResponse)|server-config virutal-host htaccess directory ||
+|passenger_buffer_upload|undef|[`PassengerBufferUpload`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerBufferUpload)|server-config virutal-host htaccess directory ||
+|passenger_concurrency_model|undef|[`PassengerConcurrencyModel`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerConcurrencyModel)|server-config virutal-host htaccess directory ||
+|passenger_conf_file|$::apache::params::passenger_conf_file|n/a|||
+|passenger_conf_package_file|$::apache::params::passenger_conf_package_file|n/a|||
+|passenger_data_buffer_dir|undef|[`PassengerDataBufferDir`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerDataBufferDir)|server-config ||
+|passenger_debug_log_file|undef|PassengerDebugLogFile|server-config |This option has been renamed in version 5.0.5 to PassengerLogFile.|
+|passenger_debugger|undef|[`PassengerDebugger`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerDebugger)|server-config virutal-host htaccess directory ||
+|passenger_default_group|undef|[`PassengerDefaultGroup`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerDefaultGroup)|server-config ||
+|passenger_default_ruby|$::apache::params::passenger_default_ruby|[`PassengerDefaultRuby`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerDefaultRuby)|server-config ||
+|passenger_default_user|undef|[`PassengerDefaultUser`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerDefaultUser)|server-config ||
+|passenger_disable_security_update_check|undef|[`PassengerDisableSecurityUpdateCheck`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerDisableSecurityUpdateCheck)|server-config ||
+|passenger_enabled|undef|[`PassengerEnabled`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerEnabled)|server-config virutal-host htaccess directory ||
+|passenger_error_override|undef|[`PassengerErrorOverride`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerErrorOverride)|server-config virutal-host htaccess directory ||
+|passenger_file_descriptor_log_file|undef|[`PassengerFileDescriptorLogFile`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerFileDescriptorLogFile)|server-config ||
+|passenger_fly_with|undef|[`PassengerFlyWith`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerFlyWith)|server-config ||
+|passenger_force_max_concurrent_requests_per_process|undef|[`PassengerForceMaxConcurrentRequestsPerProcess`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerForceMaxConcurrentRequestsPerProcess)|server-config virutal-host htaccess directory ||
+|passenger_friendly_error_pages|undef|[`PassengerFriendlyErrorPages`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerFriendlyErrorPages)|server-config virutal-host htaccess directory ||
+|passenger_group|undef|[`PassengerGroup`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerGroup)|server-config virutal-host directory ||
+|passenger_high_performance|undef|[`PassengerHighPerformance`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerHighPerformance)|server-config virutal-host htaccess directory ||
+|passenger_installed_version|undef|n/a| |If set, will enable version checking of the passenger options against the value set.|
+|passenger_instance_registry_dir|undef|[`PassengerInstanceRegistryDir`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerInstanceRegistryDir)|server-config ||
+|passenger_load_shell_envvars|undef|[`PassengerLoadShellEnvvars`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerLoadShellEnvvars)|server-config virutal-host htaccess directory ||
+|passenger_log_file|undef|[`PassengerLogFile`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerLogFile)|server-config ||
+|passenger_log_level|undef|[`PassengerLogLevel`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerLogLevel)|server-config ||
+|passenger_lve_min_uid|undef|[`PassengerLveMinUid`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerLveMinUid)|server-config virutal-host ||
+|passenger_max_instances|undef|[`PassengerMaxInstances`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxInstances)|server-config virutal-host htaccess directory ||
+|passenger_max_instances_per_app|undef|[`PassengerMaxInstancesPerApp`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxInstancesPerApp)|server-config ||
+|passenger_max_pool_size|undef|[`PassengerMaxPoolSize`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxPoolSize)|server-config ||
+|passenger_max_preloader_idle_time|undef|[`PassengerMaxPreloaderIdleTime`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxPreloaderIdleTime)|server-config virutal-host ||
+|passenger_max_request_queue_size|undef|[`PassengerMaxRequestQueueSize`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxRequestQueueSize)|server-config virutal-host htaccess directory ||
+|passenger_max_request_time|undef|[`PassengerMaxRequestTime`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxRequestTime)|server-config virutal-host htaccess directory ||
+|passenger_max_requests|undef|[`PassengerMaxRequests`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMaxRequests)|server-config virutal-host htaccess directory ||
+|passenger_memory_limit|undef|[`PassengerMemoryLimit`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMemoryLimit)|server-config virutal-host htaccess directory ||
+|passenger_meteor_app_settings|undef|[`PassengerMeteorAppSettings`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMeteorAppSettings)|server-config virutal-host htaccess directory ||
+|passenger_min_instances|undef|[`PassengerMinInstances`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerMinInstances)|server-config virutal-host htaccess directory ||
+|passenger_nodejs|undef|[`PassengerNodejs`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerNodejs)|server-config virutal-host htaccess directory ||
+|passenger_pool_idle_time|undef|[`PassengerPoolIdleTime`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerPoolIdleTime)|server-config ||
+|passenger_pre_start|undef|[`PassengerPreStart`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerPreStart)|server-config virutal-host ||
+|passenger_python|undef|[`PassengerPython`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerPython)|server-config virutal-host htaccess directory ||
+|passenger_resist_deployment_errors|undef|[`PassengerResistDeploymentErrors`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerResistDeploymentErrors)|server-config virutal-host htaccess directory ||
+|passenger_resolve_symlinks_in_document_root|undef|[`PassengerResolveSymlinksInDocumentRoot`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerResolveSymlinksInDocumentRoot)|server-config virutal-host htaccess directory ||
+|passenger_response_buffer_high_watermark|undef|[`PassengerResponseBufferHighWatermark`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerResponseBufferHighWatermark)|server-config ||
+|passenger_restart_dir|undef|[`PassengerRestartDir`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerRestartDir)|server-config virutal-host htaccess directory ||
+|passenger_rolling_restarts|undef|[`PassengerRollingRestarts`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerRollingRestarts)|server-config virutal-host htaccess directory ||
+|passenger_root|$::apache::params::passenger_root|[`PassengerRoot`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerRoot)|server-config ||
+|passenger_ruby|$::apache::params::passenger_ruby|[`PassengerRuby`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerRuby)|server-config virutal-host htaccess directory ||
+|passenger_security_update_check_proxy|undef|[`PassengerSecurityUpdateCheckProxy`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerSecurityUpdateCheckProxy)|server-config ||
+|passenger_show_version_in_header|undef|[`PassengerShowVersionInHeader`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerShowVersionInHeader)|server-config ||
+|passenger_socket_backlog|undef|[`PassengerSocketBacklog`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerSocketBacklog)|server-config ||
+|passenger_spawn_method|undef|[`PassengerSpawnMethod`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerSpawnMethod)|server-config virutal-host ||
+|passenger_start_timeout|undef|[`PassengerStartTimeout`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerStartTimeout)|server-config virutal-host htaccess directory ||
+|passenger_startup_file|undef|[`PassengerStartupFile`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerStartupFile)|server-config virutal-host htaccess directory ||
+|passenger_stat_throttle_rate|undef|[`PassengerStatThrottleRate`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerStatThrottleRate)|server-config ||
+|passenger_sticky_sessions|undef|[`PassengerStickySessions`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerStickySessions)|server-config virutal-host htaccess directory ||
+|passenger_sticky_sessions_cookie_name|undef|[`PassengerStickySessionsCookieName`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerStickySessionsCookieName)|server-config virutal-host htaccess directory ||
+|passenger_thread_count|undef|[`PassengerThreadCount`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerThreadCount)|server-config virutal-host htaccess directory ||
+|passenger_use_global_queue|undef|PassengerUseGlobalQueue|server-config ||
+|passenger_user|undef|[`PassengerUser`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerUser)|server-config virutal-host directory ||
+|passenger_user_switching|undef|[`PassengerUserSwitching`](https://www.phusionpassenger.com/library/config/apache/reference/#PassengerUserSwitching)|server-config ||
+|rack_auto_detect|undef|RackAutoDetect|server-config |These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.|
+|rack_autodetect|undef|n/a|||
+|rack_base_uri|undef|RackBaseURI|server-config |Deprecated in 3.0.0 in favor of PassengerBaseURI.|
+|rack_env|undef|[`RackEnv`](https://www.phusionpassenger.com/library/config/apache/reference/#RackEnv)|server-config virutal-host htaccess directory ||
+|rails_allow_mod_rewrite|undef|RailsAllowModRewrite|server-config |This option doesn't do anything anymore in since version 4.0.0.|
+|rails_app_spawner_idle_time|undef|RailsAppSpawnerIdleTime|server-config |This option has been removed in version 4.0.0, and replaced with PassengerMaxPreloaderIdleTime.|
+|rails_auto_detect|undef|RailsAutoDetect|server-config |These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.|
+|rails_autodetect|undef|n/a|||
+|rails_base_uri|undef|RailsBaseURI|server-config |Deprecated in 3.0.0 in favor of PassengerBaseURI.|
+|rails_default_user|undef|RailsDefaultUser|server-config |Deprecated in 3.0.0 in favor of PassengerDefaultUser.|
+|rails_env|undef|[`RailsEnv`](https://www.phusionpassenger.com/library/config/apache/reference/#RailsEnv)|server-config virutal-host htaccess directory ||
+|rails_framework_spawner_idle_time|undef|RailsFrameworkSpawnerIdleTime|server-config |This option is no longer available in version 4.0.0. There is no alternative because framework spawning has been removed altogether. You should use smart spawning instead.|
+|rails_ruby|undef|RailsRuby|server-config |Deprecated in 3.0.0 in favor of PassengerRuby.|
+|rails_spawn_method|undef|RailsSpawnMethod|server-config |Deprecated in 3.0.0 in favor of PassengerSpawnMethod.|
+|rails_user_switching|undef|RailsUserSwitching|server-config |Deprecated in 3.0.0 in favor of PassengerUserSwitching.|
+|wsgi_auto_detect|undef|WsgiAutoDetect|server-config |These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.|
 
-  Values: 'On', 'Off'.
-
-  Default: `undef`.
-
-* `passenger_pool_idle_time`: Sets the [`PassengerPoolIdleTime`](https://www.phusionpassenger.com/library/config/apache/reference/#passengerpoolidletime).
-
-  Default: `undef`.
-
-* `passenger_max_pool_size`: Sets the [`PassengerMaxPoolSize`](https://www.phusionpassenger.com/library/config/apache/reference/#passengermaxpoolsize).
-
-  Default: `undef`.
-
-* `passenger_max_request_queue_size`: Sets the [`PassengerMaxRequestQueueSize`](https://www.phusionpassenger.com/library/config/apache/reference/#passengermaxrequestqueuesize).
-
-  Default: `undef`.
-
-* `passenger_max_requests`: Sets the [`PassengerMaxRequests`](https://www.phusionpassenger.com/library/config/apache/reference/#passengermaxrequests).
-
-  Default: `undef`.
-
-* `passenger_data_buffer_dir`: Sets the [`PassengerDataBufferDir`](https://www.phusionpassenger.com/library/config/apache/reference/#passengerdatabufferdir).
-
-  Default: `undef`.
 
 ##### Class: `apache::mod::ldap`
 

--- a/README.md
+++ b/README.md
@@ -5034,7 +5034,7 @@ Default: `undef`.
 
 ##### `ssl_crl_check`
 
-Sets the certificate revocation check level via the [SSLCARevocationCheck directive] for ssl client authentication (https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcarevocationcheck). The default works out of the box but must be specified when using CRLs in production. Only applicable to Apache 2.4 or higher; the value is ignored on older versions.
+Sets the certificate revocation check level via the [SSLCARevocationCheck directive](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcarevocationcheck) for ssl client authentication. The default works out of the box but must be specified when using CRLs in production. Only applicable to Apache 2.4 or higher; the value is ignored on older versions.
 
 Default: `undef`.
 

--- a/lib/facter/apache_version.rb
+++ b/lib/facter/apache_version.rb
@@ -3,11 +3,11 @@ Facter.add(:apache_version) do
     if Facter::Util::Resolution.which('apachectl')
       apache_version = Facter::Util::Resolution.exec('apachectl -v 2>&1')
       Facter.debug "Matching apachectl '#{apache_version}'"
-      %r{^Server version: Apache\/(\d+.\d+(.\d+)?)}.match(apache_version)[1]
+      %r{^Server version: Apache/(\d+\.\d+(\.\d+)?)}.match(apache_version)[1]
     elsif Facter::Util::Resolution.which('apache2ctl')
       apache_version = Facter::Util::Resolution.exec('apache2ctl -v 2>&1')
       Facter.debug "Matching apache2ctl '#{apache_version}'"
-      %r{^Server version: Apache\/(\d+.\d+(.\d+)?)}.match(apache_version)[1]
+      %r{^Server version: Apache/(\d+\.\d+(\.\d+)?)}.match(apache_version)[1]
     end
   end
 end

--- a/locales/config.yaml
+++ b/locales/config.yaml
@@ -22,4 +22,5 @@ gettext:
   # Patterns for +Dir.glob+ used to find all files that might contain
   # translatable content, relative to the project root directory
   source_files:
+      - './lib/**/*.rb'
   

--- a/locales/ja/puppetlabs-apache.po
+++ b/locales/ja/puppetlabs-apache.po
@@ -1,0 +1,28 @@
+# 
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-03-21 14:19+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: 梅田智世 <c-umeda@nifty.com>, 2017\n"
+"Language-Team: Japanese (Japan) (https://www.transifex.com/puppet/teams/29089/ja_JP/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: ja_JP\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Translate Toolkit 2.0.0\n"
+
+#. metadata.json
+#: .summary
+msgid ""
+"Installs, configures, and manages Apache virtual hosts, web services, and "
+"modules."
+msgstr "Apacheバーチャルホスト、Webサービス、モジュールのインストール、設定、管理。"
+
+#. metadata.json
+#: .description
+msgid "Module for Apache configuration"
+msgstr "Apache設定用のモジュール。"

--- a/manifests/fastcgi/server.pp
+++ b/manifests/fastcgi/server.pp
@@ -11,12 +11,12 @@ define apache::fastcgi::server (
 
   Apache::Mod['fastcgi'] -> Apache::Fastcgi::Server[$title]
 
-  if is_absolute_path($host) {
+  if $host =~ Stdlib::Absolutepath {
     $socket = $host
   }
 
   file { "fastcgi-pool-${name}.conf":
-    ensure  => present,
+    ensure  => file,
     path    => "${::apache::confd_dir}/fastcgi-pool-${name}.conf",
     owner   => 'root',
     group   => $::apache::params::root_group,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,7 +38,7 @@ class apache (
   $purge_vhost_dir                                               = undef,
   $purge_vdir                                                    = false,
   $serveradmin                                                   = 'root@localhost',
-  $sendfile                                                      = 'On',
+  Enum['On', 'Off', 'on', 'off'] $sendfile                       = 'On',
   $error_documents                                               = false,
   $timeout                                                       = '120',
   $httpd_dir                                                     = $::apache::params::httpd_dir,
@@ -129,7 +129,6 @@ class apache (
       notify => Class['Apache::Service'],
     }
   }
-  validate_re($sendfile, [ '^[oO]n$' , '^[oO]ff$' ])
 
   # declare the web server user and group
   # Note: requiring the package means the package ought to create them and not puppet

--- a/manifests/mod/fastcgi.pp
+++ b/manifests/mod/fastcgi.pp
@@ -1,6 +1,8 @@
 class apache::mod::fastcgi {
   include ::apache
-
+  if ($::osfamily == 'Redhat' and versioncmp($::operatingsystemrelease, '7.0') >= 0) {
+    fail('mod_fastcgi is no longer supported on el7 and above.')
+  }
   # Debian specifies it's fastcgi lib path, but RedHat uses the default value
   # with no config file
   $fastcgi_lib_path = $::apache::params::fastcgi_lib_path

--- a/manifests/mod/jk.pp
+++ b/manifests/mod/jk.pp
@@ -9,58 +9,72 @@
 # https://tomcat.apache.org/connectors-doc/reference/apache.html
 #
 class apache::mod::jk (
-  $workers_file          = undef,
-  $worker_property       = {},
-  $logroot               = undef,
-  $shm_file              = undef,
-  $shm_size              = undef,
-  $mount_file            = undef,
-  $mount_file_reload     = undef,
-  $mount                 = {},
-  $un_mount              = {},
-  $auto_alias            = undef,
-  $mount_copy            = undef,
-  $worker_indicator      = undef,
-  $watchdog_interval     = undef,
-  $log_file              = undef,
-  $log_level             = undef,
-  $log_stamp_format      = undef,
-  $request_log_format    = undef,
-  $extract_ssl           = undef,
-  $https_indicator       = undef,
-  $sslprotocol_indicator = undef,
-  $certs_indicator       = undef,
-  $cipher_indicator      = undef,
-  $certchain_prefix      = undef,
-  $session_indicator     = undef,
-  $keysize_indicator     = undef,
-  $local_name_indicator  = undef,
-  $ignore_cl_indicator   = undef,
-  $local_addr_indicator  = undef,
-  $local_port_indicator  = undef,
-  $remote_host_indicator = undef,
-  $remote_addr_indicator = undef,
-  $remote_port_indicator = undef,
-  $remote_user_indicator = undef,
-  $auth_type_indicator   = undef,
-  $options               = [],
-  $env_var               = {},
-  $strip_session         = undef,
+  # Binding to mod_jk
+  Optional[String] $ip         = undef,
+  Integer          $port       = 80,
+  Boolean          $add_listen = true,
+  # Conf file content
+  $workers_file                = undef,
+  $worker_property             = {},
+  $logroot                     = undef,
+  $shm_file                    = 'jk-runtime-status',
+  $shm_size                    = undef,
+  $mount_file                  = undef,
+  $mount_file_reload           = undef,
+  $mount                       = {},
+  $un_mount                    = {},
+  $auto_alias                  = undef,
+  $mount_copy                  = undef,
+  $worker_indicator            = undef,
+  $watchdog_interval           = undef,
+  $log_file                    = 'mod_jk.log',
+  $log_level                   = undef,
+  $log_stamp_format            = undef,
+  $request_log_format          = undef,
+  $extract_ssl                 = undef,
+  $https_indicator             = undef,
+  $sslprotocol_indicator       = undef,
+  $certs_indicator             = undef,
+  $cipher_indicator            = undef,
+  $certchain_prefix            = undef,
+  $session_indicator           = undef,
+  $keysize_indicator           = undef,
+  $local_name_indicator        = undef,
+  $ignore_cl_indicator         = undef,
+  $local_addr_indicator        = undef,
+  $local_port_indicator        = undef,
+  $remote_host_indicator       = undef,
+  $remote_addr_indicator       = undef,
+  $remote_port_indicator       = undef,
+  $remote_user_indicator       = undef,
+  $auth_type_indicator         = undef,
+  $options                     = [],
+  $env_var                     = {},
+  $strip_session               = undef,
   # Location list
   # See comments in template mod/jk.conf.erb
-  $location_list         = [],
+  $location_list               = [],
   # Workers file content
   # See comments in template mod/jk/workers.properties.erb
-  $workers_file_content  = {},
+  $workers_file_content        = {},
   # Mount file content
   # See comments in template mod/jk/uriworkermap.properties.erb
-  $mount_file_content    = {},
+  $mount_file_content          = {},
 ){
 
   # Provides important variables
   include ::apache
   # Manages basic module config
   ::apache::mod { 'jk': }
+
+  # Binding to mod_jk
+  if $add_listen {
+    $_ip = $ip ? {
+      undef   => $facts['ipaddress'],
+      default => $ip,
+    }
+    ensure_resource('apache::listen', "${_ip}:${port}", {})
+  }
 
   # File resource common parameters
   File {

--- a/manifests/mod/jk.pp
+++ b/manifests/mod/jk.pp
@@ -12,7 +12,7 @@ class apache::mod::jk (
   $workers_file          = undef,
   $worker_property       = {},
   $logroot               = undef,
-  $shm_file              = 'jk-runtime-status',
+  $shm_file              = undef,
   $shm_size              = undef,
   $mount_file            = undef,
   $mount_file_reload     = undef,
@@ -22,7 +22,7 @@ class apache::mod::jk (
   $mount_copy            = undef,
   $worker_indicator      = undef,
   $watchdog_interval     = undef,
-  $log_file              = 'mod_jk.log',
+  $log_file              = undef,
   $log_level             = undef,
   $log_stamp_format      = undef,
   $request_log_format    = undef,
@@ -70,22 +70,33 @@ class apache::mod::jk (
   }
 
   # Shared memory and log paths
-  if $logroot == undef {
-    $shm_path = "${::apache::logroot}/${shm_file}"
-    $log_path = "${::apache::logroot}/${log_file}"
+  # If logroot unspecified, use default
+  $log_dir = $logroot ? {
+    undef   => $::apache::logroot,
+    default => $logroot,
   }
-  else {
-    $shm_path = "${logroot}/${shm_file}"
-    $log_path = "${logroot}/${log_file}"
+  # If absolute path or pipe, use as-is
+  # If relative path, prepend with log directory
+  # If unspecified, use default
+  $shm_path = $shm_file ? {
+    undef       => "${log_dir}/jk-runtime-status",
+    /^\"?[|\/]/ => $shm_file,
+    default     => "${log_dir}/${shm_file}",
+  }
+  $log_path = $log_file ? {
+    undef       => "${log_dir}/mod_jk.log",
+    /^\"?[|\/]/ => $log_file,
+    default     => "${log_dir}/${log_file}",
   }
 
   # Main config file
+  $mod_dir = $::apache::mod_dir
   file {'jk.conf':
-    path    => "${::apache::mod_dir}/jk.conf",
+    path    => "${mod_dir}/jk.conf",
     content => template('apache/mod/jk.conf.erb'),
     require => [
-      Exec["mkdir ${::apache::mod_dir}"],
-      File[$::apache::mod_dir],
+      Exec["mkdir ${mod_dir}"],
+      File[$mod_dir],
     ],
   }
 

--- a/manifests/mod/macro.pp
+++ b/manifests/mod/macro.pp
@@ -1,0 +1,4 @@
+class apache::mod::macro {
+  include ::apache
+  ::apache::mod { 'macro': }
+}

--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -1,36 +1,499 @@
+# Manages the settings for the mod_passenger
+# The result is the /etc/mods-available/mod_passenger.conf file
+#
+# Where do we get these settings?
+#   Settings are dervied from https://www.phusionpassenger.com/library/config/apache/reference
+#   Also in passenger source code you can strip out what are all the available options by looking in
+#     * src/apache2_module/Configuration.cpp
+#     * src/apache2_module/ConfigurationCommands.cpp
+#   Note: in the src there are several undocumented settings.
+#
+# Change Log:
+#   * As of 08/13/2017 there are 84 available/deprecated/removed settings.
+#   * Around 08/20/2017 UnionStation was discontinued options were removed.
+#   * As of 08/20/2017 there are 77 available/deprecated/removed settings.
 class apache::mod::passenger (
-  $passenger_conf_file                                                                   = $::apache::params::passenger_conf_file,
-  $passenger_conf_package_file                                                           = $::apache::params::passenger_conf_package_file,
-  $passenger_high_performance                                                            = undef,
-  $passenger_pool_idle_time                                                              = undef,
-  $passenger_max_request_queue_size                                                      = undef,
-  $passenger_max_requests                                                                = undef,
-  Optional[Enum['smart', 'direct', 'smart-lv2', 'conservative']] $passenger_spawn_method = undef,
-  $passenger_stat_throttle_rate                                                          = undef,
-  $rack_autodetect                                                                       = undef,
-  $rails_autodetect                                                                      = undef,
-  $passenger_root                                                                        = $::apache::params::passenger_root,
-  $passenger_ruby                                                                        = $::apache::params::passenger_ruby,
-  $passenger_default_ruby                                                                = $::apache::params::passenger_default_ruby,
-  $passenger_max_pool_size                                                               = undef,
-  $passenger_min_instances                                                               = undef,
-  $passenger_max_instances_per_app                                                       = undef,
-  $passenger_use_global_queue                                                            = undef,
-  $passenger_app_env                                                                     = undef,
-  Optional[Stdlib::Absolutepath] $passenger_log_file                                     = undef,
-  $passenger_log_level                                                                   = undef,
-  $passenger_data_buffer_dir                                                             = undef,
-  $manage_repo                                                                           = true,
-  $mod_package                                                                           = undef,
-  $mod_package_ensure                                                                    = undef,
-  $mod_lib                                                                               = undef,
-  $mod_lib_path                                                                          = undef,
-  $mod_id                                                                                = undef,
-  $mod_path                                                                              = undef,
+  $manage_repo                                                                               = true,
+  $mod_id                                                                                    = undef,
+  $mod_lib                                                                                   = undef,
+  $mod_lib_path                                                                              = undef,
+  $mod_package                                                                               = undef,
+  $mod_package_ensure                                                                        = undef,
+  $mod_path                                                                                  = undef,
+  $passenger_allow_encoded_slashes                                                           = undef,
+  $passenger_app_env                                                                         = undef,
+  $passenger_app_group_name                                                                  = undef,
+  $passenger_app_root                                                                        = undef,
+  $passenger_app_type                                                                        = undef,
+  $passenger_base_uri                                                                        = undef,
+  $passenger_buffer_response                                                                 = undef,
+  $passenger_buffer_upload                                                                   = undef,
+  $passenger_concurrency_model                                                               = undef,
+  $passenger_conf_file                                                                       = $::apache::params::passenger_conf_file,
+  $passenger_conf_package_file                                                               = $::apache::params::passenger_conf_package_file,
+  $passenger_data_buffer_dir                                                                 = undef,
+  $passenger_debug_log_file                                                                  = undef,
+  $passenger_debugger                                                                        = undef,
+  $passenger_default_group                                                                   = undef,
+  $passenger_default_ruby                                                                    = $::apache::params::passenger_default_ruby,
+  $passenger_default_user                                                                    = undef,
+  $passenger_disable_security_update_check                                                   = undef,
+  $passenger_enabled                                                                         = undef,
+  $passenger_error_override                                                                  = undef,
+  $passenger_file_descriptor_log_file                                                        = undef,
+  $passenger_fly_with                                                                        = undef,
+  $passenger_force_max_concurrent_requests_per_process                                       = undef,
+  $passenger_friendly_error_pages                                                            = undef,
+  $passenger_group                                                                           = undef,
+  $passenger_high_performance                                                                = undef,
+  $passenger_installed_version                                                               = undef,
+  $passenger_instance_registry_dir                                                           = undef,
+  $passenger_load_shell_envvars                                                              = undef,
+  Optional[Stdlib::Absolutepath] $passenger_log_file                                         = undef,
+  $passenger_log_level                                                                       = undef,
+  $passenger_lve_min_uid                                                                     = undef,
+  $passenger_max_instances                                                                   = undef,
+  $passenger_max_instances_per_app                                                           = undef,
+  $passenger_max_pool_size                                                                   = undef,
+  $passenger_max_preloader_idle_time                                                         = undef,
+  $passenger_max_request_queue_size                                                          = undef,
+  $passenger_max_request_time                                                                = undef,
+  $passenger_max_requests                                                                    = undef,
+  $passenger_memory_limit                                                                    = undef,
+  $passenger_meteor_app_settings                                                             = undef,
+  $passenger_min_instances                                                                   = undef,
+  $passenger_nodejs                                                                          = undef,
+  $passenger_pool_idle_time                                                                  = undef,
+  $passenger_pre_start                                                                       = undef,
+  $passenger_python                                                                          = undef,
+  $passenger_resist_deployment_errors                                                        = undef,
+  $passenger_resolve_symlinks_in_document_root                                               = undef,
+  $passenger_response_buffer_high_watermark                                                  = undef,
+  $passenger_restart_dir                                                                     = undef,
+  $passenger_rolling_restarts                                                                = undef,
+  $passenger_root                                                                            = $::apache::params::passenger_root,
+  $passenger_ruby                                                                            = $::apache::params::passenger_ruby,
+  $passenger_security_update_check_proxy                                                     = undef,
+  $passenger_show_version_in_header                                                          = undef,
+  $passenger_socket_backlog                                                                  = undef,
+  Optional[Enum['smart', 'direct', 'smart-lv2', 'conservative']] $passenger_spawn_method     = undef,
+  $passenger_start_timeout                                                                   = undef,
+  $passenger_startup_file                                                                    = undef,
+  $passenger_stat_throttle_rate                                                              = undef,
+  $passenger_sticky_sessions                                                                 = undef,
+  $passenger_sticky_sessions_cookie_name                                                     = undef,
+  $passenger_thread_count                                                                    = undef,
+  $passenger_use_global_queue                                                                = undef,
+  $passenger_user                                                                            = undef,
+  $passenger_user_switching                                                                  = undef,
+  $rack_auto_detect                                                                          = undef,
+  $rack_autodetect                                                                           = undef,
+  $rack_base_uri                                                                             = undef,
+  $rack_env                                                                                  = undef,
+  $rails_allow_mod_rewrite                                                                   = undef,
+  $rails_app_spawner_idle_time                                                               = undef,
+  $rails_auto_detect                                                                         = undef,
+  $rails_autodetect                                                                          = undef,
+  $rails_base_uri                                                                            = undef,
+  $rails_default_user                                                                        = undef,
+  $rails_env                                                                                 = undef,
+  $rails_framework_spawner_idle_time                                                         = undef,
+  $rails_ruby                                                                                = undef,
+  $rails_spawn_method                                                                        = undef,
+  $rails_user_switching                                                                      = undef,
+  $wsgi_auto_detect                                                                          = undef,
 ) inherits ::apache::params {
-
   include ::apache
-
+  if $passenger_installed_version {
+    if $passenger_allow_encoded_slashes {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_allow_encoded_slashes is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_app_env {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_app_env is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_app_group_name {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_app_group_name is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_app_root {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_app_root is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_app_type {
+      if (versioncmp($passenger_installed_version, '4.0.25') < 0) {
+        fail("Passenger config option :: passenger_app_type is not introduced until version 4.0.25 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_base_uri {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_base_uri is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_buffer_response {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_buffer_response is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_buffer_upload {
+      if (versioncmp($passenger_installed_version, '4.0.26') < 0) {
+        fail("Passenger config option :: passenger_buffer_upload is not introduced until version 4.0.26 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_concurrency_model {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_concurrency_model is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_data_buffer_dir {
+      if (versioncmp($passenger_installed_version, '5.0.0') < 0) {
+        fail("Passenger config option :: passenger_data_buffer_dir is not introduced until version 5.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_debug_log_file {
+      if (versioncmp($passenger_installed_version, '5.0.5') > 0) {
+        warning('DEPRECATED PASSENGER OPTION :: passenger_debug_log_file :: This option has been renamed in version 5.0.5 to PassengerLogFile.')
+      }
+    }
+    if $passenger_debugger {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_debugger is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_default_group {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_default_group is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_default_ruby {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_default_ruby is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_default_user {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_default_user is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_disable_security_update_check {
+      if (versioncmp($passenger_installed_version, '5.1.0') < 0) {
+        fail("Passenger config option :: passenger_disable_security_update_check is not introduced until version 5.1.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_enabled {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_enabled is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_error_override {
+      if (versioncmp($passenger_installed_version, '4.0.24') < 0) {
+        fail("Passenger config option :: passenger_error_override is not introduced until version 4.0.24 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_file_descriptor_log_file {
+      if (versioncmp($passenger_installed_version, '5.0.5') < 0) {
+        fail("Passenger config option :: passenger_file_descriptor_log_file is not introduced until version 5.0.5 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_fly_with {
+      if (versioncmp($passenger_installed_version, '4.0.45') < 0) {
+        fail("Passenger config option :: passenger_fly_with is not introduced until version 4.0.45 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_force_max_concurrent_requests_per_process {
+      if (versioncmp($passenger_installed_version, '5.0.22') < 0) {
+        fail("Passenger config option :: passenger_force_max_concurrent_requests_per_process is not introduced until version 5.0.22 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_friendly_error_pages {
+      if (versioncmp($passenger_installed_version, '4.0.42') < 0) {
+        fail("Passenger config option :: passenger_friendly_error_pages is not introduced until version 4.0.42 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_group {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_group is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_high_performance {
+      if (versioncmp($passenger_installed_version, '2.0.0') < 0) {
+        fail("Passenger config option :: passenger_high_performance is not introduced until version 2.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_instance_registry_dir {
+      if (versioncmp($passenger_installed_version, '5.0.0') < 0) {
+        fail("Passenger config option :: passenger_instance_registry_dir is not introduced until version 5.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_load_shell_envvars {
+      if (versioncmp($passenger_installed_version, '4.0.20') < 0) {
+        fail("Passenger config option :: passenger_load_shell_envvars is not introduced until version 4.0.20 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_log_file {
+      if (versioncmp($passenger_installed_version, '5.0.5') < 0) {
+        fail("Passenger config option :: passenger_log_file is not introduced until version 5.0.5 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_log_level {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_log_level is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_lve_min_uid {
+      if (versioncmp($passenger_installed_version, '5.0.28') < 0) {
+        fail("Passenger config option :: passenger_lve_min_uid is not introduced until version 5.0.28 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_max_instances {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_max_instances is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_max_instances_per_app {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_max_instances_per_app is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_max_pool_size {
+      if (versioncmp($passenger_installed_version, '1.0.0') < 0) {
+        fail("Passenger config option :: passenger_max_pool_size is not introduced until version 1.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_max_preloader_idle_time {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_max_preloader_idle_time is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_max_request_queue_size {
+      if (versioncmp($passenger_installed_version, '4.0.15') < 0) {
+        fail("Passenger config option :: passenger_max_request_queue_size is not introduced until version 4.0.15 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_max_request_time {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_max_request_time is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_max_requests {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_max_requests is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_memory_limit {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_memory_limit is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_meteor_app_settings {
+      if (versioncmp($passenger_installed_version, '5.0.7') < 0) {
+        fail("Passenger config option :: passenger_meteor_app_settings is not introduced until version 5.0.7 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_min_instances {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_min_instances is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_nodejs {
+      if (versioncmp($passenger_installed_version, '4.0.24') < 0) {
+        fail("Passenger config option :: passenger_nodejs is not introduced until version 4.0.24 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_pool_idle_time {
+      if (versioncmp($passenger_installed_version, '1.0.0') < 0) {
+        fail("Passenger config option :: passenger_pool_idle_time is not introduced until version 1.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_pre_start {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_pre_start is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_python {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_python is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_resist_deployment_errors {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_resist_deployment_errors is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_resolve_symlinks_in_document_root {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_resolve_symlinks_in_document_root is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_response_buffer_high_watermark {
+      if (versioncmp($passenger_installed_version, '5.0.0') < 0) {
+        fail("Passenger config option :: passenger_response_buffer_high_watermark is not introduced until version 5.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_restart_dir {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_restart_dir is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_rolling_restarts {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_rolling_restarts is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_root {
+      if (versioncmp($passenger_installed_version, '1.0.0') < 0) {
+        fail("Passenger config option :: passenger_root is not introduced until version 1.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_ruby {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_ruby is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_security_update_check_proxy {
+      if (versioncmp($passenger_installed_version, '5.1.0') < 0) {
+        fail("Passenger config option :: passenger_security_update_check_proxy is not introduced until version 5.1.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_show_version_in_header {
+      if (versioncmp($passenger_installed_version, '5.1.0') < 0) {
+        fail("Passenger config option :: passenger_show_version_in_header is not introduced until version 5.1.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_socket_backlog {
+      if (versioncmp($passenger_installed_version, '5.0.24') < 0) {
+        fail("Passenger config option :: passenger_socket_backlog is not introduced until version 5.0.24 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_spawn_method {
+      if (versioncmp($passenger_installed_version, '2.0.0') < 0) {
+        fail("Passenger config option :: passenger_spawn_method is not introduced until version 2.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_start_timeout {
+      if (versioncmp($passenger_installed_version, '4.0.15') < 0) {
+        fail("Passenger config option :: passenger_start_timeout is not introduced until version 4.0.15 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_startup_file {
+      if (versioncmp($passenger_installed_version, '4.0.25') < 0) {
+        fail("Passenger config option :: passenger_startup_file is not introduced until version 4.0.25 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_stat_throttle_rate {
+      if (versioncmp($passenger_installed_version, '2.2.0') < 0) {
+        fail("Passenger config option :: passenger_stat_throttle_rate is not introduced until version 2.2.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_sticky_sessions {
+      if (versioncmp($passenger_installed_version, '4.0.45') < 0) {
+        fail("Passenger config option :: passenger_sticky_sessions is not introduced until version 4.0.45 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_sticky_sessions_cookie_name {
+      if (versioncmp($passenger_installed_version, '4.0.45') < 0) {
+        fail("Passenger config option :: passenger_sticky_sessions_cookie_name is not introduced until version 4.0.45 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_thread_count {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_thread_count is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_use_global_queue {
+      if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
+        fail('REMOVED PASSENGER OPTION :: passenger_use_global_queue :: -- no message on the current passenger reference webpage -- ')
+      }
+      if (versioncmp($passenger_installed_version, '2.0.4') < 0) {
+        fail('Passenger config option :: passenger_use_global_queue is not introduced until version 2.0.4 :: ${passenger_installed_version} is the version reported')
+      }
+    }
+    if $passenger_user {
+      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
+        fail("Passenger config option :: passenger_user is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_user_switching {
+      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
+        fail("Passenger config option :: passenger_user_switching is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if ($rack_auto_detect or $rack_autodetect) {
+      if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
+        fail('REMOVED PASSENGER OPTION :: rack_auto_detect ::  These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.')
+      }
+    }
+    if $rack_base_uri {
+      if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
+        warning('DEPRECATED PASSENGER OPTION :: rack_base_uri :: Deprecated in 3.0.0 in favor of PassengerBaseURI.')
+      }
+    }
+    if $rack_env {
+      if (versioncmp($passenger_installed_version, '2.0.0') < 0) {
+        fail("Passenger config option :: rack_env is not introduced until version 2.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $rails_allow_mod_rewrite {
+      if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
+        warning("DEPRECATED PASSENGER OPTION :: rails_allow_mod_rewrite :: This option doesn't do anything anymore in since version 4.0.0.")
+      }
+    }
+    if $rails_app_spawner_idle_time {
+      if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
+        fail('REMOVED PASSENGER OPTION :: rails_app_spawner_idle_time ::  This option has been removed in version 4.0.0, and replaced with PassengerMaxPreloaderIdleTime.')
+      }
+    }
+    if ($rails_auto_detect or $rails_autodetect) {
+      if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
+        fail('REMOVED PASSENGER OPTION :: rails_auto_detect ::  These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.')
+      }
+    }
+    if $rails_base_uri {
+      if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
+        warning('DEPRECATED PASSENGER OPTION :: rails_base_uri :: Deprecated in 3.0.0 in favor of PassengerBaseURI.')
+      }
+    }
+    if $rails_default_user {
+      if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
+        warning('DEPRECATED PASSENGER OPTION :: rails_default_user :: Deprecated in 3.0.0 in favor of PassengerDefaultUser.')
+      }
+    }
+    if $rails_env {
+      if (versioncmp($passenger_installed_version, '2.0.0') < 0) {
+        fail("Passenger config option :: rails_env is not introduced until version 2.0.0 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $rails_framework_spawner_idle_time {
+      if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
+        fail('REMOVED PASSENGER OPTION :: rails_framework_spawner_idle_time ::  This option is no longer available in version 4.0.0. There is no alternative because framework spawning has been removed altogether. You should use smart spawning instead.')
+      }
+    }
+    if $rails_ruby {
+      if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
+        warning('DEPRECATED PASSENGER OPTION :: rails_ruby :: Deprecated in 3.0.0 in favor of PassengerRuby.')
+      }
+    }
+    if $rails_spawn_method {
+      if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
+        warning('DEPRECATED PASSENGER OPTION :: rails_spawn_method :: Deprecated in 3.0.0 in favor of PassengerSpawnMethod.')
+      }
+    }
+    if $rails_user_switching {
+      if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
+        warning('DEPRECATED PASSENGER OPTION :: rails_user_switching :: Deprecated in 3.0.0 in favor of PassengerUserSwitching.')
+      }
+    }
+    if $wsgi_auto_detect {
+      if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
+        fail('REMOVED PASSENGER OPTION :: wsgi_auto_detect ::  These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.')
+      }
+    }
+  }
   # Managed by the package, but declare it to avoid purging
   if $passenger_conf_package_file {
     file { 'passenger_package.conf':
@@ -87,23 +550,85 @@ class apache::mod::passenger (
   }
 
   # Template uses:
-  # - $passenger_root
-  # - $passenger_ruby
-  # - $passenger_default_ruby
-  # - $passenger_max_pool_size
-  # - $passenger_min_instances
-  # - $passenger_max_instances_per_app
-  # - $passenger_high_performance
-  # - $passenger_max_requests
-  # - $passenger_spawn_method
-  # - $passenger_stat_throttle_rate
-  # - $passenger_use_global_queue
-  # - $passenger_log_file
-  # - $passenger_log_level
-  # - $passenger_app_env
-  # - $passenger_data_buffer_dir
-  # - $rack_autodetect
-  # - $rails_autodetect
+  # - $passenger_allow_encoded_slashes : since 4.0.0.
+  # - $passenger_app_env : since 4.0.0.
+  # - $passenger_app_group_name : since 4.0.0.
+  # - $passenger_app_root : since 4.0.0.
+  # - $passenger_app_type : since 4.0.25.
+  # - $passenger_base_uri : since 4.0.0.
+  # - $passenger_buffer_response : since 4.0.0.
+  # - $passenger_buffer_upload : since 4.0.26.
+  # - $passenger_concurrency_model : since 4.0.0.
+  # - $passenger_data_buffer_dir : since 5.0.0.
+  # - $passenger_debug_log_file : since unkown. Deprecated in 5.0.5.
+  # - $passenger_debugger : since 3.0.0.
+  # - $passenger_default_group : since 3.0.0.
+  # - $passenger_default_ruby : since 4.0.0.
+  # - $passenger_default_user : since 3.0.0.
+  # - $passenger_disable_security_update_check : since 5.1.0.
+  # - $passenger_enabled : since 4.0.0.
+  # - $passenger_error_override : since 4.0.24.
+  # - $passenger_file_descriptor_log_file : since 5.0.5.
+  # - $passenger_fly_with : since 4.0.45.
+  # - $passenger_force_max_concurrent_requests_per_process : since 5.0.22.
+  # - $passenger_friendly_error_pages : since 4.0.42.
+  # - $passenger_group : since 4.0.0.
+  # - $passenger_high_performance : since 2.0.0.
+  # - $passenger_instance_registry_dir : since 5.0.0.
+  # - $passenger_load_shell_envvars : since 4.0.20.
+  # - $passenger_log_file : since 5.0.5.
+  # - $passenger_log_level : since 3.0.0.
+  # - $passenger_lve_min_uid : since 5.0.28.
+  # - $passenger_max_instances : since 3.0.0.
+  # - $passenger_max_instances_per_app : since 3.0.0.
+  # - $passenger_max_pool_size : since 1.0.0.
+  # - $passenger_max_preloader_idle_time : since 4.0.0.
+  # - $passenger_max_request_queue_size : since 4.0.15.
+  # - $passenger_max_request_time : since 3.0.0.
+  # - $passenger_max_requests : since 3.0.0.
+  # - $passenger_memory_limit : since 3.0.0.
+  # - $passenger_meteor_app_settings : since 5.0.7.
+  # - $passenger_min_instances : since 3.0.0.
+  # - $passenger_nodejs : since 4.0.24.
+  # - $passenger_pool_idle_time : since 1.0.0.
+  # - $passenger_pre_start : since 3.0.0.
+  # - $passenger_python : since 4.0.0.
+  # - $passenger_resist_deployment_errors : since 3.0.0.
+  # - $passenger_resolve_symlinks_in_document_root : since 3.0.0.
+  # - $passenger_response_buffer_high_watermark : since 5.0.0.
+  # - $passenger_restart_dir : since 3.0.0.
+  # - $passenger_rolling_restarts : since 3.0.0.
+  # - $passenger_root : since 1.0.0.
+  # - $passenger_ruby : since 4.0.0.
+  # - $passenger_security_update_check_proxy : since 5.1.0.
+  # - $passenger_show_version_in_header : since 5.1.0.
+  # - $passenger_socket_backlog : since 5.0.24.
+  # - $passenger_spawn_method : since 2.0.0.
+  # - $passenger_start_timeout : since 4.0.15.
+  # - $passenger_startup_file : since 4.0.25.
+  # - $passenger_stat_throttle_rate : since 2.2.0.
+  # - $passenger_sticky_sessions : since 4.0.45.
+  # - $passenger_sticky_sessions_cookie_name : since 4.0.45.
+  # - $passenger_thread_count : since 4.0.0.
+  # - $passenger_use_global_queue : since 2.0.4.Deprecated in 4.0.0.
+  # - $passenger_user : since 4.0.0.
+  # - $passenger_user_switching : since 3.0.0.
+  # - $rack_auto_detect : since unkown. Deprecated in 4.0.0.
+  # - $rack_base_uri : since unkown. Deprecated in 3.0.0.
+  # - $rack_env : since 2.0.0.
+  # - $rails_allow_mod_rewrite : since unkown. Deprecated in 4.0.0.
+  # - $rails_app_spawner_idle_time : since unkown. Deprecated in 4.0.0.
+  # - $rails_auto_detect : since unkown. Deprecated in 4.0.0.
+  # - $rails_base_uri : since unkown. Deprecated in 3.0.0.
+  # - $rails_default_user : since unkown. Deprecated in 3.0.0.
+  # - $rails_env : since 2.0.0.
+  # - $rails_framework_spawner_idle_time : since unkown. Deprecated in 4.0.0.
+  # - $rails_ruby : since unkown. Deprecated in 3.0.0.
+  # - $rails_spawn_method : since unkown. Deprecated in 3.0.0.
+  # - $rails_user_switching : since unkown. Deprecated in 3.0.0.
+  # - $wsgi_auto_detect : since unkown. Deprecated in 4.0.0.
+  # - $rails_autodetect : this options is only for backward compatiblity with older versions of this class
+  # - $rack_autodetect : this options is only for backward compatiblity with older versions of this class
   file { 'passenger.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/${passenger_conf_file}",

--- a/manifests/mod/prefork.pp
+++ b/manifests/mod/prefork.pp
@@ -8,6 +8,7 @@ class apache::mod::prefork (
   $maxrequestsperchild    = '4000',
   $maxconnectionsperchild = undef,
   $apache_version         = undef,
+  $listenbacklog          = '511'
 ) {
   include ::apache
   $_apache_version = pick($apache_version, $apache::apache_version)

--- a/manifests/mod/prefork.pp
+++ b/manifests/mod/prefork.pp
@@ -1,11 +1,13 @@
 class apache::mod::prefork (
-  $startservers        = '8',
-  $minspareservers     = '5',
-  $maxspareservers     = '20',
-  $serverlimit         = '256',
-  $maxclients          = '256',
-  $maxrequestsperchild = '4000',
-  $apache_version      = undef,
+  $startservers           = '8',
+  $minspareservers        = '5',
+  $maxspareservers        = '20',
+  $serverlimit            = '256',
+  $maxclients             = '256',
+  $maxrequestworkers      = undef,
+  $maxrequestsperchild    = '4000',
+  $maxconnectionsperchild = undef,
+  $apache_version         = undef,
 ) {
   include ::apache
   $_apache_version = pick($apache_version, $apache::apache_version)
@@ -23,6 +25,15 @@ class apache::mod::prefork (
   if defined(Class['apache::mod::worker']) {
     fail('May not include both apache::mod::prefork and apache::mod::worker on the same node')
   }
+
+  if versioncmp($_apache_version, '2.3.13') < 0 {
+    if $maxrequestworkers == undef {
+      warning("For newer versions of Apache, \$maxclients is deprecated, please use \$maxrequestworkers.")
+    } elsif $maxconnectionsperchild == undef {
+      warning("For newer versions of Apache, \$maxrequestsperchild is deprecated, please use \$maxconnectionsperchild.")
+    }
+  }
+
   File {
     owner => 'root',
     group => $::apache::params::root_group,
@@ -35,7 +46,9 @@ class apache::mod::prefork (
   # - $maxspareservers
   # - $serverlimit
   # - $maxclients
+  # - $maxrequestworkers
   # - $maxrequestsperchild
+  # - $maxconnectionsperchild
   file { "${::apache::mod_dir}/prefork.conf":
     ensure  => file,
     content => template('apache/mod/prefork.conf.erb'),

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -106,7 +106,11 @@ class apache::params inherits ::apache::version {
         default => 'mod_authz_ldap',
       },
       'authnz_pam'            => 'mod_authnz_pam',
-      'fastcgi'               => 'mod_fastcgi',
+      'fastcgi'               => $::apache::version::distrelease ? {
+        '5'     => 'mod_fastcgi',
+        '6'     => 'mod_fastcgi',
+        default => undef,
+      },
       'fcgid'                 => 'mod_fcgid',
       'geoip'                 => 'mod_geoip',
       'intercept_form_submit' => 'mod_intercept_form_submit',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -49,6 +49,9 @@ class apache::params inherits ::apache::version {
 
   $modsec_audit_log_parts = 'ABIJDEFHZ'
 
+  # no client certs should be trusted for auth by default.
+  $ssl_certs_dir          = undef
+
   if ($::operatingsystem == 'Ubuntu' and $::lsbdistrelease == '10.04') or ($::operatingsystem == 'SLES') {
     $verify_command = '/usr/sbin/apache2ctl -t'
   } elsif $::operatingsystem == 'FreeBSD' {
@@ -83,7 +86,6 @@ class apache::params inherits ::apache::version {
     $dev_packages         = 'httpd-devel'
     $default_ssl_cert     = '/etc/pki/tls/certs/localhost.crt'
     $default_ssl_key      = '/etc/pki/tls/private/localhost.key'
-    $ssl_certs_dir        = '/etc/pki/tls/certs'
     $ssl_sessioncache     = '/var/cache/mod_ssl/scache(512000)'
     $passenger_conf_file  = 'passenger_extra.conf'
     $passenger_conf_package_file = 'passenger.conf'
@@ -223,7 +225,6 @@ class apache::params inherits ::apache::version {
     $mpm_module          = 'worker'
     $default_ssl_cert    = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
     $default_ssl_key     = '/etc/ssl/private/ssl-cert-snakeoil.key'
-    $ssl_certs_dir       = '/etc/ssl/certs'
     $ssl_sessioncache    = "\${APACHE_RUN_DIR}/ssl_scache(512000)"
     $suphp_addhandler    = 'x-httpd-php'
     $suphp_engine        = 'off'
@@ -389,7 +390,6 @@ class apache::params inherits ::apache::version {
     $dev_packages     = undef
     $default_ssl_cert = '/usr/local/etc/apache24/server.crt'
     $default_ssl_key  = '/usr/local/etc/apache24/server.key'
-    $ssl_certs_dir    = undef
     $ssl_sessioncache  = '/var/run/ssl_scache(512000)'
     $passenger_conf_file = 'passenger.conf'
     $passenger_conf_package_file = undef
@@ -459,7 +459,6 @@ class apache::params inherits ::apache::version {
     $dev_packages     = undef
     $default_ssl_cert = '/etc/ssl/apache2/server.crt'
     $default_ssl_key  = '/etc/ssl/apache2/server.key'
-    $ssl_certs_dir    = '/etc/ssl/apache2'
     $ssl_sessioncache  = '/var/run/ssl_scache(512000)'
     $passenger_root   = '/usr'
     $passenger_ruby   = '/usr/bin/ruby'
@@ -528,7 +527,6 @@ class apache::params inherits ::apache::version {
     $mpm_module          = 'prefork'
     $default_ssl_cert    = '/etc/apache2/ssl.crt/server.crt'
     $default_ssl_key     = '/etc/apache2/ssl.key/server.key'
-    $ssl_certs_dir       = '/etc/ssl/certs'
     $ssl_sessioncache    = '/var/lib/apache2/ssl_scache(512000)'
     $suphp_addhandler    = 'x-httpd-php'
     $suphp_engine        = 'off'

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -134,6 +134,7 @@ define apache::vhost(
   $apache_version                                                                   = $::apache::apache_version,
   Optional[Enum['on', 'off', 'nodecode']] $allow_encoded_slashes                    = undef,
   Optional[Pattern[/^[\w-]+ [\w-]+$/]] $suexec_user_group                           = undef,
+  $passenger_spawn_method                                                           = undef,
   $passenger_app_root                                                               = undef,
   $passenger_app_env                                                                = undef,
   $passenger_ruby                                                                   = undef,
@@ -232,7 +233,7 @@ define apache::vhost(
     include ::apache::mod::suexec
   }
 
-  if $passenger_app_root or $passenger_app_env or $passenger_ruby or $passenger_min_instances or $passenger_max_requests or $passenger_start_timeout or $passenger_pre_start or $passenger_user or $passenger_high_performance or $passenger_nodejs or $passenger_sticky_sessions or $passenger_startup_file {
+  if $passenger_spawn_method or $passenger_app_root or $passenger_app_env or $passenger_ruby or $passenger_min_instances or $passenger_max_requests or $passenger_start_timeout or $passenger_pre_start or $passenger_user or $passenger_high_performance or $passenger_nodejs or $passenger_sticky_sessions or $passenger_startup_file {
     include ::apache::mod::passenger
   }
 
@@ -968,6 +969,7 @@ define apache::vhost(
   }
 
   # Template uses:
+  # - $passenger_spawn_method
   # - $passenger_app_root
   # - $passenger_app_env
   # - $passenger_ruby
@@ -979,7 +981,7 @@ define apache::vhost(
   # - $passenger_nodejs
   # - $passenger_sticky_sessions
   # - $passenger_startup_file
-  if $passenger_app_root or $passenger_app_env or $passenger_ruby or $passenger_min_instances or $passenger_start_timeout or $passenger_pre_start or $passenger_user or $passenger_nodejs or $passenger_sticky_sessions or $passenger_startup_file{
+  if $passenger_spawn_method or $passenger_app_root or $passenger_app_env or $passenger_ruby or $passenger_min_instances or $passenger_start_timeout or $passenger_pre_start or $passenger_user or $passenger_nodejs or $passenger_sticky_sessions or $passenger_startup_file{
     concat::fragment { "${name}-passenger":
       target  => "${priority_real}${filename}.conf",
       order   => 300,

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -61,7 +61,7 @@ define apache::vhost(
   $access_log_env_var                                                               = false,
   Optional[Array] $access_logs                                                      = undef,
   $aliases                                                                          = undef,
-  Optional[Variant[Hash, Array[Hash]]] $directories                                 = undef,
+  Optional[Variant[Hash, Array[Variant[Array,Hash]]]] $directories                  = undef,
   Boolean $error_log                                                                = true,
   $error_log_file                                                                   = undef,
   $error_log_pipe                                                                   = undef,

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -394,7 +394,10 @@ define apache::vhost(
   }
 
   # Load mod_alias if needed and not yet loaded
-  if ($scriptalias or $scriptaliases != []) or ($aliases and $aliases != []) or ($redirect_source and $redirect_dest) {
+  if ($scriptalias or $scriptaliases != [])
+    or ($aliases and $aliases != [])
+    or ($redirect_source and $redirect_dest)
+    or ($redirectmatch_regexp or $redirectmatch_status or $redirectmatch_dest){
     if ! defined(Class['apache::mod::alias'])  and ($ensure == 'present') {
       include ::apache::mod::alias
     }

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -225,7 +225,7 @@ define apache::vhost(
     include ::apache::mod::vhost_alias
   }
 
-  if $wsgi_daemon_process {
+  if $wsgi_application_group or $wsgi_daemon_process or ($wsgi_import_script and $wsgi_import_script_options) or $wsgi_process_group or ($wsgi_script_aliases and ! empty($wsgi_script_aliases)) or $wsgi_pass_authorization {
     include ::apache::mod::wsgi
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-apache",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "author": "puppet",
   "summary": "Installs, configures, and manages Apache virtual hosts, web services, and modules.",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -62,8 +62,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "10.04",
-        "12.04",
         "14.04",
         "16.04"
       ]

--- a/metadata.json
+++ b/metadata.json
@@ -47,7 +47,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-apache",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "puppet",
   "summary": "Installs, configures, and manages Apache virtual hosts, web services, and modules.",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-apache",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "author": "puppet",
   "summary": "Installs, configures, and manages Apache virtual hosts, web services, and modules.",
   "license": "Apache-2.0",

--- a/readmes/README_ja_JP.md
+++ b/readmes/README_ja_JP.md
@@ -1,0 +1,5389 @@
+# apache
+
+[モジュールの概要]: #module-description
+
+[セットアップ]: #setup
+[Apacheの使用を始める]: #beginning-with-apache
+
+[使用方法]: #usage
+[バーチャルホストの設定]: #configuring-virtual-hosts
+[SSLを使ったバーチャルホストの設定]: #configuring-virtual-hosts-with-ssl
+[バーチャルホストのポートおよびアドレスのバインディング設定]: #configuring-virtual-host-port-and-address-bindings
+[アプリおよびプロセッサのバーチャルホストの設定]: #configuring-virtual-hosts-for-apps-and-processors
+[IPベースのバーチャルホストの設定]: #configuring-ip-based-virtual-hosts
+[Apacheモジュールのインストール]: #installing-apache-modules
+[任意モジュールのインストール]: #installing-arbitrary-modules
+[固有モジュールのインストール]: #installing-specific-modules
+[FastCGIサーバの設定]: #configuring-fastcgi-servers-to-handle-php-files
+[ロードバランシングの例]: #load-balancing-examples
+[apacheの影響]: #what-the-apache-module-affects
+
+[リファレンス]: #reference
+[パブリッククラス]: #public-classes
+[プライベートクラス]: #private-classes
+[パブリック定義タイプ]: #public-defined-types
+[プライベート定義タイプ]: #private-defined-types
+[テンプレート]: #templates
+
+[制約事項]: #limitations
+
+[開発]: #development
+[貢献]: #contributing
+[テスト]: #testing
+
+[`AddDefaultCharset`]: https://httpd.apache.org/docs/current/mod/core.html#adddefaultcharset
+[`add_listen`]: #add_listen
+[`Alias`]: https://httpd.apache.org/docs/current/mod/mod_alias.html#alias
+[`AliasMatch`]: https://httpd.apache.org/docs/current/mod/mod_alias.html#aliasmatch
+[エイリアスサーバ]: https://httpd.apache.org/docs/current/urlmapping.html
+[`AllowEncodedSlashes`]: https://httpd.apache.org/docs/current/mod/core.html#allowencodedslashes
+[`apache`]: #class-apache
+[`apache_version`]: #apache_version
+[`apache::balancer`]: #defined-type-apachebalancer
+[`apache::balancermember`]: #defined-type-apachebalancermember
+[`apache::fastcgi::server`]: #defined-type-apachefastcgiserver
+[`apache::mod`]: #defined-type-apachemod
+[`apache::mod::<MODULE NAME>`]: #classes-apachemodmodule-name
+[`apache::mod::alias`]: #class-apachemodalias
+[`apache::mod::auth_cas`]: #class-apachemodauth_cas
+[`apache::mod::auth_mellon`]: #class-apachemodauth_mellon
+[`apache::mod::authn_dbd`]: #class-apachemodauthn_dbd
+[`apache::mod::authnz_ldap`]: #class-apachemodauthnz_ldap
+[`apache::mod::cluster`]: #class-apachemodcluster
+[`apache::mod::disk_cache`]: #class-apachemoddisk_cache
+[`apache::mod::dumpio`]: #class-apachemoddumpio
+[`apache::mod::event`]: #class-apachemodevent
+[`apache::mod::ext_filter`]: #class-apachemodext_filter
+[`apache::mod::geoip`]: #class-apachemodgeoip
+[`apache::mod::itk`]: #class-apachemoditk
+[`apache::mod::jk`]: #class-apachemodjk
+[`apache::mod::ldap`]: #class-apachemodldap
+[`apache::mod::passenger`]: #class-apachemodpassenger
+[`apache::mod::peruser`]: #class-apachemodperuser
+[`apache::mod::prefork`]: #class-apachemodprefork
+[`apache::mod::proxy`]: #class-apachemodproxy
+[`apache::mod::proxy_balancer`]: #class-apachemodproxybalancer
+[`apache::mod::proxy_fcgi`]: #class-apachemodproxy_fcgi
+[`apache::mod::proxy_html`]: #class-apachemodproxy_html
+[`apache::mod::security`]: #class-apachemodsecurity
+[`apache::mod::shib`]: #class-apachemodshib
+[`apache::mod::ssl`]: #class-apachemodssl
+[`apache::mod::status`]: #class-apachemodstatus
+[`apache::mod::userdir`]: #class-apachemoduserdir
+[`apache::mod::worker`]: #class-apachemodworker
+[`apache::mod::wsgi`]: #class-apachemodwsgi
+[`apache::params`]: #class-apacheparams
+[`apache::version`]: #class-apacheversion
+[`apache::vhost`]: #defined-type-apachevhost
+[`apache::vhost::custom`]: #defined-type-apachevhostcustom
+[`apache::vhost::WSGIImportScript`]: #wsgiimportscript
+[Apache HTTPサーバ]: https://httpd.apache.org
+[Apacheモジュール]: https://httpd.apache.org/docs/current/mod/
+[配列]: https://docs.puppet.com/puppet/latest/reference/lang_data_array.html
+
+[オーディットログ]: https://github.com/SpiderLabs/ModSecurity/wiki/ModSecurity-2-Data-Formats#audit-log
+
+[beaker-rspec]: https://github.com/puppetlabs/beaker-rspec
+
+[証明書失効リスト]: https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcarevocationfile
+[証明書失効リストパス]: https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcarevocationpath
+[コモンゲートウェイインターフェース]: https://httpd.apache.org/docs/current/howto/cgi.html
+[`confd_dir`]: #confd_dir
+[`content`]: #content
+[カスタムエラードキュメント]: https://httpd.apache.org/docs/current/custom-error.html
+[`custom_fragment`]: #custom_fragment
+
+[`default_mods`]: #default_mods
+[`default_ssl_crl`]: #default_ssl_crl
+[`default_ssl_crl_path`]: #default_ssl_crl_path
+[`default_ssl_vhost`]: #default_ssl_vhost
+[`dev_packages`]: #dev_packages
+[`directory`]: #directory
+[`directories`]: #parameter-directories-for-apachevhost
+[`DirectoryIndex`]: https://httpd.apache.org/docs/current/mod/mod_dir.html#directoryindex
+[`docroot`]: #docroot
+[`docroot_owner`]: #docroot_owner
+[`docroot_group`]: #docroot_group
+[`DocumentRoot`]: https://httpd.apache.org/docs/current/mod/core.html#documentroot
+
+[`EnableSendfile`]: https://httpd.apache.org/docs/current/mod/core.html#enablesendfile
+[適用モード]: http://selinuxproject.org/page/Guide/Mode
+[`ensure`]: https://docs.puppet.com/latest/type.html#package-attribute-ensure
+[`error_log_file`]: #error_log_file
+[`error_log_syslog`]: #error_log_syslog
+[`error_log_pipe`]: #error_log_pipe
+[`ExpiresByType`]: https://httpd.apache.org/docs/current/mod/mod_expires.html#expiresbytype
+[エクスポートリソース]: http://docs.puppet.com/latest/reference/lang_exported.md
+[`ExtendedStatus`]: https://httpd.apache.org/docs/current/mod/core.html#extendedstatus
+
+[Facter]: http://docs.puppet.com/facter/
+[FastCGI]: http://www.fastcgi.com/
+[FallbackResource]: https://httpd.apache.org/docs/current/mod/mod_dir.html#fallbackresource
+[`fallbackresource`]: #fallbackresource
+[`FileETag`]: https://httpd.apache.org/docs/current/mod/core.html#fileetag
+[フィルタルール]: https://httpd.apache.org/docs/current/filter.html
+[`filters`]: #filters
+[`ForceType`]: https://httpd.apache.org/docs/current/mod/core.html#forcetype
+
+[GeoIPScanProxyHeaders]: http://dev.maxmind.com/geoip/legacy/mod_geoip2/#Proxy-Related_Directives
+[`gentoo/puppet-portage`]: https://github.com/gentoo/puppet-portage
+
+[ハッシュ]: https://docs.puppet.com/puppet/latest/reference/lang_data_hash.html
+[`HttpProtocolOptions`]: http://httpd.apache.org/docs/current/mod/core.html#httpprotocoloptions
+
+[`IncludeOptional`]: https://httpd.apache.org/docs/current/mod/core.html#includeoptional
+[`Include`]: https://httpd.apache.org/docs/current/mod/core.html#include
+[インターバル構文]: https://httpd.apache.org/docs/current/mod/mod_expires.html#AltSyn
+[`ip`]: #ip
+[`ip_based`]: #ip_based
+[IPベースのバーチャルホスト]: https://httpd.apache.org/docs/current/vhosts/ip-based.html
+
+[`KeepAlive`]: https://httpd.apache.org/docs/current/mod/core.html#keepalive
+[`KeepAliveTimeout`]: https://httpd.apache.org/docs/current/mod/core.html#keepalivetimeout
+[`keepalive`パラメータ]: #keepalive
+[`keepalive_timeout`]: #keepalive_timeout
+[`limitreqfieldsize`]: https://httpd.apache.org/docs/current/mod/core.html#limitrequestfieldsize
+
+[`lib`]: #lib
+[`lib_path`]: #lib_path
+[`Listen`]: https://httpd.apache.org/docs/current/bind.html
+[`ListenBackLog`]: https://httpd.apache.org/docs/current/mod/mpm_common.html#listenbacklog
+[`LoadFile`]: https://httpd.apache.org/docs/current/mod/mod_so.html#loadfile
+[`LogFormat`]: https://httpd.apache.org/docs/current/mod/mod_log_config.html#logformat
+[`logroot`]: #logroot
+[ログセキュリティ]: https://httpd.apache.org/docs/current/logs.html#security
+
+[`manage_docroot`]: #manage_docroot
+[`manage_user`]: #manage_user
+[`manage_group`]: #manage_group
+[`supplementary_groups`]: #supplementary_groups
+[`MaxConnectionsPerChild`]: https://httpd.apache.org/docs/current/mod/mpm_common.html#maxconnectionsperchild
+[`max_keepalive_requests`]: #max_keepalive_requests
+[`MaxRequestWorkers`]: https://httpd.apache.org/docs/current/mod/mpm_common.html#maxrequestworkers
+[`MaxSpareThreads`]: https://httpd.apache.org/docs/current/mod/mpm_common.html#maxsparethreads
+[MIME `content-type`]: https://www.iana.org/assignments/media-types/media-types.xhtml
+[`MinSpareThreads`]: https://httpd.apache.org/docs/current/mod/mpm_common.html#minsparethreads
+[`mod_alias`]: https://httpd.apache.org/docs/current/mod/mod_alias.html
+[`mod_auth_cas`]: https://github.com/Jasig/mod_auth_cas
+[`mod_auth_kerb`]: http://modauthkerb.sourceforge.net/configure.html
+[`mod_authnz_external`]: https://github.com/phokz/mod-auth-external
+[`mod_auth_dbd`]: http://httpd.apache.org/docs/current/mod/mod_authn_dbd.html
+[`mod_auth_mellon`]: https://github.com/UNINETT/mod_auth_mellon
+[`mod_dbd`]: http://httpd.apache.org/docs/current/mod/mod_dbd.html
+[`mod_disk_cache`]: https://httpd.apache.org/docs/2.2/mod/mod_disk_cache.html
+[`mod_dumpio`]: https://httpd.apache.org/docs/2.4/mod/mod_dumpio.html
+[`mod_env`]: http://httpd.apache.org/docs/current/mod/mod_env.html
+[`mod_expires`]: https://httpd.apache.org/docs/current/mod/mod_expires.html
+[`mod_ext_filter`]: https://httpd.apache.org/docs/current/mod/mod_ext_filter.html
+[`mod_fcgid`]: https://httpd.apache.org/mod_fcgid/mod/mod_fcgid.html
+[`mod_geoip`]: http://dev.maxmind.com/geoip/legacy/mod_geoip2/
+[`mod_info`]: https://httpd.apache.org/docs/current/mod/mod_info.html
+[`mod_ldap`]: https://httpd.apache.org/docs/2.2/mod/mod_ldap.html
+[`mod_mpm_event`]: https://httpd.apache.org/docs/current/mod/event.html
+[`mod_negotiation`]: https://httpd.apache.org/docs/current/mod/mod_negotiation.html
+[`mod_pagespeed`]: https://developers.google.com/speed/pagespeed/module/?hl=en
+[`mod_passenger`]: https://www.phusionpassenger.com/library/config/apache/reference/
+[`mod_php`]: http://php.net/manual/en/book.apache.php
+[`mod_proxy`]: https://httpd.apache.org/docs/current/mod/mod_proxy.html
+[`mod_proxy_balancer`]: https://httpd.apache.org/docs/current/mod/mod_proxy_balancer.html
+[`mod_reqtimeout`]: https://httpd.apache.org/docs/current/mod/mod_reqtimeout.html
+[`mod_rewrite`]: https://httpd.apache.org/docs/current/mod/mod_rewrite.html
+[`mod_security`]: https://www.modsecurity.org/
+[`mod_ssl`]: https://httpd.apache.org/docs/current/mod/mod_ssl.html
+[`mod_status`]: https://httpd.apache.org/docs/current/mod/mod_status.html
+[`mod_version`]: https://httpd.apache.org/docs/current/mod/mod_version.html
+[`mod_wsgi`]: https://modwsgi.readthedocs.org/en/latest/
+[モジュール貢献ガイド]: https://docs.puppet.com/forge/contributing.html
+[`mpm_module`]: #mpm_module
+[マルチプロセッシングモジュール]: https://httpd.apache.org/docs/current/mpm.html
+
+[名前ベースのバーチャルホスト]: https://httpd.apache.org/docs/current/vhosts/name-based.html
+[`no_proxy_uris`]: #no_proxy_uris
+
+[オープンソース版Puppet]: https://docs.puppet.com/puppet/
+[`Options`]: https://httpd.apache.org/docs/current/mod/core.html#options
+
+[`path`]: #path
+[`Peruser`]: https://www.freebsd.org/cgi/url.cgi?ports/www/apache22-peruser-mpm/pkg-descr
+[`port`]: #port
+[`priority`]: #defined-types-apachevhost
+[`proxy_dest`]: #proxy_dest
+[`proxy_dest_match`]: #proxy_dest_match
+[`proxy_pass`]: #proxy_pass
+[`ProxyPass`]: https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypass
+[`ProxySet`]: https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxyset
+[Puppet Enterprise]: https://docs.puppet.com/pe/
+[Puppet Forge]: https://forge.puppet.com
+[Puppet]: https://puppet.com
+[Puppetモジュール]: https://docs.puppet.com/puppet/latest/reference/modules_fundamentals.html
+[Puppetモジュールのコード]: https://github.com/puppetlabs/puppetlabs-apache/blob/master/manifests/default_mods.pp
+[`purge_configs`]: #purge_configs
+[`purge_vhost_dir`]: #purge_vhost_dir
+[Python]: https://www.python.org/
+
+[Rack]: http://rack.github.io/
+[`rack_base_uris`]: #rack_base_uris
+[RFC 2616]: https://www.ietf.org/rfc/rfc2616.txt
+[`RequestReadTimeout`]: https://httpd.apache.org/docs/current/mod/mod_reqtimeout.html#requestreadtimeout
+[rspec-puppet]: http://rspec-puppet.com/
+
+[`ScriptAlias`]: https://httpd.apache.org/docs/current/mod/mod_alias.html#scriptalias
+[`ScriptAliasMatch`]: https://httpd.apache.org/docs/current/mod/mod_alias.html#scriptaliasmatch
+[`scriptalias`]: #scriptalias
+[SELinux]: http://selinuxproject.org/
+[`ServerAdmin`]: https://httpd.apache.org/docs/current/mod/core.html#serveradmin
+[`serveraliases`]: #serveraliases
+[`ServerLimit`]: https://httpd.apache.org/docs/current/mod/mpm_common.html#serverlimit
+[`ServerName`]: https://httpd.apache.org/docs/current/mod/core.html#servername
+[`ServerRoot`]: https://httpd.apache.org/docs/current/mod/core.html#serverroot
+[`ServerTokens`]: https://httpd.apache.org/docs/current/mod/core.html#servertokens
+[`ServerSignature`]: https://httpd.apache.org/docs/current/mod/core.html#serversignature
+[サービス属性リスタート]: http://docs.puppet.com/latest/type.html#service-attribute-restart
+[`source`]: #source
+[`SSLCARevocationCheck`]: https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcarevocationcheck
+[SSL証明書のキーファイル]: https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcertificatekeyfile
+[SSLチェーン]: https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcertificatechainfile
+[SSL暗号化]: https://httpd.apache.org/docs/current/ssl/index.html
+[`ssl`]: #ssl
+[`ssl_cert`]: #ssl_cert
+[`ssl_compression`]: #ssl_compression
+[`ssl_key`]: #ssl_key
+[`StartServers`]: https://httpd.apache.org/docs/current/mod/mpm_common.html#startservers
+[suPHP]: http://www.suphp.org/Home.html
+[`suphp_addhandler`]: #suphp_addhandler
+[`suphp_configpath`]: #suphp_configpath
+[`suphp_engine`]: #suphp_engine
+[対応するオペレーティングシステム]: https://forge.puppet.com/supported#puppet-supported-modules-compatibility-matrix
+
+[`ThreadLimit`]: https://httpd.apache.org/docs/current/mod/mpm_common.html#threadlimit
+[`ThreadsPerChild`]: https://httpd.apache.org/docs/current/mod/mpm_common.html#threadsperchild
+[`TimeOut`]: https://httpd.apache.org/docs/current/mod/core.html#timeout
+[テンプレート]: http://docs.puppet.com/puppet/latest/reference/lang_template.html
+[`TraceEnable`]: https://httpd.apache.org/docs/current/mod/core.html#traceenable
+
+[`verify_config`]: #verify_config
+[`vhost`]: #defined-type-apachevhost
+[`vhost_dir`]: #vhost_dir
+[`virtual_docroot`]: #virtual_docroot
+
+[Webサーバゲートウェイインターフェース ]: https://www.python.org/dev/peps/pep-3333/#abstract
+[`WSGIRestrictEmbedded`]: http://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIRestrictEmbedded.html
+[`WSGIPythonPath`]: http://modwsgi.readthedocs.org/en/develop/configuration-directives/WSGIPythonPath.html
+[`WSGIPythonHome`]: http://modwsgi.readthedocs.org/en/develop/configuration-directives/WSGIPythonHome.html
+
+#### 目次
+
+1. [モジュールの概要 - apacheモジュールとは？　何をするためのもの？][モジュールの概要]
+2. [セットアップ - apacheの使用を開始するにあたっての基礎][セットアップ]
+    - [apacheモジュールが影響を与えるもの][apacheの影響]
+    - [Apacheの使用を始める - インストール][Apacheの使用を始める]
+3. [使用方法 - 設定に使用できるクラスと定義タイプ][使用方法]
+    - [バーチャルホストの設定 - 使用開始に役立つ例][バーチャルホストの設定]
+    - [PHPファイルを処理するFastCGIサーバの設定][FastCGIサーバの設定]
+    - [エクスポートおよび非エクスポートリソースのロードバランシング][ロードバランシングの例]
+4. [リファレンス - モジュールの機能と動作について][リファレンス]
+    - [パブリッククラス][]
+    - [プライベートクラス][]
+    - [パブリック定義タイプ][]
+    - [プライベート定義タイプ][]
+    - [テンプレート][]
+5. [制約事項 - OSの互換性など][制約事項]
+6. [開発 - モジュールへの貢献方法][開発]
+    - [apacheモジュールへの貢献][貢献]
+    - [テストの実施 - クイックガイド][テストの実施]
+
+## モジュールの概要
+
+[Apache HTTPサーバ][] (Apache HTTPD、あるいは単にApacheとも呼ばれます)は、広く使用されているWebサーバです。この[Puppetモジュール][]によって、インフラ内でApacheを管理するための設定がシンプルなものになります。幅広いバーチャルホストセットアップを設定および管理し、[Apacheモジュール][]を効率的にインストールして設定することができます。
+
+## セットアップ
+
+### apacheモジュールが影響を与えるもの:
+
+- (作成し、書き込みを行う)設定ファイルおよびディレクトリ
+  - **警告**: Puppetにより管理*されていない*設定はパージされます。
+- Apacheのパッケージ/サービス/設定ファイル
+- Apacheモジュール
+- バーチャルホスト
+- リッスンするポート
+- FreeBSDおよびGentooの`/etc/make.conf` 
+
+Gentooでは、このモジュールは [`gentoo/puppet-portage`][] Puppetモジュールに依存します。Gentooについては、いくつかのオプションが適用され、一部の機能や設定が有効になりますが、このモジュールに[対応するオペレーティングシステム][]ではない点に留意してください。
+
+> **警告**: このモジュールにより、Apache設定ファイルおよびディレクトリが修正され、Puppetで管理されていない設定がパージされます。Apache設定はPuppetで管理する必要があります。これは、管理されていない設定ファイルにより、予期せぬ不具合が生じる可能性があるためです。
+>
+>全面的なPuppet管理を一時的に無効にするには、[`apache`][]クラス宣言の[`purge_configs`][]パラメータをfalseに設定します。この手順は、カスタマイズした設定を保存し、リロケーションするための一時的な対策としてのみ推奨されます。
+
+### Apacheの使用を始める
+
+デフォルトパラメータを用いてPuppetでApacheをインストールするには、[`apache`][]クラスを宣言します。
+
+``` puppet
+class { 'apache': }
+```
+
+デフォルトオプションを用いてこのクラスを宣言すると、モジュールでは以下のことが実行されます。
+
+- オペレーティングシステムに適したApacheソフトウェアパッケージおよび[必要なApacheモジュール](#default_mods)をインストールします。
+- オペレーティングシステムに応じた[デフォルトロケーション](#conf_dir)を用いて、ディレクトリ内に必要な設定ファイルを配置します。
+- デフォルトのバーチャルホストおよび標準的なポート('80')とアドレス('\*')のバインディングを用いてサーバを設定します。
+- ドキュメントルートディレクトリを作成します。オペレーティングシステムによって異なりますが、通常は`/var/www`です。
+- Apacheサービスを開始します。
+
+Apacheのデフォルト設定は、オペレーティングシステムによって異なります。これらのデフォルトは、テスト環境では機能しますが、本稼働環境には推奨されません。実際のサイトに応じてクラスのパラメータをカスタマイズすることを推奨します。
+
+例えば、以下の宣言では、apacheモジュールの[デフォルトのバーチャルホスト設定][バーチャルホストの設定]を使わずにApacheがインストールされるので、すべてのApacheバーチャルホストをカスタマイズすることができます。
+
+``` puppet
+class { 'apache':
+  default_vhost => false,
+}
+```
+
+> **注意**: `default_vhost`を`false`に設定する場合、少なくとも1つの`apache::vhost`リソースを追加する必要があります。追加しなければ、Apacheは起動しません。デフォルトのバーチャルホストを設定するには、`apache`クラスで`default_vhost`を設定するか、[`apache::vhost`][]定義タイプを使用します。[`apache::vhost`][]定義タイプを用いて、追加の固有バーチャルホストを設定することもできます。
+
+## 使用方法
+
+### バーチャルホストの設定
+
+デフォルトの[`apache`][]クラスは、ポート80にバーチャルホストを設定します。すべてのインターフェースをリッスンし、[`docroot`][]パラメータのデフォルトディレクトリ`/var/www`をサーブします。
+
+
+基本の[名前ベースのバーチャルホスト][]を設定するには、[`apache::vhost`][]定義タイプで[`port`][]および[`docroot`][]パラメータを指定します。
+
+``` puppet
+apache::vhost { 'vhost.example.com':
+  port    => '80',
+  docroot => '/var/www/vhost',
+}
+```
+
+すべてのバーチャルホストパラメータのリストについては、[`apache::vhost`][]定義タイプのリファレンスを参照してください。
+
+> **注意**: Apacheはバーチャルホストをアルファベット順に処理します。サーバ管理者は、バーチャルホスト設定ファイル名の先頭に数字を付けることで、 Apacheバーチャルホスト処理の優先順位を設定できます。[`apache::vhost`][]定義タイプは、デフォルトの [`priority`][]である15を適用します。これはPuppetではバーチャルホストのファイル名の先頭に`15-`が付いていると解釈されます。そのため、優先順位が同じサイトが複数ある場合や、`priority`パラメータの値をfalseに設定して優先順位番号を無効にした場合でも、Apacheはバーチャルホストをアルファベット順に処理します。
+
+`docroot`のユーザおよびグループのオーナーシップを設定するには、[`docroot_owner`][]および[`docroot_group`][]パラメータを使用します。
+
+``` puppet
+apache::vhost { 'user.example.com':
+  port          => '80',
+  docroot       => '/var/www/user',
+  docroot_owner => 'www-data',
+  docroot_group => 'www-data',
+}
+```
+
+#### SSLを使ったバーチャルホストの設定
+
+[SSL encryption][]およびデフォルトのSSL証明書を使うようにバーチャルホストを設定するには、[`ssl`][]パラメータを設定します。また、[`port`][]パラメータを指定する必要もあります。通常は、'443'という値がHTTPSリクエストに対応します。
+
+``` puppet
+apache::vhost { 'ssl.example.com':
+  port    => '443',
+  docroot => '/var/www/ssl',
+  ssl     => true,
+}
+```
+
+SSLおよび固有SSL証明書を使うようにバーチャルホストを設定するには、[`ssl_cert`][]および[`ssl_key`][]パラメータで証明書およびキーへのパスを使用します。
+
+``` puppet
+apache::vhost { 'cert.example.com':
+  port     => '443',
+  docroot  => '/var/www/cert',
+  ssl      => true,
+  ssl_cert => '/etc/ssl/fourth.example.com.cert',
+  ssl_key  => '/etc/ssl/fourth.example.com.key',
+}
+```
+
+同じドメインでSSLと暗号化されていないバーチャルホストを混ぜて設定するには、それぞれを個別の[`apache::vhost`][]定義タイプで宣言します。
+
+``` puppet
+# The non-ssl virtual host
+apache::vhost { 'mix.example.com non-ssl':
+  servername => 'mix.example.com',
+  port       => '80',
+  docroot    => '/var/www/mix',
+}
+
+# The SSL virtual host at the same domain
+apache::vhost { 'mix.example.com ssl':
+  servername => 'mix.example.com',
+  port       => '443',
+  docroot    => '/var/www/mix',
+  ssl        => true,
+}
+```
+
+暗号化されていない接続をSSLにリダイレクトするようにバーチャルホストを設定するには、それぞれを個別の[`apache::vhost`][]定義タイプで宣言し、SSLが有効化されているバーチャルホストに、暗号化されていないリクエストをリダイレクトします。
+
+``` puppet
+apache::vhost { 'redirect.example.com non-ssl':
+  servername      => 'redirect.example.com',
+  port            => '80',
+  docroot         => '/var/www/redirect',
+  redirect_status => 'permanent',
+  redirect_dest   => 'https://redirect.example.com/'
+}
+
+apache::vhost { 'redirect.example.com ssl':
+  servername => 'redirect.example.com',
+  port       => '443',
+  docroot    => '/var/www/redirect',
+  ssl        => true,
+}
+```
+
+#### バーチャルホストのポートおよびアドレスのバインディング設定　
+
+バーチャルホストはデフォルトですべてのIPアドレス('\*')をリッスンします。特定のIPアドレスをリッスンするようにバーチャルホストを設定するには、[`ip`][]パラメータを使用します。
+
+``` puppet
+apache::vhost { 'ip.example.com':
+  ip      => '127.0.0.1',
+  port    => '80',
+  docroot => '/var/www/ip',
+}
+```
+
+[`ip`][]パラメータにIPアドレスの配列を使えば、1つのバーチャルホストに複数のIPアドレスを設定することもできます。
+
+``` puppet
+apache::vhost { 'ip.example.com':
+  ip      => ['127.0.0.1','169.254.1.1'],
+  port    => '80',
+  docroot => '/var/www/ip',
+}
+```
+
+[`port`][]パラメータにポートの配列を使えば、1つのバーチャルホストに複数のポートを設定することができます。
+
+``` puppet
+apache::vhost { 'ip.example.com':
+  ip      => ['127.0.0.1'],
+  port    => ['80','8080']
+  docroot => '/var/www/ip',
+}
+```
+
+[エイリアスサーバ][]を使ってバーチャルホストを設定するには、[`serveraliases`][]パラメータを使ってエイリアスを指定します。
+
+``` puppet
+apache::vhost { 'aliases.example.com':
+  serveraliases => [
+    'aliases.example.org',
+    'aliases.example.net',
+  ],
+  port          => '80',
+  docroot       => '/var/www/aliases',
+}
+```
+
+`/var/www/example.com`に'http://example.com.loc'をマッピングするケースのように、 同じ名前のディレクトリにマッピングされたサブドメイン用にワイルドカードエイリアスを使ってバーチャルホストを設定するには、[`serveraliases`][]パラメータを使ってワイルドカードエイリアスを、[`virtual_docroot`][]パラメータを使ってドキュメントルートを定義します。
+
+``` puppet
+apache::vhost { 'subdomain.loc':
+  vhost_name      => '*',
+  port            => '80',
+  virtual_docroot => '/var/www/%-2+',
+  docroot         => '/var/www',
+  serveraliases   => ['*.loc',],
+}
+```
+
+[フィルタルール][]を使ってバーチャルホストを設定するには、[`filters`][]パラメータを使って、フィルタディレクティブを[array][]として渡します。
+
+``` puppet
+apache::vhost { 'subdomain.loc':
+  port    => '80',
+  filters => [
+    'FilterDeclare  COMPRESS',
+    'FilterProvider COMPRESS DEFLATE resp=Content-Type $text/html',
+    'FilterChain    COMPRESS',
+    'FilterProtocol COMPRESS DEFLATE change=yes;byteranges=no',
+  ],
+  docroot => '/var/www/html',
+}
+```
+
+#### アプリおよびプロセッサのバーチャルホストの設定　
+
+[suPHP][]を使ってバーチャルホストを設定するには、以下のパラメータを使用します。
+
+* [`suphp_engine`][]、suPHPエンジンを有効にします。
+* [`suphp_addhandler`][]、MIMEタイプを定義します。
+* [`suphp_configpath`][]、suPHPがPHPインタープリタに渡すパスを設定します。 
+* [`directory`][]、ディレクトリ、ファイル、ロケーションの各ディレクティブブロックを設定します。
+
+例:　
+
+``` puppet
+apache::vhost { 'suphp.example.com':
+  port             => '80',
+  docroot          => '/home/appuser/myphpapp',
+  suphp_addhandler => 'x-httpd-php',
+  suphp_engine     => 'on',
+  suphp_configpath => '/etc/php5/apache2',
+  directories      => [
+    { 'path'  => '/home/appuser/myphpapp',
+      'suphp' => {
+        user  => 'myappuser',
+        group => 'myappgroup',
+      },
+    },
+  ],
+}
+```
+
+[Python][]アプリケーション用の[Webサーバゲートウェイインターフェース][] (WSGI)を使ってバーチャルホストを設定するには、`wsgi`パラメータセットを使用します。
+
+``` puppet
+apache::vhost { 'wsgi.example.com':
+  port                        => '80',
+  docroot                     => '/var/www/pythonapp',
+  wsgi_application_group      => '%{GLOBAL}',
+  wsgi_daemon_process         => 'wsgi',
+  wsgi_daemon_process_options => {
+    processes    => '2',
+    threads      => '15',
+    display-name => '%{GROUP}',
+  },
+  wsgi_import_script          => '/var/www/demo.wsgi',
+  wsgi_import_script_options  => {
+    process-group     => 'wsgi',
+    application-group => '%{GLOBAL}',
+  },
+  wsgi_process_group          => 'wsgi',
+  wsgi_script_aliases         => { '/' => '/var/www/demo.wsgi' },
+}
+```
+
+Apache 2.2.16の時点では、Apacheは[FallbackResource][]をサポートしています。これは、一般的なRewriteRulesに代わるシンプルなディレクティブです。[`fallbackresource`][]パラメータを使えば、FallbackResourceを設定できます。
+
+``` puppet
+apache::vhost { 'wordpress.example.com':
+  port             => '80',
+  docroot          => '/var/www/wordpress',
+  fallbackresource => '/index.php',
+}
+```
+
+> **注意**: Apache 2.2.24以降では、`fallbackresource`パラメータがサポートするのは'disabled'値のみです。
+
+[コモンゲートウェイインターフェース][] (CGI)ファイル用の指定ディレクトリを使ってバーチャルホストを設定するには、[`scriptalias`][]パラメータを使って`cgi-bin`パスを定義します。
+
+``` puppet
+apache::vhost { 'cgi.example.com':
+  port        => '80',
+  docroot     => '/var/www/cgi',
+  scriptalias => '/usr/lib/cgi-bin',
+}
+```
+
+[Rack][]用のバーチャルホストを設定するには、[`rack_base_uris`][]パラメータを使用します。
+
+``` puppet
+apache::vhost { 'rack.example.com':
+  port           => '80',
+  docroot        => '/var/www/rack',
+  rack_base_uris => ['/rackapp1', '/rackapp2'],
+}
+```
+
+#### IPベースのバーチャルホストの設定　
+
+任意のポートをリッスンし、固有IPアドレスのリクエストに応答する[IPベースのバーチャルホスト][]を設定することができます。この例では、サーバはポート80および81をリッスンします。これは、この例のバーチャルホストが[`port`][]パラメータにより宣言されて_いない_ ためです。
+
+``` puppet
+apache::listen { '80': }
+
+apache::listen { '81': }
+```
+
+[`ip_based`][]パラメータを使ってIPベースのバーチャルホストを設定します。
+
+``` puppet
+apache::vhost { 'first.example.com':
+  ip       => '10.0.0.10',
+  docroot  => '/var/www/first',
+  ip_based => true,
+}
+
+apache::vhost { 'second.example.com':
+  ip       => '10.0.0.11',
+  docroot  => '/var/www/second',
+  ip_based => true,
+}
+```
+
+任意の[SSL][SSL暗号化]構成と暗号化されていない構成を組み合わせ、IPベースと[名前ベースのバーチャルホスト][]を混ぜて設定することもできます。
+
+この例では、1つのIPアドレス(この例では、10.0.0.10)に2つのIPベースのバーチャルホストを追加します。一方はSSLを使用するもの、もう一方は暗号化されていないものです。
+
+``` puppet
+apache::vhost { 'The first IP-based virtual host, non-ssl':
+  servername => 'first.example.com',
+  ip         => '10.0.0.10',
+  port       => '80',
+  ip_based   => true,
+  docroot    => '/var/www/first',
+}
+
+apache::vhost { 'The first IP-based vhost, ssl':
+  servername => 'first.example.com',
+  ip         => '10.0.0.10',
+  port       => '443',
+  ip_based   => true,
+  docroot    => '/var/www/first-ssl',
+  ssl        => true,
+}
+```
+
+次に、第2のIPアドレス(10.0.0.20)に2つの名前ベースのバーチャルホストを追加します。
+
+``` puppet
+apache::vhost { 'second.example.com':
+  ip      => '10.0.0.20',
+  port    => '80',
+  docroot => '/var/www/second',
+}
+
+apache::vhost { 'third.example.com':
+  ip      => '10.0.0.20',
+  port    => '80',
+  docroot => '/var/www/third',
+}
+```
+
+10.0.0.10または10.0.0.20のいずれかで応答する名前ベースのバーチャルホストを追加するには、Apacheのデフォルトの`Listen 80`を無効にする**必要があります**。これは、前述のIPベースのバーチャルホストとコンフリクトするためです。無効にするには、[`add_listen`][]パラメータを`false`に設定します。
+
+``` puppet
+apache::vhost { 'fourth.example.com':
+  port       => '80',
+  docroot    => '/var/www/fourth',
+  add_listen => false,
+}
+
+apache::vhost { 'fifth.example.com':
+  port       => '80',
+  docroot    => '/var/www/fifth',
+  add_listen => false,
+}
+```
+
+### Apacheモジュールのインストール　
+
+Puppet apacheモジュールを使って[Apacheモジュール][]をインストールするには、2つの方法があります。
+
+- [`apache::mod::<MODULE NAME>`][] クラスを使って、[パラメータを伴う固有のApacheモジュールをインストール][固有モジュールのインストール]する方法
+- [`apache::mod`][]定義タイプを使って、[任意のApacheモジュールをインストール][任意モジュールのインストール]する方法
+
+#### 固有モジュールのインストール
+
+Puppet apacheモジュールは、多くの一般的な[Apacheモジュール][]のインストールをサポートしており、多くの場合、パラメータ化された設定オプションがあります。サポートされるApacheモジュールのリストについては、[`apache::mod::<MODULE NAME>`][]クラスリファレンスを参照してください。
+
+例えば、[`apache::mod::ssl`][]クラスを宣言すれば、デフォルト設定で`mod_ssl` Apacheモジュールをインストールすることができます。
+
+``` puppet
+class { 'apache::mod::ssl': }
+```
+
+[`apache::mod::ssl`][]には複数のパラメータ化されたオプションがあり、宣言する際に設定することができます。たとえば、圧縮を有効にして`mod_ssl`を有効化するには、[`ssl_compression`][]パラメータをtrueに設定します。
+
+``` puppet
+class { 'apache::mod::ssl':
+  ssl_compression => true,
+}
+```
+
+一部のモジュールには必須条件があります。[`apache::mod::<MODULE NAME>`][]のリファレンスを参照してください。
+
+#### 任意モジュールのインストール
+
+オペレーティングシステムのパッケージマネージャでインストール可能な任意のモジュールの名前を[`apache::mod`][]定義タイプに渡し、それをインストールすることができます。固有モジュールクラスとは異なり、 [`apache::mod`][]定義タイプでは、インストールされている他のモジュールや固有のパラメータに基づいてインストールが調整されることはありません。Puppetはモジュールのパッケージを取得し、インストールするだけです。詳細な設定はユーザが必要に応じて行います。
+
+例えば、[`mod_authnz_external`][] Apacheモジュールをインストールするには、'mod_authnz_external'の名前を使って定義タイプを宣言します。
+
+``` puppet
+apache::mod { 'mod_authnz_external': }
+```
+
+この方法でApacheモジュールを定義する際には、いくつかのオプションパラメータを指定できます。詳細については、[定義タイプのリファレンス][`apache::mod`]を参照してください。
+
+### PHPファイルを処理するFastCGIサーバの設定
+
+[`apache::fastcgi::server`][]定義タイプを追加すれば、 [FastCGI][]サーバで特定のファイルに関するリクエストを処理することができます。以下の例では、PHPリクエストを処理するFastCGIサーバをポート9000の127.0.0.1 (ローカルホスト)で定義しています。
+
+``` puppet
+apache::fastcgi::server { 'php':
+  host       => '127.0.0.1:9000',
+  timeout    => 15,
+  flush      => false,
+  faux_path  => '/var/www/php.fcgi',
+  fcgi_alias => '/php.fcgi',
+  file_type  => 'application/x-httpd-php'
+}
+```
+
+[`custom_fragment`][]パラメータを使えば、指定したファイルタイプがFastCGIサーバで処理されるように、バーチャルホストを設定することができます。
+
+``` puppet
+apache::vhost { 'www':
+  ...
+  custom_fragment => 'AddType application/x-httpd-php .php'
+  ...
+}
+```
+
+### ロードバランシングの例
+
+Apacheは、[`mod_proxy`][] Apacheモジュールを通じて、複数のグループのサーバにわたるロードバランシングをサポートしています。Puppetでは、[`apache::balancer`][]および[`apache::balancermember`][]定義タイプにより、Apacheロードバランシンググループ(バランサクラスタとも呼ばれます)をサポートしています。
+
+[エクスポートリソース][]でロードバランシングを有効にするには、[`apache::balancermember`][]定義タイプをロードバランサメンバーサーバからエクスポートします。
+
+``` puppet
+@@apache::balancermember { "${::fqdn}-puppet00":
+  balancer_cluster => 'puppet00',
+  url              => "ajp://${::fqdn}:8009",
+  options          => ['ping=5', 'disablereuse=on', 'retry=5', 'ttl=120'],
+}
+```
+
+次に、プロキシサーバでロードバランシンググループを作成します。
+
+``` puppet
+apache::balancer { 'puppet00': }
+```
+
+リソースをエクスポートせずにロードバランシングを有効にするには、プロキシサーバで以下を宣言します。
+
+``` puppet
+apache::balancer { 'puppet00': }
+
+apache::balancermember { "${::fqdn}-puppet00":
+  balancer_cluster => 'puppet00',
+  url              => "ajp://${::fqdn}:8009",
+  options          => ['ping=5', 'disablereuse=on', 'retry=5', 'ttl=120'],
+}
+```
+
+次に、プロキシサーバで`apache::balancer`および`apache::balancermember`定義タイプを宣言します。
+
+バランサで[ProxySet](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxyset)ディレクティブを使うには、`apache::balancer`の[`proxy_set`](#proxy_set)パラメータを使用します。
+
+``` puppet
+apache::balancer { 'puppet01':
+  proxy_set => {
+    'stickysession' => 'JSESSIONID',
+    'lbmethod'      => 'bytraffic',
+  },
+}
+```
+
+ロードバランシングのスケジューラのアルゴリズム(`lbmethod`)は、[mod_proxy_balancerドキュメント](https://httpd.apache.org/docs/current/mod/mod_proxy_balancer.html)に記載されています。
+
+## リファレンス
+
+- [**パブリッククラス**](#public-classes)
+    - [クラス: apache](#class-apache)
+    - [クラス: apache::dev](#class-apachedev)
+    - [クラス: apache::vhosts](#class-apachevhosts)
+    - [クラス: apache::mod::\*](#classes-apachemodname)
+- [**プライベートクラス**](#private-classes)
+    - [クラス: apache::confd::no_accf](#class-apacheconfdno_accf)
+    - [クラス: apache::default_confd_files](#class-apachedefault_confd_files)
+    - [クラス: apache::default_mods](#class-apachedefault_mods)
+    - [クラス: apache::package](#class-apachepackage)
+    - [クラス: apache::params](#class-apacheparams)
+    - [クラス: apache::service](#class-apacheservice)
+    - [クラス: apache::version](#class-apacheversion)
+- [**パブリック定義タイプ**](#public-defined-types)
+    - [定義タイプ: apache::balancer](#defined-type-apachebalancer)
+    - [定義タイプ: apache::balancermember](#defined-type-apachebalancermember)
+    - [定義タイプ: apache::custom_config](#defined-type-apachecustom_config)
+    - [定義タイプ: apache::fastcgi::server](#defined-type-fastcgi-server)
+    - [定義タイプ: apache::listen](#defined-type-apachelisten)
+    - [定義タイプ: apache::mod](#defined-type-apachemod)
+    - [定義タイプ: apache::namevirtualhost](#defined-type-apachenamevirtualhost)
+    - [定義タイプ: apache::vhost](#defined-type-apachevhost)
+    - [定義タイプ: apache::vhost::custom](#defined-type-apachevhostcustom)
+- [**プライベート定義タイプ**](#private-defined-types)
+    - [定義タイプ: apache::default_mods::load](#defined-type-default_mods-load)
+    - [定義タイプ: apache::peruser::multiplexer](#defined-type-apacheperusermultiplexer)
+    - [定義タイプ: apache::peruser::processor](#defined-type-apacheperuserprocessor)
+    - [定義タイプ: apache::security::file_link](#defined-type-apachesecurityfile_link)
+- [**テンプレート**](#templates)
+
+### パブリッククラス
+
+#### クラス: `apache`
+
+システムでのApacheの基本的な設定とインストールをガイドします。
+
+デフォルトオプションを用いてこのクラスを宣言すると、Puppetでは以下が実行されます。
+
+- オペレーティングシステムに適したApacheソフトウェアパッケージおよび[必要なApacheモジュール](#default_mods)をインストールします。
+- [デフォルトロケーション](#conf_dir)を用いて、ディレクトリ内に必要な設定ファイルを配置します。デフォルトロケーションは、オペレーティングシステムによって異なります。
+- デフォルトのバーチャルホストおよび標準的なポート('80')とアドレス('\*')のバインディングを用いてサーバを設定します。
+- ドキュメントルートディレクトリを作成します。オペレーティングシステムによって異なりますが、通常は`/var/www`です。
+- Apacheサービスを開始します。
+
+ここでは、デフォルトの`apache`クラスを宣言するだけです。
+
+``` puppet
+class { 'apache': }
+```
+
+##### `allow_encoded_slashes`
+
+[`AllowEncodedSlashes`][]宣言のサーバデフォルトを設定します。これにより、'\'および'/'を含むURLに対する応答が変更されます。このパラメータを指定しない場合、サーバの設定でこの宣言が省かれ、Apacheのデフォルト設定'off'が使用されます。
+
+値: 'on'、'off'、'nodecode'。
+
+デフォルト値: `undef`。
+
+##### `apache_version`
+
+使用するApacheのバージョンを定義し、モジュールテンプレートの挙動、パッケージ名、デフォルトのApacheモジュールを設定します。このパラメータを理由なく手動で設定することは、推奨していません。
+
+デフォルト値: [`apache::version`][]クラスにより検出されたオペレーティングシステムとリリースバージョンによって異なります。
+
+##### `conf_dir`
+
+Apacheサーバのメイン設定ファイルを置くディレクトリを設定します。
+
+デフォルト値: オペレーティングシステムによって異なります。
+
+- **Debian**: `/etc/apache2`
+- **FreeBSD**: `/usr/local/etc/apache22`
+- **Gentoo**: `/etc/apache2`
+- **Red Hat**: `/etc/httpd/conf`
+
+##### `conf_template`
+
+メインのApache設定ファイルで使用される[テンプレート][]を定義します。apacheモジュールは、`conf.d`エントリによりカスタマイズされた最小限の設定ファイルを使用するように設計されているため、このパラメータの変更には潜在的なリスクが伴います。
+
+デフォルト値: `apache/httpd.conf.erb`。
+
+##### `confd_dir`
+
+Apacheサーバのカスタム設定ディレクトリの場所を設定します。
+
+デフォルト値: オペレーティングシステムによって異なります。
+
+- **Debian**: `/etc/apache2/conf.d`
+- **FreeBSD**: `/usr/local/etc/apache22`
+- **Gentoo**: `/etc/apache2/conf.d`
+- **Red Hat**: `/etc/httpd/conf.d`
+
+##### `default_charset`
+
+メイン設定ファイルで[`AddDefaultCharset`][]ディレクティブとして使用されます。
+
+デフォルト値: `undef`。
+
+##### `default_confd_files`
+
+[`confd_dir`][]パラメータにより定義されるディレクトリに、インクルード可能なApache設定ファイルのデフォルトセットを生成するかどうかを決定します。この設定ファイルは、サーバのオペレーティングシステムにApacheパッケージとともに通常インストールされるものに相当します。
+
+ブーリアン。
+
+デフォルト値: `true`。
+
+##### `default_mods`
+
+オペレーティングシステムに応じたデフォルトの[Apacheモジュール][]のセットを設定して有効にするかどうかを決定します。
+
+`false`の場合、Puppetはオペレーティングシステム上でHTTPデーモンを機能させるのに必要なApacheモジュールのみを含めます。[`apache::mod::<MODULE NAME>`][]クラスまたは[`apache::mod`][]定義タイプを使えば、他のモジュールを個別に宣言することができます。
+
+`true`の場合、Puppetはオペレーティングシステムと [`apache_version`][]および[`mpm_module`][]パラメータの値に応じて、その他のモジュールもインストールします。このモジュールリストは頻繁に変更されるので、最新のリストについては[Puppetモジュールのコード][]を参照してください。
+
+このパラメータに配列が含まれる場合、Puppetは渡されたすべてのApacheモジュールを有効にします。
+
+値: ブーリアンまたはApacheモジュール名の配列。
+
+デフォルト値: `true`。
+
+##### `default_ssl_ca`
+
+Apacheサーバのデフォルトの証明書認証局を設定します。
+
+デフォルト値を使えばApacheサーバは機能しますが、本稼働環境にこのサーバをデプロイする前に、各自の認証局情報を用いてこのパラメータを更新する**必要があります**。
+
+ブーリアン。
+
+デフォルト値: `undef`。
+
+##### `default_ssl_cert`
+
+[SSL暗号化][]証明書の保存場所を設定します。
+
+デフォルト値を使えばApacheサーバは機能しますが、本稼働環境にこのサーバをデプロイする前に、各自の証明書ロケーション情報を用いてこのパラメータを更新する**必要があります**。
+
+デフォルト値: オペレーティングシステムによって異なります。
+
+- **Debian**: `/etc/ssl/certs/ssl-cert-snakeoil.pem`
+- **FreeBSD**: `/usr/local/etc/apache22/server.crt`
+- **Gentoo**: `/etc/ssl/apache2/server.crt`
+- **Red Hat**: `/etc/pki/tls/certs/localhost.crt`
+
+##### `default_ssl_chain`
+
+デフォルトの[SSLチェーン][]の保存場所を設定します。 
+
+デフォルト値を使えばApacheサーバは機能しますが、本稼働環境にこのサーバをデプロイする前に、各自のSSLチェーンを用いてこのパラメータを更新する**必要があります**。
+
+デフォルト値: `undef`。
+
+##### `default_ssl_crl`
+
+使用するデフォルトの[証明書失効リスト][] (CRL)ファイルのパスを設定します。
+
+デフォルト値を使えばApacheサーバは機能しますが、本稼働環境にこのサーバをデプロイする前に、CRLファイルパスを用いてこのパラメータを更新する**必要があります**。このパラメータは、[`default_ssl_crl_path`][]とともに使用することも、その代わりに使用することもできます。
+
+デフォルト値: `undef`。
+
+##### `default_ssl_crl_path`
+
+サーバの[証明書失効リストパス][]を設定します。これにはCRLが含まれます。
+
+デフォルト値を使えばApacheサーバは機能しますが、本稼働環境でこのサーバをデプロイする前に、CRLファイルパスを用いてこのパラメータを更新する**必要があります**。
+
+デフォルト値: `undef`。
+
+##### `default_ssl_crl_check`
+
+[`SSLCARevocationCheck`][]ディレクティブを通じてデフォルトの証明書失効チェックレベルを設定します。このパラメータはApache 2.4以上にのみ適用され、それ以前のバージョンでは無視されます。
+
+デフォルト値を使えばApacheサーバは機能しますが、本稼働環境で証明書失効リストを使用する際には、このパラメータを指定する**必要があります**。
+
+デフォルト値: `undef`。
+
+##### `default_ssl_key`
+
+[SSL証明書キーファイル][]の保存場所を設定します。
+
+デフォルト値を使えばApacheサーバは機能しますが、本稼働環境にこのサーバをデプロイする前に、各自のSSLキーのロケーションを用いてこのパラメータを更新する**必要があります**。
+
+デフォルト値: オペレーティングシステムによって異なります。
+
+- **Debian**: `/etc/ssl/private/ssl-cert-snakeoil.key`
+- **FreeBSD**: `/usr/local/etc/apache22/server.key`
+- **Gentoo**: `/etc/ssl/apache2/server.key`
+- **Red Hat**: `/etc/pki/tls/private/localhost.key`
+
+
+##### `default_ssl_vhost`
+
+デフォルトの[SSL][SSL暗号化]バーチャルホストを設定します。
+
+`true`の場合、Puppetは [`apache::vhost`][]定義タイプを用いて、以下のバーチャルホストを自動的に設定します。
+
+```puppet
+apache::vhost { 'default-ssl':
+  port            => 443,
+  ssl             => true,
+  docroot         => $docroot,
+  scriptalias     => $scriptalias,
+  serveradmin     => $serveradmin,
+  access_log_file => "ssl_${access_log_file}",
+  }
+```
+
+> **注意**: SSLバーチャルホストはHTTPSクエリにのみ応答します。
+
+
+ブーリアン。
+
+デフォルト値: `false`。
+
+##### `default_type`
+
+_Apache 2.2のみ_。サーバが他の方法で適切な`content-type`を決定できない場合に送信される[MIME `content-type`][]を設定します。このディレクティブはApache 2.4以降では廃止予定になっており、設定ファイルの下位互換性確保の目的でのみ使われます。 
+
+デフォルト値: `undef`。
+
+##### `default_vhost`
+
+クラスが宣言された際にデフォルトのバーチャルホストを設定します。
+
+[カスタマイズしたバーチャルホスト][バーチャルホストの設定]を設定するには、このパラメータの値を`false`に設定します。
+
+> **注意**: 少なくとも1つのバーチャルホストがなければ、Apacheは起動しません。このパラメータを`false`に設定する場合は、別の場所でバーチャルホストを設定する必要があります。
+
+ブーリアン。
+
+デフォルト値: `true`。
+
+##### `dev_packages`
+
+使用する固有devパッケージを設定します。
+
+値: 文字列または文字列の配列。
+
+IUS yumリポジトリからhttpd 2.4を使用する例:
+
+``` puppet
+include ::apache::dev
+class { 'apache':
+ apache_name => 'httpd24u',
+ dev_packages => 'httpd24u-devel',
+}
+```
+
+デフォルト値: オペレーティングシステムによって異なります。
+
+- **Red Hat:** 'httpd-devel'
+- **Debian 8/Ubuntu 13.10以降:** ['libaprutil1-dev', 'libapr1-dev', 'apache2-dev']
+- **それ以前のDebian/Ubuntuバージョン:** ['libaprutil1-dev', 'libapr1-dev', 'apache2-prefork-dev']
+- **FreeBSD, Gentoo:** `undef`
+- **Suse:** ['libapr-util1-devel', 'libapr1-devel']
+
+##### `docroot`
+
+デフォルトの[`DocumentRoot`][]の場所を設定します。
+
+デフォルト値: オペレーティングシステムによって異なります。
+
+- **Debian**: `/var/www/html`
+- **FreeBSD**: `/usr/local/www/apache22/data`
+- **Gentoo**: `/var/www/localhost/htdocs`
+- **Red Hat**: `/var/www/html`
+
+##### `error_documents`
+
+Apacheサーバの[カスタムエラードキュメント][]を有効にするかどうかを決定します。
+
+ブーリアン。
+
+デフォルト値: `false`。
+
+##### `group`
+
+リクエストに応答するために生成されるApacheプロセスを所有するグループIDを設定します。
+
+デフォルトでは、Puppetはこのグループを`apache`クラスの下のリソースとして管理するよう試み、[`apache::params`][]クラスにより検出されたオペレーティングシステムに基づいてグループを決定します。このグループリソースを作成せずに、別のPuppetモジュールで作成されたグループを使用するには、[`manage_group`][]パラメータの値を`false`に設定します。
+
+> **注意**: このパラメータを修正すると、Apacheが子プロセスを生成してリソースにアクセスする際に使用するグループIDのみが変更されます。親サーバプロセスを所有するユーザは変更されません。
+
+##### `httpd_dir`
+
+Apacheサーバの基本設定ディレクトリを設定します。これは、特別に再パッケージされたApacheサーバビルドにおいて、デフォルトのディストリビューションパッケージと組み合わせると意図せぬ結果が生じる可能性がある場合に役立ちます。
+
+デフォルト値: オペレーティングシステムによって異なります。
+
+- **Debian**: `/etc/apache2`
+- **FreeBSD**: `/usr/local/etc/apache22`
+- **Gentoo**: `/etc/apache2`
+- **Red Hat**: `/etc/httpd`
+
+##### `http_protocol_options`
+
+HTTPプロトコルチェックの厳密さを指定します。
+
+有効なオプション: 以下の値の選択肢のシーケンス: `Strict`または`Unsafe`、`RegisteredMethods`または`LenientMethods`、`Allow0.9`または`Require1.0`。
+
+デフォルト '`Strict LenientMethods Allow0.9`'。
+
+##### `keepalive`
+
+[`KeepAlive`][]ディレクティブによってHTTPの持続的接続を有効にするかどうかを決定します。 'On'に設定する場合は、[`keepalive_timeout`][]および[`max_keepalive_requests`][]パラメータを使って関連オプションを設定してください。 
+
+値: 'Off', 'On'。
+
+デフォルト値: 'Off'。
+
+##### `keepalive_timeout`
+
+[`KeepAliveTimeout`]ディレクティブによって、HTTPの持続的接続でApacheサーバが後続のリクエストを行うまでの待機時間を設定します。このパラメータが意味を持つのは、[`keepalive` parameter][]を有効にしている場合のみです。
+
+デフォルト値: '15'。
+
+##### `max_keepalive_requests`
+
+[`keepalive` parameter][]が有効の場合に、1回の接続で許可されるリクエストの数を制限します。
+
+デフォルト値: '100'。
+
+##### `lib_path`
+
+[Apacheモジュール][Apacheモジュール]ファイルの保存場所を指定します。
+
+デフォルト値: オペレーティングシステムによって異なります。
+
+- **Debian**および**Gentoo**: `/usr/lib/apache2/modules`
+- **FreeBSD**: `/usr/local/libexec/apache24`
+- **Red Hat**: `modules`
+
+> **注意**: このパラメータは、特別な理由がない限り手動で設定しないでください。
+
+##### `log_level`
+
+エラーログの詳細レベルを変更します。値: 'alert'、'crit'、'debug'、'emerg'、'error'、'info'、'notice'、'warn'。
+
+デフォルト値: 'warn'。
+
+##### `log_formats`
+
+追加の[`LogFormat`][]ディレクティブを定義します。値: [ハッシュ][]、例:
+
+``` puppet
+$log_formats = { vhost_common => '%v %h %l %u %t \"%r\" %>s %b' }
+```
+
+Puppetの作成する`httpd.conf`には、以下のような複数の`LogFormats`が事前定義されています。
+
+``` httpd
+LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+LogFormat "%h %l %u %t \"%r\" %>s %b" common
+LogFormat "%{Referer}i -> %U" referer
+LogFormat "%{User-agent}i" agent
+LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %s %b \"%{Referer}i\" \"%{User-agent}i\"" forwarded
+```
+
+定義した`log_formats`パラメータに上記のいずれかが含まれる場合は、**ユーザの**定義により上書きされます。
+
+##### `logroot`
+
+バーチャルホストのApacheログファイルのディレクトリを変更します。
+
+デフォルト値: オペレーティングシステムによって異なります。
+
+- **Debian**: `/var/log/apache2`
+- **FreeBSD**: `/var/log/apache22`
+- **Gentoo**: `/var/log/apache2`
+- **Red Hat**: `/var/log/httpd`
+
+##### `logroot_mode`
+
+デフォルトの[`logroot`][]ディレクトリをオーバーライドします。
+
+> **注意**: 影響を把握できない場合は、ログが保存されているディレクトリへの書き込みアクセス権限を付与_しないで_ください。詳細については、[Apacheドキュメント][ログセキュリティ]を参照してください。
+
+デフォルト値: `undef`。
+
+##### `manage_group`
+
+`false`の場合、Puppetではグループリソースは作成されません。
+
+別のPuppetモジュールで作成されたグループをApacheの実行に使用する場合は、この値を`false`に設定してください。このパラメータを設定せずに過去に作成されたグループを使用しようとすると、重複リソースエラーが生じます。
+
+ブーリアン。
+
+デフォルト値: `true`。
+
+##### `supplementary_groups`
+
+ユーザの所属するグループのリスト。主要グループに加えて設定する場合に使用します。
+
+デフォルト値: 追加グループなし。
+
+注意: このオプションは、`manage_user`がtrueに設定されている場合のみ有効です。
+
+##### `manage_user`
+
+`false`の場合、Puppetではユーザリソースが作成されません。
+
+このパラメータは、別のPuppetモジュールで作成されたユーザをApache実行に使用する場合などに使用します。このパラメータを設定せずに過去に作成されたユーザを使用しようとすると、重複リソースエラーが生じます。
+
+ブーリアン。
+
+デフォルト値: `true`。
+
+##### `mod_dir`
+
+Puppetが[Apacheモジュール][]の設定ファイルを置く場所を設定します。
+
+デフォルト値: オペレーティングシステムによって異なります。
+
+- **Debian**: `/etc/apache2/mods-available`
+- **FreeBSD**: `/usr/local/etc/apache22/Modules`
+- **Gentoo**: `/etc/apache2/modules.d`
+- **Red Hat**: `/etc/httpd/conf.d`
+
+##### `mod_packages`
+
+デフォルトのモジュールパッケージ名をユーザがオーバーライドすることを許可します。
+
+```puppet
+include apache::params
+class { 'apache':
+ mod_packages => merge($::apache::params::mod_packages, {
+ 'auth_kerb' => 'httpd24-mod_auth_kerb',
+ })
+}
+```
+
+ハッシュ。デフォルト値: `$apache::params::mod_packages`。
+
+##### `mpm_module`
+
+HTTPDプロセスに関してロードおよび設定する[マルチプロセッシングモジュール][] (MPM)を決定します。値: 'event'、'itk'、'peruser'、'prefork'、'worker'、`false`。
+
+カスタムパラメータを用いて以下のクラスを明示的に宣言するためには、このパラメータを`false`に設定する必要があります。 
+
+- [`apache::mod::event`][]
+- [`apache::mod::itk`][]
+- [`apache::mod::peruser`][]
+- [`apache::mod::prefork`][]
+- [`apache::mod::worker`][]
+
+デフォルト値: オペレーティングシステムによって異なります。
+
+- **Debian**: 'worker'
+- **FreeBSD、Gentoo、Red Hat**: 'prefork'
+
+##### `package_ensure`
+
+`package`リソースの[`ensure`][]属性を制御します。値: 'absent'、'installed' (またはそれに相当する'present')、またはバージョン文字列。
+
+デフォルト値: 'installed'。
+
+##### `pidfile`
+
+pidファイルのカスタムロケーションの設定を許可します。カスタムビルトのApache rpmを使用する場合に役立ちます。
+
+デフォルト値: オペレーティングシステムによって異なります。
+
+- **Debian:** '\${APACHE_PID_FILE}'
+- **FreeBSD:** '/var/run/httpd.pid'
+- **Red Hat:** 'run/httpd.pid'
+
+##### `ports_file`
+
+Apacheポート設定を含むファイルのパスを設定します。
+
+デフォルト値: '{$conf_dir}/ports.conf'。
+
+##### `purge_configs`
+
+他のすべてのApache設定およびバーチャルホストを削除します。
+
+このパラメータを`false`に設定すると、一時的な対策として、既存の設定や管理されていない設定をApacheモジュールと共存させることができます。この場合、設定をこのモジュール内のリソースに移すことを推奨します。バーチャルホストの設定については、[`purge_vhost_dir`][]を参照してください。
+
+ブーリアン。
+
+デフォルト値: `true`。
+
+##### `purge_vhost_dir`
+
+[`vhost_dir`][]パラメータの値が[`confd_dir`][]パラメータの値と異なる場合は、このパラメータにより、Puppetにより管理されて_いない_`vhost_dir`内の設定を削除するかどうかが決定されます。
+
+`purge_vhost_dir`を`false`に設定すると、一時的な対策として、`vhost_dir`内の既存の設定や管理されていない設定をapacheモジュールと共存させることができます。
+
+ブーリアン。
+
+デフォルト値: [`purge_configs`][]と同じ。
+
+##### `rewrite_lock`
+
+リライトロックのカスタムロケーションの設定を可能にします。これは、バーチャルホストの[`rewrites`][]パラメータでタイプprgのRewriteMapを使用している場合のベストプラクティスとされています。このパラメータは、Apacheバージョン2.2以前のみに適用され、それよりも新しいバージョンでは無視されます。
+
+デフォルト値: `undef`。
+
+##### `sendfile`
+
+[`EnableSendfile`][]ディレクティブで静的ファイルをサーブする際に、ApacheがLinuxカーネルの`sendfile`サポートを使用するようにします。値: 'On'、'Off'。
+
+デフォルト値: 'On'。
+
+##### `serveradmin`
+
+Apacheの[`ServerAdmin`][]ディレクティブでApacheサーバ管理者の連絡先情報を設定します。
+
+デフォルト値: 'root@localhost'。
+
+##### `servername`
+
+Apacheの[`ServerName`][]ディレクティブでApacheサーバ名を設定します。
+
+`false`に設定すると、ServerNameは設定されません。
+
+デフォルト値:  [Facter][]により報告された'fqdn' fact。
+
+##### `server_root`
+
+Apacheの[`ServerRoot`][]ディレクティブでApacheサーバのルートを設定します。
+
+デフォルト値: オペレーティングシステムによって異なります。
+
+- **Debian**: `/etc/apache2`
+- **FreeBSD**: `/usr/local`
+- **Gentoo**: `/var/www`
+- **Red Hat**: `/etc/httpd`
+
+##### `server_signature`
+
+Apacheの[`ServerSignature`][]ディレクティブで、エラードキュメントや一部の[Apacheモジュール][]のアウトプットなどの、サーバ生成ドキュメントの下部に表示される末尾のフッタの行を設定します。値: 'Off'、'On'。
+
+デフォルト値: 'On'。
+
+##### `server_tokens`
+
+Apacheの[`ServerTokens`][]ディレクティブで、Apacheからブラウザに送信される、Apacheやオペレーティングシステムに関する情報の量を制御します。
+
+デフォルト値: 'OS'。
+
+##### `service_enable`
+
+システムの起動時にPuppetがApache HTTPDサービスを有効にするかどうかを決定します。
+
+ブーリアン。
+
+デフォルト値: `true`。
+
+##### `service_ensure`
+
+サービスが稼働していることをPuppetが確認するかどうかを決定します。値: `true` (または'running')、`false` (または'stopped')。
+
+値を`false`または'stopped'にすると、'httpd'サービスリソースの`ensure`パラメータが`false`に設定されます。この設定は、Pacemakerなどの別のアプリケーションでサービスを管理する場合に役立ちます。
+
+デフォルト値: 'running'。
+
+##### `service_name`
+
+Apacheサービスの名前を設定します。
+
+デフォルト値: オペレーティングシステムによって異なります。
+
+- **DebianおよびGentoo**: 'apache2'
+- **FreeBSD**: 'apache22'
+- **Red Hat**: 'httpd'
+
+##### `service_manage`
+
+PuppetでHTTPDサービスの状態を管理するかどうかを決定します。
+
+ブーリアン。
+
+デフォルト値: `true`。
+
+##### `service_restart`
+
+HTTPDサービスの再起動にあたり、Puppetが特定のコマンドを使用するかどうかを決定します。
+
+値: Apacheサービスを再起動するためのコマンド。デフォルト設定では、 [デフォルトのPuppet挙動][サービス属性リスタート]が使われます。
+
+デフォルト値: `undef`。
+
+##### `ssl_ca`
+
+SSL証明書認証局を指定します。 [SSLCACertificateFile](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcacertificatefile)。
+
+これはバーチャルホストレベルでオーバーライドすることが可能です。
+
+デフォルト値: `undef`。
+
+
+##### `timeout`
+
+Apacheの[`TimeOut`][]ディレクティブを設定します。このディレクティブは、一部のイベントに関してリクエスト履行を止めるまでの Apacheの待機秒数を定義します。
+
+デフォルト値: 120。
+
+##### `trace_enable`
+
+[`TraceEnable`][]ディレクティブで、Apacheが`TRACE`リクエスト([RFC 2616][]ごと)をどのように処理するかを制御します。
+
+値: 'Off', 'On'。
+
+デフォルト値: 'On'。
+
+##### `use_systemd`
+
+systemdモジュールをCentos 7サーバにインストールするかどうかを制御します。これは、カスタムビルトのRPMを使用している場合は特に役立ちます。 
+
+ブーリアン。
+
+デフォルト値: `true`。
+
+##### `file_mode`
+
+設定ファイルの許可モードを設定します。
+
+値: 文字列、記号表記法または数字表記法での許可モード。
+
+デフォルト値: '0644'。
+
+##### `root_directory_options`
+
+httpd.confの/ディレクトリで指定するオプションの配列。
+
+デフォルト値: 'FollowSymLinks'。
+
+##### `root_directory_secured`
+
+httpd.confの/ディレクトリについて、デフォルトのアクセスポリシーを設定します。`false`にすると、特定のアクセスポリシーがないすべてのリソースへのアクセスが許可されます。 `true`にするとデフォルトですべてのリソースへのアクセスが拒否されます。`true`の場合、リソースへのアクセスを許可するには、具体的なルールを使用する必要があります([`directories`](#parameter-directories-for-apachevhost)パラメータを用いたディレクトリブロックなどで)。
+
+ブーリアン。
+
+デフォルト値: `false`。
+
+##### `vhost_dir`
+
+バーチャルホストの設定ファイルの保存場所を変更します。
+
+デフォルト値: オペレーティングシステムによって異なります。
+
+- **Debian**: `/etc/apache2/sites-available`
+- **FreeBSD**: `/usr/local/etc/apache22/Vhosts`
+- **Gentoo**: `/etc/apache2/vhosts.d`
+- **Red Hat**: `/etc/httpd/conf.d`
+
+##### `vhost_include_pattern`
+
+`vhost_dir`に含まれるファイルのパターンを定義します。
+
+`[^.#]\*.conf[^~]`などの値に設定すると、このディレクトリで偶発的に作成されたファイル(バージョン管理システムやエディタのバックアップにより作成されたファイルなど)がサーバ設定に*含まれなく*なります。
+
+デフォルト: '*'、また、このモジュールの過去のバージョンのBC。
+
+一部のオペレーティングシステムでは、`*.conf`の値が使用されます。デフォルトでは、このモジュールは`.conf`で終わる設定ファイルを作成します。
+
+##### `user`
+
+Apacheがリクエストの応答に使用するユーザを変更します。Apacheの親プロセスは引き続きルートとして稼働しますが、子プロセスはこのパラメータで定義されたユーザとしてリソースにアクセスします。Puppetがこのユーザを管理しないようにするには、[`manage_user`][]パラメータを`false`に設定します。
+
+デフォルト値: [`apache::params`][]クラスにより設定されたユーザに依存します。これはオペレーティングシステムによって異なります。
+
+- **Debian**: 'www-data'
+- **FreeBSD**: 'www'
+- **Gentoo**および**Red Hat**: 'apache'
+
+Puppetがこのユーザを管理しないようにするには、[`manage_user`][]パラメータをfalseに設定します。
+
+##### `apache_name`
+
+インストールするApacheパッケージの名前。Red Hatのソフトウェアコレクションのパッケージなど、標準的ではないApacheパッケージを使用している場合は、デフォルト設定をオーバーライドする必要があるかもしれません。
+
+デフォルト値: [`apache::params`][]クラスにより設定されたユーザに依存します。これはオペレーティングシステムによって異なります。
+
+- **Debian**: 'apache2'
+- **FreeBSD**: 'apache24'
+- **Gentoo**: 'www-servers/apache'
+- **Red Hat**: 'httpd'
+
+##### `error_log`
+
+メインサーバインスタンスのエラーログファイルの名前。`/`、`|`、または`syslog`で始まる文字列の場合、フルパスが設定されます。それ以外の場合は、ファイル名の先頭に`$logroot`がつきます。
+
+デフォルト値: オペレーティングシステムによって異なります。
+
+- **Debian**: 'error.log'
+- **FreeBSD**: 'httpd-error.log'
+- **Gentoo**: 'error.log'
+- **Red Hat**: 'error_log'
+- **Suse**: 'error.log'
+
+##### `scriptalias`
+
+グローバルスクリプトエイリアスに使用するディレクトリ。
+
+デフォルト値: オペレーティングシステムによって異なります。
+
+- **Debian**: '/usr/lib/cgi-bin'
+- **FreeBSD**: '/usr/local/www/apache24/cgi-bin'
+- **Gentoo**: 'var/www/localhost/cgi-bin'
+- **Red Hat**: '/var/www/cgi-bin'
+- **Suse**: '/usr/lib/cgi-bin'
+
+##### `access_log_file`
+
+メインサーバインスタンスのアクセスログファイルの名前。
+
+デフォルト値: オペレーティングシステムによって異なります。
+
+- **Debian**: 'error.log'
+- **FreeBSD**: 'httpd-access.log'
+- **Gentoo**: 'access.log'
+- **Red Hat**: 'access_log'
+- **Suse**: 'access.log'
+
+#### クラス: `apache::dev`
+
+Apache開発ライブラリをインストールします。
+
+デフォルト値: オペレーティングシステムによって異なります。使用するオペレーティングシステムに基づく、[`apache::params`][]クラスの[`dev_packages`][]パラメータ。
+
+- **Debian**: Ubuntu 13.10およびDebian 8では'libaprutil1-dev'、'libapr1-dev'、'apache2-dev'。その他のバージョンでは'apache2-prefork-dev'。
+- **FreeBSD**: `undef`; FreeBSDでは、`apache::dev`を宣言する前に`apache::package`または`apache`クラスを宣言する必要があります。
+- **Gentoo**: `undef`
+- **Red Hat**: 'httpd-devel'
+
+#### クラス: `apache::vhosts`
+
+[`apache::vhost`][]定義タイプを作成します。
+
+**パラメータ**:
+
+* `vhosts`: [`apache::vhost`][]定義タイプのパラメータを指定します。
+
+  値: [ハッシュ][]、キーは名前を表し、値は[`apache::vhost`][]定義タイプのパラメータの[ハッシュ][]を表します。
+
+  デフォルト値: '{}'。
+
+  > **注意**: すべてのバーチャルホストのパラメータのリストや[バーチャルホストの設定]については、[`apache::vhost`][]定義タイプのリファレンスを参照してください。
+
+  例えば、[名前ベースのバーチャルホスト][名前ベースのバーチャルホスト]のcustom_vhost_1を作成するには、`vhosts`パラメータを'{ "custom_vhost_1" => { "docroot" => "/var/www/custom_vhost_1", "port" => "81" }'に設定し、このクラスを宣言します。
+
+``` puppet
+class { 'apache::vhosts':
+  vhosts => {
+    'custom_vhost_1' => {
+      'docroot' => '/var/www/custom_vhost_1',
+      'port'    => '81',
+    },
+  },
+}
+```
+
+#### クラス: `apache::mod::<MODULE NAME>`
+
+指定した[Apacheモジュール][]を有効にします。Apacheモジュールを有効にして設定するには、このクラスを宣言します。
+
+例えば、アイコンなしで[`mod_alias`][]をインストールして有効にするには、`icons_options`パラメータをNone'に設定して[`apache::mod::alias`][]クラスを宣言します。
+
+``` puppet
+class { 'apache::mod::alias':
+  icons_options => 'None',
+}
+```
+
+以下のApacheモジュールにはサポートするクラスがあり、その多くは、パラメータ化された設定が可能です。[`apache::mod`][]定義タイプを使えば、他のApacheモジュールをインストールできます。
+
+* `actions`
+* `alias` ([`apache::mod::alias`][]参照)
+* `auth_basic`
+* `auth_cas`\* ([`apache::mod::auth_cas`][]参照)
+* `auth_mellon`\* ([`apache::mod::auth_mellon`][]参照)
+* `auth_kerb`
+* `authn_core`
+* `authn_dbd`\* ([`apache::mod::authn_dbd`][]参照)
+* `authn_file`
+* `authnz_ldap`\* ([`apache::mod::authnz_ldap`][]参照)
+* `authnz_pam`
+* `authz_default`
+* `authz_user`
+* `autoindex`
+* `cache`
+* `cgi`
+* `cgid`
+* `cluster` ([`apache::mod::cluster`][]参照)
+* `dav`
+* `dav_fs`
+* `dav_svn`\*
+* `dbd`
+* `deflate\`
+* `dev`
+* `dir`\*
+* `disk_cache` ([`apache::mod::disk_cache`][]参照)
+* `dumpio` ([`apache::mod::dumpio`][]参照)
+* `env`
+* `event` ([`apache::mod::event`][]参照)
+* `expires`
+* `ext_filter` ([`apache::mod::ext_filter`][]参照)
+* `fastcgi`
+* `fcgid`
+* `filter`
+* `geoip` ([`apache::mod::geoip`][]参照)
+* `headers`
+* `include`
+* `info`\*
+* `intercept_form_submit`
+* `itk`
+* `jk` ([`apache::mod::jk`]参照)
+* `ldap` ([`apache::mod::ldap`][]参照)
+* `lookup_identity`
+* `mime`
+* `mime_magic`\*
+* `negotiation`
+* `nss`\* ([`apache::mod::nss`][]参照)
+* `pagespeed` ([`apache::mod::pagespeed`][]参照)
+* `passenger`\* ([`apache::mod::passenger`][]参照)
+* `perl`
+* `peruser`
+* `php` ([`mpm_module`][]を`prefork`に設定する必要があります)
+* `prefork`\*
+* `proxy`\* ([`apache::mod::proxy`][]参照)
+* `proxy_ajp`
+* `proxy_balancer`\* ([`apache::mod::proxy_balancer`][]参照)
+* `proxy_balancer`
+* `proxy_html` ([`apache::mod::proxy_html`][]参照)
+* `proxy_http`
+* `python`
+* `reqtimeout`
+* `remoteip`\*
+* `rewrite`
+* `rpaf`\*
+* `setenvif`
+* `security`
+* `shib`\* ([`apache::mod::shib`]参照)
+* `speling`
+* `ssl`\* ([`apache::mod::ssl`][]参照)
+* `status`\* ([`apache::mod::status`][]参照)
+* `suphp`
+* `userdir`\* ([`apache::mod::userdir`][]参照)
+* `version`
+* `vhost_alias`
+* `worker`\*
+* `wsgi` ([`apache::mod::wsgi`][]参照)
+* `xsendfile`
+
+モジュールに付いている*のマークは、設定やモジュールを設定するためのパラメータが含まれるテンプレートがあることを示しています。ほとんどのApacheモジュールクラスパラメータにはデフォルト値があり、設定は必要ありません。 テンプレートのあるモジュールについては、Puppetでモジュールとともにテンプレートファイルがインストールされます。これらのテンプレートファイルは、モジュールが機能するために必要です。
+
+##### クラス: `apache::mod::alias`
+
+[`mod_alias`][]をインストールして管理します。
+
+**パラメータ**:
+
+* `icons_options`: Apache [`Options`]ディレクティブにより、アイコンディレクトリのディレクトリリスティングを無効にします。
+
+  デフォルト値: 'Indexes MultiViews'。
+
+* `icons_path`: `/icons/`エイリアスのローカルパスを設定します。
+
+  デフォルト値: オペレーティングシステムによって異なります。
+
+    * **Debian**: `/usr/share/apache2/icons`
+    * **FreeBSD**: `/usr/local/www/apache24/icons`
+    * **Gentoo**: `/var/www/icons`
+    * *Red Hat**: `/var/www/icons`、ただし、Apache 2.4は`/usr/share/httpd/icons`
+
+#### クラス: `apache::mod::disk_cache`
+
+Apache 2.2に[`mod_disk_cache`][]、またはApache 2.4に[`mod_cache_disk`][]をインストールして設定します。
+
+デフォルト値: Apacheバージョンとオペレーティングシステムによって異なります。
+
+- **Debian**: `/var/cache/apache2/mod_cache_disk`
+- **FreeBSD**: `/var/cache/mod_cache_disk`
+- **Red Hat、Apache 2.4**: `/var/cache/httpd/proxy`
+- **Red Hat、Apache 2.2**: `/var/cache/mod_proxy`
+
+キャッシュルートを指定するには、パスを文字列として`cache_root`パラメータに渡します。
+
+``` puppet
+class {'::apache::mod::disk_cache':
+  cache_root => '/path/to/cache',
+}
+```
+
+##### クラス: `apache::mod::diskio`
+
+[`mod_diskio`][]をインストールして設定します。
+
+```puppet
+class{'apache':
+  default_mods => `false`,
+  log_level    => 'dumpio:trace7',
+}
+class{'apache::mod::diskio':
+  disk_io_input  => 'On',
+  disk_io_output => 'Off',
+}
+```
+
+**パラメータ**:
+
+* `dump_io_input`: すべての入力データをエラーログにダンプします。
+
+  値: 'On'、'Off'。
+
+  デフォルト値: 'Off'。
+
+* `dump_io_output`: すべての出力データをエラーログにダンプします。
+
+  値: 'On'、'Off'。
+
+  デフォルト値: 'Off'。
+
+##### クラス: `apache::mod::event`
+
+[`mod_mpm_event`][]をインストールして管理します。同じサーバ上に、`apache::mod::event`と一緒に[`apache::mod::itk`][]、[`apache::mod::peruser`][]、[`apache::mod::prefork`][]、[`apache::mod::worker`][]を含めることはできません。
+
+**パラメータ**:
+
+* `listenbacklog`: モジュールの[`ListenBackLog`][]ディレクティブでペンディング接続キューの最大長を設定します。`false`に設定すると、このパラメータが削除されます。
+
+  デフォルト値: '511'。
+
+* `maxrequestworkers` (_Apache 2.3.12以前_: `maxclients`): モジュールの[`MaxRequestWorkers`][]ディレクティブで、Apacheが同時に処理できる接続の最大数を設定します。`false`に設定すると、このパラメータが削除されます。
+
+  デフォルト値: '150'。
+
+* `maxconnectionsperchild` (_Apache 2.3.8以前_: `maxrequestsperchild`): モジュールの[`MaxConnectionsPerChild`][]ディレクティブで、子サーバが稼働中に処理する接続の数を制限します。`false`に設定すると、このパラメータが削除されます。 
+
+  デフォルト値: '0'。
+
+* `maxsparethreads` and `minsparethreads`: [`MaxSpareThreads`][]および[`MinSpareThreads`][]ディレクティブで、待機スレッドの最大数と最小数を設定します。`false`に設定すると、このパラメータが削除されます。
+
+  デフォルト値: それぞれ'75'および'25'。
+
+* `serverlimit`: [`ServerLimit`][]ディレクティブで、プロセスの設定数を制限します。`false`に設定すると、このパラメータが削除されます。
+
+  デフォルト値: '25'。
+
+* `startservers`: モジュールの[`StartServers`][]ディレクティブで、起動時に作成される子サーバプロセスの数を設定します。`false`に設定すると、このパラメータが削除されます。
+
+  デフォルト値: '2'。
+
+* `threadlimit`: モジュールの[`ThreadLimit`][]ディレクティブで、イベントスレッドの数を制限します。`false`に設定すると、このパラメータが削除されます。 
+
+  デフォルト値: '64'。
+
+* `threadsperchild`: [`ThreadsPerChild`][]ディレクティブで、各子サーバにより作成されるスレッドの数を設定します。
+
+  デフォルト値: '25'。`false`に設定すると、このパラメータが削除されます。
+
+##### クラス: `apache::mod::auth_cas`
+
+[`mod_auth_cas`][]をインストールして管理します。パラメータの名前はApacheモジュールのディレクティブと共通です。
+
+`cas_login_url`および`cas_validate_url`パラメータは必須です。 その他のいくつかのパラメータのデフォルト値は`undef`です。
+
+> **注意**: auth_casモジュールは、EPELにより提供される依存関係パッケージがなければ、RH/CentOSで使用できません。 [https://github.com/Jasig/mod_auth_cas]()を参照してください。
+
+**パラメータ**:
+
+- `cas_attribute_prefix`: ヘッダを追加します。SAMLバリデーションが有効になっている場合には、このヘッダの値が属性値になります。
+
+  デフォルト値: CAS_。
+
+- `cas_attribute_delimiter`:`cas_attribute_prefix`により作成されたヘッダの属性値の区切り文字。
+
+  デフォルト値: ,。
+
+- `cas_authoritative`: オプションの認証ディレクティブを承認してバインドするかどうかを決定します。
+
+  デフォルト値: `undef`。
+
+- `cas_certificate_path`: `cas_login_url`および`cas_validate_url`のサーバについて、証明書認証局のX509証明書へのパスを設定します。
+
+  デフォルト値: `undef`。
+
+- `cas_cache_clean_interval`: キャッシュクリーニング時間の最小秒数を設定します。
+
+  デフォルト値: `undef`。
+
+- `cas_cookie_domain`: `Set-Cookie` HTTPヘッダの`Domain=`パラメータの値を設定します。 
+
+  デフォルト値: `undef`。
+
+- `cas_cookie_entropy`: セッション識別子を作成する際に使用するバイト数を設定します。
+
+  デフォルト値: `undef`。
+
+- `cas_cookie_http_only`: `mod_auth_cas`がクッキーを発行する際のオプションの`HttpOnly`フラグを設定します。
+
+  デフォルト値: `undef`。
+
+- `cas_cookie_path`: casクッキーセッションデータの保存場所。Webサーバユーザによる書き込みを可能にする必要があります。
+
+  デフォルト値: OSによって異なります。
+
+- `cas_cookie_path_mode`: `cas_cookie_path`のモード。
+
+  デフォルト値: '0750'。
+
+- `cas_debug`: モジュールのデバッギングモードを有効にするかどうかを決定します。
+
+  デフォルト値: 'Off'。
+
+- `cas_idle_timeout`: 待機タイムアウトの制限を秒数で設定します。
+
+  デフォルト値: `undef`。
+
+- `cas_login_url`: **必須**。ユーザがCASで保護されたリソースへのアクセスを試み、かつアクティブなセッションがない場合に、モジュールがユーザをリダイレクトする先のURLを設定します。
+
+- `cas_proxy_validate_url`: プロキシバリデーションを実施する際に使用するURL。
+
+  デフォルト値: `undef`。
+
+- `cas_root_proxied_as`: このApacheサーバへのアクセスがプロキシされた場合に、エンドユーザに表示されるURLを設定します。
+
+  デフォルト値: `undef`。
+
+- `cas_scrub_request_headers`: mod_auth_cas内で特別な意味を持つ可能性のあるインバウンドリクエストヘッダを削除します。
+
+- `cas_sso_enabled`: シングルサインアウトの実験的サポートを有効にします(POSTデータが壊れる可能性があります)。
+
+  デフォルト値: 'Off'。
+
+- `cas_timeout`: `mod_auth_cas`セッションのアクティブ状態を維持する時間(秒数)を制限します。
+
+  デフォルト値: `undef`。
+
+- `cas_validate_depth`: チェーンされた証明書バリデーションの深さを制限します。
+
+  デフォルト値: `undef`。
+
+- `cas_validate_saml`: SAMLに関するCASサーバからの解析応答。
+
+  デフォルト値: 'Off'。
+
+- `cas_validate_server`: CASサーバの証明書をバリデーションするかどうか(1.1 - RedHat 7では廃止予定)。
+
+  デフォルト値: `undef`。
+
+- `cas_validate_url`: **必須**。HTTPクエリ文字列でクライアントの提示するチケットをバリデーションする際に使用するURL。
+
+- `cas_version`: 従うべきCASプロトコルバージョン。値: '1'、'2'。
+
+  デフォルト値: '2'。
+
+- `suppress_warning`: RedHat上にいることを示す警告を表示しないようにします(`mod_auth_cas`パッケージは、現在はepel-testingレポジトリで使用できます)。
+
+  デフォルト値: `false`。
+
+##### クラス: `apache::mod::auth_mellon`
+
+[`mod_auth_mellon`][]をインストールして管理します。パラメータの名前はApacheモジュールのディレクティブと共通です。
+
+``` puppet
+class{ 'apache::mod::auth_mellon':
+  mellon_cache_size => 101,
+}
+```
+
+**パラメータ**:　
+
+* `mellon_cache_entry_size`: 1回のセッションの最大サイズ。
+
+  デフォルト値: `undef`。
+
+* `mellon_cache_size`: mellonキャッシュのサイズ、単位はメガバイト。
+
+  デフォルト値: 100。
+
+* `mellon_lock_file`: ロックファイルの場所。
+
+  デフォルト値: '`/run/mod_auth_mellon/lock`'。
+
+* `mellon_post_directory`: ポストリクエストが保存される場所のフルパス。
+
+  デフォルト値: '`/var/cache/apache2/mod_auth_mellon/`'。
+
+* `mellon_post_ttl`: ポストリクエストの維持時間。
+
+  デフォルト値: `undef`。
+
+* `mellon_post_size`: ポストリクエストの最大サイズ。
+
+  デフォルト値: `undef`。
+
+* `mellon_post_count`: ポストリクエストの最大数。
+
+ デフォルト値: `undef`。
+
+##### クラス: `apache::mod::authn_dbd`
+
+`mod_authn_dbd`をインストールし、`authn_dbd.conf.erb`テンプレートを使用して設定を生成します。オプションで、AuthnProviderAliasを作成します。
+
+``` puppet
+class { 'apache::mod::authn_dbd':
+  $authn_dbd_params =>
+    'host=db01 port=3306 user=apache password=xxxxxx dbname=apacheauth',
+  $authn_dbd_query  => 'SELECT password FROM authn WHERE user = %s',
+  $authn_dbd_alias  => 'db_auth',
+}
+```
+
+**パラメータ**:　
+
+* `authn_dbd_alias`: AuthnProviderAlias'の名前。
+
+* `authn_dbd_dbdriver`: 使用するデータベースドライブを指定します。
+
+  デフォルト値: 'mysql'。
+
+* `authn_dbd_exptime`: DBDExptimeに相当します。
+
+  デフォルト値: 300。
+
+* `authn_dbd_keep`: DBDKeepに相当します。
+
+  デフォルト値: 8。
+
+* `authn_dbd_max`: DBDMaxに相当します。
+
+  デフォルト値: 20。
+
+* `authn_dbd_min`: DBDMinに相当します。
+
+  デフォルト値: 4。
+
+* `authn_dbd_params`: **必須**。接続文字列に関して、DBDParamsに相当します。
+
+* `authn_dbd_query`: 認証に関してユーザとパスワードを問い合わせるかどうか。
+
+##### クラス: `apache::mod::authnz_ldap`
+
+`mod_authnz_ldap`をインストールし、`authnz_ldap.conf.erb`テンプレートを使用して設定を生成します。
+
+**パラメータ**:　
+
+* `package_name`: パッケージの名前。
+
+  デフォルト値: `undef`。
+
+* `verify_server_cert`: サーバの証明書を確認するかどうか。
+
+  デフォルト値: `undef`。
+
+##### クラス: `apache::mod::cluster`
+
+**注意**: `mod_cluster`に関して提供されている公式なパッケージはありません。そのため、Apacheモジュールの外部から使用できるようにする必要があります。バイナリはhttp://mod-cluster.jboss.org/にあります。
+
+``` puppet
+class { '::apache::mod::cluster':
+  ip                      => '172.17.0.1',
+  allowed_network         => '172.17.0.',
+  balancer_name           => 'mycluster',
+  version                 => '1.3.1'
+}
+```
+
+**パラメータ**:　
+
+* `port`: mod_clusterのリッスンポート。
+
+  デフォルト値: '6666'。
+
+* `server_advertise`: サーバをアドバタイズするかどうか。
+
+  デフォルト値: `true`。
+
+* `advertise_frequency`: アドバタイズメッセージ間のインターバルを秒数[.ミリ秒]で設定します。
+
+  デフォルト値: 10。
+
+* `manager_allowed_network`: ネットワークにmod_cluster_managerへのアクセスを許可するかどうか。
+
+  デフォルト値: '127.0.0.1'。
+
+* `keep_alive_timeout`: Apacheがリクエストを待機する長さを秒数で指定します。
+
+  デフォルト値: 60。
+
+* `max_keep_alive_requests`: 維持されるリクエストの最大数。
+
+  デフォルト値: 0。
+
+* `enable_mcpm_receive`: MCPMを有効にするかどうか。 
+
+  デフォルト値: `true`。
+
+* `ip`: リッスンするIPアドレスを指定します。
+
+* `allowed_network`: バランスドメンバーネットワーク。
+
+* `version`: `mod_cluster`バージョンを指定します。httpd 2.4ではバージョン1.3.0以上が必要です。
+
+##### クラス: `apache::mod::deflate`
+
+[`mod_deflate`][]をインストールして設定します。
+
+**パラメータ**:　
+
+* `types`: デフレートする[MIMEタイプ][MIME `content*type`]の[配列][]。 
+
+  デフォルト値: [ 'text/html text/plain text/xml'、'text/css'、'application/x*javascript application/javascript application/ecmascript'、'application/rss+xml'、'application/json' ]。
+
+* `notes`: [ハッシュ][]、キーはタイプを表し、値はノート名を表します。
+
+  デフォルト値: { 'Input'  => 'instream'、'Output' => 'outstream'、'Ratio'  => 'ratio' }。
+
+##### クラス: `apache::mod::expires`
+
+[`mod_expires`][]をインストールし、`expires.conf.erb`を使用して設定を生成します。
+
+**パラメータ**:　
+
+* `expires_active`: ドキュメント領域に関して`Expires`ヘッダの生成を有効にします。
+
+  ブーリアン。
+
+  デフォルト値: `true`。
+
+* `expires_default`: [`ExpiresByType`][]構文または[インターバル構文][]を用いた有効期限計算のためのデフォルトアルゴリズムを指定します。
+
+  デフォルト値: `undef`。
+
+* `expires_by_type`: [MIME `content*type`][]とその有効時間のセットを記述します。
+
+  値: [ハッシュ][ハッシュ]の[配列][]、各ハッシュのキーは有効なMIME `content*type` ('text/json'など)、値は以下の有効な [インターバル構文][]。
+
+  デフォルト値: `undef`。
+
+##### クラス: `apache::mod::ext_filter`
+
+[`mod_ext_filter`][]をインストールして設定します。
+
+``` puppet
+class { 'apache::mod::ext_filter':
+  ext_filter_define => {
+    'slowdown'       => 'mode=output cmd=/bin/cat preservescontentlength',
+    'puppetdb-strip' => 'mode=output outtype=application/json cmd="pdb-resource-filter"',
+  },
+}
+```
+
+**パラメータ**:　
+
+* `ext_filter_define`: フィルタ名とそのパラメータのハッシュ。
+
+  デフォルト値: `undef`。
+
+##### クラス: `apache::mod::fcgid`
+
+[`mod_fcgid`][]をインストールして設定します。
+
+このクラスでは、使用可能なすべてのオプションを個別にパラメータ化するのではなく、`options` [ハッシュ][]を使って`mod_fcgid`を設定します。例:
+
+``` puppet
+class { 'apache::mod::fcgid':
+  options => {
+    'FcgidIPCDir'  => '/var/run/fcgidsock',
+    'SharememPath' => '/var/run/fcgid_shm',
+    'AddHandler'   => 'fcgid-script .fcgi',
+  },
+}
+```
+
+すべてのオプションのリストについては、[公式`mod_fcgid`ドキュメント][`mod_fcgid`]を参照してください。
+
+`apache::mod::fcgid`を含める場合は、ディレクトリごと、バーチャルホストごとに[`FcgidWrapper`][]を設定できます。最初にモジュールをロードする必要があります。`apache::vhost`で`fcgiwrapper`パラメータを設定している場合、Puppetは自動的にはモジュールを有効化しません。
+
+``` puppet
+include apache::mod::fcgid
+
+apache::vhost { 'example.org':
+  docroot     => '/var/www/html',
+  directories => {
+    path        => '/var/www/html',
+    fcgiwrapper => {
+      command => '/usr/local/bin/fcgiwrapper',
+    }
+  },
+}
+```
+
+##### クラス: `apache::mod::geoip`
+
+[`mod_geoip`][]をインストールして管理します。
+
+**パラメータ**:　
+
+* `db_file`: GeoIPデータベースファイルのパスを設定します。
+
+  値: パス、または複数のGeoIPデータベースファイルの[配列][]パス。
+
+  デフォルト値: `/usr/share/GeoIP/GeoIP.dat`。
+
+* `enable`: [`mod_geoip`][]を全体で有効にするかどうかを決定します。
+
+  ブーリアン。
+
+  デフォルト値: `false`。　
+
+* `flag`: GeoIPフラグを設定します。
+
+  値: 'CheckCache'、'IndexCache'、'MemoryCache'、'Standard'。
+
+  デフォルト値: 'Standard'。
+
+* `output`: 使用するアウトプット変数を定義します。
+
+  値: 'All'、'Env'、'Request'、'Notes'。
+
+  デフォルト値: 'All'。
+
+* `enable_utf8`: アウトプットをISO*8859*1 (ラテン*1)からUTF*8に変更します。
+
+  ブーリアン。
+
+  デフォルト値: `undef`。
+
+* `scan_proxy_headers`: [GeoIPScanProxyHeaders][]オプションを有効にします。
+
+  ブーリアン。
+
+  デフォルト値: `undef`。
+
+* `scan_proxy_header_field`: クライアントのIPアドレスの決定に使用するヘッダの[`mod_geoip`][]を指定します。
+
+  デフォルト値: `undef`。
+
+* `use_last_xforwarededfor_ip` (sic): IPアドレスのカンマ区切りリストで見つかったクライアントのIPの最初または最後のIPアドレスを使うかどうかを決定します。
+
+  ブーリアン。
+
+  デフォルト値: `undef`。
+
+##### クラス: `apache::mod::info`
+
+サーバ設定の全体的な概要を提供する[`mod_info`][]をインストールして管理します。
+
+**パラメータ**:　
+
+* `allow_from`: IPv4またはIPv6アドレスのホワイトリスト、または`/server*info`にアクセスできる範囲。
+
+  値: IPv4アドレス、IPv6アドレス、または範囲の1つまたは複数のオクテット、またはいずれかの配列。
+
+  デフォルト値: ['127.0.0.1','::1']。
+
+* `apache_version`: 文字列で表されるApacheのバージョン番号、'2.2'や'2.4'など。
+
+  デフォルト値: [`$::apache::apache_version`][`apache_version`]の値。
+
+
+* `restrict_access`: アクセス制限を有効にするかどうかを決定します。`false`の場合、`allow_from`ホワイトリストは無視され、すべてのIPアドレスが `/server*info`にアクセスできるようになります。
+
+  ブーリアン。
+
+  デフォルト値: `true`。
+
+##### クラス: `apache::mod::jk`
+
+`mod_jk`をインストールして管理します。これは、Apache httpdリダイレクションと古いバージョンのTomCatおよびJBossを結ぶコネクタです。
+
+**注意**: mod\_jkに関して提供されている公式のパッケージはありません。そのため、apacheモジュールの制御以外の手段で使用できるようにする必要があります。バイナリは[Apache Tomcatコネクタダウンロードページ](https://tomcat.apache.org/download-connectors.cgi)にあります。
+
+``` puppet
+class { '::apache::mod::jk':
+  workers_file = 'conf/workers.properties',
+  mount_file   = 'conf/uriworkermap.properties',
+  shm_file     = 'run/jk.shm',
+  shm_size     = '50M',
+  $workers_file_content = {
+    <Content>
+  },
+}
+```
+
+**`apache::mod::jk`**内のパラメータ:
+
+`mod_jk`パラメータを理解するための情報源としては、[公式ドキュメント](https://tomcat.apache.org/connectors-doc/reference/apache.html)が最適です。ただし、\*file_contentはこれに含まれません。
+
+**workers\_file\_content**
+
+各ディレクティブにはフォーマット`worker.<Worker name>.<Property>=<Value>`があります。このマップは複数ハッシュのハッシュとして表され、外側のハッシュはワーカーを指定し、内側の各ハッシュは各ワーカーのプロパティと値を指定します。
+また、2つのグローバルディレクティブ 'worker.list'および'worker.mantain'もあります。  
+例えば、ワーカーファイルは以下のようになります。
+
+```
+worker.list = status
+worker.list = some_name,other_name
+
+worker.mantain = 60
+
+# Optional comment
+worker.some_name.type=ajp13
+worker.some_name.socket_keepalive=true
+
+# I just like comments
+worker.other_name.type=ajp12 (why would you?)
+worker.other_name.socket_keepalive=false
+```
+
+以下のようにパラメータ化する必要があります。
+
+```
+$workers_file_content = {
+  worker_lists   => ['status', 'some_name,other_name'],
+  worker_mantain => '60',
+  some_name      => {
+    comment          => 'Optional comment',
+    type             => 'ajp13',
+    socket_keepalive => 'true',
+  },
+  other_name     => {
+    comment          => 'I just like comments',
+    type             => 'ajp12',
+    socket_keepalive => 'false',
+  },
+}
+```
+
+**mount\_file\_content**
+
+各ディレクティブにはフォーマット`<URI> = <Worker name>`があります。このマップは複数ハッシュのハッシュとして表され、外側のハッシュはワーカーを指定し、内側の各ハッシュは次の2つのアイテムを含みます: uri_list - ワーカーにマップするURIを用いた配列 - およびコメント - ワーカーに関するコメントを記したオプションの文字列。 
+例えば、マウントファイルは以下のようになります。
+
+```
+# Worker 1
+/context_1/ = worker_1
+/context_1/* = worker_1
+
+# Worker 2
+/ = worker_2
+/context_2/ = worker_2
+/context_2/* = worker_2
+```
+
+以下のようにパラメータ化する必要があります。　
+
+```
+$mount_file_content = {
+  worker_1 => {
+    uri_list => ['/context_1/', '/context_1/*'],
+    comment  => 'Worker 1',
+  },
+  worker_2 => {
+    uri_list => ['/context_2/', '/context_2/*'],
+    comment  => 'Worker 2',
+  },
+},
+```
+
+##### クラス: `apache::mod::passenger`
+
+[`mod_passenger`][]をインストールして管理します。Red Hatベースのシステムの場合は、[passengerドキュメント](https://www.phusionpassenger.com/library/install/apache/install/oss/el6/#step-1:-upgrade-your-kernel,-or-disable-selinux)に記載された最小要件を満たしていることを確認してください。
+
+**パラメータ**:　
+
+* `passenger_high_performance`: [`PassengerHighPerformance`](https://www.phusionpassenger.com/library/config/apache/reference/#passengerhighperformance)を設定します。
+
+  値: 'On'、'Off'。　
+
+  デフォルト値: `undef`。
+
+* `passenger_pool_idle_time`: [`PassengerPoolIdleTime`](https://www.phusionpassenger.com/library/config/apache/reference/#passengerpoolidletime)を設定します。
+
+  デフォルト値: `undef`。
+
+* `passenger_max_pool_size`: [`PassengerMaxPoolSize`](https://www.phusionpassenger.com/library/config/apache/reference/#passengermaxpoolsize)を設定します。
+
+  デフォルト値: `undef`。
+
+* `passenger_max_request_queue_size`: [`PassengerMaxRequestQueueSize`](https://www.phusionpassenger.com/library/config/apache/reference/#passengermaxrequestqueuesize)を設定します。
+
+  デフォルト値: `undef`。
+
+* `passenger_max_requests`: [`PassengerMaxRequests`](https://www.phusionpassenger.com/library/config/apache/reference/#passengermaxrequests)を設定します。
+
+  デフォルト値: `undef`。
+
+* `passenger_data_buffer_dir`: [`PassengerDataBufferDir`](https://www.phusionpassenger.com/library/config/apache/reference/#passengerdatabufferdir)を設定します。
+
+  デフォルト値: `undef`。
+
+##### クラス: `apache::mod::ldap`
+
+[`mod_ldap`][]をインストールして設定し、[`LDAPTrustedGlobalCert`](https://httpd.apache.org/docs/current/mod/mod_ldap.html#ldaptrustedglobalcert)ディレクティブの修正を可能にします。
+
+``` puppet
+class { 'apache::mod::ldap':
+  ldap_trusted_global_cert_file => '/etc/pki/tls/certs/ldap-trust.crt',
+  ldap_trusted_global_cert_type => 'CA_DER',
+  ldap_shared_cache_size        => '500000',
+  ldap_cache_entries            => '1024',
+  ldap_cache_ttl                => '600',
+  ldap_opcache_entries          => '1024',
+  ldap_opcache_ttl              => '600',
+}
+```
+
+**パラメータ**　
+
+* `apache_version`: インストールされたApacheバージョンを指定します。
+
+  デフォルト値: `undef`。
+
+* `ldap_trusted_global_cert_file`: LDAPサーバ上でSSLまたはTLS接続を確立する際に使用する、信頼できるCA証明書のパスとファイル名を指定します。
+
+* `ldap_trusted_global_cert_type`:グローバルな信頼できる証明書フォーマットを指定します。
+
+  デフォルト値: 'CA_BASE64'。
+
+* `ldap_shared_cache_size`: 共有されたメモリのキャッシュのサイズをバイトで指定します。
+
+* `ldap_cache_entries`: 一次LDAPキャッシュのエントリの最大数を指定します。
+
+* `ldap_cache_ttl`: キャッシュされたアイテムが有効に保たれる時間を秒数で指定します。
+
+* `ldap_opcache_entries`: LDAP比較演算のキャッシュに用いるエントリ数を指定します。
+
+* `ldap_opcache_ttl`: 演算キャッシュのエントリが有効に保たれる時間を秒数で指定します。
+
+* `package_name`: カスタムパッケージ名を指定します。
+
+  デフォルト値: `undef`。
+
+##### クラス: `apache::mod::negotiation`
+
+[`mod_negotiation`][]をインストールして設定します。
+
+**パラメータ**:　
+
+* `force_language_priority`: `ForceLanguagePriority`オプションを設定します。
+
+  値: 文字列。
+
+  デフォルト値: `Prefer Fallback`。
+
+* `language_priority`: モジュールの`LanguagePriority`オプションを設定するための言語の[配列][]。
+
+  デフォルト値: [ 'en'、'ca'、'cs'、'da'、'de'、'el'、'eo'、'es'、'et'、'fr'、'he'、'hr'、'it'、'ja'、'ko'、'ltz'、'nl'、'nn'、'no'、'pl'、'pt'、'pt*BR'、'ru'、'sv'、'zh*CN'、'zh*TW' ]。
+
+##### クラス: `apache::mod::nss`
+
+NSS暗号化ライブラリを使用するApacheのSSLプロバイダ。
+
+**パラメータ:**
+
+- `transfer_log`: access.logのパス。
+- `error_log`: error.logのパス。
+- `passwd_file`: NSSPassPhraseDialogディレクティブに使用するファイルのパス。
+- `port`: SSLポート。デフォルト値8443。
+
+##### クラス: `apache::mod::pagespeed`
+
+[`mod_pagespeed`][]をインストールして管理します。これは、Webページをリライトして冗長性と帯域を軽減するためのGoogleモジュールです。
+
+このapacheモジュールには`mod-pagespeed-stable`が必要ですが、Puppetはパッケージを自動的にインストールするために必要なソフトウェアを管理**しません**。パッケージがインストールされていないか、お使いのパッケージマネージャで使用できない場合にこのクラスを宣言すると、Puppet実行は失敗します。
+
+> **注意:** お使いのシステムが最新のGoogle Pagespeed要件を満たしていることを確認してください。
+
+**パラメータ**:　
+
+以下のパラメータはモジュールのディレクティブに相当します。詳細については、[モジュールのドキュメント][`mod_pagespeed`]を参照してください。
+
+* `inherit_vhost_config`: デフォルト値: 'on'。
+* `filter_xhtml`: デフォルト値: `false`。
+* `cache_path`: デフォルト値: '/var/cache/mod_pagespeed/'。
+* `log_dir`: デフォルト値: '/var/log/pagespeed'。
+* `memcache_servers`: デフォルト値: []。
+* `rewrite_level`: デフォルト値: 'CoreFilters'。
+* `disable_filters`: デフォルト値: []。
+* `enable_filters`: デフォルト値: []。
+* `forbid_filters`: デフォルト値: []。
+* `rewrite_deadline_per_flush_ms`: デフォルト値: 10。
+* `additional_domains`: デフォルト値: `undef`。
+* `file_cache_size_kb`: デフォルト値: 102400。
+* `file_cache_clean_interval_ms`: デフォルト値: 3600000。
+* `lru_cache_per_process`: デフォルト値: 1024。
+* `lru_cache_byte_limit`: デフォルト値: 16384。
+* `css_flatten_max_bytes`: デフォルト値: 2048。
+* `css_inline_max_bytes`: デフォルト値: 2048。
+* `css_image_inline_max_bytes`: デフォルト値: 2048。
+* `image_inline_max_bytes`: デフォルト値: 2048。
+* `js_inline_max_bytes`: デフォルト値: 2048。
+* `css_outline_min_bytes`: デフォルト値: 3000。
+* `js_outline_min_bytes`: デフォルト値: 3000。
+* `inode_limit`: デフォルト値: 500000。
+* `image_max_rewrites_at_once`: デフォルト値: 8。
+* `num_rewrite_threads`: デフォルト値: 4。
+* `num_expensive_rewrite_threads`: デフォルト値: 4。
+* `collect_statistics`: デフォルト値: 'on'。
+* `statistics_logging`: デフォルト値: 'on'。
+* `allow_view_stats`: デフォルト値: []。
+* `allow_pagespeed_console`: デフォルト値: []。
+* `allow_pagespeed_message`: デフォルト値: []。
+* `message_buffer_size`: デフォルト値: 100000。
+* `additional_configuration`: ディレクティブ値ペアのハッシュ、またはpagespeed設定の最後に挿入する行の配列。デフォルト値: '{ }'。
+
+##### クラス: `apache::mod::passenger`　
+
+`mod_passenger`をインストールして設定します。
+
+>**注意**: passengerモジュールは、EPELにより提供される依存関係パッケージと`mod_passengers`カスタムリポジトリがなければ、RH/CentOSでは使用できません。前述の`manage_repo`パラメータと[https://www.phusionpassenger.com/library/install/apache/install/oss/el7/]()を参照してください。
+
+**パラメータ**:__``<>
+
+* `passenger_conf_file`: `$::apache::params::passenger_conf_file`
+* `passenger_conf_package_file: `$::apache::params::passenger_conf_package_file`
+* `passenger_high_performance`: デフォルト値: `undef`
+* `passenger_pool_idle_time`: デフォルト値: `undef`
+* `passenger_max_request_queue_size`: デフォルト値: `undef`
+* `passenger_max_requests`: デフォルト値: `undef`
+* `passenger_spawn_method`: デフォルト値: `undef`
+* `passenger_stat_throttle_rate`: デフォルト値: `undef`
+* `rack_autodetect`: デフォルト値: `undef`
+* `rails_autodetect`: デフォルト値: `undef`
+* `passenger_root` : `$::apache::params::passenger_root`
+* `passenger_ruby` : `$::apache::params::passenger_ruby`
+* `passenger_default_ruby`: `$::apache::params::passenger_default_ruby`
+* `passenger_max_pool_size`: デフォルト値: `undef`
+* `passenger_min_instances`: デフォルト値: `undef`
+* `passenger_max_instances_per_app`: デフォルト値: `undef`
+* `passenger_use_global_queue`: デフォルト値: `undef`
+* `passenger_app_env`: デフォルト値: `undef`
+* `passenger_log_file`: デフォルト値: `undef`
+* `passenger_log_level`: デフォルト値: `undef`
+* `passenger_data_buffer_dir`: デフォルト値: `undef`
+* `manage_repo`: phusionpassenger.comリポジトリを管理するかどうか。デフォルト値: `true`
+* `mod_package`: デフォルト値: `undef`
+* `mod_package_ensure`: デフォルト値: `undef`
+* `mod_lib`: デフォルト値: `undef`
+* `mod_lib_path`: デフォルト値: `undef`
+* `mod_id`: デフォルト値: `undef`
+* `mod_path`: デフォルト値: `undef`
+
+##### クラス: `apache::mod::proxy`
+
+I`mod_proxy`をインストールし、`proxy.conf.erb`テンプレートを使用して設定を生成します。
+
+**`apache::mod::proxy`内のパラメータ**:
+
+.
+
+- `allow_from`: デフォルト値: `undef`
+- `apache_version`: デフォルト値: `undef`
+- `package_name`: デフォルト値: `undef`
+- `proxy_requests`: デフォルト値: 'Off'
+- `proxy_via`: デフォルト値: 'On'
+
+##### クラス: `apache::mod::proxy_balancer`
+
+ロードバランシングを提供する[`mod_proxy_balancer`][]をインストールして管理します。
+
+**パラメータ**:　
+
+* `manager`: バランサマネージャのサポートを有効にするかどうかを決定します。
+
+  デフォルト値: `false`。
+
+* `manager_path`: バランサマネージャのサーバロケーション。
+
+  デフォルト値: '/balancer*manager'。
+
+* `allow_from`: `/balancer*manager`にアクセスできるIPv4またはIPv6アドレスの[配列][]。
+
+  デフォルト値: ['127.0.0.1','::1']。　
+
+* `apache_version`: 文字列で表されるApacheのバージョン番号、'2.2'や'2.4'など。　
+
+  デフォルト値: [`$::apache::apache_version`][`apache_version`]の値。Apache 2.4以上では、`mod_slotmem_shm`がロードされます。
+
+##### クラス: `apache::mod::php`
+
+[`mod_php`][]をインストールして設定します。
+
+**パラメータ**:　
+
+以下のパラメータのデフォルト値は、オペレーティングシステムによって異なります。このクラスのパラメータのほとんどは、`mod_php`ディレクティブに相当します。詳細については、[モジュールのドキュメント][`mod_php`]を参照してください。
+
+* `package_name`: `mod_php`をインストールするパッケージの名前。
+* `path`: `mod_php`共有オブジェクト(`.so`)ファイルのパスを定義します。
+* `source`: デフォルト設定のパスを定義します。値には`puppet:///`パスが含まれます。
+* `template`: Puppetが設定ファイルの生成に使用する`php.conf`テンプレートのパスを定義します。
+* `content`: `php.conf`に任意のコンテンツを追加します。
+
+##### クラス: `apache::mod::proxy_html`
+
+**注意**: `mod_proxy_html`に関して提供されている公式なパッケージはありません。そのため、apacheモジュールの外部から使用できるようにする必要があります。
+
+##### クラス: `apache::mod::reqtimeout`
+
+[`mod_reqtimeout`][]をインストールして設定します。
+
+**パラメータ**　
+
+* `timeouts`: [`RequestReadTimeout`][]オプションを設定します。
+
+  値:  文字列または[配列][]。
+
+  デフォルト値: ['header=20-40,MinRate=500', 'body=20,MinRate=500']。
+
+##### クラス: `apache::mod::rewrite`
+
+Apacheモジュール`mod_rewrite`をインストールして有効にします。
+
+##### クラス: `apache::mod::shib`
+
+[Shibboleth](http://shibboleth.net/) Apacheモジュール`mod_shib`をインストールします。このモジュールは、Shibboleth認証プロバイダおよびShibboleth FederationsによるSAML2シングルサインオン(SSO)認証を有効にするものです。このクラスを定義すると、`apache::vhost`インスタンス内でShibboleth固有のパラメータが有効になります。
+
+このクラスでインストールおよび設定されるのは、Shibboleth SSO認証をコンシュームするWebアプリケーションのApacheコンポーネントのみです。PuppetでShibboleth設定を手動で管理することも、[Shibboleth Puppetモジュール](https://github.com/aethylred/puppet-shibboleth)を使用することもできます。
+
+**注意**: shibbolethモジュールは、Shibbolethのリポジトリにより提供される依存関係パッケージがなければ、RH/CentOSでは使用できません。[http://wiki.aaf.edu.au/tech-info/sp-install-guide]()を参照してください。
+
+##### クラス: `apache::mod::ssl`
+
+[Apache SSL機能][`mod_ssl`]をインストールし、`ssl.conf.erb`テンプレートを使用して設定を生成します。ほとんどのオペレーティングシステムでは、この`ssl.conf`はモジュール設定ディレクトリに置かれています。Red Hatベースのオペレーティングシステムでは、このファイルは`/etc/httpd/conf.d`にあります。これは、RPMが設定を保存するのと同じロケーションです。
+
+バーチャルホストでSSLを使用するには、`::apache`の[`default_ssl_vhost`][]パラメータを`true`に設定する**か**、[`apache::vhost`][]の[`ssl`][]パラメータを`true`に設定する必要があります。
+
+- `ssl_cipher`: デフォルト値: 'HIGH:MEDIUM:!aNULL:!MD5:!RC4'
+- `ssl_compression`: デフォルト値: false
+- `ssl_cryptodevice`: デフォルト値: 'builtin'
+- `ssl_honorcipherorder`: デフォルト値: true
+- `ssl_openssl_conf_cmd`: デフォルト値: undef
+- `ssl_options`: デフォルト値: [ 'StdEnvVars' ]
+- `ssl_pass_phrase_dialog`: デフォルト値: 'builtin'
+- `ssl_protocol`: デフォルト値: [ 'all', '-SSLv2', '-SSLv3' ]
+- `ssl_proxy_protocol`: デフォルト値: []
+- `ssl_random_seed_bytes`: 有効なオプション: 文字列、デフォルト値: '512'
+- `ssl_sessioncache`: 有効なオプション: 文字列。デフォルト値: '300'
+- `ssl_sessioncachetimeout`: 有効なオプション: 文字列。デフォルト値: '300'
+- `ssl_mutex`: デフォルト値: OSによって異なります。有効なオプション: [mod_ssl][mod_ssl]ドキュメントを参照
+  - RedHat/FreeBSD/Suse/Gentoo: 'default'
+  - Debian/Ubuntu + Apache >= 2.4: 'default'
+  - Debian/Ubuntu + Apache < 2.4: 'file:\${APACHE_RUN_DIR}/ssl_mutex'
+**パラメータ:
+
+* `ssl_cipher`
+
+  デフォルト値: 'HIGH:MEDIUM:!aNULL:!MD5:!RC4'
+
+* `ssl_compression`
+
+  デフォルト値: `false`
+
+* `ssl_cryptodevice`
+
+  デフォルト値: 'builtin'
+
+* `ssl_honorcipherorder`
+
+  デフォルト値: `true`
+
+* `ssl_openssl_conf_cmd`
+
+  デフォルト値: `undef`
+
+* `ssl_options`
+
+  デフォルト値: [ 'StdEnvVars' ]
+
+* `ssl_pass_phrase_dialog`
+
+  デフォルト値: 'builtin'　
+
+* `ssl_protocol`
+
+  デフォルト値: [ 'all', '*SSLv2', '*SSLv3' ]
+
+* `ssl_random_seed_bytes`
+
+  値: 文字列。
+
+  デフォルト値: '512'
+
+* `ssl_sessioncachetimeout`
+
+  値: 文字列。
+
+  デフォルト値: '300'
+
+* `ssl_mutex`:
+
+  値: [mod_ssl][mod_ssl]ドキュメントを参照。
+
+  デフォルト値: OSによって異なります:
+
+  * RedHat/FreeBSD/Suse/Gentoo: 'default'.
+  * Debian/Ubuntu + Apache >= 2.4: 'default'.
+  * Debian/Ubuntu + Apache < 2.4: 'file:\${APACHE_RUN_DIR}/ssl_mutex'.
+  * Ubuntu 10.04: 'file:/var/run/apache2/ssl_mutex'.
+
+
+##### クラス: `apache::mod::status`
+
+[`mod_status`][]をインストールし、`status.conf.erb`テンプレートを使用して設定を生成します。
+
+**パラメータ**:　
+
+* `allow_from`: `/server-status`にアクセスできるIPv4またはIPv6アドレスの[配列][]。
+
+  デフォルト値: ['127.0.0.1','::1']。
+* `extended_status`: [`ExtendedStatus`][]ディレクティブをつうじて、各リクエストに関する拡張ステータス情報を追跡するかどうかを決定します。
+
+  値: 'Off'、'On'。
+
+  デフォルト値: 'On'。
+
+* `status_path`: ステータスページのサーバロケーション。
+
+  デフォルト値: '/server-status'。
+
+##### クラス: `apache::mod::userdir`
+
+`http://example.com/~user/`構文を用いて、ユーザ指定のディレクトリにアクセスできるようにします。すべてのパラメータは、[公式のApacheドキュメント](https://httpd.apache.org/docs/2.4/mod/mod_userdir.html)で見られます。
+
+**パラメータ**:　
+
+* `overrides`: ディレクティブタイプの[配列][]。
+
+  デフォルト値: '[ 'FileInfo', 'AuthConfig', 'Limit', 'Indexes' ]'。
+
+##### クラス: `apache::mod::version`
+
+多くのオペレーティングシステムおよびApache構成上で[`mod_version`][]をインストールします。
+
+Apache 2.4を使用するDebianおよびUbuntuが`apache::mod::version`で分類された場合は、`mod_version`がビルトインされているためロードできない旨の警告をPuppetが表示します。
+
+##### クラス: `apache::mod::security`
+
+Trustwaveの[`mod_security`][]をインストールして設定します。これはすべてのバーチャルホストでデフォルトで有効化され、実行されます。
+
+**パラメータ**:　
+
+* `activated_rules`: `modsec_crs_path`のルールの[配列][]またはsymlinkを使用してアクティベートする絶対値。 
+* `allowed_methods`: 許可されるHTTPメソッドのスペース*区切りリスト。
+
+  デフォルト値: 'GET HEAD POST OPTIONS'。
+
+* `content_types`: 1つまたは複数の許可される[MIMEタイプ][MIME `content*type`]のリスト。
+
+  デフォルト値: 'application/x*www*form*urlencoded|multipart/form*data|text/xml|application/xml|application/x*amf'。
+
+* `crs_package`: CRSルールをインストールするパッケージの名前。
+
+  デフォルト値: [`apache::params`][]内の`modsec_crs_package`。
+
+* `manage_security_crs`: security_crs.confルールファイルを管理します。
+
+  デフォルト値: `true`。
+
+* `modsec_dir`: Puppetがmodsec設定およびアクティベートされたルールリンクをインストールする場所のパスを定義します。 
+
+  デフォルト値: 'On'、[`apache::params`][]の`modsec_dir`により設定。
+${modsec\_dir}/activated\_rules。
+
+* `modsec_secruleengine`: modsecルールエンジンを設定します。値: 'On'、'Off'、'DetectionOnly'。
+
+  デフォルト値: [`apache::params`][]の`modsec_secruleengine`。
+
+* `restricted_extensions`: 禁止されるファイル拡張子のスペース*区切りリスト。
+
+  デフォルト値: '.asa/ .asax/ .ascx/ .axd/ .backup/ .bak/ .bat/ .cdx/ .cer/ .cfg/ .cmd/ .com/ .config/ .conf/ .cs/ .csproj/ .csr/ .dat/ .db/ .dbf/ .dll/ .dos/ .htr/ .htw/ .ida/ .idc/ .idq/ .inc/ .ini/ .key/ .licx/ .lnk/ .log/ .mdb/ .old/ .pass/ .pdb/ .pol/ .printer/ .pwd/ .resources/ .resx/ .sql/ .sys/ .vb/ .vbs/ .vbproj/ .vsdisco/ .webinfo/ .xsd/ .xsx/'。
+
+* `restricted_headers`: 禁止されるヘッダのスラッシュおよびスペースで区切ったリスト。
+
+  デフォルト値: 'Proxy*Connection/ /Lock*Token/ /Content*Range/ /Translate/ /via/ /if/'。
+
+* `secdefaultaction`: OWASP ModSecurityコアルールセットに関して、動作モード、自己完結('deny')、コラボレーティブ検出('pass')を設定します。
+
+  デフォルト値: 'deny'。"log,auditlog,deny,status:406,tag:'SLA 24/7'"などの完全な値を設定することもできます。
+
+* `secpcrematchlimit`: PCREライブラリのマッチ限度数を設定します。
+
+  デフォルト値: 1500。
+
+* `secpcrematchlimitrecursion`: PCREライブラリのマッチ再帰制限数を設定します。
+
+  デフォルト値: 1500。　
+
+* `logroot`: オーディットおよびデバッグログの場所を設定します。
+
+  デフォルト値はApacheのログディレクトリ(Redhat: `/var/log/httpd`、Debian: `/var/log/apache2`)。
+
+* `audit_log_releavant_status`: オーディットロギングの目的に関して、考慮すべき応答ステータスコードを設定します。
+
+  デフォルト値: '^(?:5|4(?!04))'。
+
+* `audit_log_parts`: [オーディットログ][]に入れるべきセクションを設定します。
+
+  デフォルト値: 'ABIJDEFHZ'。
+
+* `anomaly_score_blocking`: OWASP ModSecurityコアルールセットのコラボレーティブ検出ブロッキングをアクティベートまたはディアクティベートします。
+
+  デフォルト値: 'off'。
+
+* `inbound_anomaly_threshold`: OWASP ModSecurityコアルールセットのコラボレーティブ検出モードに関して、インバウンドブロッキングルールのスコアリング閾値レベルを設定します。
+
+  デフォルト値: 5。
+
+* `outbound_anomaly_threshold`: OWASP ModSecurityコアルールセットのコラボレーティブ検出モードに関して、アウトバウンドブロッキングルールのスコアリング閾値レベルを設定します。
+
+  デフォルト値: 4。　
+
+* `critical_anomaly_score`: OWASP ModSecurityコアルールセットのコラボレーティブ検出モードに関して、重要なセキュリティレベルのスコアリングポイントを設定します。
+
+  デフォルト値: 5。　
+
+* `error_anomaly_score`: OWASP ModSecurityコアルールセットのコラボレーティブ検出モードに関して、エラー深刻度レベルのスコアリングポイントを設定します。
+
+  デフォルト値: 4。　
+
+* `warning_anomaly_score`: OWASP ModSecurityコアルールセットのコラボレーティブ検出モードに関して、警告深刻度レベルのスコアリングポイントを設定します。
+
+  デフォルト値: 3。
+
+* `notice_anomaly_score`: OWASP ModSecurityコアルールセットのコラボレーティブ検出モードに関して、通知深刻度レベルのスコアリングポイントを設定します。 
+
+デフォルト値: 2。
+
+* `secrequestmaxnumargs`: リクエストの引数の最大数を設定します。
+
+  デフォルト値: 255。
+
+* `secrequestbodylimit`:  バッファリングに関してModSecurityが受け入れる最大リクエストボディサイズを設定します。
+
+  デフォルト値: '13107200'。
+
+* `secrequestbodynofileslimit`: バッファリングに関してModSecurityが受け入れる最大リクエストボディサイズを設定します。リクエスト内でトランスポートされたファイルのサイズは除外されます。 
+
+  デフォルト値: '131072'。
+
+* `secrequestbodyinmemorylimit`: ModSecurityがメモリに保存する最大リクエストボディサイズを設定します。
+
+  デフォルト値: '131072'。
+
+##### クラス: `apache::mod::wsgi`
+
+[`mod_wsgi`][]を使用したPythonサポートを有効にします。
+
+**パラメータ**:　
+
+* `mod_path`: `mod_wsgi`共有オブジェクト(`.so`)ファイルのパスを定義します。
+
+  デフォルト値: `undef`。　
+
+  * `mod_path`パラメータに`/`が含まれていない場合、Puppetではオペレーティングシステムのデフォルトのモジュールパスの先頭にこれを付加します。含まれている場合は、そのとおりに扱われます。
+
+* `package_name`: `mod_wsgi`をインストールするパッケージの名前。
+
+  デフォルト値: `undef`。　
+
+* `wsgi_python_home`: '/path/to/venv'などの[`WSGIPythonHome`][]ディレクティブを定義します。
+
+  値: パスを指定する文字列。
+
+  デフォルト値: `undef`。
+
+* `wsgi_python_path`: '/path/to/venv/site*packages'などの[`WSGIPythonPath`][]ディレクティブを定義します。
+
+  値: パスを指定する文字列。　
+
+  デフォルト値: `undef`。
+
+* `wsgi_restrict_embedded`: 'On'などの[`WSGIRestrictEmbedded`][]ディレクティブを定義します。
+
+値: On|Off|undef。
+
+デフォルト値: undef。
+
+* `wsgi_socket_prefix`: "\${APACHE\_RUN\_DIR}WSGI"などの[`WSGISocketPrefix`][]ディレクティブを定義します。
+
+  デフォルト値: [`apache::params`][]の`wsgi_socket_prefix`。
+
+このクラスのパラメータはモジュールのディレクティブに相当します。詳細については、[モジュールのドキュメント][`mod_wsgi`]を参照してください。
+
+### プライベートクラス
+
+#### クラス: `apache::confd::no_accf`
+
+FreeBSDの Apache 2.4で必要とされる`no-accf.conf`設定ファイルを`conf.d`内に作成します。
+
+#### クラス: `apache::default_confd_files`
+
+FreeBSDに`conf.d`を含めます。
+
+#### クラス: `apache::default_mods`
+
+デフォルト設定の実行に必要なApacheモジュールをインストールします。詳細については、`apache`クラスの[`default_mods`][]パラメータを参照してください。
+
+#### クラス: `apache::package`
+
+基本のApacheパッケージをインストールして設定します。
+
+#### クラス: `apache::params`
+
+各種のオペレーティングシステムのApacheパラメータを管理します。 
+
+#### クラス: `apache::service`
+
+Apacheデーモンを管理します。
+
+#### クラス: `apache::version`
+
+オペレーティングシステムに基づき、Apacheバージョンの自動検出を試みます。 
+
+### パブリック定義タイプ　
+
+#### 定義タイプ: `apache::balancer`
+
+[`mod_proxy`][]を用いて、Apacheロードバランシンググループ(バランサクラスタとも呼ばれます)を作成します。各ロードバランシンググループには、1つ以上のバランサメンバーが必要です。これは、 [`apache::balancermember`][]定義タイプによりPuppet内で宣言することができます。
+
+各Apacheロードバランシンググループにつき、1つの`apache::balancer`定義タイプを宣言します。すべてのバランサメンバーについて`apache::balancermember`定義タイプをエクスポートし、[エクスポートリソース][]を用いて単一のApacheロードバランササーバで収集することもできます。
+
+**パラメータ**:　
+
+##### `name`
+
+バランサクラスタのタイトルと、その設定を含む`conf.d`の名前を設定します。
+
+##### `proxy_set`
+
+キー‐値ペアを[`ProxySet`][]行として設定します。値: [ハッシュ][]。
+
+デフォルト値: '{}'。
+
+##### `collect_exported`
+
+[エクスポートリソース][]を使用するかどうかを決定します。
+
+すべてのバックエンドサーバを静的に宣言する場合は、このパラメータを`false`に設定し、宣言済みの既存のバランサメンバーリソースに依存するようにします。また、[配列][]引数とともに`apache::balancermember`を使用します。
+
+中央ノードで収集したエクスポートリソースを使用してバックエンドサーバを動的に宣言するには、このパラメータを`true`に設定し、バランサメンバーノードによりエクスポートされたバランサメンバーリソースを収集します。
+
+エクスポートリソースを使用しない場合は、1回のPuppet実行ですべてのバランサメンバーが設定されます。エクスポートリソースを使用する場合は、まずバランシングしたノードについてPuppetを実行し、次にバランサで実行する必要があります。
+
+ブーリアン。
+
+デフォルト値: `true`。　
+
+#### 定義タイプ: `apache::balancermember`
+
+[`mod_proxy_balancer`][]のメンバーを定義します。これにより、ロードバランサの`apache.cfg`内でリッスンするサービス設定ブロック内のバランサメンバーが設定されます。
+
+**パラメータ**:　
+
+##### `balancer_cluster`
+
+**必須**。
+
+Apacheサービスのインスタンス名を設定します。宣言された[`apache::balancer`][]リソースの名前と一致する必要があります。
+
+##### `url`
+
+バランサメンバーサーバとの連絡に使用するURLを指定します。
+
+デフォルト値: 'http://${::fqdn}/'。
+
+##### `options`
+
+URL後に[オプション](https://httpd.apache.org/docs/current/mod/mod_proxy.html#balancermember)の[配列][]を指定します。[`ProxyPass`][]で使用可能な任意のキー-値ペアを使用できます。
+
+デフォルト値: 空配列。
+
+#### 定義タイプ: `apache::custom_config`
+
+Apacheサーバの`conf.d`ディレクトリにカスタム設定ファイルを追加します。このファイルが無効で、この定義タイプの[`verify_config`][]パラメータの値が`true`になっている場合は、Puppet実行時にエラーが生じます。
+
+**パラメータ**:　
+
+##### `ensure`
+
+設定ファイルが存在するべきかどうかを指定します。
+
+値: 'absent'、'present'。
+
+デフォルト値: 'present'。　
+
+##### `confdir`　
+
+Puppetが設定ファイルを置くディレクトリを設定します。 
+
+デフォルト値: [`$::apache::confd_dir`][`confd_dir`]の値。
+
+##### `content`
+
+設定ファイルのコンテンツを設定します。`content`および[`source`][]パラメータは、相互排他的な関係にあります。
+
+デフォルト値: `undef`。
+
+##### `filename`
+
+Puppetが設定を保存する`confdir`下のファイル名を設定します。
+
+デフォルト値: `priority`パラメータから生成したファイル名およびリソース名。
+
+##### `priority`
+
+Apacheでは設定ファイルがアルファベット順に処理されるため、ファイル名の先頭にこのパラメータの数値を付加することで、設定ファイルの優先順位を設定します。
+
+設定ファイル名の優先順位の接頭値を無視するには、このパラメータを`false`に設定します。
+
+デフォルト値: '25'。　
+
+##### `source`
+
+設定ファイルのソースを指し示します。[`content`][]および`source`パラメータは、相互排他的な関係にあります。
+
+デフォルト値: `undef`。　
+
+##### `verify_command`
+
+Puppetが設定ファイルの確認に用いるコマンドを指定します。完全修飾コマンドを使用してください。
+
+このパラメータは、[`verify_config`][]パラメータの値が`true`になっている場合にのみ使用されます。`verify_command`が失敗すると、Puppet実行により設定ファイルが削除されてエラーが生じますが、Apacheサービスには通知されません。
+
+デフォルト値: '/usr/sbin/apachectl -t'。
+
+##### `verify_config`
+
+Apacheサービスに通知する前に設定ファイルのバリデーションを行うかどうかを指定します。
+
+ブーリアン。
+
+デフォルト値: `true`。　
+
+#### 定義タイプ: `apache::fastcgi::server`
+
+特定のファイルタイプを処理する1つまたは複数の外部FastCGIサーバを定義します。この定義タイプは、[`mod_fastcgi`][FastCGI]とともに使用します。
+
+**パラメータ**　
+
+##### `host`
+
+FastCGIのホスト名またはIPアドレスおよびTCPポート番号(1-65535)を決定します。
+
+デフォルト値: '127.0.0.1:9000'。
+
+##### `timeout`
+
+リクエストが中止され、エラーLogLevelにイベントが記録されるまでに、[FastCGI][]アプリケーションが非アクティブの状態で待機する秒数を設定します。この非アクティブタイマーは、FastCGIアプリケーションとの接続が待機中の場合のみ適用されます。アプリケーションの待ち行列に入ったリクエストに対して時間内に記述やフラッシュによる応答がないと、リクエストは中止されます。アプリケーションとの通信は完了したものの、クライアントとの通信が完了しなかった(応答がバッファリングされた)場合は、タイムアウトは適用されません。
+
+デフォルト値: 15。
+
+##### `flush`
+
+アプリケーションから受信したデータを、強制的に[`mod_fastcgi`][FastCGI]がクライアントに書き込みます。デフォルトでは、アプリケーションをできるだけ早くフリーな状態にするために、`mod_fastcgi`はデータをバッファリングします。 
+
+デフォルト値: `false`。　
+
+##### `faux_path`
+
+Apacheには、このファイル名を決定するURIを処理する[FastCGI][]があります。このパラメータで設定されたパスは、ローカルのファイルシステムに存在する必要はありません。
+
+デフォルト値: "/var/www/${name}.fcgi"。
+
+##### `alias`
+
+FastCGIサーバとアクションを内部でリンクします。このエイリアスは一意である必要があります。
+
+デフォルト値: "/${name}.fcgi"。
+
+##### `file_type`
+
+FastCGIサーバにより処理するファイルの[MIME `content-type`][]を設定します。
+
+デフォルト値: 'application/x-httpd-php'。
+
+#### 定義タイプ: `apache::listen`
+
+Apacheサーバまたはバーチャルホストのリッスンするアドレスとポートを定義する、Apache設定ディレクトリの`ports.conf`に、[`Listen`][]ディレクティブを追加します。[`apache::vhost`][]クラスはこの定義タイプを使用します。タイトルは `<PORT>`、`<IPV4>:<PORT>`、または`<IPV6>:<PORT>`の形式をとります。
+
+#### 定義タイプ: `apache::mod`
+
+対応する[`apache::mod::<MODULE NAME>`][]クラスを持たないApacheモジュール用のパッケージをインストールし、Apacheサーバの`module`および`enable`ディレクトリ内で、モジュールのデフォルト設定ファイルを確認または配置します。デフォルトのロケーションは、オペレーティングシステムによって異なります。
+
+**パラメータ**:　
+
+##### `package`
+
+**必須**。　
+
+PuppetがApacheモジュールのインストールに使用するパッケージの名前。
+
+デフォルト値: `undef`。　
+
+##### `package_ensure`
+
+Apacheモジュールをインストールの必要性をPuppetが確認するかどうかを決定します。
+
+値: 'absent'、'present'。　
+
+デフォルト値: 'present'。　
+
+##### `lib`
+
+モジュールの共有オブジェクト名を定義します。特別な理由がない限り、手動で設定しないでください。
+
+デフォルト値: `mod_$name.so`。
+
+##### `lib_path`
+
+モジュールのライブラリのパスを指定します。特別な理由がない限り、手動で設定しないでください。[`path`][]パラメータは、この値をオーバーライドします。
+
+デフォルト値: `apache`クラスの[`lib_path`][]パラメータ。
+
+
+##### `loadfile_name`
+
+モジュールの[`LoadFile`][]ディレクティブのファイル名を設定します。Apacheの処理はアルファベット順に行われるため、ファイル名によってモジュールのロード順序も設定できます。
+
+値: `\*.load`の形式のファイル名。
+
+デフォルト値: '$name.load'のように、リソース名の後に'load'をつけた値。
+
+##### `loadfiles`
+
+[`LoadFile`][]ディレクティブの配列を指定します。
+
+デフォルト値: `undef`。　
+
+##### `path`
+
+モジュールのパスを指定します。特別な理由がない限り、このパラメータは手動で設定しないでください。
+
+デフォルト値: [`lib_path`][]/[`lib`][]。
+
+#### 定義タイプ: `apache::namevirtualhost`
+
+[名前ベースのバーチャルホスト][]を有効にし、Apache HTTPD設定ディレクトリの `ports.conf`ファイルに関連するすべてのディレクティブを追加します。タイトルは、'\*'、'\*:\<PORT\>'、'\_default\_:\<PORT\>、'\<IP\>'、または'\<IP\>:\<PORT\>'の形式をとることができます。
+
+#### 定義タイプ: `apache::vhost`
+
+apacheモジュールでは、バーチャルホストのセットアップと設定に関して、かなりの柔軟性が認められています。この柔軟性の一部は、定義リソースタイプの`vhost`によるものです。これを使えば、さまざまなパラメータを用いて、Apacheを何度も検証することができます。
+
+`apache::vhost`定義タイプを使えば、デフォルトの範囲外の要件を持つバーチャルホストについて、特別な設定をすることができます。基本の`::apache`クラス内でデフォルトのバーチャルホストを設定することも、カスタマイズしたバーチャルホストをデフォルトとして設定することもできます。カスタマイズしたバーチャルホストの[`priority`][]の数値は基本のクラスよりも小さくなるため、Apacheはカスタマイズしたバーチャルホストを先に処理します。
+
+`apache::vhost`定義タイプでは、`concat::fragment`を使用して設定ファイルを構築します。定義タイプがもともとサポートしていない設定の要素についてカスタムフラグメントを挿入するには、カスタムフラグメントをひとつずつ追加します。
+
+`apache::vhost`定義タイプでは、カスタムフラグメントの`order`パラメータについては10の倍数が使用されるため、10の倍数ではない`order`が機能します。
+
+**パラメータ**:　
+
+##### `access_log`
+
+`*_access.log`ディレクティブ(`*_file`,`*_pipe`または`*_syslog`)を設定するかどうかを決定します。
+
+ブーリアン。
+
+デフォルト値: `true`。　
+
+##### `access_log_env_var`
+
+特定の環境変数を持つリクエストのみをロギングするように指定します。
+
+デフォルト値: `undef`。　
+
+##### `access_log_file`
+
+[`logroot`][]に置く`*_access.log`のファイル名を設定します。バーチャルホスト---例えばexample.comなど---を与えると、[SSL暗号化][SSL暗号化]バーチャルホストの場合はデフォルト値が'example.com_ssl.log'、暗号化されていないバーチャルホストの場合は'example.com_access.log'になります。
+
+デフォルト値: `false`。　
+
+##### `access_log_format`
+
+アクセスログに、[`LogFormat`][]のニックネームかカスタムフォーマットの文字列のいずれを使うかを指定します。 
+
+デフォルト値: 'combined'。
+
+##### `access_log_pipe`
+
+Apacheがアクセスログメッセージを送信するパイプを指定します。
+
+デフォルト値: `undef`。　
+
+##### `access_log_syslog`
+
+すべてのアクセスログメッセージをsyslogに送ります。
+
+デフォルト値: `undef`。　
+
+##### `add_default_charset`
+
+[`AddDefaultCharset`][]ディレクティブのデフォルトのメディア文字セット値を設定します。これは`text/plain`および`text/html`応答に追加されます。
+
+デフォルト値: `undef`。　
+
+##### `add_listen`
+
+バーチャルホストが[`Listen`][]ステートメントを作成するかどうかを決定します。
+
+`add_listen`を`false`に設定すると、バーチャルホストは`Listen`ステートメントを作成しません。これは、`ip`パラメータを渡されていないバーチャルホストと渡されているバーチャルホストを組み合わせる場合に重要となります。 
+
+ブーリアン。
+
+デフォルト値: `true`。　
+
+##### `use_optional_includes`
+
+Apache 2.4以降の`additional_includes`について、Apacheが[`Include`][]の代わりに[`IncludeOptional`][]ディレクティブを使うかどうかを指定します。
+
+ブーリアン。
+
+デフォルト値: `false`。　
+
+##### `additional_includes`
+
+追加の静的なバーチャルホスト固有のApache設定ファイルのパスを指定します。このパラメータを使えば、このモジュールでサポートされていない固有のカスタム設定を実装することができます。
+
+値: パスを指定する文字列また文字列の[配列][]。
+
+デフォルト値: 空配列。　
+
+##### `aliases`
+
+[ハッシュ][ハッシュ]のリストをバーチャルホストに渡し、[`mod_alias`][]ドキュメントに従って[`Alias`][]、[`AliasMatch`][]、[`ScriptAlias`][]、または[`ScriptAliasMatch`][]ディレクティブを作成します。
+
+例:
+
+``` puppet
+aliases => [
+  { aliasmatch       => '^/image/(.*)\.jpg$',
+    path             => '/files/jpg.images/$1.jpg',
+  },
+  { alias            => '/image',
+    path             => '/ftp/pub/image',
+  },
+  { scriptaliasmatch => '^/cgi-bin(.*)',
+    path             => '/usr/local/share/cgi-bin$1',
+  },
+  { scriptalias      => '/nagios/cgi-bin/',
+    path             => '/usr/lib/nagios/cgi-bin/',
+  },
+  { alias            => '/nagios',
+    path             => '/usr/share/nagios/html',
+  },
+],
+```
+
+`alias`、`aliasmatch`、`scriptalias`、`scriptaliasmatch`キーを機能させるには、`<Directory /path/to/directory>`、`<Location /some/location/here>`などの、それぞれに対応するコンテキストが必要です。Puppetは`aliases`パラメータで指定された順序でディレクティブを作成します。[`mod_alias`][]ドキュメントにもあるように、シャドーイングを避けるため、まず具体性の高い`alias`、`aliasmatch`、`scriptalias`、`scriptaliasmatch`パラメータを追加してから、全般的なパラメータを追加してください。
+
+> **注意**: `scriptaliases`パラメータの代わりに`aliases`パラメータを使用すれば、各種のエイリアスディレクティブの順序を正確に制御できます。`scriptaliases`パラメータを使って`ScriptAliases`を定義すると、すべての*`Alias`ディレクティブの後に*すべての*`ScriptAlias`ディレクティブが*処理されます。これは`Alias`ディレクティブによる`ScriptAlias`ディレクティブのシャドーイングにつながり、多くの場合、問題が生じます。例えば、Nagiosに関する問題が生じる可能性があります。
+
+I[`apache::mod::passenger`][]がロードされ、`PassengerHighPerformance`が`true`になっている場合、`Alias`ディレクティブが`PassengerEnabled => off`ステートメントを履行できない可能性があります。詳細については、[この記事](http://www.conandalton.net/2010/06/passengerenabled-off-not-working.html)を参照してください。
+
+##### `allow_encoded_slashes`
+
+バーチャルホストの[`AllowEncodedSlashes`][]宣言を設定し、サーバのデフォルトをオーバーライドします。これにより、`\`および`/`文字を含むURLに対するバーチャルホストの応答が変更されます。値: 'nodecode'、'off'、'on'。デフォルト設定では、サーバ設定からこの宣言が省かれ、Apacheのデフォルト設定'Off'が選択されます。
+
+デフォルト値: `undef`。　
+
+##### `block`
+
+Apacheがアクセスをブロックする対象のリストを指定します。有効なオプション: 'scm'、これにより、`.svn`、`.git`、`.bzr`ディレクティブへのWebアクセスがブロックされます。
+
+デフォルト値: 空[配列][]。
+
+##### `cas_attribute_prefix`
+
+SAMLバリデーションが有効になっている場合に、このヘッダの値を属性値としてヘッダを追加します。
+
+デフォルト値: [`apache::mod::auth_cas`][]により設定された値。
+
+##### `cas_attribute_delimiter`
+
+`cas_attribute_prefix`により作成されたヘッダの属性値の区切り文字を設定します。
+
+デフォルト値: [`apache::mod::auth_cas`][]により設定された値。
+
+##### `cas_login_url`
+
+ユーザがCASで保護されたリソースへのアクセスを試み、かつアクティブなセッションがない場合に、モジュールがユーザをリダイレクトする先のURLを設定します。
+
+デフォルト値: [`apache::mod::auth_cas`][]により設定された値。　
+
+##### `cas_scrub_request_headers`
+
+mod_auth_cas内で特別な意味を持つ可能性のあるインバウンドリクエストヘッダを削除します。
+
+デフォルト値: [`apache::mod::auth_cas`][]により設定された値。　
+
+##### `cas_sso_enabled`
+
+`cas_sso_enabled`: シングルサインアウトの実験的サポートを有効にします(POSTデータが壊れる可能性があります)。
+
+デフォルト値: [`apache::mod::auth_cas`][]により設定された値。　
+
+##### `cas_validate_saml`
+
+SAMLに関するCASサーバからの解析応答。
+
+デフォルト値: [`apache::mod::auth_cas`][]により設定された値。　
+
+##### `cas_validate_url`
+
+HTTPクエリ文字列でクライアントの提示するチケットをバリデーションする際に使用するURL。
+
+デフォルト値: [`apache::mod::auth_cas`][]により設定された値。
+
+##### `custom_fragment`
+
+カスタム設定ディレクティブの文字列を渡し、バーチャルホスト設定の最後に配置します。
+
+デフォルト値: `undef`。　
+
+##### `default_vhost`
+
+任意の`apache::vhost`定義タイプを、他の`apache::vhost`定義タイプと一致しないリクエストをサーブするためのデフォルトとして設定します。 
+
+デフォルト値: `false`。　
+
+##### `directories`
+
+[`directories`](#parameter-directories-for-apachevhost)セクションを参照してください。
+
+##### `directoryindex`
+
+ディレクトリ名の最後で'/'を指定することで、クライアントがディレクトリのインデックスをリクエストした際に探すべきリソースのリストを設定します。詳細については、[`DirectoryIndex`][]ディレクティブドキュメントを参照してください。
+
+デフォルト値: `undef`。　
+
+##### `docroot`
+
+**必須**。　
+
+[`DocumentRoot`][]ロケーションを設定します。Apacheはここからファイルをサーブします。
+
+`docroot`と[`manage_docroot`][]がともに`false`に設定されている場合、[`DocumentRoot`][]は設定されず、それに付随する`<Directory /path/to/directory>`ブロックは作成されません。
+
+値: ディレクトリパスを指定する文字列。
+
+##### `docroot_group`
+
+[`docroot`][]ディレクトリへのグループアクセスを設定します。
+
+値: システムグループを指定する文字列。
+
+デフォルト値: 'root'。
+
+##### `docroot_owner`
+
+[`docroot`][]ディレクトリへの個々のユーザのアクセスを設定します。
+
+値: ユーザアカウントを指定する文字列。
+
+デフォルト値: 'root'。　
+
+##### `docroot_mode`
+
+[`docroot`][]ディレクトリへのアクセス許可を数字表記法で設定します。
+
+値: 文字列。　
+
+デフォルト値: `undef`。　
+
+##### `manage_docroot`
+
+Puppetが[`docroot`][]ディレクトリを管理するかどうかを決定します。
+
+ブーリアン。
+
+デフォルト値: `true`。　
+
+##### `error_log`
+
+`*_error.log`ディレクティブを設定するかどうかを指定します。
+
+ブーリアン。
+
+デフォルト値: `true`。
+
+##### `error_log_file`
+
+バーチャルホストのエラーログについて、`*_error.log`ファイルを優先します。このパラメータが定義されていない場合、Puppetはまず[`error_log_pipe`][]で、次に[`error_log_syslog`][]で値を確認します。
+
+これらのパラメータをいずれも設定しない場合は、例えばバーチャルホストが`example.com`なら、PuppetはSSLバーチャルホストのデフォルトを'$logroot/example.com_error_ssl.log'、非SSLバーチャルホストのデフォルトを'$logroot/example.com_error.log'とします。
+
+デフォルト値: `undef`。
+
+##### `error_log_pipe`
+
+エラーログメッセージを送るパイプを指定します。
+
+[`error_log_file`][]パラメータに値がある場合は、このパラメータに効力は生じません。このパラメータにも`error_log_file`にも値がない場合、Puppetは[`error_log_syslog`][]をチェックします。
+
+デフォルト値: `undef`。
+
+##### `error_log_syslog`
+
+すべてのエラーログメッセージをsyslogに送るかどうかを決定します。
+
+[`error_log_file`][]パラメータまたは[`error_log_pipe`][]パラメータのいずれかに値がある場合、このパラメータの効力は生じません。これらのパラメータのいずれにも値がない場合は、例えばバーチャルホスト`example.com`では、PuppetはSSLバーチャルホストのデフォルトを'$logroot/example.com_error_ssl.log'、非SSLバーチャルホストのデフォルトを '$logroot/example.com_error.log'とします。
+
+ブーリアン。
+
+デフォルト値: `undef`。
+
+##### `error_documents`
+
+このバーチャルホストの[エラードキュメント](https://httpd.apache.org/docs/current/mod/core.html#errordocument)設定のオーバーライドに使用できるハッシュのリスト。
+
+例:
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  error_documents => [
+    { 'error_code' => '503', 'document' => '/service-unavail' },
+    { 'error_code' => '407', 'document' => 'https://example.com/proxy/login' },
+  ],
+}
+```
+
+デフォルト値: '[]'。
+
+##### `ensure`
+
+バーチャルホストが存在するかどうかを指定します。
+
+値: 'absent'、'present'。　
+
+デフォルト値: 'present'。
+
+##### `fallbackresource`
+
+[FallbackResource](https://httpd.apache.org/docs/current/mod/mod_dir.html#fallbackresource)ディレクティブを設定します。このディレクティブは、ファイルシステム内のどこにもマッピングされていないURLに対してどのようなアクションをとるか指定します。指定されていない場合は'HTTP 404 (Not Found)'が返されます。値は'/'で始めるか、'disabled'とする必要があります。
+
+デフォルト値: `undef`。
+
+#####`fastcgi_idle_timeout`
+
+fastcgiを使用する場合に、このオプションにより、サーバ応答のタイムアウトを設定します。
+
+デフォルト値: `undef`。
+
+##### `file_e_tag`
+
+[`FileETag`][]宣言のサーバデフォルトを設定します。これにより、静的ファイルの応答ヘッダフィールドが変更されます。
+
+値: 'INode'、'MTime'、'Size'、'All'、'None'。
+
+デフォルト値: `undef`、この場合、Apacheのデフォルト設定'MTime Size'が使用されます。
+
+##### `filters`
+
+[フィルタ](https://httpd.apache.org/docs/current/mod/mod_filter.html)により、アウトプットコンテンツフィルタのスマートな文脈依存設定が有効になります。
+
+``` puppet
+apache::vhost { "$::fqdn":
+  filters => [
+    'FilterDeclare   COMPRESS',
+    'FilterProvider  COMPRESS DEFLATE resp=Content-Type $text/html',
+    'FilterChain     COMPRESS',
+    'FilterProtocol  COMPRESS DEFLATE change=yes;byteranges=no',
+  ],
+}
+```
+
+##### `force_type`
+
+[`ForceType`][]ディレクティブを設定します。このディレクティブは、[MIME `content-type`][]がこのパラメータの値に一致するすべてのマッチングファイルをApacheに強制的にサーブさせます。
+
+#### `add_charset`
+
+ディレクトリおよびファイル拡張子ごとに、Apacheにカスタムコンテンツ文字セットを設定させます。
+
+##### `headers`
+
+レスポンスヘッダを置換、結合、または削除するための行を追加します。詳細については、[Apacheのmod_headersドキュメント](https://httpd.apache.org/docs/current/mod/mod_headers.html#header)を参照してください。
+
+値: 文字列または文字列の配列。
+
+デフォルト値: `undef`。
+
+##### `ip`
+
+バーチャルホストがリッスンするIPアドレスを設定します。デフォルトでは、Apacheのデフォルト挙動が使用され、すべてのIPをリッスンします。
+
+値: 文字列または文字列の配列。　
+
+デフォルト値: `undef`。
+
+##### `ip_based`
+
+[IPベースの](https://httpd.apache.org/docs/current/vhosts/ip-based.html)バーチャルホストを有効にします。このパラメータにより、NameVirtualHostディレクティブの作成が禁止されます。これは、このディレクティブが名前ベースのバーチャルホストにリクエストを送る際に使用されるためです。
+
+デフォルト値: `false`。
+
+##### `itk`
+
+ハッシュで[ITK](http://mpm-itk.sesse.net/)を設定します。
+
+通常は、以下のように使用します。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot => '/path/to/directory',
+  itk     => {
+    user  => 'someuser',
+    group => 'somegroup',
+  },
+}
+```
+
+値: ハッシュ。キーを含めることもできます。
+
+* ユーザ + グループ
+* `assignuseridexpr`
+* `assigngroupidexpr`
+* `maxclientvhost`
+* `nice`
+* `limituidrange` (Linux 3.5.0以降)
+* `limitgidrange` (Linux 3.5.0以降)
+
+通常は、以下のように使用します。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot => '/path/to/directory',
+  itk     => {
+    user  => 'someuser',
+    group => 'somegroup',
+  },
+}
+```　
+
+デフォルト値: `undef`。
+
+##### `jk_mounts`
+
+'JkMount'および'JkUnMount'ディレクティブによりバーチャルホストを設定し、TomcatとApacheの間をマッピングするURLのパスを処理します。
+
+このパラメータは、ハッシュの配列にする必要があります。各ハッシュには、'worker'と、'mount'または'unmount'キーのいずれかが含まれている必要があります。
+
+通常は、以下のように使用します。　
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  jk_mounts => [
+    { mount   => '/*',     worker => 'tcnode1', },
+    { unmount => '/*.jpg', worker => 'tcnode1', },
+  ],
+}
+```
+デフォルト値: `undef`。
+
+##### `keepalive`
+
+バーチャルホストで[`KeepAlive`][]ディレクティブによるHTTPの持続的接続を有効にするかどうかを決定します。デフォルトでは、グローバルなサーバ全体の[`KeepAlive`][]設定が有効になります。
+
+バーチャルホストの関連オプションを設定するには、`keepalive_timeout`および`max_keepalive_requests`パラメータを使用します。
+
+値: 'Off', 'On'。
+
+デフォルト値: `undef`。　
+
+##### `keepalive_timeout`
+
+バーチャルホストの[`KeepAliveTimeout`]ディレクティブを設定します。これにより、HTTPの持続的接続で後続のリクエストを実行するまでの待機時間が決まります。デフォルトでは、グローバルなサーバ全体の[`KeepAlive`][]設定が有効になります。
+
+このパラメータが意味を持つのは、グローバルなサーバ全体の[`keepalive`パラメータ][]またはバーチャルホストごとの`keepalive`パラメータのいずれかが有効になっている場合のみです。
+
+デフォルト値: `undef`。　
+
+##### `max_keepalive_requests`
+
+接続1回につき許可されるバーチャルホストへのリクエスト数を制限します。デフォルトでは、グローバルなサーバ全体の[`KeepAlive`][]設定が有効になります。
+
+このパラメータが意味を持つのは、グローバルなサーバ全体の[`keepalive`パラメータ][]またはバーチャルホストごとの`keepalive`パラメータのいずれかが有効になっている場合のみです。　
+
+デフォルト値: `undef`。　
+
+##### `auth_kerb`
+
+バーチャルホストの[`mod_auth_kerb`][]パラメータを有効にします。
+
+通常は、以下のように使用します。　
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  auth_kerb              => `true`,
+  krb_method_negotiate   => 'on',
+  krb_auth_realms        => ['EXAMPLE.ORG'],
+  krb_local_user_mapping => 'on',
+  directories            => {
+    path         => '/var/www/html',
+    auth_name    => 'Kerberos Login',
+    auth_type    => 'Kerberos',
+    auth_require => 'valid-user',
+  },
+}
+```
+
+関連するパラメータは、`mod_auth_kerb`ディレクティブの名前に従います。
+
+- `krb_method_negotiate`: Negotiateメソッドを使用するかどうかを決定します。デフォルト値: 'on'。
+- `krb_method_k5passwd`: Kerberos v5に関してパスワードベースの認証を使用するかどうかを決定します。デフォルト値: 'on'。
+- `krb_authoritative`: 'off'に設定すると、認証コントロールを別のモジュールに渡すことができます。デフォルト値: 'on'。
+- `krb_auth_realms`: 認証に使用するKerberos領域の配列を指定します。デフォルト値: '[]'。
+- `krb_5keytab`: Kerberos v5キータブファイルのロケーションを指定します。デフォルト値: `undef`。
+- `krb_local_user_mapping`: 今後の使用のために、ユーザ名から@REALMを取り除きます。デフォルト値: `undef`。
+
+ブーリアン。
+
+デフォルト値: `false`。
+
+##### `krb_verify_kdc`
+
+このオプションを使えば、ローカルなキータブに対する認証チケットを無効にし、KDCスプーフィング攻撃を防ぐことができます。
+
+デフォルト値: 'on'。
+
+##### `krb_servicename`
+
+Apacheが認証に使用するサービス名を指定します。この名前に対応するキーをキータブに保存する必要があります。
+
+デフォルト値: 'HTTP'。
+
+##### `krb_save_credentials`
+
+このオプションにより、認証情報の保存機能が有効になります。
+
+デフォルト値: 'off'。
+
+##### `logroot`
+
+バーチャルホストのログファイルの保存場所を指定します。
+
+デフォルト値: '/var/log/<apache log location>/'。
+
+##### `$logroot_ensure`
+
+バーチャルホストのlogrootディレクトリを削除するかどうかを決定します。
+
+値: 'directory'、'absent'。
+
+デフォルト値: 'directory'。
+
+##### `logroot_mode`
+
+logrootディレクトリで設定されたモードをオーバーライドします。影響を把握できない場合は、ログが保存されているディレクトリへの書き込みアクセス権限を付与*しないで*ください。詳細については、[Apacheのログセキュリティドキュメント](https://httpd.apache.org/docs/2.4/logs.html#security)を参照してください。
+
+デフォルト値: `undef`。
+
+##### `logroot_owner`
+
+logrootディレクトリへの個々のユーザのアクセスを設定します。
+
+デフォルト値：`undef`。
+
+##### `logroot_group`
+
+[`logroot`][]ディレクトリへのグループアクセスを設定します。
+
+デフォルト値：`undef`。
+
+##### `log_level`
+
+エラーログの詳細レベルを指定します。
+
+値: 'emerg'、'alert'、'crit'、'error'、'warn'、'notice'、'info'、'debug'。
+
+デフォルト値: グローバルサーバ設定については'warn'。バーチャルホストごとにオーバーライドできます。
+
+###### `modsec_body_limit`
+
+バッファリングに関してModSecurityが受け入れる最大リクエストボディサイズをバイト数で設定します。
+
+値: 整数。
+
+デフォルト値: `undef`。
+
+###### `modsec_disable_vhost`
+
+バーチャルホストで[`mod_security`][]を無効にします。[`apache::mod::security`][]が含まれている場合にのみ有効です。
+
+ブーリアン。
+
+デフォルト値: `undef`。
+
+###### `modsec_disable_ids`
+
+バーチャルホストから`mod_security` IDを削除します。
+
+値: バーチャルホストから削除する`mod_security` IDの配列。ハッシュも使用できます。この場合、特定のロケーションからのIDの削除が可能です。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  modsec_disable_ids => [ 90015, 90016 ],
+}
+```
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  modsec_disable_ids => { '/location1' => [ 90015, 90016 ] },
+}
+```
+
+デフォルト値: `undef`。
+
+###### `modsec_disable_ips`
+
+[`mod_security`][]ルールマッチングから除外するIPアドレスの配列を指定します。
+
+デフォルト値: `undef`。
+
+###### `modsec_disable_msgs`
+
+バーチャルホストから削除するmod_security Msgの配列。ハッシュも使用できます。この場合、特定のロケーションからのMsgの削除が可能です。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  modsec_disable_msgs => [ 'Blind SQL Injection Attack', 'Session Fixation Attack' ],
+}
+```
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  modsec_disable_msgs => { '/location1' => [ 'Blind SQL Injection Attack', 'Session Fixation Attack' ] },
+}
+```
+
+デフォルト値: `undef`。
+
+###### `modsec_disable_tags`
+
+ バーチャルホストから削除するmod_securityタグの配列。ハッシュも使用できます。この場合、特定のロケーションからのタグの削除が可能です。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  modsec_disable_tags => [ 'WEB_ATTACK/SQL_INJECTION', 'WEB_ATTACK/XSS' ],
+}
+```
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  modsec_disable_tags => { '/location1' => [ 'WEB_ATTACK/SQL_INJECTION', 'WEB_ATTACK/XSS' ] },
+}
+```
+
+デフォルト値: `undef`。
+
+##### `modsec_audit*`
+
+* `modsec_audit_log`
+* `modsec_audit_log_file`
+* `modsec_audit_log_pipe`
+
+この3つのパラメータは、いずれも`mod_security`オーディットログの送信方法を決定します([SecAuditLog](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual#SecAuditLog))。
+
+* `modsec_audit_log_file`が設定されている場合は、[`logroot`][]と比較されます。
+
+  デフォルト値: `undef`。
+
+* `modsec_audit_log_pipe`を設定する場合は、パイプで始める必要があります。例えば、'|/path/to/mlogc /path/to/mlogc.conf'のようになります。
+
+  デフォルト値: `undef`。
+
+* `modsec_audit_log`が`true`になっている場合、バーチャルホスト---example.comなど---を与えると、[SSL暗号化][SSL encryption]バーチャルホストの場合はデフォルト値が'example.com\_security\_ssl.log'、暗号化されていないバーチャルホストの場合は'example.com\_security.log'になります。
+
+  デフォルト値: `false`。
+
+上述のパラメータがいずれも設定されていない場合、グローバルオーディットログが使用されます(''/var/log/httpd/modsec\_audit.log''; Debianおよびデリバティブ: ''/var/log/apache2/modsec\_audit.log''; その他: )。
+
+##### `no_proxy_uris`
+
+プロキシを使用しないURLを指定します。このパラメータは、[`proxy_dest`](#proxy_dest)と組み合わせて使用することはできません。
+
+デフォルト値: []。
+
+##### `no_proxy_uris_match`
+
+このディレクティブは[`no_proxy_uris`][]と同じですが、正規表現をとります。
+
+デフォルト値: []。　
+
+##### `proxy_preserve_host`
+
+[ProxyPreserveHostディレクティブ](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypreservehost)を設定します。
+
+このパラメータを`true`に設定すると、受信リクエストの`Host:`行が有効になり、ホスト名ではなくホストにプロキシされます。`false`に設定すると、このディレクティブが'Off'になります。
+
+ブーリアン。
+
+デフォルト値: `false`。
+
+##### `proxy_add_headers`
+
+[ProxyAddHeadersディレクティブ](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxyaddheaders)を設定します。
+
+このパラメータは、プロキシ関連のHTTPヘッダ(X-Forwarded-For、X-Forwarded-Host、X-Forwarded-Server)をバックエンドサーバに送信するかどうかを制御します。
+
+ブーリアン。
+
+デフォルト値: `false`。
+
+##### `proxy_error_override`
+
+[ProxyErrorOverrideディレクティブ](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxyerroroverride)を設定します。このディレクティブは、プロキシされたコンテンツに関するエラーページをApacheによりオーバーライドすべきかどうかを制御します。
+
+ブーリアン。
+
+デフォルト値: `false`。
+
+##### `options`
+
+指定されたバーチャルホストの[`Options`][]を設定します。例:
+
+``` puppet
+apache::vhost { 'site.name.fdqn':
+  …
+  options => ['Indexes','FollowSymLinks','MultiViews'],
+}
+```
+
+> **注意**: [`apache::vhost`][]の[`directories`][]パラメータを使うと、'Options'、'Override'、'DirectoryIndex'は`directories`内のパラメータであるため、無視されます。
+
+デフォルト値: ['Indexes','FollowSymLinks','MultiViews']。
+
+##### `override`
+
+指定されたバーチャルホストのオーバーライドを設定します。[AllowOverride](https://httpd.apache.org/docs/current/mod/core.html#allowoverride)引数の配列を使用できます。
+
+デフォルト値: '[none]'。
+
+##### `passenger_app_root`
+
+[PassengerRoot](https://www.phusionpassenger.com/library/config/apache/reference/#passengerapproot)を設定します。これは、DocumentRootと異なる場合のPassengerアプリケーションルートのロケーションです。
+
+値: パスを指定する文字列。
+
+デフォルト値: `undef`。
+
+##### `passenger_app_env`
+
+[PassengerAppEnv](https://www.phusionpassenger.com/library/config/apache/reference/#passengerappenv)を設定します。これは、Passengerアプリケーションに関する環境です。指定されていない場合は、グローバル設定の'production'がデフォルトになります。
+
+値: 環境名を指定する文字列。
+
+デフォルト値: `undef`。
+
+##### `passenger_log_file`
+
+デフォルトでは、PassengerログメッセージはApacheグローバルエラーログに書き込まれます。[PassengerLogFile](https://www.phusionpassenger.com/library/config/apache/reference/#passengerlogfile)を使えば、そのメッセージを別のファイルに書き込むように設定することができます。このオプションは、Passenger 5.0.5以降でのみ使用できます。
+
+値: パスを指定する文字列。
+
+デフォルト値: `undef`。
+
+##### `passenger_log_level`
+
+このオプションを使えば、ログファイルに書き込む情報の量を指定できます。設定されていない場合は、[PassengerLogLevel](https://www.phusionpassenger.com/library/config/apache/reference/#passengerloglevel)は設定ファイルに表示されず、デフォルト値が使用されます。
+
+デフォルト値: 3.0.0以前のPassengerバージョン: '0'; 5.0.0以降: '3'。
+
+##### `passenger_ruby`
+
+[PassengerRuby](https://www.phusionpassenger.com/library/config/apache/reference/#passengerruby)を設定します。これは、バーチャルホスト上でこのアプリケーションに関して使用するRubyインタープリタです。
+
+デフォルト値: `undef`。
+
+##### `passenger_min_instances`
+
+[PassengerMinInstances](https://www.phusionpassenger.com/library/config/apache/reference/#passengermininstances)を設定します。これは、実行するアプリケーションプロセスの最小数です。
+
+##### `passenger_max_requests`
+
+[PassengerMaxRequests](https://www.phusionpassenger.com/library/config/apache/reference/#pas
+sengermaxrequests)を設定します。これは、アプリケーションプロセスが処理するリクエストの最大数です。
+
+##### `passenger_max_instances_per_app`
+
+[PassengerMaxInstancesPerApp](https://www.phusionpassenger.com/library/config/apache/reference/#passengermaxinstancesperapp)を設定します。これは、単一のアプリケーションに関して同時に存在できるアプリケーションプロセスの最大数です。
+
+デフォルト値: `undef`。
+
+##### `passenger_start_timeout`
+
+[PassengerStartTimeout](https://www.phusionpassenger.com/library/config/apache/reference/#passengerstarttimeout)を設定します。これは、アプリケーション起動のタイムアウトです。
+
+##### `passenger_pre_start`
+
+[PassengerPreStart](https://www.phusionpassenger.com/library/config/apache/reference/#passengerprestart)を設定します。これは、プレ起動が必要とされる場合のアプリケーションのURLです。 
+
+##### `passenger_user`
+
+[PassengerUser](https://www.phusionpassenger.com/library/config/apache/reference/#passengeruser)を設定します。これは、サンドボックスアプリケーションの実行ユーザです。
+
+##### `passenger_high_performance`
+
+[`PassengerHighPerformance`](https://www.phusionpassenger.com/library/config/apache/reference/#passengerhighperformance)パラメータを設定します。
+
+値: `true`、`false`。
+
+デフォルト値: `undef`。
+
+##### `passenger_nodejs`
+
+[`PassengerNodejs`](https://www.phusionpassenger.com/library/config/apache/reference/#passengernodejs)を設定します。これは、バーチャルホスト上でこのアプリケーションに関して使用するNodeJSインタープリタです。
+
+##### `passenger_sticky_sessions`
+
+[`PassengerStickySessions`](https://www.phusionpassenger.com/library/config/apache/reference/#passengerstickysessions)パラメータを設定します。
+
+ブーリアン。
+
+デフォルト値: `undef`。
+
+##### `passenger_startup_file`
+
+[`PassengerStartupFile`](https://www.phusionpassenger.com/library/config/apache/reference/#passengerstartupfile)パスを設定します。このパスは、アプリケーションルートに関連しています。
+
+##### `php_flags & values`
+
+バーチャルホストごとの設定[`php_value`または`php_flag`](http://php.net/manual/en/configuration.changes.php)を許可します。これらのフラグや値は、ユーザまたはアプリケーションにより上書きすることができます。
+
+デフォルト値: '{}'。
+
+##### `php_admin_flags & values`
+
+バーチャルホストごとの設定[`php_admin_value`または`php_admin_flag`](http://php.net/manual/en/configuration.changes.php)を許可します。これらのフラグや値は、ユーザまたはアプリケーションにより上書きすることができます。
+
+デフォルト値: '{}'。
+
+##### `port`
+
+ホストを設定するポートを設定します。モジュールのデフォルトでは、ホストがリッスンするのは、非SSLバーチャルホストではポート80、SSLバーチャルホストではポート443です。ホストはこのパラメータで設定されたポートのみをリッスンします。
+
+##### `priority`
+
+Apache HTTPD VirtualHost設定ファイルに関連するロード順序を設定します。 
+
+優先順位に一致するものがない場合は、アルファベット順で最初の名前ベースのバーチャルホストが使用されます。同様に、高い優先順位を渡すと、他に一致する名前がなければ、アルファベット順で最初の名前ベースのバーチャルホストが使用されます。
+
+> **注意:** このパラメータを使用する必要はありません。ただし、使用する場合は、`apache::vhost`の`default_vhost`パラメータの優先順位は'15'になる点に留意してください。
+
+ファイル名の優先順位の接頭値を無視するには、優先順位として`false`を渡します。
+
+デフォルト値: '25'。
+
+##### `proxy_dest`
+
+[ProxyPass](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypass)設定の宛先アドレスを指定します。
+
+デフォルト値: `undef`。
+
+##### `proxy_pass`
+
+[ProxyPass](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypass)設定の`path => URI`値の配列を指定します。オプションで、配列としてパラメータを追加できます。
+
+デフォルト値: `undef`。
+
+``` puppet
+apache::vhost { 'site.name.fdqn':
+  …
+  proxy_pass => [
+    { 'path' => '/a', 'url' => 'http://backend-a/' },
+    { 'path' => '/b', 'url' => 'http://backend-b/' },
+    { 'path' => '/c', 'url' => 'http://backend-a/c', 'params' => {'max'=>20, 'ttl'=>120, 'retry'=>300}},
+    { 'path' => '/l', 'url' => 'http://backend-xy',
+      'reverse_urls' => ['http://backend-x', 'http://backend-y'] },
+    { 'path' => '/d', 'url' => 'http://backend-a/d',
+      'params' => { 'retry' => '0', 'timeout' => '5' }, },
+    { 'path' => '/e', 'url' => 'http://backend-a/e',
+      'keywords' => ['nocanon', 'interpolate'] },
+    { 'path' => '/f', 'url' => 'http://backend-f/',
+      'setenv' => ['proxy-nokeepalive 1','force-proxy-request-1.0 1']},
+    { 'path' => '/g', 'url' => 'http://backend-g/',
+      'reverse_cookies' => [{'path' => '/g', 'url' => 'http://backend-g/',}, {'domain' => 'http://backend-g', 'url' => 'http:://backend-g',},], },
+    { 'path' => '/h', 'url' => 'http://backend-h/h',
+      'no_proxy_uris' => ['/h/admin', '/h/server-status'] },
+  ],
+}
+```
+
+* `reverse_urls`。*オプション。*この設定は、`mod_proxy_balancer`とともに使用する場合に役立ちます。値: 配列または文字列。
+* `reverse_cookies`。*オプション。*`ProxyPassReverseCookiePath`および`ProxyPassReverseCookieDomain`を設定します。
+* `params`。*オプション。*接続設定などのProxyPassキー-値パラメータを許可します。
+* `setenv`。*オプション。*プロキシディレクティブの[環境変数](https://httpd.apache.org/docs/current/mod/mod_proxy.html#envsettings)を設定します。値: 配列。
+
+##### `proxy_dest_match`
+
+このディレクティブは[`proxy_dest`][]と同じですが、正規表現をとります。詳細については、[ProxyPassMatch](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassmatch)を参照してください。
+
+##### `proxy_dest_reverse_match`
+
+[`proxy_dest_match`][]が指定されている場合に、ProxyPassReverseを渡せるようにします。詳細については、[ProxyPassReverse](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassreverse)を参照してください。
+
+##### `proxy_pass_match`
+
+このディレクティブは[`proxy_pass`][]と同じですが、正規表現をとります。詳細については、[ProxyPassMatch](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassmatch)を参照してください。
+
+##### `rack_base_uris`
+
+rack設定のリソース識別子を設定します。指定されたファイルパスは、_rack.erbテンプレート内の[Phusion Passenger](http://www.modrails.com/documentation/Users%20guide%20Apache.html#_railsbaseuri_and_rackbaseuri)のrackアプリケーションルートとしてリストされます。
+
+デフォルト値: `undef`。
+
+#####`passenger_base_uris`
+
+任意のURIをPhusion Passengerのサーブするアプリケーションとして指定するのに使用します。指定されたファイルパスは、_passenger_base_uris.erbテンプレート内の[Phusion Passenger](https://www.phusionpassenger.com/documentation/Users%20guide%20Apache.html#PassengerBaseURI)のpassengerアプリケーションルートとしてリストされます。
+
+デフォルト値: `undef`。
+
+##### `redirect_dest`
+
+リダイレクト先のアドレスを指定します。
+
+デフォルト値: `undef`。
+
+##### `redirect_source`
+
+`redirect_dest`で指定された宛先にリダイレクトするソースURIを指定します。リダイレクトするアイテムが複数提供されている場合は、ソースと宛先の長さを一致させる必要があります。また、アイテムは順序に依存します。
+
+``` puppet
+apache::vhost { 'site.name.fdqn':
+  …
+  redirect_source => ['/images','/downloads'],
+  redirect_dest   => ['http://img.example.com/','http://downloads.example.com/'],
+}
+```
+
+##### `redirect_status`
+
+リダイレクトに追加するステータスを指定します。
+
+デフォルト値: `undef`。
+
+``` puppet
+apache::vhost { 'site.name.fdqn':
+  …
+  redirect_status => ['temp','permanent'],
+}
+```
+
+##### `redirectmatch_*`
+
+* `redirectmatch_regexp`
+* `redirectmatch_status`
+* `redirectmatch_dest`
+
+任意の正規表現について呼び出すサーバステータスとユーザの転送先を決定します。配列として入力します。
+
+デフォルト値: `undef`。
+
+``` puppet
+apache::vhost { 'site.name.fdqn':
+  …
+  redirectmatch_status => ['404','404'],
+  redirectmatch_regexp => ['\.git(/.*|$)/','\.svn(/.*|$)'],
+  redirectmatch_dest => ['http://www.example.com/1','http://www.example.com/2'],
+}
+```
+
+##### `request_headers`
+
+他のリクエストヘッダの追加、リクエストヘッダの削除など、収集した[リクエストヘッダ](https://httpd.apache.org/docs/current/mod/mod_headers.html#requestheader)をさまざまな形で修正します。
+
+デフォルト値: `undef`。
+
+``` puppet
+apache::vhost { 'site.name.fdqn':
+  …
+  request_headers => [
+    'append MirrorID "mirror 12"',
+    'unset MirrorID',
+  ],
+}
+```
+
+##### `rewrites`
+
+URLリライトルールを作成します。ハッシュの配列が求められます。
+
+値: 'comment'、'rewrite_base'、'rewrite_cond'、'rewrite_rule'、'rewrite_map'のいずれかのハッシュキー。
+
+デフォルト値: `undef`。
+
+誰かがindex.htmlにアクセスした場合、welcome.htmlを表示するように指定できます。
+
+``` puppet
+apache::vhost { 'site.name.fdqn':
+  …
+  rewrites => [ { rewrite_rule => ['^index\.html$ welcome.html'] } ]
+}
+```
+
+このパラメータにより条件をリライトし、`true`の場合に関連ルールを実行させることが可能です。例えば、ビジターがIEを使っている場合のみURLをリライトするには、以下のように設定します。
+
+``` puppet
+apache::vhost { 'site.name.fdqn':
+  …
+  rewrites => [
+    {
+      comment      => 'redirect IE',
+      rewrite_cond => ['%{HTTP_USER_AGENT} ^MSIE'],
+      rewrite_rule => ['^index\.html$ welcome.html'],
+    },
+  ],
+}
+```
+
+複数の条件を適用することもできます。たとえば、ブラウザがLynxかMozilla(バージョン1または2)の場合にのみ、index.htmlをwelcome.htmlにリライトする場合は、以下のようになります。
+
+``` puppet
+apache::vhost { 'site.name.fdqn':
+  …
+  rewrites => [
+    {
+      comment      => 'Lynx or Mozilla v1/2',
+      rewrite_cond => ['%{HTTP_USER_AGENT} ^Lynx/ [OR]', '%{HTTP_USER_AGENT} ^Mozilla/[12]'],
+      rewrite_rule => ['^index\.html$ welcome.html'],
+    },
+  ],
+}
+```
+
+複数のリライトと条件を設定することも可能です。
+
+``` puppet
+apache::vhost { 'site.name.fdqn':
+  …
+  rewrites => [
+    {
+      comment      => 'Lynx or Mozilla v1/2',
+      rewrite_cond => ['%{HTTP_USER_AGENT} ^Lynx/ [OR]', '%{HTTP_USER_AGENT} ^Mozilla/[12]'],
+      rewrite_rule => ['^index\.html$ welcome.html'],
+    },
+    {
+      comment      => 'Internet Explorer',
+      rewrite_cond => ['%{HTTP_USER_AGENT} ^MSIE'],
+      rewrite_rule => ['^index\.html$ /index.IE.html [L]'],
+    },
+    {
+      rewrite_base => /apps/,
+      rewrite_rule => ['^index\.cgi$ index.php', '^index\.html$ index.php', '^index\.asp$ index.html'],
+    },
+    { comment      => 'Rewrite to lower case',
+      rewrite_cond => ['%{REQUEST_URI} [A-Z]'],
+      rewrite_map  => ['lc int:tolower'],
+      rewrite_rule => ['(.*) ${lc:$1} [R=301,L]'],
+    },
+  ],
+}
+```
+
+リライトのルールおよび条件については、[`mod_rewrite`ドキュメント][`mod_rewrite`]を参照してください。
+
+##### `rewrite_inherit`
+
+バーチャルホストが全体のリライトルールを継承するかどうかを決定します。
+
+デフォルト値: `false`。
+
+リライトルールは、全体(`$conf_file`または`$confd_dir`で)またはバーチャルホストの`.conf`ファイル内で指定することができます。デフォルトでは、バーチャルホストは全体の設定を継承しません。継承を有効にするには、`rewrites`パラメータを指定し、`rewrite_inherit`パラメータを`true`に設定します。
+
+``` puppet
+apache::vhost { 'site.name.fdqn':
+  …
+  rewrites => [
+    <rules>,
+  ],
+  rewrite_inherit => `true`,
+}
+```
+
+> **注意**: この設定を有効にするには、`rewrites`パラメータが**必須**です。
+
+バーチャルホストに以下のディレクティブが含まれている場合は、Apacheが全体の`Rewrite`ルールを有効にします。
+
+``` ApacheConf
+RewriteEngine On
+RewriteOptions Inherit
+```
+
+[公式`mod_rewrite`ドキュメント](https://httpd.apache.org/docs/2.2/mod/mod_rewrite.html)のセクション"Rewriting in Virtual Hosts"を参照してください。
+
+##### `scriptalias`
+
+'/usr/scripts'などの、パス'/cgi-bin'のエイリアスとするCGIスクリプトのディレクトリを定義します。
+
+デフォルト値: `undef`。
+
+##### `scriptaliases`
+
+> **注意**: このパラメータは廃止予定であり、`aliases`パラメータに置き換えられます。
+
+ハッシュの配列をバーチャルホストに渡し、[`mod_alias`ドキュメント][`mod_alias`]に従ってScriptAliasまたはScriptAliasMatchステートメントのいずれかを作成します。
+
+``` puppet
+scriptaliases => [
+  {
+    alias => '/myscript',
+    path  => '/usr/share/myscript',
+  },
+  {
+    aliasmatch => '^/foo(.*)',
+    path       => '/usr/share/fooscripts$1',
+  },
+  {
+    aliasmatch => '^/bar/(.*)',
+    path       => '/usr/share/bar/wrapper.sh/$1',
+  },
+  {
+    alias => '/neatscript',
+    path  => '/usr/share/neatscript',
+  },
+]
+```
+
+ScriptAliasおよびScriptAliasMatchディレクティブは、指定した順に作成されます。 [AliasおよびAliasMatch](#aliases)ディレクティブと同様、シャドーイングを避けるため、まず具体的なエイリアスを指定してから、全般的なものを指定してください。
+
+##### `serveradmin`
+
+エラーページの表示時にApacheが表示するEメールアドレスを指定します。 
+
+デフォルト値: `undef`。
+
+##### `serveraliases`
+
+サイトの[ServerAliases](https://httpd.apache.org/docs/current/mod/core.html#serveralias)を設定します。
+
+デフォルト値: '[]'。
+
+##### `servername`
+
+バーチャルホストに接続するホスト名に対応するサーバ名を設定します。
+
+デフォルト値: リソースのタイトル。
+
+##### `setenv`
+
+HTTPDにより使用し、バーチャルホストの環境変数を設定します。
+
+デフォルト値: '[]'。
+
+例:
+
+``` puppet
+apache::vhost { 'setenv.example.com':
+  setenv => ['SPECIAL_PATH /foo/bin'],
+}
+```
+
+##### `setenvif`
+
+HTTPDにより使用し、条件を用いてバーチャルホストの環境変数を設定します。
+
+デフォルト値: '[]'。
+
+##### `setenvifnocase`
+
+HTTPDにより使用し、条件を用いてバーチャルホストの環境変数を設定します(大文字小文字を区別しないマッチング)。
+
+デフォルト値: '[]'。
+
+##### `suphp_*`
+
+* `suphp_addhandler`
+* `suphp_configpath`
+* `suphp_engine`
+
+[suPHP](http://suphp.org/DocumentationView.html?file=apache/CONFIG)によりバーチャルホストを設定します。
+
+* `suphp_addhandler`。デフォルト値: RedHatおよびFreeBSDでは'php5-script'、DebianおよびGentooでは'x-httpd-php'。
+* `suphp_configpath`。デフォルト値: RedHatおよびFreeBSDでは`undef`、DebianおよびGentooでは'/etc/php5/apache2'。
+* `suphp_engine`。値: 'on'または'off'。デフォルト値: 'off'。
+
+suPHPによるバーチャルホスト設定の例:
+
+``` puppet
+apache::vhost { 'suphp.example.com':
+  port             => '80',
+  docroot          => '/home/appuser/myphpapp',
+  suphp_addhandler => 'x-httpd-php',
+  suphp_engine     => 'on',
+  suphp_configpath => '/etc/php5/apache2',
+  directories      => { path => '/home/appuser/myphpapp',
+    'suphp'        => { user => 'myappuser', group => 'myappgroup' },
+  }
+}
+```
+
+##### `vhost_name`
+
+名前ベースのバーチャルホストを有効にします。バーチャルホストにIPではなくポートが割り当てられている場合は、バーチャルホスト名は'vhost_name:port'になります。バーチャルホストにIPもポートも割り当てられていない場合は、バーチャルホスト名はリソースのタイトルに設定されます。
+
+デフォルト値: '*'。
+
+##### `virtual_docroot`
+
+同じ名前を持つディレクトリにマッピングされたワイルドカードエイリアスサブドメインにより、バーチャルホストを設定します。例えば、'http://example.com' would map to '/var/www/example.com'のようになります。
+
+デフォルト値: `false`。
+
+``` puppet
+apache::vhost { 'subdomain.loc':
+  vhost_name      => '*',
+  port            => '80',
+  virtual_docroot => '/var/www/%-2+',
+  docroot         => '/var/www',
+  serveraliases   => ['*.loc',],
+}
+```
+
+##### `wsgi*`
+
+* `wsgi_daemon_process`
+* `wsgi_daemon_process_options`
+* `wsgi_process_group`
+* `wsgi_script_aliases`
+* `wsgi_pass_authorization`
+
+[WSGI](https://github.com/GrahamDumpleton/mod_wsgi)によりバーチャルホストを設定します。
+
+* `wsgi_daemon_process`: WSGIデーモンの名前を設定するハッシュ。[特定のキー](http://modwsgi.readthedocs.org/en/latest/configuration-directives/WSGIDaemonProcess.html)を使用できます。デフォルト値: `undef`。
+* `wsgi_daemon_process_options`。_オプション。_ デフォルト値: `undef`。
+* `wsgi_process_group`: バーチャルホストが実行されるグループIDを設定します。デフォルト値: `undef`。
+* `wsgi_script_aliases`: ファイルシステム.wsgiパスへのWebパスのハッシュにする必要があります。デフォルト値: `undef`。
+* `wsgi_script_aliases_match`: ファイルシステム.wsgiパスへのWebパスの正規表現のハッシュにする必要があります。デフォルト値: `undef`。
+* `wsgi_pass_authorization`: 'On'に設定すると、Apacheの代わりにWSGIアプリケーションを使って認証を処理します。詳細については、[mod_wsgi's WSGIPassAuthorizationドキュメント] (https://modwsgi.readthedocs.org/en/latest/configuration-directives/WSGIPassAuthorization.html)を参照してください。デフォルト値: `undef`、これにより、Apacheのデフォルト値である'Off'が使われます。
+* `wsgi_chunked_request`: チャンク形式のリクエストのサポートを有効にします。デフォルト値: `undef`。
+
+WSGIによるバーチャルホスト設定の例:
+
+``` puppet
+apache::vhost { 'wsgi.example.com':
+  port                        => '80',
+  docroot                     => '/var/www/pythonapp',
+  wsgi_daemon_process         => 'wsgi',
+  wsgi_daemon_process_options =>
+    { processes    => '2',
+      threads      => '15',
+      display-name => '%{GROUP}',
+     },
+  wsgi_process_group          => 'wsgi',
+  wsgi_script_aliases         => { '/' => '/var/www/demo.wsgi' },
+  wsgi_chunked_request        => 'On',
+}
+```
+
+#### `apache::vhost`のパラメータ`directories`
+
+`apache::vhost`クラスの`directories`パラメータは、バーチャルホストにハッシュの配列を渡し、[Directory](https://httpd.apache.org/docs/current/mod/core.html#directory)、[File](https://httpd.apache.org/docs/current/mod/core.html#files)、[Location](https://httpd.apache.org/docs/current/mod/core.html#location)ディレクティブブロックを作成します。これらのブロックは、'< Directory /path/to/directory>...< /Directory>'の形式をとります。
+
+`path`キーは、ディレクトリ、ファイル、ロケーションブロックのパスを設定します。この値は、'directory'、'files'、または'location'プロバイダのパスか、'directorymatch'、'filesmatch'、または 'locationmatch'プロバイダの正規表現でなければなりません。`directories`に渡される各ハッシュには、キーのひとつとして`path`が含まれていなければ**なりません**。
+
+`provider`キーはオプションです。設定されていない場合、このキーのデフォルトは'directory'になります。値: 'directory'、'files'、'proxy'、'location'、'directorymatch'、'filesmatch'、'proxymatch'、'locationmatch'。`provider`を'directorymatch'に設定すると、 Apache設定ファイルでキーワード'DirectoryMatch'が使用されます。
+
+`directories`の使用例:
+
+``` puppet
+apache::vhost { 'files.example.net':
+  docroot     => '/var/www/files',
+  directories => [
+    { 'path'     => '/var/www/files',
+      'provider' => 'files',
+      'deny'     => 'from all',
+     },
+  ],
+}
+```
+
+> **注意:** 少なくとも1つのディレクトリが`docroot`パラメータとマッチする必要があります。ディレクトリの宣言を開始すると、`apache::vhost`は必要なすべてのディレクトリブロックが宣言されるものと見なします。定義されない場合、`docroot`パラメータにマッチする1つのデフォルトディレクトリブロックが作成されます。
+
+`directory`、`files`、または`location`ハッシュ内に、使用可能なハンドラを配置し、キーとして表す必要があります。以下のようになります。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot     => '/path/to/directory',
+  directories => [ { path => '/path/to/directory', handler => value } ],
+}
+```
+
+これらのハッシュで設定していないハンドラは、Puppet内で'undefined'と見なされ、バーチャルホストに追加されず、モジュールではデフォルト値が使われます。サポートされているハンドラは、次のとおりです。
+
+##### `addhandlers`
+
+[AddHandler](https://httpd.apache.org/docs/current/mod/mod_mime.html#addhandler)ディレクティブを設定します。これは、ファイル名の拡張子を指定されたハンドラにマッピングするものです。ハッシュのリストを使用し、`extensions`はハンドラによりマッピングされた拡張子を記述するために使用されます。`{ handler => 'handler-name', extensions => ['extension'] }`の形式をとります。
+
+例:
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot     => '/path/to/directory',
+  directories => [
+    { path        => '/path/to/directory',
+      addhandlers => [{ handler => 'cgi-script', extensions => ['.cgi']}],
+    },
+  ],
+}
+```
+
+##### `allow`
+
+[Allow](https://httpd.apache.org/docs/2.2/mod/mod_authz_host.html#allow)ディレクティブを設定します。これは、ホスト名またはIPに基づく認証をグループ化するものです。**廃止予定:**このパラメータは、Apacheが変更されたため、廃止予定になっています。Apache 2.2以下でのみ機能します。1つのルールに対する単一の文字列としても、複数のルールに対する配列としても使用できます。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot     => '/path/to/directory',
+  directories => [
+    { path  => '/path/to/directory',
+      allow => 'from example.org',
+    },
+  ],
+}
+```
+
+##### `allow_override`
+
+[.htaccess](https://httpd.apache.org/docs/current/mod/core.html#allowoverride)ファイルで許可されるディレクティブのタイプを設定します。配列を使用できます。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot      => '/path/to/directory',
+  directories  => [
+    { path           => '/path/to/directory',
+      allow_override => ['AuthConfig', 'Indexes'],
+    },
+  ],
+}
+```
+
+##### `auth_basic_authoritative`
+
+[AuthBasicAuthoritative](https://httpd.apache.org/docs/current/mod/mod_auth_basic.html#authbasicauthoritative)の値を設定します。これにより、下位のApacheモジュールに権限と認証を渡すかどうかが決定されます。
+
+##### `auth_basic_fake`
+
+[AuthBasicFake](https://httpd.apache.org/docs/current/mod/mod_auth_basic.html#authbasicfake)の値を設定します。これにより、任意のディレクティブブロックに関する認証情報が静的に設定されます。
+
+##### `auth_basic_provider`
+
+[AuthBasicProvider](https://httpd.apache.org/docs/current/mod/mod_auth_basic.html#authbasicprovider)の値を設定します。これにより、任意のロケーションの認証プロバイダが設定されます。
+
+##### `auth_digest_algorithm`
+
+[AuthDigestAlgorithm](https://httpd.apache.org/docs/current/mod/mod_auth_digest.html#authdigestalgorithm)の値を設定します。これにより、チャレンジおよびレスポンスハッシュの計算に用いるアルゴリズムを選択します。
+
+###### `auth_digest_domain`
+
+[AuthDigestDomain](https://httpd.apache.org/docs/current/mod/mod_auth_digest.html#authdigestdomain)の値を設定します。これにより、ダイジェスト認証に関して、同じ保護スペースで1つまたは複数のURIを指定できます。
+
+##### `auth_digest_nonce_lifetime`
+
+[AuthDigestNonceLifetime](https://httpd.apache.org/docs/current/mod/mod_auth_digest.html#authdigestnoncelifetime)の値を設定します。これにより、サーバのノンスが有効になる長さを制御します。
+
+##### `auth_digest_provider`
+
+[AuthDigestProvider](https://httpd.apache.org/docs/current/mod/mod_auth_digest.html#authdigestprovider)の値を設定します。これにより、任意のロケーションに関する認証プロバイダを設定します。
+
+##### `auth_digest_qop`
+
+[AuthDigestQop](https://httpd.apache.org/docs/current/mod/mod_auth_digest.html#authdigestqop)の値を設定します。これにより、ダイジェスト認証で用いる保護品質を決定します。
+
+##### `auth_digest_shmem_size`
+
+[AuthAuthDigestShmemSize](https://httpd.apache.org/docs/current/mod/mod_auth_digest.html#authdigestshmemsize)の値を設定します。これにより、クライアントの追跡に関して、サーバに割り当てられる共通メモリの量を定義します。
+
+##### `auth_group_file`
+
+[AuthGroupFile](https://httpd.apache.org/docs/current/mod/mod_authz_groupfile.html#authgroupfile)の値を設定します。これにより、認証に関して、ユーザグループのリストを含むテキストファイルの名前を設定します。
+
+##### `auth_name`
+
+[AuthName](https://httpd.apache.org/docs/current/mod/mod_authn_core.html#authname)の値を設定します。これにより、認証領域の名前を設定します。
+
+##### `auth_require`
+
+アクセスを許可するのに必要なエンティティ名を設定します。詳細については、[Require](https://httpd.apache.org/docs/current/mod/mod_authz_host.html#requiredirectives)を参照してください。
+
+##### `auth_type`
+
+[AuthType](https://httpd.apache.org/docs/current/mod/mod_authn_core.html#authtype)の値を設定します。これにより、ユーザ認証のタイプをガイドします。
+
+##### `auth_user_file`
+
+[AuthUserFile](https://httpd.apache.org/docs/current/mod/mod_authn_file.html#authuserfile)の値を設定します。これにより、認証に関するユーザ/パスワードを含むテキストファイルの名前を設定します。
+
+##### `auth_merging`
+
+[AuthMerging](https://httpd.apache.org/docs/current/mod/mod_authz_core.html#authmerging)の値を設定します。これにより、認証ロジックを組み合わせるかどうかを決定します。
+
+##### `auth_ldap_url`
+
+[AuthLDAPURL](https://httpd.apache.org/docs/current/mod/mod_authnz_ldap.html#authldapurl)の値を設定します。これにより、AuthBasicProvider 'ldap'を使用する場合のLDAPサーバのURLを決定します。
+
+##### `auth_ldap_bind_dn`
+
+[AuthLDAPBindDN](https://httpd.apache.org/docs/current/mod/mod_authnz_ldap.html#authldapbinddn)の値を設定します。これにより、AuthBasicProvider 'ldap'を使用する場合に、エントリの検索時にLDAPサーバにバインドするオプションのDNを使用できるようになります。
+
+##### `auth_ldap_bind_password`
+
+[AuthLDAPBindPassword](https://httpd.apache.org/docs/current/mod/mod_authnz_ldap.html#authldapbindpassword)の値を設定します。これにより、AuthBasicProvider 'ldap'を使用する場合に、バインドDNとともに用いるオプションのバインドパスワードを使用できるようになります。
+
+##### `auth_ldap_group_attribute`
+
+[AuthLDAPGroupAttribute](https://httpd.apache.org/docs/current/mod/mod_authnz_ldap.html#authldapgroupattribute)の値の配列。ldapグループ内のユーザメンバーの確認に使用するLDAP属性を指定します。
+
+デフォルト値: "member"および "uniquemember"。
+
+##### `auth_ldap_group_attribute_is_dn`
+
+[AuthLDAPGroupAttributeIsDN](https://httpd.apache.org/docs/current/mod/mod_authnz_ldap.html#authldapgroupattributeisdn)の値を設定し、ldapグループのメンバーにDNかシンプルなユーザ名のどちらを使用するかを指定します。onに設定すると、グループメンバーシップの確認時に、クライアントユーザ名の識別名が使用されます。そうでない場合は、ユーザ名が使われます。有効な値は"on"か"off"です。
+
+##### `custom_fragment`
+
+カスタム設定ディレクティブの文字列を渡し、ディレクトリ設定の最後に配置します。
+
+``` puppet
+apache::vhost { 'monitor':
+  …
+  directories => [
+    {
+      path => '/path/to/directory',
+      custom_fragment => '
+<Location /balancer-manager>
+  SetHandler balancer-manager
+  Order allow,deny
+  Allow from all
+</Location>
+<Location /server-status>
+  SetHandler server-status
+  Order allow,deny
+  Allow from all
+</Location>
+ProxyStatus On',
+    },
+  ]
+}
+```
+
+##### `dav`
+
+[Dav](http://httpd.apache.org/docs/current/mod/mod_dav.html#dav)の値を設定します。これにより、WebDAV HTTPメソッドを有効にするかどうかを決定します。値としては、'On'、'Off'、またはプロバイダの名前を使用できます。'On'に設定すると、`mod_dav_fs`モジュールにより実装されているデフォルトのファイルシステムプロバイダが有効になります。 
+
+##### `dav_depth_infinity`
+
+[DavDepthInfinity](http://httpd.apache.org/docs/current/mod/mod_dav.html#davdepthinfinity)の値を設定します。これは、`Depth: Infinity`ヘッダを持つ`PROPFIND`リクエストの処理を有効にするのに使用されます。
+
+##### `dav_min_timeout`
+
+[DavMinTimeout](http://httpd.apache.org/docs/current/mod/mod_dav.html#davmintimeout)の値を設定します。DAVリソースでサーバがロック状態を維持する時間(秒数)を指定します。
+
+##### `deny`
+
+[Deny](https://httpd.apache.org/docs/2.2/mod/mod_authz_host.html#deny)ディレクティブを設定し、サーバへのアクセスを否定するホストを指定します。**廃止予定:** このパラメータは、Apacheが変更されたため、廃止予定になっています。Apache 2.2以下でのみ機能します。1つのルールに対する単一の文字列としても、複数のルールに対する配列としても使用できます。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot     => '/path/to/directory',
+  directories => [
+    { path => '/path/to/directory',
+      deny => 'from example.org',
+    },
+  ],
+}
+```
+
+##### `error_documents`
+
+ディレクトリの[ErrorDocument](https://httpd.apache.org/docs/current/mod/core.html#errordocument)設定をオーバーライドするハッシュの配列。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  directories => [
+    { path            => '/srv/www',
+      error_documents => [
+        { 'error_code' => '503',
+          'document'   => '/service-unavail',
+        },
+      ],
+    },
+  ],
+}
+```
+
+##### `ext_filter_options`
+
+[ExtFilterOptions](https://httpd.apache.org/docs/current/mod/mod_ext_filter.html)ディレクティブを設定します。
+このディレクティブを使用する前に、`class { 'apache::mod::ext_filter': }`を宣言する必要があります。
+
+``` puppet
+apache::vhost { 'filter.example.org':
+  docroot     => '/var/www/filter',
+  directories => [
+    { path               => '/var/www/filter',
+      ext_filter_options => 'LogStderr Onfail=abort',
+    },
+  ],
+}
+```
+
+##### `geoip_enable`
+
+[GeoIPEnable](http://dev.maxmind.com/geoip/legacy/mod_geoip2/#Configuration)ディレクティブを設定します。
+このディレクティブを使用する前に、`class {'apache::mod::geoip': }`を宣言する必要があります。
+
+``` puppet
+apache::vhost { 'first.example.com':
+  docroot     => '/var/www/first',
+  directories => [
+    { path         => '/var/www/first',
+      geoip_enable => `true`,
+    },
+  ],
+}
+```
+
+##### `headers`
+
+[Header](https://httpd.apache.org/docs/current/mod/mod_headers.html#header)ディレクティブの行を追加します。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot     => '/path/to/directory',
+  directories => {
+    path    => '/path/to/directory',
+    headers => 'Set X-Robots-Tag "noindex, noarchive, nosnippet"',
+  },
+}
+```
+
+##### `index_options`
+
+[ディレクトリインデキシング](https://httpd.apache.org/docs/current/mod/mod_autoindex.html#indexoptions)の設定を可能にします。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot     => '/path/to/directory',
+  directories => [
+    { path           => '/path/to/directory',
+      directoryindex => 'disabled', # this is needed on Apache 2.4 or mod_autoindex doesn't work
+      options        => ['Indexes','FollowSymLinks','MultiViews'],
+      index_options  => ['IgnoreCase', 'FancyIndexing', 'FoldersFirst', 'NameWidth=*', 'DescriptionWidth=*', 'SuppressHTMLPreamble'],
+    },
+  ],
+}
+```
+
+##### `index_order_default`
+
+ディレクトリインデックスの[デフォルトの順序付け](https://httpd.apache.org/docs/current/mod/mod_autoindex.html#indexorderdefault)を設定します。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot     => '/path/to/directory',
+  directories => [
+    { path                => '/path/to/directory',
+      order               => 'Allow,Deny',
+      index_order_default => ['Descending', 'Date'],
+    },
+  ],
+}
+```
+
+###### `index_style_sheet`
+
+[IndexStyleSheet](https://httpd.apache.org/docs/current/mod/mod_autoindex.html#indexstylesheet)を設定します。これにより、ディレクトリインデックスにCSSスタイルシートが追加されます。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot     => '/path/to/directory',
+  directories => [
+    { path              => '/path/to/directory',
+      options           => ['Indexes','FollowSymLinks','MultiViews'],
+      index_options     => ['FancyIndexing'],
+      index_style_sheet => '/styles/style.css',
+    },
+  ],
+}
+```
+
+##### `limit`
+
+ディレクトリブロック内に[Limit](https://httpd.apache.org/docs/current/mod/core.html#limit)ブロックを作成します。`require`ディレクティブを含めることもできます。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot     => '/path/to/docroot',
+  directories => [
+    { path     => '/',
+      provider => 'location',
+      limit    => [
+        { methods => 'GET HEAD',
+          require => ['valid-user']
+        },
+      ],
+    },
+  ],
+}
+```
+
+##### `limit_except`
+
+ディレクトリブロック内に[LimitExcept](https://httpd.apache.org/docs/current/mod/core.html#limitexcept)ブロックを作成します。`require`ディレクティブを含めることもできます。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot     => '/path/to/docroot',
+  directories => [
+    { path         => '/',
+      provider     => 'location',
+      limit_except => [
+        { methods => 'GET HEAD',
+          require => ['valid-user']
+        },
+      ],
+    },
+  ],
+}
+```
+
+##### `mellon_enable`
+
+[MellonEnable][`mod_auth_mellon`]ディレクトリを設定し、 [`mod_auth_mellon`][]を有効にします。[`apache::mod::auth_mellon`][]を使って`mod_auth_mellon`をインストールできます。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot     => '/path/to/directory',
+  directories => [
+    { path                       => '/',
+      provider                   => 'directory',
+      mellon_enable              => 'info',
+      mellon_sp_private_key_file => '/etc/certs/${::fqdn}.key',
+      mellon_endpoint_path       => '/mellon',
+      mellon_set_env_no_prefix   => { 'ADFS_GROUP' => 'http://schemas.xmlsoap.org/claims/Group',
+                                      'ADFS_EMAIL' => 'http://schemas.xmlsoap.org/claims/EmailAddress', },
+      mellon_user => 'ADFS_LOGIN',
+    },
+    { path          => '/protected',
+      provider      => 'location',
+      mellon_enable => 'auth',
+      auth_type     => 'Mellon',
+      auth_require  => 'valid-user',
+      mellon_cond   => ['ADFS_LOGIN userA [MAP]','ADFS_LOGIN userB [MAP]'],
+    },
+  ]
+}
+```
+
+関連するパラメータは、`mod_auth_mellon`ディレクティブの名前に従います。
+
+- `mellon_cond`: アクセスを許可するために満たす必要のあるmellon条件の配列をとり、配列内の各アイテムについて [MellonCond][`mod_auth_mellon`]ディレクティブを作成します。
+- `mellon_endpoint_path`: [MellonEndpointPath][`mod_auth_mellon`]を設定し、mellonエンドポイントパスを設定します。
+- `mellon_sp_metadata_file`: SPメタデータファイルの[MellonSPMetadataFile][`mod_auth_mellon`]ロケーションを設定します。
+- `mellon_idp_metadata_file`: IDPメタデータファイルの[MellonIDPMetadataFile][`mod_auth_mellon`]ロケーションを設定します。
+- `mellon_saml_rsponse_dump`: [MellonSamlResponseDump][`mod_auth_mellon`]ディレクティブを設定し、SAMLのデバッグを有効にします。
+- `mellon_set_env_no_prefix`:環境変数にマッピングする属性名のハッシュに関する [MellonSetEnvNoPrefix][`mod_auth_mellon`]ディレクティブを
+設定します。
+- `mellon_sp_private_key_file`: サービスプロバイダのプライベートキー保存場所に関する[MellonSPPrivateKeyFile][`mod_auth_mellon`]ディレクティブを設定します。
+- `mellon_sp_cert_file`: サービスプロバイダの公開キー保存場所に関する[MellonSPCertFile][`mod_auth_mellon`]ディレクティブを設定します。
+- `mellon_user`: ユーザ名に関して使用する[MellonUser][`mod_auth_mellon`]属性を設定します。
+
+##### `options`
+
+任意のディレクトリブロックに関する[オプション](https://httpd.apache.org/docs/current/mod/core.html#options)をリスト化します。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot     => '/path/to/directory',
+  directories => [
+    { path    => '/path/to/directory',
+      options => ['Indexes','FollowSymLinks','MultiViews'],
+    },
+  ],
+}
+```
+
+##### `order`
+
+[Apacheコアドキュメント](https://httpd.apache.org/docs/2.2/mod/mod_authz_host.html#order)に従い、AllowおよびDenyステートメントの処理順序を設定します。**廃止予定:** このパラメータは、Apacheが変更されたため、廃止予定になっています。Apache 2.2以下でのみ機能します。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot     => '/path/to/directory',
+  directories => [
+    { path  => '/path/to/directory',
+      order => 'Allow,Deny',
+    },
+  ],
+}
+```
+
+##### `passenger_enabled`
+
+[PassengerEnabled](http://www.modrails.com/documentation/Users%20guide%20Apache.html#PassengerEnabled)ディレクティブの値を'on'または'off'に設定します。`apache::mod::passenger`を含める必要があります。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot     => '/path/to/directory',
+  directories => [
+    { path              => '/path/to/directory',
+      passenger_enabled => 'on',
+    },
+  ],
+}
+```
+
+> **注意:** PassengerEnabledディレクティブをPassengerHighPerformanceディレクティブとともに使用すると、[問題](http://www.conandalton.net/2010/06/passengerenabled-off-not-working.html)が生じます。
+
+##### `php_value`および`php_flag`
+
+`php_value`はディレクトリの値を設定し、`php_flag`はブーリアンを用いてディレクトリを設定します。詳細は[こちら](http://php.net/manual/en/configuration.changes.php)で確認できます。
+
+##### `php_admin_value`および`php_admin_flag`
+
+`php_admin_value`はディレクトリの値を設定し、`php_admin_flag`はブーリアンを用いてディレクトリを設定します。詳細は[こちら](http://php.net/manual/en/configuration.changes.php)で確認できます。
+
+
+##### `require`
+
+
+[Apache Authzドキュメント](https://httpd.apache.org/docs/current/mod/mod_authz_core.html#require)に従い、`Require`ディレクティブを設定します。`require`が設定されていない場合、`Require all granted`がデフォルトになります。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot     => '/path/to/directory',
+  directories => [
+    { path    => '/path/to/directory',
+      require => 'ip 10.17.42.23',
+    }
+  ],
+}
+```
+
+より複雑な要件設定が必要な場合、apache >= 2.4では[RequireAll](https://httpd.apache.org/docs/2.4/mod/mod_authz_core.html#requireall)、[RequireNone](https://httpd.apache.org/docs/2.4/mod/mod_authz_core.html#requirenone)または[RequireAny](https://httpd.apache.org/docs/2.4/mod/mod_authz_core.html#requireany)ディレクティブを使用できます。'any'、'none'、'all'のみをサポートする(その他の値は無視されます)'enforce'キーを使うと、以下のように設定できます。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot     => '/path/to/directory',
+  directories => [
+    { path    => '/path/to/directory',
+      require => {
+        enforce  => 'any',
+        requires => [
+          'ip 1.2.3.4',
+          'not host host.example.com',
+          'user xyz',
+        ],
+      },
+    },
+  ],
+}
+```
+
+`require`を`unmanaged`に設定すると、何も設定されません。これは、カスタムフラグメントで扱われる複雑な認証/権限要件に役立ちます。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot     => '/path/to/directory',
+  directories => [
+    { path    => '/path/to/directory',
+      require => 'unmanaged',
+    }
+  ],
+}
+```
+
+
+
+##### `satisfy`
+
+[Apacheコアドキュメント](https://httpd.apache.org/docs/2.2/mod/core.html#satisfy)に従い、`Satisfy`ディレクティブを設定します。**廃止予定:** このパラメータは、Apacheが変更されたため、廃止予定になっています。Apache 2.2以下でのみ機能します。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot     => '/path/to/directory',
+  directories => [
+    { path    => '/path/to/directory',
+      satisfy => 'Any',
+    }
+  ],
+}
+```
+
+##### `sethandler`
+
+[Apache Coreドキュメント](https://httpd.apache.org/docs/2.2/mod/core.html#sethandler)に従い、`SetHandler`ディレクティブを設定します。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot     => '/path/to/directory',
+  directories => [
+    { path       => '/path/to/directory',
+      sethandler => 'None',
+    }
+  ],
+}
+```
+
+##### `set_output_filter`
+
+[Apache Coreドキュメント](https://httpd.apache.org/docs/current/mod/core.html#setoutputfilter)に従い、`SetOutputFilter`ディレクティブを設定します。
+
+``` puppet
+apache::vhost{ 'filter.example.net':
+  docroot     => '/path/to/directory',
+  directories => [
+    { path              => '/path/to/directory',
+      set_output_filter => puppetdb-strip-resource-params,
+    },
+  ],
+}
+```
+
+##### `rewrites`
+
+バーチャルホストディレクトリ内でURL [`rewrites`](#rewrites)ルールを作成します。ハッシュの配列が求められます。ハッシュキーは'comment'、'rewrite_base'、'rewrite_cond'または'rewrite_rule'のいずれかにすることができます。
+
+``` puppet
+apache::vhost { 'secure.example.net':
+  docroot     => '/path/to/directory',
+  directories => [
+    { path        => '/path/to/directory',
+      rewrites => [ { comment      => 'Permalink Rewrites',
+                      rewrite_base => '/'
+                    },
+                    { rewrite_rule => [ '^index\.php$ - [L]' ]
+                    },
+                    { rewrite_cond => [ '%{REQUEST_FILENAME} !-f',
+                                        '%{REQUEST_FILENAME} !-d',
+                                      ],
+                      rewrite_rule => [ '. /index.php [L]' ],
+                    }
+                  ],
+    },
+  ],
+}
+```
+
+> **注意**: ディレクトリにリライトを含める場合は、`apache::mod::rewrite`も含めてください。また、バーチャルホストのディレクトリのリライト設定ではなく、`apache::vhost`の`rewrites`パラメータを用いたリライトの設定を考慮してください。
+
+##### `shib_request_settings`
+
+アプリケーションリクエストに関して、有効なコンテンツ設定の設定または変更を可能にします。このコマンドは、次の2つのパラメータをとります: コンテンツ設定の名前、およびそれについて設定する値。有効な設定については、Shibboleth [コンテンツ設定ドキュメント](https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPContentSettings)を参照してください。このキーは、`apache::mod::shib`が定義されていない場合は無効になります。詳細については、[`mod_shib`ドキュメント](https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPApacheConfig#NativeSPApacheConfig-Server/VirtualHostOptions)を参照してください。
+
+``` puppet
+apache::vhost { 'secure.example.net':
+  docroot     => '/path/to/directory',
+  directories => [
+    { path                  => '/path/to/directory',
+      shib_request_settings => { 'requiresession' => 'On' },
+      shib_use_headers      => 'On',
+    },
+  ],
+}
+```
+
+##### `shib_use_headers`
+
+'On'に設定すると、アプリケーションに属性を公開するリクエストヘッダの使用がオンになります。このキーの値は'On'または'Off'です。デフォルト値は'Off'です。このキーは、`apache::mod::shib`が定義されていない場合は無効になります。詳細については、[`mod_shib`ドキュメント](https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPApacheConfig#NativeSPApacheConfig-Server/VirtualHostOptions)を参照してください。
+
+##### `ssl_options`
+
+[SSLOptions](https://httpd.apache.org/docs/current/mod/mod_ssl.html#ssloptions)の文字列またはリスト。これにより、SSLエンジンのランタイムオプションが設定されます。このハンドラは、バーチャルホストの親ブロック内のSSLOptionsセットよりも優先されます。
+
+``` puppet
+apache::vhost { 'secure.example.net':
+  docroot     => '/path/to/directory',
+  directories => [
+    { path        => '/path/to/directory',
+      ssl_options => '+ExportCertData',
+    },
+    { path        => '/path/to/different/dir',
+      ssl_options => [ '-StdEnvVars', '+ExportCertData'],
+    },
+  ],
+}
+```
+
+##### `suphp`
+
+[suPHP_UserGroup](http://www.suphp.org/DocumentationView.html?file=apache/CONFIG)設定に関する'user'および'group'キーを含むハッシュ。バーチャルホスト宣言で`suphp_engine => on`とともに使用する必要があり、`directories`内でのみ渡すことができます。
+
+``` puppet
+apache::vhost { 'secure.example.net':
+  docroot     => '/path/to/directory',
+  directories => [
+    { path  => '/path/to/directory',
+      suphp => {
+        user  => 'myappuser',
+        group => 'myappgroup',
+      },
+    },
+  ],
+}
+```
+##### `additional_includes`
+
+バーチャルホストディレクトリ内にある追加の静的な固有のApache設定ファイルのパスを指定します。値: 文字列パスの配列。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot     => '/path/to/directory',
+  directories => [
+    { path  => '/path/to/different/dir',
+      additional_includes => [ '/custom/path/includes', '/custom/path/another_includes', ],
+    },
+  ],
+}
+```
+
+#### `apache::vhost`のSSLパラメータ
+
+`::vhost`のすべてのSSLパラメータは、基本の`apache`クラスで設定された値がデフォルトになります。以下のパラメータを使えば、特定のバーチャルホストに関する個別のSSL設定を調整できます。
+
+##### `ssl`
+
+バーチャルホストのSSLを有効にします。SSLバーチャルホストはHTTPSクエリにのみ応答します。値: ブーリアン。
+
+デフォルト値: `false`。
+
+##### `ssl_ca`
+
+SSL証明書認証局を指定します。
+
+デフォルト値: `undef`。
+
+##### `ssl_cert`
+
+SSL証明書を指定します。
+
+デフォルト値: オペレーティングシステムによって異なります。
+
+* RedHat: '/etc/pki/tls/certs/localhost.crt'
+* Debian: '/etc/ssl/certs/ssl-cert-snakeoil.pem'
+* FreeBSD: '/usr/local/etc/apache22/server.crt'
+* Gentoo: '/etc/ssl/apache2/server.crt'
+
+##### `ssl_protocol`
+
+[SSLProtocol](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslprotocol)を指定します。許可されるプロトコルの配列またはスペースで区切った文字列が求められます。
+
+デフォルト値: 'all'、'-SSLv2'、'-SSLv3'。
+
+##### `ssl_cipher`
+
+[SSLCipherSuite](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslciphersuite)を指定します。
+
+デフォルト値: 'HIGH:MEDIUM:!aNULL:!MD5'。
+
+##### `ssl_honorcipherorder`
+
+[SSLHonorCipherOrder](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslhonorcipherorder)を指定し、クライアントの優先順ではなくサーバの優先順をApacheに使用させます。値:
+
+値: ブーリアン、'on'、'off'。
+
+デフォルト値: `true`。
+
+##### `ssl_certs_dir`
+
+SSL証明書ディレクトリのロケーションを指定します。 
+
+デフォルト値: オペレーティングシステムによって異なります。
+
+- Debian: '/etc/ssl/certs'
+- Red Hat: '/etc/pki/tls/certs'
+- FreeBSD: `undef`
+- Gentoo: '/etc/ssl/apache2'
+
+##### `ssl_chain`
+
+SSLチェーンを指定します。このデフォルト値は設定しなくても機能しますが、本稼働環境で使用する前に、固有の証明書情報により基本の`apache`クラス内で更新する必要があります。
+
+デフォルト値: `undef`。
+
+##### `ssl_crl`
+
+使用する証明書失効リストを指定します。(このデフォルト値は設定しなくても機能しますが、本稼働環境で使用する前に、固有の証明書情報により基本の`apache`クラス内で更新する必要があります。)
+
+デフォルト値: `undef`。
+
+##### `ssl_crl_path`
+
+証明書失効リストの保存場所を指定します。(このデフォルト値は設定しなくても機能しますが、本稼働環境で使用する前に、固有の証明書情報により基本の`apache`クラス内で更新する必要があります。)
+
+デフォルト値: `undef`。
+
+##### `ssl_crl_check`
+
+[SSLCARevocationCheckディレクティブ](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcarevocationcheck)により、証明書失効チェックレベルを設定します。このデフォルト値は設定しなくても機能しますが、本稼働環境でCRLを使用する際に指定する必要があります。Apache 2.4以上にのみ適用されます。それ以前のバージョンでは、この値は無視されます。
+
+デフォルト値: `undef`。
+
+##### `ssl_key`
+
+SSLキーを指定します。
+
+デフォルト値はオペレーティングシステムによって異なります。このデフォルト値は設定しなくても機能しますが、本稼働環境で使用する前に、固有の証明書情報により基本の`apache`クラス内で更新する必要があります。
+
+* RedHat: '/etc/pki/tls/private/localhost.key'
+* Debian: '/etc/ssl/private/ssl-cert-snakeoil.key'
+* FreeBSD: '/usr/local/etc/apache22/server.key'
+* Gentoo: '/etc/ssl/apache2/server.key'
+
+##### `ssl_verify_client`
+
+[SSLVerifyClient](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslverifyclient)ディレクティブを設定します。これにより、クライアント認証に関する証明書確認レベルが設定されます。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  …
+  ssl_verify_client => 'optional',
+}
+```
+
+値: 'none'、'optional'、'require'、'optional_no_ca'。
+
+デフォルト値: `undef`。
+
+
+##### `ssl_verify_depth`
+
+[SSLVerifyDepth](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslverifydepth)ディレクティブを設定します。これにより、クライアント認証確認におけるCA証明書の最大深さが指定されます。
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  …
+  ssl_verify_depth => 1,
+}
+```
+
+デフォルト値: `undef`。
+
+##### `ssl_proxy_protocol`
+
+[SSLProxyProtocol](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxyprotocol)ディレクティブを設定します。これにより、プロキシに関するサーバ環境を確立する際に`mod_ssl`が使用すべきSSLプロトコルフレーバーを制御します。提示されたプロトコルのうちの1つのみを使用しているサーバに接続します。
+
+デフォルト値: `undef`。
+
+##### `ssl_proxy_verify`
+
+[SSLProxyVerify](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxyverify)ディレクティブを設定します。これにより、リクエストをリモートSSLサーバに転送するようにプロキシが設定されている場合のリモートサーバの証明書確認を設定します。
+
+デフォルト値: `undef`。
+
+##### `ssl_proxy_verify_depth`
+
+[SSLProxyVerifyDepth](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxyverifydepth)ディレクティブを設定します。これにより、リモートサーバに有効な証明書がないと判断するにあたり、mod_sslが行う確認の深さを設定します。
+
+深さ0では、自己署名リモートサーバ証明書のみが許可されます。デフォルトの深さ 1では、リモートサーバ証明書を自己署名にすることも、サーバが直接知っているCAにより署名することもできます。
+
+デフォルト値: `undef`。
+
+##### `ssl_proxy_ca_cert`
+
+[SSLProxyCACertificateFile](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxycacertificatefile)ディレクティブを設定します。これにより、やりとりするリモートサーバに関する認証局(CA)の証明書を集められるオールインワンファイルを指定します。これはリモートサーバ認証に用いられます。このファイルは、PEMエンコード証明書ファイルを優先順に連結したものにする必要があります。
+
+デフォルト値: `undef`。
+
+##### `ssl_proxy_machine_cert`
+
+[SSLProxyMachineCertificateFile](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxymachinecertificatefile)ディレクティブを設定します。これにより、このサーバがリモートサーバの認証に用いる証明書とキーを保存するオールインワンファイルを指定します。このファイルは、PEMエンコード証明書ファイルを優先順に連結したものにする必要があります。 
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  …
+  ssl_proxy_machine_cert => '/etc/httpd/ssl/client_certificate.pem',
+}
+```
+
+デフォルト値: `undef`。
+
+##### `ssl_proxy_check_peer_cn`
+
+[SSLProxyCheckPeerCN](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxycheckpeercn)ディレクティブを設定します。これにより、リモートサーバの証明書のCNフィールドをリクエストURLのホスト名と比較するかどうかを指定します。 
+
+値: 'on'、'off'。
+
+デフォルト値: `undef`。
+
+##### `ssl_proxy_check_peer_name`
+
+[SSLProxyCheckPeerName](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxycheckpeername)ディレクティブを設定します。これにより、リモートサーバの証明書のCNフィールドをリクエストURLのホスト名と比較するかどうかを決定します。
+
+値: 'on'、'off'。　
+
+デフォルト値: `undef`。
+
+##### `ssl_proxy_check_peer_expire`
+
+[SSLProxyCheckPeerExpire](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxycheckpeerexpire)ディレクティブを設定します。これにより、リモートサーバの証明書の有効期限をチェックするかどうかを指定します。
+
+値: 'on'、'off'。　
+
+デフォルト値: `undef`。
+
+##### `ssl_options`
+
+[SSLOptions](https://httpd.apache.org/docs/current/mod/mod_ssl.html#ssloptions)ディレクティブを設定します。これにより、各種のSSLエンジンのランタイムオプションを設定します。これは任意のバーチャルホスト全体の設定で、文字列にすることも配列にすることもできます。
+
+文字列:
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  …
+  ssl_options => '+ExportCertData',
+}
+```
+
+配列:
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  …
+  ssl_options => [ '+StrictRequire', '+ExportCertData' ],
+}
+```
+
+デフォルト値: `undef`。
+
+##### `ssl_openssl_conf_cmd`
+
+[SSLOpenSSLConfCmd](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslopensslconfcmd)ディレクティブを設定します。これにより、OpenSSLパラメータを直接設定できます。
+
+デフォルト値: `undef`。
+
+##### `ssl_proxyengine`
+
+[SSLProxyEngine](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxyengine)を使用するかどうかを指定します。
+
+ブーリアン。
+
+デフォルト値: `true`。
+
+##### `ssl_stapling`
+
+[SSLUseStapling](http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslusestapling)を使用するかどうかを指定します。デフォルトでは、全体で設定されているものを使用します。
+
+このパラメータはApache 2.4以上にのみ適用され、それ以前のバージョンでは無視されます。
+
+ブーリアンまたは`undef`。
+
+デフォルト値: `undef`。
+
+##### `ssl_stapling_timeout`
+
+[SSLStaplingResponderTimeout](http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslstaplingrespondertimeout)ディレクティブの設定に使用できます。
+
+このパラメータはApache 2.4以上にのみ適用され、それ以前のバージョンでは無視されます。　
+
+デフォルト値: なし。
+
+##### `ssl_stapling_return_errors`
+
+[SSLStaplingReturnResponderErrors](http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslstaplingreturnrespondererrors)ディレクティブの設定に使用できます。
+
+このパラメータはApache 2.4以上にのみ適用され、それ以前のバージョンでは無視されます。　
+
+デフォルト値: なし。　
+
+#### 定義タイプ: FastCGIサーバ
+
+このタイプは、mod\_fastcgiとともに使用します。特定のファイルタイプを扱う1つまたは複数の外部FastCGIサーバを定義することができます。
+
+** 注意 ** Ubuntu 10.04+では、マルチバースリポジトリを手動で有効にする必要があります。
+
+例:
+
+``` puppet
+apache::fastcgi::server { 'php':
+  host        => '127.0.0.1:9000',
+  timeout     => 15,
+  flush       => `false`,
+  faux_path   => '/var/www/php.fcgi',
+  fcgi_alias  => '/php.fcgi',
+  file_type   => 'application/x-httpd-php',
+  pass_header => ''
+}
+```
+
+その後、バーチャルホスト内で、上で指定したfastcgiサーバで扱う特定のファイルタイプを設定することができます。
+
+``` puppet
+apache::vhost { 'www':
+  ...
+  custom_fragment => 'AddType application/x-httpd-php .php'
+  ...
+}
+```
+
+##### `host`
+
+FastCGIサーバのホスト名またはIPアドレスおよびTCPポート番号(1-65535)。
+
+unixソケットを渡すこともできます。
+
+``` puppet
+apache::fastcgi::server { 'php':
+  host        => '/var/run/fcgi.sock',
+}
+```
+
+##### `timeout`
+
+リクエストが中止され、(エラーLogLevel)にイベントが記録されるまでに、FastCGIアプリケーションが非アクティブの状態で待機する秒数。この非アクティブタイマーは、FastCGIアプリケーションとの接続が待機中の場合のみ適用されます。アプリケーションの待ち行列に入ったリクエストに対して、時間内に記述やフラッシュによる応答がないと、リクエストは中止されます。アプリケーションとの通信が完了したものの、クライアントとの通信が完了しなかった(応答がバッファリングされた)場合は、タイムアウトは適用されません。
+
+##### `flush`
+
+アプリケーションから受信したデータを、強制的にクライアントに書き込みます。デフォルトでは、アプリケーションをできるだけ早くフリーな状態にするために、`mod_fastcgi`はデータをバッファリングします。 
+
+##### `faux_path`
+
+ローカルファイルシステムに存在する必要はありません。Apacheがこのファイル名に解読するURIは、この外部FastCGIアプリケーションにより処理されます。
+
+##### `alias`
+
+一意のエイリアス。 アクションとFastCGIサーバをリンクさせるために内部で用いられます。
+
+##### `file_type`
+
+FastCGIサーバにより処理するファイルのMIMEタイプ。
+
+##### `pass_header`
+
+リクエスト環境で渡されるHTTPリクエストヘッダの名前。このオプションにより、通常はCGI環境で利用できないヘッダコンテンツ(認証など)が利用できるようになります。
+
+#### 定義タイプ: `apache::vhost::custom`
+
+`apache::vhost::custom`定義タイプは、 `apache::custom_config`定義タイプのシンラッパーで、Apacheにおいてバーチャルホストディレクトリに固有のデフォルト設定の一部をオーバーライドします。 
+
+**`apache::vhost::custom`内のパラメータ**:
+
+##### `content`
+
+設定ファイルのコンテンツを設定します。
+
+##### `ensure`
+
+バーチャルホストファイルが存在するかどうかを指定します。
+
+値: 'absent'、'present'。
+
+デフォルト値: 'present'。
+
+##### `priority`
+
+Apache HTTPD VirtualHost設定ファイルに関する相対的なロード順序を設定します。
+
+デフォルト値: '25'。
+
+##### `verify_config`
+
+Apacheサービスに通知する前に設定ファイルのバリデーションを行うかどうかを指定します。
+
+ブーリアン。
+
+デフォルト値: `true`。
+
+### プライベート定義タイプ
+
+#### 定義タイプ: `apache::peruser::multiplexer`
+
+この定義タイプは、Apacheモジュールにクラスがあるかどうかを確認します。クラスがある場合は、そのクラスを含めます。ない場合は、モジュール名を[`apache::mod`][]定義タイプに渡します。
+
+#### 定義タイプ: `apache::peruser::multiplexer`　
+
+FreeBSDに関してのみ、[`Peruser`][]モジュールを有効にします。
+
+#### 定義タイプ: `apache::peruser::processor`
+
+FreeBSDに関してのみ、[`Peruser`][]モジュールを有効にします。　
+
+#### 定義タイプ: `apache::security::file_link`
+
+[`apache::mod::security`][]の`activated_rules`をディスク上のそれぞれのCRSルールにリンクします。
+
+### テンプレート
+
+Apacheモジュールは、[`apache::vhost`][]および[`apache::mod`][]定義タイプを有効にするにあたり、テンプレートに大きく依存しています。このテンプレートは、オペレーティングシステムに固有の[Facter][] factsをベースに構築されています。明示的にコールアウトされない限り、ほとんどのテンプレートは設定には使われません。
+
+### 関数
+#### apache_pw_hash
+Apacheが読みこむhtpasswdファイルに適したフォーマットでパスワードをハッシュします。
+
+現在はSHAハッシュを使用しています。これは、このフォーマットは安全ではないとされているものの、ほとんどのプラットフォームでサポートされているもっとも安全なフォーマットであるためです。
+
+## 制約事項
+
+### 全般
+
+このモジュールは、以下に関して、[オープンソースPuppet][]および[Puppet Enterprise][]の両方でCIテストが実施されています。
+
+- CentOS 5および6
+- Ubuntu 12.04および14.04
+- Debian 7
+- RHEL 5、6、7
+
+このモジュールでは、FreeBSD、Gentoo、Amazon Linuxなどの、他のディストリビューションおよびオペレーティングシステムで使用できる機能も提供されていますが、そうしたシステムについては公式なテストは実施されておらず、新たに不具合が生じる可能性があります。
+
+### FreeBSD
+
+FreeBSDでこのモジュールを使用するには、apache24-2.4.12 (www/apache24)以降を使用する_必要があります_。 
+
+### Gentoo
+
+Gentooでは、このモジュールは[`gentoo/puppet-portage`][] Puppetモジュールに依存します。Gentooに関しては、一部の機能や設定が適用または有効化されますが、このモジュールに[対応するオペレーティングシステム][]ではありません。
+
+### RHEL/CentOS
+[`apache::mod::auth_cas`][]、[`apache::mod::passenger`][]、[`apache::mod::proxy_html`][]、[`apache::mod::shib`][]クラスは、追加のリポジトリから依存関係パッケージが提供されていなければ、RH/CentOSでは機能しません。
+
+関連するリポジトリとパッケージについては、以下の各ドキュメントを参照してください。
+
+#### RHEL/CentOS 5
+
+[`apache::mod::passenger`][]および[`apache::mod::proxy_html`][]クラスは、リポジトリに適合するパッケージがないため、テストされていません。
+
+#### RHEL/CentOS 6
+
+[`apache::mod::passenger`][]クラスは、EL6リポジトリに適合するパッケージがないため、インストールされません。
+
+#### RHEL/CentOS 7
+
+[`apache::mod::passenger`][]および[`apache::mod::proxy_html`][]クラスは、EL7リポジトリに適合するパッケージがないため、テストされていません。また、[`apache::vhost`][]定義タイプの[`rack_base_uris`][]パラメータも、同様の理由でテストされていません。
+
+### SELinuxおよびカスタムパス
+
+[SELinux][]が[適用モード][]になっていて、`logroot`、`mod_dir`、`vhost_dir`、`docroot`に関してカスタムパスを使用したい場合は、ファイルのコンテキストを各自で管理する必要があります。
+
+これにはPuppetを使用できます。
+
+``` puppet
+exec { 'set_apache_defaults':
+  command => 'semanage fcontext -a -t httpd_sys_content_t "/custom/path(/.*)?"',
+  path    => '/bin:/usr/bin/:/sbin:/usr/sbin',
+  require => Package['policycoreutils-python'],
+}
+
+package { 'policycoreutils-python':
+  ensure => installed,
+}
+
+exec { 'restorecon_apache':
+  command => 'restorecon -Rv /apache_spec',
+  path    => '/bin:/usr/bin/:/sbin:/usr/sbin',
+  before  => Class['Apache::Service'],
+  require => Class['apache'],
+}
+
+class { 'apache': }
+
+host { 'test.server':
+  ip => '127.0.0.1',
+}
+
+file { '/custom/path':
+  ensure => directory,
+}
+
+file { '/custom/path/include':
+  ensure  => present,
+  content => '#additional_includes',
+}
+
+apache::vhost { 'test.server':
+  docroot             => '/custom/path',
+  additional_includes => '/custom/path/include',
+}
+```
+
+`chcon`ではなく、`semanage fcontext`を用いてコンテキストを設定する必要があります。これは、Puppetの`file`リソースでは、リソースにより指定されていない場合、その値のコンテキストがリセットされるためです。
+
+### Ubuntu 10.04
+
+[`apache::vhost::WSGIImportScript`][]パラメータにより、Apacheの古いバージョンではサポートされていないバーチャルホスト内のステートメントが作成され、不具合が生じます。これは今後のリファクタリングで修正される予定です。
+
+### Ubuntu 16.04
+[`apache::mod::suphp`][]クラスは、リポジトリに適合するパッケージがないため、テストされていません。
+
+## 開発
+
+### 貢献
+
+[Puppet Forge][]上の[Puppet][]モジュールはオープンプロジェクトであり、その価値を維持するにはコミュニティからの貢献が欠かせません。Puppetが提供する膨大な数のプラットフォームや、無数のハードウェア、ソフトウェア、デプロイ設定に弊社がアクセスすることは不可能です。
+
+できるだけ変更に簡単に貢献していただき、お使いの環境でモジュールが動作するようにしたいと考えています。モジュールの品質の維持と改善のため、Puppetは貢献者に守っていただくガイドラインを設けています。
+
+詳細については、[モジュールコントリビューションガイド][]を参照してください。
+
+### テスト
+
+このプロジェクトには、機能検証のための[rspec-puppet][]および[beaker-rspec][]に関するテストが含まれています。このツールの詳しい使い方については、それぞれのドキュメントを参照してください。
+
+#### テストのクイックスタート: Ruby > 1.8.7
+
+```
+gem install bundler
+bundle install
+bundle exec rake spec
+bundle exec rspec spec/acceptance
+RS_DEBUG=yes bundle exec rspec spec/acceptance
+```
+
+#### テストのクイックスタート: Ruby = 1.8.7
+
+```
+gem install bundler
+bundle install --without system_tests
+bundle exec rake spec
+```

--- a/readmes/README_ja_JP.md
+++ b/readmes/README_ja_JP.md
@@ -29,7 +29,6 @@
 
 [開発]: #development
 [貢献]: #contributing
-[テスト]: #testing
 
 [`AddDefaultCharset`]: https://httpd.apache.org/docs/current/mod/core.html#adddefaultcharset
 [`add_listen`]: #add_listen
@@ -90,6 +89,7 @@
 [コモンゲートウェイインターフェース]: https://httpd.apache.org/docs/current/howto/cgi.html
 [`confd_dir`]: #confd_dir
 [`content`]: #content
+[CONTRIBUTING.md]: CONTRIBUTING.md
 [カスタムエラードキュメント]: https://httpd.apache.org/docs/current/custom-error.html
 [`custom_fragment`]: #custom_fragment
 
@@ -1369,7 +1369,7 @@ HTTPDサービスの再起動にあたり、Puppetが特定のコマンドを使
 
 ##### `ssl_ca`
 
-SSL証明書認証局を指定します。 [SSLCACertificateFile](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcacertificatefile)。
+SSL証明書認証局を指定します。[SSLCACertificateFile](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcacertificatefile)を使用してSSLクライアント認証で使用する証明書を確認します。
 
 これはバーチャルホストレベルでオーバーライドすることが可能です。
 
@@ -1437,7 +1437,7 @@ httpd.confの/ディレクトリについて、デフォルトのアクセスポ
 
 `[^.#]\*.conf[^~]`などの値に設定すると、このディレクトリで偶発的に作成されたファイル(バージョン管理システムやエディタのバックアップにより作成されたファイルなど)がサーバ設定に*含まれなく*なります。
 
-デフォルト: '*'、また、このモジュールの過去のバージョンのBC。
+デフォルト値: '*'。
 
 一部のオペレーティングシステムでは、`*.conf`の値が使用されます。デフォルトでは、このモジュールは`.conf`で終わる設定ファイルを作成します。
 
@@ -1595,6 +1595,7 @@ class { 'apache::mod::alias':
 * `jk` ([`apache::mod::jk`]参照)
 * `ldap` ([`apache::mod::ldap`][]参照)
 * `lookup_identity`
+* `macro` ([`apache:mod:macro`][]参照)
 * `mime`
 * `mime_magic`\*
 * `negotiation`
@@ -1636,7 +1637,7 @@ class { 'apache::mod::alias':
 
 [`mod_alias`][]をインストールして管理します。
 
-**パラメータ**:
+**パラメータ**:　
 
 * `icons_options`: Apache [`Options`]ディレクティブにより、アイコンディレクトリのディレクトリリスティングを無効にします。
 
@@ -1685,17 +1686,17 @@ class{'apache::mod::diskio':
 }
 ```
 
-**パラメータ**:
+**パラメータ**:　
 
 * `dump_io_input`: すべての入力データをエラーログにダンプします。
 
-  値: 'On'、'Off'。
+  値: 'On'、'Off'。　
 
   デフォルト値: 'Off'。
 
 * `dump_io_output`: すべての出力データをエラーログにダンプします。
 
-  値: 'On'、'Off'。
+  値: 'On'、'Off'。　
 
   デフォルト値: 'Off'。
 
@@ -1703,7 +1704,7 @@ class{'apache::mod::diskio':
 
 [`mod_mpm_event`][]をインストールして管理します。同じサーバ上に、`apache::mod::event`と一緒に[`apache::mod::itk`][]、[`apache::mod::peruser`][]、[`apache::mod::prefork`][]、[`apache::mod::worker`][]を含めることはできません。
 
-**パラメータ**:
+**パラメータ**:　
 
 * `listenbacklog`: モジュールの[`ListenBackLog`][]ディレクティブでペンディング接続キューの最大長を設定します。`false`に設定すると、このパラメータが削除されます。
 
@@ -1745,7 +1746,7 @@ class{'apache::mod::diskio':
 
 > **注意**: auth_casモジュールは、EPELにより提供される依存関係パッケージがなければ、RH/CentOSで使用できません。 [https://github.com/Jasig/mod_auth_cas]()を参照してください。
 
-**パラメータ**:
+**パラメータ**:　
 
 - `cas_attribute_prefix`: ヘッダを追加します。SAMLバリデーションが有効になっている場合には、このヘッダの値が属性値になります。
 
@@ -1912,7 +1913,7 @@ class { 'apache::mod::authn_dbd':
 
 * `authn_dbd_min`: DBDMinに相当します。
 
-  デフォルト値: 4。
+  デフォルト値: 4。　
 
 * `authn_dbd_params`: **必須**。接続文字列に関して、DBDParamsに相当します。
 
@@ -2086,7 +2087,7 @@ apache::vhost { 'example.org':
 
   ブーリアン。
 
-  デフォルト値: `false`。　
+  デフォルト値: `false`。
 
 * `flag`: GeoIPフラグを設定します。
 
@@ -2132,9 +2133,9 @@ apache::vhost { 'example.org':
 
   値: IPv4アドレス、IPv6アドレス、または範囲の1つまたは複数のオクテット、またはいずれかの配列。
 
-  デフォルト値: ['127.0.0.1','::1']。
+  デフォルト値: ['127.0.0.1','::1']。　
 
-* `apache_version`: 文字列で表されるApacheのバージョン番号、'2.2'や'2.4'など。
+* `apache_version`: 文字列で表されるApacheのバージョン番号、'2.2'や'2.4'など。　
 
   デフォルト値: [`$::apache::apache_version`][`apache_version`]の値。
 
@@ -2153,6 +2154,7 @@ apache::vhost { 'example.org':
 
 ``` puppet
 class { '::apache::mod::jk':
+  ip           = '192.168.2.15',
   workers_file = 'conf/workers.properties',
   mount_file   = 'conf/uriworkermap.properties',
   shm_file     = 'run/jk.shm',
@@ -2165,7 +2167,31 @@ class { '::apache::mod::jk':
 
 **`apache::mod::jk`**内のパラメータ:
 
-`mod_jk`パラメータを理解するための情報源としては、[公式ドキュメント](https://tomcat.apache.org/connectors-doc/reference/apache.html)が最適です。ただし、\*file_contentはこれに含まれません。
+`mod_jk`パラメータを理解するための情報源としては、[公式ドキュメント](https://tomcat.apache.org/connectors-doc/reference/apache.html)が最適です。ただし、次はこれに含まれません:
+
+**add_listen**
+
+パラメータ`ip`および `port`に従って`Listen`ディレクティブを定義して(下記参照)、ApacheがIP/portの組合せをリッスンし`mod_jk`にリダイレクトするようにします。
+`Listen *:<Port>`または`Listen <Port>`のように、別の`Listen`ディレクティブが`mod_jk`バインディングで必要なものと競合するときに役立ちます。
+
+タイプ: ブール値
+デフォルト: true
+
+**ip**
+
+`mod_jk`にバインディングするIP。
+バインディングアドレスがプライマリのネットワークインターフェースIPではないときに役立ちます。
+
+タイプ: 文字列
+デフォルト: `$facts['ipaddress']`
+
+**port**
+
+`mod_jk`にバインディングするポート。
+リバースプロキシまたはキャッシュのような、別のものがポート80でリクエストを受信して、異なるポートのApacheに転送する必要があるときに役立ちます。
+
+タイプ: 文字列(数値)
+デフォルト: '80'
 
 **workers\_file\_content**
 
@@ -2188,7 +2214,7 @@ worker.other_name.type=ajp12 (why would you?)
 worker.other_name.socket_keepalive=false
 ```
 
-以下のようにパラメータ化する必要があります。
+以下のようにパラメータ化する必要があります。　
 
 ```
 $workers_file_content = {
@@ -2238,7 +2264,39 @@ $mount_file_content = {
 },
 ```
 
-##### クラス: `apache::mod::passenger`
+**shm\_file and log\_file**
+
+これらのファイルがどのように定義されているかによって、クラスはそれらの最終パスを別々に作成します。
+- 相対パス: `logroot`で提供されたパスを追加します (下記参照)
+- 絶対パスまたはパイプ: 提供されたパスをそのまま使用します
+
+例 (RHEL 6):
+
+```
+shm_file => 'shm_file'
+# Ends up in
+$shm_path = '/var/log/httpd/shm_file'
+```
+```
+shm_file => '/run/shm_file'
+# Ends up in
+$shm_path = '/run/shm_file'
+```
+```
+shm_file => '"|rotatelogs /var/log/httpd/mod_jk.log.%Y%m%d 86400 -180"'
+# Ends up in
+$shm_path = '"|rotatelogs /var/log/httpd/mod_jk.log.%Y%m%d 86400 -180"'
+```
+
+> デフォルトのlogrootは十分健全です。このため、絶対パスを指定することは推奨しません。
+
+**logroot**
+
+`shm_file`および`log_file`のベースディレクトリは`logroot`パラメータで決定されます。指定されない場合、デフォルトは`apache::params::logroot`です。
+
+> デフォルトのlogrootは十分健全です。このため、上書きすることは推奨しません。
+
+##### クラス: `apache::mod::passenger`　
 
 [`mod_passenger`][]をインストールして管理します。Red Hatベースのシステムの場合は、[passengerドキュメント](https://www.phusionpassenger.com/library/install/apache/install/oss/el6/#step-1:-upgrade-your-kernel,-or-disable-selinux)に記載された最小要件を満たしていることを確認してください。
 
@@ -2320,7 +2378,7 @@ class { 'apache::mod::ldap':
 
 * `force_language_priority`: `ForceLanguagePriority`オプションを設定します。
 
-  値: 文字列。
+  値: 文字列。　
 
   デフォルト値: `Prefer Fallback`。
 
@@ -2391,7 +2449,7 @@ NSS暗号化ライブラリを使用するApacheのSSLプロバイダ。
 
 >**注意**: passengerモジュールは、EPELにより提供される依存関係パッケージと`mod_passengers`カスタムリポジトリがなければ、RH/CentOSでは使用できません。前述の`manage_repo`パラメータと[https://www.phusionpassenger.com/library/install/apache/install/oss/el7/]()を参照してください。
 
-**パラメータ**:__``<>
+**パラメータ**:　
 
 * `passenger_conf_file`: `$::apache::params::passenger_conf_file`
 * `passenger_conf_package_file: `$::apache::params::passenger_conf_package_file`
@@ -2427,8 +2485,6 @@ NSS暗号化ライブラリを使用するApacheのSSLプロバイダ。
 I`mod_proxy`をインストールし、`proxy.conf.erb`テンプレートを使用して設定を生成します。
 
 **`apache::mod::proxy`内のパラメータ**:
-
-.
 
 - `allow_from`: デフォルト値: `undef`
 - `apache_version`: デフォルト値: `undef`
@@ -2530,19 +2586,19 @@ Apacheモジュール`mod_rewrite`をインストールして有効にします�
 
 * `ssl_compression`
 
-  デフォルト値: `false`
+  デフォルト値: `false`。
 
 * `ssl_cryptodevice`
 
-  デフォルト値: 'builtin'
+  デフォルト値: 'builtin'　
 
 * `ssl_honorcipherorder`
 
-  デフォルト値: `true`
+  デフォルト値: `true`。
 
 * `ssl_openssl_conf_cmd`
 
-  デフォルト値: `undef`
+  デフォルト値: `undef`。
 
 * `ssl_options`
 
@@ -2558,13 +2614,13 @@ Apacheモジュール`mod_rewrite`をインストールして有効にします�
 
 * `ssl_random_seed_bytes`
 
-  値: 文字列。
+  値: 文字列。　
 
   デフォルト値: '512'
 
 * `ssl_sessioncachetimeout`
 
-  値: 文字列。
+  値: 文字列。　
 
   デフォルト値: '300'
 
@@ -2588,7 +2644,7 @@ Apacheモジュール`mod_rewrite`をインストールして有効にします�
 
 * `allow_from`: `/server-status`にアクセスできるIPv4またはIPv6アドレスの[配列][]。
 
-  デフォルト値: ['127.0.0.1','::1']。
+  デフォルト値: ['127.0.0.1','::1']。　
 * `extended_status`: [`ExtendedStatus`][]ディレクティブをつうじて、各リクエストに関する拡張ステータス情報を追跡するかどうかを決定します。
 
   値: 'Off'、'On'。
@@ -2661,7 +2717,7 @@ ${modsec\_dir}/activated\_rules。
 
 * `secpcrematchlimit`: PCREライブラリのマッチ限度数を設定します。
 
-  デフォルト値: 1500。
+  デフォルト値: 1500。　
 
 * `secpcrematchlimitrecursion`: PCREライブラリのマッチ再帰制限数を設定します。
 
@@ -2685,7 +2741,7 @@ ${modsec\_dir}/activated\_rules。
 
 * `inbound_anomaly_threshold`: OWASP ModSecurityコアルールセットのコラボレーティブ検出モードに関して、インバウンドブロッキングルールのスコアリング閾値レベルを設定します。
 
-  デフォルト値: 5。
+  デフォルト値: 5。　
 
 * `outbound_anomaly_threshold`: OWASP ModSecurityコアルールセットのコラボレーティブ検出モードに関して、アウトバウンドブロッキングルールのスコアリング閾値レベルを設定します。
 
@@ -2731,17 +2787,17 @@ ${modsec\_dir}/activated\_rules。
 
 * `mod_path`: `mod_wsgi`共有オブジェクト(`.so`)ファイルのパスを定義します。
 
-  デフォルト値: `undef`。　
+  デフォルト値: `undef`。
 
   * `mod_path`パラメータに`/`が含まれていない場合、Puppetではオペレーティングシステムのデフォルトのモジュールパスの先頭にこれを付加します。含まれている場合は、そのとおりに扱われます。
 
 * `package_name`: `mod_wsgi`をインストールするパッケージの名前。
 
-  デフォルト値: `undef`。　
+  デフォルト値: `undef`。
 
 * `wsgi_python_home`: '/path/to/venv'などの[`WSGIPythonHome`][]ディレクティブを定義します。
 
-  値: パスを指定する文字列。
+  値: パスを指定する文字列。　
 
   デフォルト値: `undef`。
 
@@ -2825,7 +2881,7 @@ Apacheデーモンを管理します。
 
 ブーリアン。
 
-デフォルト値: `true`。　
+デフォルト値: `true`。
 
 #### 定義タイプ: `apache::balancermember`
 
@@ -2835,7 +2891,7 @@ Apacheデーモンを管理します。
 
 ##### `balancer_cluster`
 
-**必須**。
+**必須**。　
 
 Apacheサービスのインスタンス名を設定します。宣言された[`apache::balancer`][]リソースの名前と一致する必要があります。
 
@@ -2849,7 +2905,7 @@ Apacheサービスのインスタンス名を設定します。宣言された[`
 
 URL後に[オプション](https://httpd.apache.org/docs/current/mod/mod_proxy.html#balancermember)の[配列][]を指定します。[`ProxyPass`][]で使用可能な任意のキー-値ペアを使用できます。
 
-デフォルト値: 空配列。
+デフォルト値: 空配列。　
 
 #### 定義タイプ: `apache::custom_config`
 
@@ -2861,7 +2917,7 @@ Apacheサーバの`conf.d`ディレクトリにカスタム設定ファイルを
 
 設定ファイルが存在するべきかどうかを指定します。
 
-値: 'absent'、'present'。
+値: 'absent'、'present'。　
 
 デフォルト値: 'present'。　
 
@@ -2875,7 +2931,7 @@ Puppetが設定ファイルを置くディレクトリを設定します。
 
 設定ファイルのコンテンツを設定します。`content`および[`source`][]パラメータは、相互排他的な関係にあります。
 
-デフォルト値: `undef`。
+デフォルト値: `undef`。　
 
 ##### `filename`
 
@@ -2889,11 +2945,11 @@ Apacheでは設定ファイルがアルファベット順に処理されるた�
 
 設定ファイル名の優先順位の接頭値を無視するには、このパラメータを`false`に設定します。
 
-デフォルト値: '25'。　
+デフォルト値: '25'。
 
 ##### `source`
 
-設定ファイルのソースを指し示します。[`content`][]および`source`パラメータは、相互排他的な関係にあります。
+設定ファイルのソースを指します。[`content`][]および`source`パラメータは互いに排他的です。
 
 デフォルト値: `undef`。　
 
@@ -2911,7 +2967,7 @@ Apacheサービスに通知する前に設定ファイルのバリデーショ�
 
 ブーリアン。
 
-デフォルト値: `true`。　
+デフォルト値: `true`。
 
 #### 定義タイプ: `apache::fastcgi::server`
 
@@ -2935,7 +2991,7 @@ FastCGIのホスト名またはIPアドレスおよびTCPポート番号(1-65535
 
 アプリケーションから受信したデータを、強制的に[`mod_fastcgi`][FastCGI]がクライアントに書き込みます。デフォルトでは、アプリケーションをできるだけ早くフリーな状態にするために、`mod_fastcgi`はデータをバッファリングします。 
 
-デフォルト値: `false`。　
+デフォルト値: `false`。
 
 ##### `faux_path`
 
@@ -2971,7 +3027,7 @@ Apacheサーバまたはバーチャルホストのリッスンするアドレ�
 
 PuppetがApacheモジュールのインストールに使用するパッケージの名前。
 
-デフォルト値: `undef`。　
+デフォルト値: `undef`。
 
 ##### `package_ensure`
 
@@ -3006,7 +3062,7 @@ Apacheモジュールをインストールの必要性をPuppetが確認する�
 
 [`LoadFile`][]ディレクティブの配列を指定します。
 
-デフォルト値: `undef`。　
+デフォルト値: `undef`。
 
 ##### `path`
 
@@ -3028,6 +3084,15 @@ apacheモジュールでは、バーチャルホストのセットアップと�
 
 `apache::vhost`定義タイプでは、カスタムフラグメントの`order`パラメータについては10の倍数が使用されるため、10の倍数ではない`order`が機能します。
 
+> **Note:** `apache::vhost`を作成するとき、`default`または`default-ssl`を指定することはできません。これはこの属性を持つvhostsが常にモジュールによって管理されるためです。これは`Apache::Vhost['default']`または`Apache::Vhost['default-ssl]`リソースを上書きできないことを意味します。 オプションの回避策として、`my default`などの別の名前のvhostを作成して、`default`および`default_ssl`が`false`に設定されていることを確認します。
+
+```
+class { 'apache':
+  default_vhost     => false
+  default_ssl_vhost => false,
+}
+```
+
 **パラメータ**:　
 
 ##### `access_log`
@@ -3042,13 +3107,13 @@ apacheモジュールでは、バーチャルホストのセットアップと�
 
 特定の環境変数を持つリクエストのみをロギングするように指定します。
 
-デフォルト値: `undef`。　
+デフォルト値: `undef`。
 
 ##### `access_log_file`
 
 [`logroot`][]に置く`*_access.log`のファイル名を設定します。バーチャルホスト---例えばexample.comなど---を与えると、[SSL暗号化][SSL暗号化]バーチャルホストの場合はデフォルト値が'example.com_ssl.log'、暗号化されていないバーチャルホストの場合は'example.com_access.log'になります。
 
-デフォルト値: `false`。　
+デフォルト値: `false`。
 
 ##### `access_log_format`
 
@@ -3060,19 +3125,19 @@ apacheモジュールでは、バーチャルホストのセットアップと�
 
 Apacheがアクセスログメッセージを送信するパイプを指定します。
 
-デフォルト値: `undef`。　
+デフォルト値: `undef`。
 
 ##### `access_log_syslog`
 
 すべてのアクセスログメッセージをsyslogに送ります。
 
-デフォルト値: `undef`。　
+デフォルト値: `undef`。
 
 ##### `add_default_charset`
 
 [`AddDefaultCharset`][]ディレクティブのデフォルトのメディア文字セット値を設定します。これは`text/plain`および`text/html`応答に追加されます。
 
-デフォルト値: `undef`。　
+デフォルト値: `undef`。
 
 ##### `add_listen`
 
@@ -3082,7 +3147,7 @@ Apacheがアクセスログメッセージを送信するパイプを指定し�
 
 ブーリアン。
 
-デフォルト値: `true`。　
+デフォルト値: `true`。
 
 ##### `use_optional_includes`
 
@@ -3090,7 +3155,7 @@ Apache 2.4以降の`additional_includes`について、Apacheが[`Include`][]の
 
 ブーリアン。
 
-デフォルト値: `false`。　
+デフォルト値: `false`。
 
 ##### `additional_includes`
 
@@ -3104,7 +3169,7 @@ Apache 2.4以降の`additional_includes`について、Apacheが[`Include`][]の
 
 [ハッシュ][ハッシュ]のリストをバーチャルホストに渡し、[`mod_alias`][]ドキュメントに従って[`Alias`][]、[`AliasMatch`][]、[`ScriptAlias`][]、または[`ScriptAliasMatch`][]ディレクティブを作成します。
 
-例:
+例:　
 
 ``` puppet
 aliases => [
@@ -3154,7 +3219,7 @@ SAMLバリデーションが有効になっている場合に、このヘッダ�
 
 `cas_attribute_prefix`により作成されたヘッダの属性値の区切り文字を設定します。
 
-デフォルト値: [`apache::mod::auth_cas`][]により設定された値。
+デフォルト値: [`apache::mod::auth_cas`][]により設定された値。　
 
 ##### `cas_login_url`
 
@@ -3190,13 +3255,13 @@ HTTPクエリ文字列でクライアントの提示するチケットをバリ�
 
 カスタム設定ディレクティブの文字列を渡し、バーチャルホスト設定の最後に配置します。
 
-デフォルト値: `undef`。　
+デフォルト値: `undef`。
 
 ##### `default_vhost`
 
 任意の`apache::vhost`定義タイプを、他の`apache::vhost`定義タイプと一致しないリクエストをサーブするためのデフォルトとして設定します。 
 
-デフォルト値: `false`。　
+デフォルト値: `false`。
 
 ##### `directories`
 
@@ -3206,7 +3271,7 @@ HTTPクエリ文字列でクライアントの提示するチケットをバリ�
 
 ディレクトリ名の最後で'/'を指定することで、クライアントがディレクトリのインデックスをリクエストした際に探すべきリソースのリストを設定します。詳細については、[`DirectoryIndex`][]ディレクティブドキュメントを参照してください。
 
-デフォルト値: `undef`。　
+デフォルト値: `undef`。
 
 ##### `docroot`
 
@@ -3224,7 +3289,7 @@ HTTPクエリ文字列でクライアントの提示するチケットをバリ�
 
 値: システムグループを指定する文字列。
 
-デフォルト値: 'root'。
+デフォルト値: 'root'。　
 
 ##### `docroot_owner`
 
@@ -3240,7 +3305,7 @@ HTTPクエリ文字列でクライアントの提示するチケットをバリ�
 
 値: 文字列。　
 
-デフォルト値: `undef`。　
+デフォルト値: `undef`。
 
 ##### `manage_docroot`
 
@@ -3248,7 +3313,7 @@ Puppetが[`docroot`][]ディレクトリを管理するかどうかを決定し�
 
 ブーリアン。
 
-デフォルト値: `true`。　
+デフォルト値: `true`。
 
 ##### `error_log`
 
@@ -3288,7 +3353,7 @@ Puppetが[`docroot`][]ディレクトリを管理するかどうかを決定し�
 
 このバーチャルホストの[エラードキュメント](https://httpd.apache.org/docs/current/mod/core.html#errordocument)設定のオーバーライドに使用できるハッシュのリスト。
 
-例:
+例:　
 
 ``` puppet
 apache::vhost { 'sample.example.net':
@@ -3307,7 +3372,7 @@ apache::vhost { 'sample.example.net':
 
 値: 'absent'、'present'。　
 
-デフォルト値: 'present'。
+デフォルト値: 'present'。　
 
 ##### `fallbackresource`
 
@@ -3356,7 +3421,7 @@ apache::vhost { "$::fqdn":
 
 レスポンスヘッダを置換、結合、または削除するための行を追加します。詳細については、[Apacheのmod_headersドキュメント](https://httpd.apache.org/docs/current/mod/mod_headers.html#header)を参照してください。
 
-値: 文字列または文字列の配列。
+値: 文字列または文字列の配列。　
 
 デフォルト値: `undef`。
 
@@ -3388,7 +3453,7 @@ apache::vhost { 'sample.example.net':
     group => 'somegroup',
   },
 }
-```
+```　
 
 値: ハッシュ。キーを含めることもできます。
 
@@ -3400,7 +3465,7 @@ apache::vhost { 'sample.example.net':
 * `limituidrange` (Linux 3.5.0以降)
 * `limitgidrange` (Linux 3.5.0以降)
 
-通常は、以下のように使用します。
+通常は、以下のように使用します。　
 
 ``` puppet
 apache::vhost { 'sample.example.net':
@@ -3438,7 +3503,7 @@ apache::vhost { 'sample.example.net':
 
 バーチャルホストの関連オプションを設定するには、`keepalive_timeout`および`max_keepalive_requests`パラメータを使用します。
 
-値: 'Off', 'On'。
+値: 'Off'、'On'。
 
 デフォルト値: `undef`。　
 
@@ -3446,7 +3511,7 @@ apache::vhost { 'sample.example.net':
 
 バーチャルホストの[`KeepAliveTimeout`]ディレクティブを設定します。これにより、HTTPの持続的接続で後続のリクエストを実行するまでの待機時間が決まります。デフォルトでは、グローバルなサーバ全体の[`KeepAlive`][]設定が有効になります。
 
-このパラメータが意味を持つのは、グローバルなサーバ全体の[`keepalive`パラメータ][]またはバーチャルホストごとの`keepalive`パラメータのいずれかが有効になっている場合のみです。
+このパラメータが意味を持つのは、グローバルなサーバ全体の[`keepalive`パラメータ][]またはバーチャルホストごとの`keepalive`パラメータのいずれかが有効になっている場合のみです。　
 
 デフォルト値: `undef`。　
 
@@ -3456,7 +3521,7 @@ apache::vhost { 'sample.example.net':
 
 このパラメータが意味を持つのは、グローバルなサーバ全体の[`keepalive`パラメータ][]またはバーチャルホストごとの`keepalive`パラメータのいずれかが有効になっている場合のみです。　
 
-デフォルト値: `undef`。　
+デフォルト値: `undef`。
 
 ##### `auth_kerb`
 
@@ -3654,7 +3719,7 @@ apache::vhost { 'sample.example.net':
 
 プロキシを使用しないURLを指定します。このパラメータは、[`proxy_dest`](#proxy_dest)と組み合わせて使用することはできません。
 
-デフォルト値: []。
+デフォルト値: []。　
 
 ##### `no_proxy_uris_match`
 
@@ -3711,11 +3776,19 @@ apache::vhost { 'site.name.fdqn':
 
 デフォルト値: '[none]'。
 
+##### `passenger_spawn_method`
+
+[PassengerSpawnMethod](https://www.phusionpassenger.com/library/config/apache/reference/#passengerspawnmethod)を設定します。Passengerが引き起こしたアプリケーションに直接か、preforkのcopy-on-writeメカニズムを使用します。
+
+有効なオプション: `smart`または`direct`。
+
+デフォルト値: `undef`。
+
 ##### `passenger_app_root`
 
 [PassengerRoot](https://www.phusionpassenger.com/library/config/apache/reference/#passengerapproot)を設定します。これは、DocumentRootと異なる場合のPassengerアプリケーションルートのロケーションです。
 
-値: パスを指定する文字列。
+値: パスを指定する文字列。　
 
 デフォルト値: `undef`。
 
@@ -3731,7 +3804,7 @@ apache::vhost { 'site.name.fdqn':
 
 デフォルトでは、PassengerログメッセージはApacheグローバルエラーログに書き込まれます。[PassengerLogFile](https://www.phusionpassenger.com/library/config/apache/reference/#passengerlogfile)を使えば、そのメッセージを別のファイルに書き込むように設定することができます。このオプションは、Passenger 5.0.5以降でのみ使用できます。
 
-値: パスを指定する文字列。
+値: パスを指定する文字列。　
 
 デフォルト値: `undef`。
 
@@ -4901,7 +4974,7 @@ apache::vhost { 'sample.example.net':
 
 ##### `ssl_ca`
 
-SSL証明書認証局を指定します。
+使用するSSL認証局を指定して、認証に使用するクライアントの証明書を検証します。これを使用するには、`ssl_verify_client`も設定する必要があります。
 
 デフォルト値: `undef`。
 
@@ -4938,14 +5011,9 @@ SSL証明書を指定します。
 
 ##### `ssl_certs_dir`
 
-SSL証明書ディレクトリのロケーションを指定します。 
+SSL認証ディレクトリの場所を指定してクライアントの証明書を検証します。`ssl_verify_client`も設定されていない限り使用されません(下記参照)。
 
-デフォルト値: オペレーティングシステムによって異なります。
-
-- Debian: '/etc/ssl/certs'
-- Red Hat: '/etc/pki/tls/certs'
-- FreeBSD: `undef`
-- Gentoo: '/etc/ssl/apache2'
+デフォルト: undef
 
 ##### `ssl_chain`
 
@@ -4961,13 +5029,13 @@ SSLチェーンを指定します。このデフォルト値は設定しなく�
 
 ##### `ssl_crl_path`
 
-証明書失効リストの保存場所を指定します。(このデフォルト値は設定しなくても機能しますが、本稼働環境で使用する前に、固有の証明書情報により基本の`apache`クラス内で更新する必要があります。)
+証明書失効リストの保存場所を指定して、クライアント認証の証明書を検証します(このデフォルト値は設定しなくても機能しますが、本稼働環境で使用する前に、固有の証明書情報により基本の`apache`クラス内で更新する必要があります)。
 
 デフォルト値: `undef`。
 
 ##### `ssl_crl_check`
 
-[SSLCARevocationCheckディレクティブ](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcarevocationcheck)により、証明書失効チェックレベルを設定します。このデフォルト値は設定しなくても機能しますが、本稼働環境でCRLを使用する際に指定する必要があります。Apache 2.4以上にのみ適用されます。それ以前のバージョンでは、この値は無視されます。
+[SSLCARevocationCheckディレクティブ](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcarevocationcheck)により、SSLクライアント認証の証明書失効チェックレベルを設定します。このデフォルト値は設定しなくても機能しますが、本稼働環境でCRLを使用する際に指定する必要があります。Apache 2.4以上にのみ適用され、それ以前のバージョンではこの値は無視されます。
 
 デフォルト値: `undef`。
 
@@ -5000,11 +5068,12 @@ apache::vhost { 'sample.example.net':
 
 ##### `ssl_verify_depth`
 
-[SSLVerifyDepth](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslverifydepth)ディレクティブを設定します。これにより、クライアント認証確認におけるCA証明書の最大深さが指定されます。
+[SSLVerifyDepth](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslverifydepth)ディレクティブを設定します。これにより、クライアント認証確認におけるCA証明書の最大深さが指定されます。これを有効にするには、`ssl_verify_client`を設定する必要があります。
 
 ``` puppet
 apache::vhost { 'sample.example.net':
   …
+  ssl_verify_client => 'require',
   ssl_verify_depth => 1,
 }
 ```
@@ -5029,13 +5098,13 @@ apache::vhost { 'sample.example.net':
 
 深さ0では、自己署名リモートサーバ証明書のみが許可されます。デフォルトの深さ 1では、リモートサーバ証明書を自己署名にすることも、サーバが直接知っているCAにより署名することもできます。
 
-デフォルト値: `undef`。
+デフォルト値: `undef`。　
 
 ##### `ssl_proxy_ca_cert`
 
 [SSLProxyCACertificateFile](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxycacertificatefile)ディレクティブを設定します。これにより、やりとりするリモートサーバに関する認証局(CA)の証明書を集められるオールインワンファイルを指定します。これはリモートサーバ認証に用いられます。このファイルは、PEMエンコード証明書ファイルを優先順に連結したものにする必要があります。
 
-デフォルト値: `undef`。
+デフォルト値: `undef`。　
 
 ##### `ssl_proxy_machine_cert`
 
@@ -5048,15 +5117,15 @@ apache::vhost { 'sample.example.net':
 }
 ```
 
-デフォルト値: `undef`。
+デフォルト値: `undef`。　
 
 ##### `ssl_proxy_check_peer_cn`
 
 [SSLProxyCheckPeerCN](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxycheckpeercn)ディレクティブを設定します。これにより、リモートサーバの証明書のCNフィールドをリクエストURLのホスト名と比較するかどうかを指定します。 
 
-値: 'on'、'off'。
+値: 'on'、'off'。　
 
-デフォルト値: `undef`。
+デフォルト値: `undef`。　
 
 ##### `ssl_proxy_check_peer_name`
 
@@ -5064,7 +5133,7 @@ apache::vhost { 'sample.example.net':
 
 値: 'on'、'off'。　
 
-デフォルト値: `undef`。
+デフォルト値: `undef`。　
 
 ##### `ssl_proxy_check_peer_expire`
 
@@ -5072,7 +5141,7 @@ apache::vhost { 'sample.example.net':
 
 値: 'on'、'off'。　
 
-デフォルト値: `undef`。
+デフォルト値: `undef`。　
 
 ##### `ssl_options`
 
@@ -5102,7 +5171,7 @@ apache::vhost { 'sample.example.net':
 
 [SSLOpenSSLConfCmd](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslopensslconfcmd)ディレクティブを設定します。これにより、OpenSSLパラメータを直接設定できます。
 
-デフォルト値: `undef`。
+デフォルト値: `undef`。　
 
 ##### `ssl_proxyengine`
 
@@ -5116,11 +5185,11 @@ apache::vhost { 'sample.example.net':
 
 [SSLUseStapling](http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslusestapling)を使用するかどうかを指定します。デフォルトでは、全体で設定されているものを使用します。
 
-このパラメータはApache 2.4以上にのみ適用され、それ以前のバージョンでは無視されます。
+このパラメータはApache 2.4以上にのみ適用され、それ以前のバージョンでは無視されます。　
 
 ブーリアンまたは`undef`。
 
-デフォルト値: `undef`。
+デフォルト値: `undef`。　
 
 ##### `ssl_stapling_timeout`
 
@@ -5128,7 +5197,7 @@ apache::vhost { 'sample.example.net':
 
 このパラメータはApache 2.4以上にのみ適用され、それ以前のバージョンでは無視されます。　
 
-デフォルト値: なし。
+デフォルト値: なし。　
 
 ##### `ssl_stapling_return_errors`
 
@@ -5218,9 +5287,9 @@ FastCGIサーバにより処理するファイルのMIMEタイプ。
 
 バーチャルホストファイルが存在するかどうかを指定します。
 
-値: 'absent'、'present'。
+値: 'absent'、'present'。　
 
-デフォルト値: 'present'。
+デフォルト値: 'present'。　
 
 ##### `priority`
 
@@ -5238,13 +5307,13 @@ Apacheサービスに通知する前に設定ファイルのバリデーショ�
 
 ### プライベート定義タイプ
 
-#### 定義タイプ: `apache::peruser::multiplexer`
+#### 定義タイプ: `apache::peruser::multiplexer`　
 
 この定義タイプは、Apacheモジュールにクラスがあるかどうかを確認します。クラスがある場合は、そのクラスを含めます。ない場合は、モジュール名を[`apache::mod`][]定義タイプに渡します。
 
 #### 定義タイプ: `apache::peruser::multiplexer`　
 
-FreeBSDに関してのみ、[`Peruser`][]モジュールを有効にします。
+FreeBSDに関してのみ、[`Peruser`][]モジュールを有効にします。　
 
 #### 定義タイプ: `apache::peruser::processor`
 
@@ -5364,26 +5433,4 @@ apache::vhost { 'test.server':
 
 できるだけ変更に簡単に貢献していただき、お使いの環境でモジュールが動作するようにしたいと考えています。モジュールの品質の維持と改善のため、Puppetは貢献者に守っていただくガイドラインを設けています。
 
-詳細については、[モジュールコントリビューションガイド][]を参照してください。
-
-### テスト
-
-このプロジェクトには、機能検証のための[rspec-puppet][]および[beaker-rspec][]に関するテストが含まれています。このツールの詳しい使い方については、それぞれのドキュメントを参照してください。
-
-#### テストのクイックスタート: Ruby > 1.8.7
-
-```
-gem install bundler
-bundle install
-bundle exec rake spec
-bundle exec rspec spec/acceptance
-RS_DEBUG=yes bundle exec rspec spec/acceptance
-```
-
-#### テストのクイックスタート: Ruby = 1.8.7
-
-```
-gem install bundler
-bundle install --without system_tests
-bundle exec rake spec
-```
+詳細については、[モジュールコントリビューションガイド][]および[CONTRIBUTING.md][]を参照してください。

--- a/spec/acceptance/init_task_spec.rb
+++ b/spec/acceptance/init_task_spec.rb
@@ -1,0 +1,20 @@
+# run a test task
+require 'spec_helper_acceptance'
+
+describe 'apache tasks', if: pe_install? && puppet_version =~ %r{(5\.\d\.\d)} do
+  describe 'reload' do
+    it 'execute reload' do
+      pp = <<-EOS
+      class { 'apache':
+        default_vhost => false,
+      }
+      apache::listen { '9090':}
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+
+      result = run_task(task_name: 'apache', params: 'action=reload')
+      expect_multiple_regexes(result: result, regexes: [%r{reload successful}, %r{Job completed. 1/1 nodes succeeded}])
+    end
+  end
+end

--- a/spec/acceptance/mod_passenger_spec.rb
+++ b/spec/acceptance/mod_passenger_spec.rb
@@ -2,6 +2,87 @@ require 'spec_helper_acceptance'
 require_relative './version.rb'
 
 describe 'apache::mod::passenger class' do
+  passenger_config_options = {
+      'passenger_allow_encoded_slashes' => {Type: 'OnOff', PassOpt: :PassengerAllowEncodedSlashes, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_app_env' => {Type: 'String', PassOpt: :PassengerAppEnv, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_app_group_name' => {Type: 'String', PassOpt: :PassengerAppGroupName, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_app_root' => {Type: 'FullPath', PassOpt: :PassengerAppRoot, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_app_type' => {Type: 'String', PassOpt: :PassengerAppType, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_base_uri' => {Type: 'URI', PassOpt: :PassengerBaseURI, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_buffer_response' => {Type: 'OnOff', PassOpt: :PassengerBufferResponse, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_buffer_upload' => {Type: 'OnOff', PassOpt: :PassengerBufferUpload, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_concurrency_model' => {Type: ["process", "thread"], PassOpt: :PassengerConcurrencyModel, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_data_buffer_dir' => {Type: 'FullPath', PassOpt: :PassengerDataBufferDir, Context: 'server config'},
+      'passenger_debug_log_file' => {Type: 'String', PassOpt: :PassengerDebugLogFile, Context: 'server config'},
+      'passenger_debugger' => {Type: 'OnOff', PassOpt: :PassengerDebugger, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_default_group' => {Type: 'String', PassOpt: :PassengerDefaultGroup, Context: 'server config'},
+      'passenger_default_ruby' => {Type: 'FullPath', PassOpt: :PassengerDefaultRuby, Context: 'server config'},
+      'passenger_default_user' => {Type: 'String', PassOpt: :PassengerDefaultUser, Context: 'server config'},
+      'passenger_disable_security_update_check' => {Type: 'OnOff', PassOpt: :PassengerDisableSecurityUpdateCheck, Context: 'server config'},
+      'passenger_enabled' => {Type: 'OnOff', PassOpt: :PassengerEnabled, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_error_override' => {Type: 'OnOff', PassOpt: :PassengerErrorOverride, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_file_descriptor_log_file' => {Type: 'FullPath', PassOpt: :PassengerFileDescriptorLogFile, Context: 'server config'},
+      'passenger_fly_with' => {Type: 'FullPath', PassOpt: :PassengerFlyWith, Context: 'server config'},
+      'passenger_force_max_concurrent_requests_per_process' => {Type: 'Integer', PassOpt: :PassengerForceMaxConcurrentRequestsPerProcess, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_friendly_error_pages' => {Type: 'OnOff', PassOpt: :PassengerFriendlyErrorPages, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_group' => {Type: 'String', PassOpt: :PassengerGroup, Context: 'server config, virtual host, directory'},
+      'passenger_high_performance' => {Type: 'OnOff', PassOpt: :PassengerHighPerformance, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_instance_registry_dir' => {Type: 'FullPath', PassOpt: :PassengerInstanceRegistryDir, Context: 'server config'},
+      'passenger_load_shell_envvars' => {Type: 'OnOff', PassOpt: :PassengerLoadShellEnvvars, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_log_file' => {Type: 'FullPath', PassOpt: :PassengerLogFile, Context: 'server config'},
+      'passenger_log_level' => {Type: 'Integer', PassOpt: :PassengerLogLevel, Context: 'server config'},
+      'passenger_lve_min_uid' => {Type: 'Integer', PassOpt: :PassengerLveMinUid, Context: 'server config, virtual host'},
+      'passenger_max_instances' => {Type: 'Integer', PassOpt: :PassengerMaxInstances, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_max_instances_per_app' => {Type: 'Integer', PassOpt: :PassengerMaxInstancesPerApp, Context: 'server config'},
+      'passenger_max_pool_size' => {Type: 'Integer', PassOpt: :PassengerMaxPoolSize, Context: 'server config'},
+      'passenger_max_preloader_idle_time' => {Type: 'Integer', PassOpt: :PassengerMaxPreloaderIdleTime, Context: 'server config, virtual host'},
+      'passenger_max_request_queue_size' => {Type: 'Integer', PassOpt: :PassengerMaxRequestQueueSize, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_max_request_time' => {Type: 'Integer', PassOpt: :PassengerMaxRequestTime, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_max_requests' => {Type: 'Integer', PassOpt: :PassengerMaxRequests, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_memory_limit' => {Type: 'Integer', PassOpt: :PassengerMemoryLimit, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_meteor_app_settings' => {Type: 'FullPath', PassOpt: :PassengerMeteorAppSettings, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_min_instances' => {Type: 'Integer', PassOpt: :PassengerMinInstances, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_nodejs' => {Type: 'FullPath', PassOpt: :PassengerNodejs, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_pool_idle_time' => {Type: 'Integer', PassOpt: :PassengerPoolIdleTime, Context: 'server config'},
+      'passenger_pre_start' => {Type: 'URI', PassOpt: :PassengerPreStart, Context: 'server config, virtual host'},
+      'passenger_python' => {Type: 'FullPath', PassOpt: :PassengerPython, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_resist_deployment_errors' => {Type: 'OnOff', PassOpt: :PassengerResistDeploymentErrors, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_resolve_symlinks_in_document_root' => {Type: 'OnOff', PassOpt: :PassengerResolveSymlinksInDocumentRoot, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_response_buffer_high_watermark' => {Type: 'Integer', PassOpt: :PassengerResponseBufferHighWatermark, Context: 'server config'},
+      'passenger_restart_dir' => {Type: 'Path', PassOpt: :PassengerRestartDir, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_rolling_restarts' => {Type: 'OnOff', PassOpt: :PassengerRollingRestarts, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_root' => {Type: 'FullPath', PassOpt: :PassengerRoot, Context: 'server config'},
+      'passenger_ruby' => {Type: 'FullPath', PassOpt: :PassengerRuby, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_security_update_check_proxy' => {Type: 'URI', PassOpt: :PassengerSecurityUpdateCheckProxy, Context: 'server config'},
+      'passenger_show_version_in_header' => {Type: 'OnOff', PassOpt: :PassengerShowVersionInHeader, Context: 'server config'},
+      'passenger_socket_backlog' => {Type: 'Integer', PassOpt: :PassengerSocketBacklog, Context: 'server config'},
+      'passenger_spawn_method' => {Type: ["smart", "direct"], PassOpt: :PassengerSpawnMethod, Context: 'server config, virtual host'},
+      'passenger_start_timeout' => {Type: 'Integer', PassOpt: :PassengerStartTimeout, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_startup_file' => {Type: 'RelPath', PassOpt: :PassengerStartupFile, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_stat_throttle_rate' => {Type: 'Integer', PassOpt: :PassengerStatThrottleRate, Context: 'server config'},
+      'passenger_sticky_sessions' => {Type: 'OnOff', PassOpt: :PassengerStickySessions, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_sticky_sessions_cookie_name' => {Type: 'String', PassOpt: :PassengerStickySessionsCookieName, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_thread_count' => {Type: 'Integer', PassOpt: :PassengerThreadCount, Context: 'server config, virtual host, directory, .htaccess'},
+      'passenger_use_global_queue' => {Type: 'String', PassOpt: :PassengerUseGlobalQueue, Context: ''},
+      'passenger_user' => {Type: 'String', PassOpt: :PassengerUser, Context: 'server config, virtual host, directory'},
+      'passenger_user_switching' => {Type: 'OnOff', PassOpt: :PassengerUserSwitching, Context: 'server config'},
+      'rack_auto_detect' => {Type: 'String', PassOpt: :RackAutoDetect, Context: 'server config'},
+      'rack_base_uri' => {Type: 'String', PassOpt: :RackBaseURI, Context: 'server config'},
+      'rack_env' => {Type: 'String', PassOpt: :RackEnv, Context: 'server config, virtual host, directory, .htaccess'},
+      'rails_allow_mod_rewrite' => {Type: 'String', PassOpt: :RailsAllowModRewrite, Context: 'server config'},
+      'rails_app_spawner_idle_time' => {Type: 'String', PassOpt: :RailsAppSpawnerIdleTime, Context: 'server config'},
+      'rails_auto_detect' => {Type: 'String', PassOpt: :RailsAutoDetect, Context: 'server config'},
+      'rails_base_uri' => {Type: 'String', PassOpt: :RailsBaseURI, Context: 'server config'},
+      'rails_default_user' => {Type: 'String', PassOpt: :RailsDefaultUser, Context: 'server config'},
+      'rails_env' => {Type: 'String', PassOpt: :RailsEnv, Context: 'server config, virtual host, directory, .htaccess'},
+      'rails_framework_spawner_idle_time' => {Type: 'String', PassOpt: :RailsFrameworkSpawnerIdleTime, Context: 'server config'},
+      'rails_ruby' => {Type: 'String', PassOpt: :RailsRuby, Context: 'server config'},
+      'rails_spawn_method' => {Type: 'String', PassOpt: :RailsSpawnMethod, Context: 'server config'},
+      'rails_user_switching' => {Type: 'String', PassOpt: :RailsUserSwitching, Context: 'server config'},
+      'wsgi_auto_detect' => {Type: 'String', PassOpt: :WsgiAutoDetect, Context: 'server config'},
+      'rails_autodetect' => {Type: 'OnOff', PassOpt: :RailsAutoDetect, Context: 'server config'},
+      'rack_autodetect' => {Type: 'OnOff', PassOpt: :RackAutoDetect, Context: 'server config'},
+  }
   case fact('osfamily')
   when 'Debian'
     conf_file = "#{$mod_dir}/passenger.conf"
@@ -122,9 +203,61 @@ describe 'apache::mod::passenger class' do
         end
       end
     end
-      context "default passenger config" do
-        it 'succeeds in puppeting passenger' do
-          pp = <<-EOS
+    context "setting passenger options within the apache 'Directory' directive" do
+      it 'should allow something with no error' do
+        all_passenger_directory_options = passenger_config_options.select {|k,v| /directory/ =~ v[:Context]}
+        passenger_directory_options = ''
+        all_passenger_directory_options.each do |k,v|
+          passenger_directory_options << "'%s' => '%s',\n" % [k,'something']
+        end
+        pp = <<-EOS
+          class { 'apache': service_ensure => stopped }
+          class { 'apache::mod::passenger': }
+          /* a simple ruby rack 'hello world' app */
+          file { '/var/www/passenger':
+           ensure => directory,
+           owner  => '#{rackapp_user}',
+           group  => '#{rackapp_group}',
+          }
+          file { '/var/www/passenger/config.ru':
+            ensure  => file,
+            owner   => '#{rackapp_user}',
+            group   => '#{rackapp_group}',
+            content => "app = proc { |env| [200, { \\"Content-Type\\" => \\"text/html\\" }, [\\"hello <b>world</b>\\"]] }\\nrun app",
+          }
+          apache::vhost { 'passenger.example.com':
+            port          => '80',
+            docroot       => '/var/www/passenger/public',
+            docroot_group => '#{rackapp_group}',
+            docroot_owner => '#{rackapp_user}',
+            directories => [
+               { 'path' => '/var/www/passenger',
+                 #{passenger_directory_options}
+               }     
+            ],
+            require       => File['/var/www/passenger/config.ru'],
+          }
+          host { 'passenger.example.com': ip => '127.0.0.1', }
+        EOS
+        apply_manifest(pp, :catch_failures => true)
+      end
+      describe file("#{$vhost_dir}/25-passenger.example.com.conf") do
+        all_passenger_directory_options = passenger_config_options.select {|k,v| /directory/ =~ v[:Context]}
+        all_passenger_directory_options.each do |k,v|
+          case v[:Type]
+            when 'QuotedString', 'RelPath', 'FullPath', 'Path'
+              it { is_expected.to contain "#{v[:PassOpt]} \"something\"" }
+            when 'String', 'URI', 'Integer'
+              it { is_expected.to contain "#{v[:PassOpt]} something" }
+            else
+              it { is_expected.to contain "#{v[:PassOpt]} something" }
+          end
+        end
+      end
+    end
+    context "default passenger config" do
+      it 'succeeds in puppeting passenger' do
+        pp = <<-EOS
           /* stock apache and mod_passenger */
           class { 'apache': }
           class { 'apache::mod::passenger': }
@@ -146,38 +279,38 @@ describe 'apache::mod::passenger class' do
         it { is_expected.to contain "PassengerRoot \"#{passenger_root}\"" }
 
         case fact('operatingsystem')
-        when 'Ubuntu'
-          case fact('lsbdistrelease')
-          when '10.04'
-            it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
-            it { is_expected.not_to contain "/PassengerDefaultRuby/" }
-          when '12.04'
-            it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
-            it { is_expected.not_to contain "/PassengerDefaultRuby/" }
-          when '14.04'
-            it { is_expected.to contain "PassengerDefaultRuby \"#{passenger_ruby}\"" }
-            it { is_expected.not_to contain "/PassengerRuby/" }
-          when '16.04'
-            it { is_expected.to contain "PassengerDefaultRuby \"#{passenger_ruby}\"" }
-            it { is_expected.not_to contain "/PassengerRuby/" }
-          else
-            # This may or may not work on Ubuntu releases other than the above
-            it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
-            it { is_expected.not_to contain "/PassengerDefaultRuby/" }
-          end
-        when 'Debian'
-          case fact('lsbdistcodename')
-          when 'wheezy'
-            it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
-            it { is_expected.not_to contain "/PassengerDefaultRuby/" }
-          when 'jessie'
-            it { is_expected.to contain "PassengerDefaultRuby \"#{passenger_ruby}\"" }
-            it { is_expected.not_to contain "/PassengerRuby/" }
-          else
-            # This may or may not work on Debian releases other than the above
-            it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
-            it { is_expected.not_to contain "/PassengerDefaultRuby/" }
-          end
+          when 'Ubuntu'
+            case fact('lsbdistrelease')
+              when '10.04'
+                it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
+                it { is_expected.not_to contain "/PassengerDefaultRuby/" }
+              when '12.04'
+                it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
+                it { is_expected.not_to contain "/PassengerDefaultRuby/" }
+              when '14.04'
+                it { is_expected.to contain "PassengerDefaultRuby \"#{passenger_ruby}\"" }
+                it { is_expected.not_to contain "/PassengerRuby/" }
+              when '16.04'
+                it { is_expected.to contain "PassengerDefaultRuby \"#{passenger_ruby}\"" }
+                it { is_expected.not_to contain "/PassengerRuby/" }
+              else
+                # This may or may not work on Ubuntu releases other than the above
+                it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
+                it { is_expected.not_to contain "/PassengerDefaultRuby/" }
+            end
+          when 'Debian'
+            case fact('lsbdistcodename')
+              when 'wheezy'
+                it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
+                it { is_expected.not_to contain "/PassengerDefaultRuby/" }
+              when 'jessie'
+                it { is_expected.to contain "PassengerDefaultRuby \"#{passenger_ruby}\"" }
+                it { is_expected.not_to contain "/PassengerRuby/" }
+              else
+                # This may or may not work on Debian releases other than the above
+                it { is_expected.to contain "PassengerRuby \"#{passenger_ruby}\"" }
+                it { is_expected.not_to contain "/PassengerDefaultRuby/" }
+            end
         end
       end
 
@@ -194,8 +327,8 @@ describe 'apache::mod::passenger class' do
           # passenger-memory-stats output on newer Debian/Ubuntu verions do not contain
           # these two lines
           unless ((fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '14.04') or
-                 (fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '16.04') or
-                 (fact('operatingsystem') == 'Debian' && fact('operatingsystemmajrelease') == '8'))
+              (fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '16.04') or
+              (fact('operatingsystem') == 'Debian' && fact('operatingsystemmajrelease') == '8'))
             expect(r.stdout).to match(/### Processes: [0-9]+/)
             expect(r.stdout).to match(/### Total private dirty RSS: [0-9\.]+ MB/)
           end
@@ -213,8 +346,8 @@ describe 'apache::mod::passenger class' do
             # spacing may vary
             expect(r.stdout).to match(/[\-]+ General information [\-]+/)
             if fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '14.04' or
-               (fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '16.04') or
-               fact('operatingsystem') == 'Debian' && fact('operatingsystemmajrelease') == '8'
+                (fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '16.04') or
+                fact('operatingsystem') == 'Debian' && fact('operatingsystemmajrelease') == '8'
               expect(r.stdout).to match(/Max pool size[ ]+: [0-9]+/)
               expect(r.stdout).to match(/Processes[ ]+: [0-9]+/)
               expect(r.stdout).to match(/Requests in top-level queue[ ]+: [0-9]+/)

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -636,7 +636,7 @@ describe 'apache', :type => :class do
         it "should fail" do
           expect do
             catalogue
-          end.to raise_error(Puppet::PreformattedError, /Evaluation Error: Error while evaluating a Resource Statement, Class\[Apache\]: parameter 'sendfile' expects a match for Enum\['Off', 'On', 'off', 'on'\], got 'foo'/)
+          end.to raise_error(Puppet::PreformattedError, /Evaluation Error: Error while evaluating a Resource Statement, Class\[Apache\]: parameter 'sendfile' expects a match for Enum\['Off', 'On', 'off', 'on'\]/)
         end
       end
       context "On" do

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -636,7 +636,7 @@ describe 'apache', :type => :class do
         it "should fail" do
           expect do
             catalogue
-          end.to raise_error(Puppet::Error, /"foo" does not match/)
+          end.to raise_error(Puppet::PreformattedError, /Evaluation Error: Error while evaluating a Resource Statement, Class\[Apache\]: parameter 'sendfile' expects a match for Enum\['Off', 'On', 'off', 'on'\], got 'foo'/)
         end
       end
       context "On" do

--- a/spec/classes/mod/jk_spec.rb
+++ b/spec/classes/mod/jk_spec.rb
@@ -3,13 +3,14 @@ require 'spec_helper'
 describe 'apache::mod::jk', :type => :class do
   it_behaves_like 'a mod class, without including apache'
 
-  shared_examples 'minimal resources' do
+  shared_examples 'minimal resources' do |mod_dir|
     it { is_expected.to compile }
     it { is_expected.to compile.with_all_deps }
     it { is_expected.to create_class('apache::mod::jk') }
     it { is_expected.to contain_class('apache') }
     it { is_expected.to contain_apache__mod('jk') }
     it { is_expected.to contain_file('jk.conf').that_notifies('Class[apache::service]') }
+    it { is_expected.to contain_file('jk.conf').with({ :path => "#{mod_dir}/jk.conf" }) }
   end
 
   context "RHEL 6 with only required facts and no parameters" do
@@ -30,7 +31,10 @@ describe 'apache::mod::jk', :type => :class do
       { :logroot => '/var/log/httpd' }
     end
 
-    it_behaves_like 'minimal resources'
+    mod_dir = '/etc/httpd/conf.d'
+    let (:mod_dir) { mod_dir }
+
+    it_behaves_like 'minimal resources', mod_dir
     it {
       verify_contents(catalogue, 'jk.conf', ['<IfModule jk_module>', '</IfModule>'])
     }
@@ -55,11 +59,73 @@ describe 'apache::mod::jk', :type => :class do
       { :logroot => '/var/log/apache2' }
     end
 
-    it_behaves_like 'minimal resources'
+    mod_dir = '/etc/apache2/mods-available'
+    let (:mod_dir) { mod_dir }
+
+    it_behaves_like 'minimal resources', mod_dir
     it {
       verify_contents(catalogue, 'jk.conf', ['<IfModule jk_module>', '</IfModule>'])
     }
 
+  end
+
+  {
+    :default => {
+      :shm_file => :undef,
+      :log_file => :undef,
+      :shm_path => '/var/log/httpd/jk-runtime-status',
+      :log_path => '/var/log/httpd/mod_jk.log',
+    },
+    :relative => {
+      :shm_file => 'shm_file',
+      :log_file => 'log_file',
+      :shm_path => '/var/log/httpd/shm_file',
+      :log_path => '/var/log/httpd/log_file',
+    },
+    :absolute => {
+      :shm_file => '/run/shm_file',
+      :log_file => '/tmp/log_file',
+      :shm_path => '/run/shm_file',
+      :log_path => '/tmp/log_file',
+    },
+    :pipe => {
+      :shm_file => :undef,
+      :log_file => '"|rotatelogs /var/log/httpd/mod_jk.log.%Y%m%d 86400 -180"',
+      :shm_path => '/var/log/httpd/jk-runtime-status',
+      :log_path => '"|rotatelogs /var/log/httpd/mod_jk.log.%Y%m%d 86400 -180"',
+    },
+  }.each do |option, paths|
+    context "RHEL 6 with #{option} shm_file and log_file paths" do
+
+      let (:facts) do
+        {
+          :osfamily               => 'RedHat',
+          :operatingsystem        => 'RedHat',
+          :operatingsystemrelease => '6',
+        }
+      end
+
+      let (:pre_condition) do
+        'include apache'
+      end
+
+      let (:params) do {
+        :logroot => '/var/log/httpd',
+        :shm_file => paths[:shm_file],
+        :log_file => paths[:log_file],
+      } end
+
+      it { is_expected.to contain_file('jk.conf').with_content(
+        "# This file is generated automatically by Puppet - DO NOT EDIT\n"\
+        "# Any manual changes will be overwritten\n"\
+        "\n"\
+        "<IfModule jk_module>\n"\
+        "  JkShmFile #{paths[:shm_path]}\n"\
+        "  JkLogFile #{paths[:log_path]}\n"\
+        "</IfModule>\n"
+      ) }
+
+    end
   end
 
 end

--- a/spec/classes/mod/passenger_spec.rb
+++ b/spec/classes/mod/passenger_spec.rb
@@ -2,6 +2,169 @@ require 'spec_helper'
 
 describe 'apache::mod::passenger', :type => :class do
   it_behaves_like "a mod class, without including apache"
+  context "validating all passenger params - using Debian" do
+    let :facts do
+      {
+          :osfamily               => 'Debian',
+          :operatingsystemrelease => '6',
+          :kernel                 => 'Linux',
+          :concat_basedir         => '/dne',
+          :lsbdistcodename        => 'squeeze',
+          :operatingsystem        => 'Debian',
+          :id                     => 'root',
+          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :is_pe                  => false,
+      }
+    end
+    it { is_expected.to contain_class("apache::params") }
+    it { is_expected.to contain_apache__mod('passenger') }
+    it { is_expected.to contain_package("libapache2-mod-passenger") }
+    it { is_expected.to contain_file('zpassenger.load').with({
+                                                                 'path' => '/etc/apache2/mods-available/zpassenger.load',
+                                                             }) }
+    it { is_expected.to contain_file('passenger.conf').with({
+                                                                'path' => '/etc/apache2/mods-available/passenger.conf',
+                                                            }) }
+
+    passenger_config_options = {
+        'passenger_allow_encoded_slashes' => {type: 'OnOff', pass_opt: :PassengerAllowEncodedSlashes},
+        'passenger_app_env' => {type: 'String', pass_opt: :PassengerAppEnv},
+        'passenger_app_group_name' => {type: 'String', pass_opt: :PassengerAppGroupName},
+        'passenger_app_root' => {type: 'FullPath', pass_opt: :PassengerAppRoot},
+        'passenger_app_type' => {type: 'String', pass_opt: :PassengerAppType},
+        'passenger_base_uri' => {type: 'URI', pass_opt: :PassengerBaseURI},
+        'passenger_buffer_response' => {type: 'OnOff', pass_opt: :PassengerBufferResponse},
+        'passenger_buffer_upload' => {type: 'OnOff', pass_opt: :PassengerBufferUpload},
+        'passenger_concurrency_model' => {type: ["process", "thread"], pass_opt: :PassengerConcurrencyModel},
+        'passenger_data_buffer_dir' => {type: 'FullPath', pass_opt: :PassengerDataBufferDir},
+        'passenger_debug_log_file' => {type: 'String', pass_opt: :PassengerDebugLogFile},
+        'passenger_debugger' => {type: 'OnOff', pass_opt: :PassengerDebugger},
+        'passenger_default_group' => {type: 'String', pass_opt: :PassengerDefaultGroup},
+        'passenger_default_ruby' => {type: 'FullPath', pass_opt: :PassengerDefaultRuby},
+        'passenger_default_user' => {type: 'String', pass_opt: :PassengerDefaultUser},
+        'passenger_disable_security_update_check' => {type: 'OnOff', pass_opt: :PassengerDisableSecurityUpdateCheck},
+        'passenger_enabled' => {type: 'OnOff', pass_opt: :PassengerEnabled},
+        'passenger_error_override' => {type: 'OnOff', pass_opt: :PassengerErrorOverride},
+        'passenger_file_descriptor_log_file' => {type: 'FullPath', pass_opt: :PassengerFileDescriptorLogFile},
+        'passenger_fly_with' => {type: 'FullPath', pass_opt: :PassengerFlyWith},
+        'passenger_force_max_concurrent_requests_per_process' => {type: 'Integer', pass_opt: :PassengerForceMaxConcurrentRequestsPerProcess},
+        'passenger_friendly_error_pages' => {type: 'OnOff', pass_opt: :PassengerFriendlyErrorPages},
+        'passenger_group' => {type: 'String', pass_opt: :PassengerGroup},
+        'passenger_high_performance' => {type: 'OnOff', pass_opt: :PassengerHighPerformance},
+        'passenger_instance_registry_dir' => {type: 'FullPath', pass_opt: :PassengerInstanceRegistryDir},
+        'passenger_load_shell_envvars' => {type: 'OnOff', pass_opt: :PassengerLoadShellEnvvars},
+        'passenger_log_file' => {type: 'FullPath', pass_opt: :PassengerLogFile},
+        'passenger_log_level' => {type: 'Integer', pass_opt: :PassengerLogLevel},
+        'passenger_lve_min_uid' => {type: 'Integer', pass_opt: :PassengerLveMinUid},
+        'passenger_max_instances' => {type: 'Integer', pass_opt: :PassengerMaxInstances},
+        'passenger_max_instances_per_app' => {type: 'Integer', pass_opt: :PassengerMaxInstancesPerApp},
+        'passenger_max_pool_size' => {type: 'Integer', pass_opt: :PassengerMaxPoolSize},
+        'passenger_max_preloader_idle_time' => {type: 'Integer', pass_opt: :PassengerMaxPreloaderIdleTime},
+        'passenger_max_request_queue_size' => {type: 'Integer', pass_opt: :PassengerMaxRequestQueueSize},
+        'passenger_max_request_time' => {type: 'Integer', pass_opt: :PassengerMaxRequestTime},
+        'passenger_max_requests' => {type: 'Integer', pass_opt: :PassengerMaxRequests},
+        'passenger_memory_limit' => {type: 'Integer', pass_opt: :PassengerMemoryLimit},
+        'passenger_meteor_app_settings' => {type: 'FullPath', pass_opt: :PassengerMeteorAppSettings},
+        'passenger_min_instances' => {type: 'Integer', pass_opt: :PassengerMinInstances},
+        'passenger_nodejs' => {type: 'FullPath', pass_opt: :PassengerNodejs},
+        'passenger_pool_idle_time' => {type: 'Integer', pass_opt: :PassengerPoolIdleTime},
+        'passenger_pre_start' => {type: 'URI', pass_opt: :PassengerPreStart},
+        'passenger_python' => {type: 'FullPath', pass_opt: :PassengerPython},
+        'passenger_resist_deployment_errors' => {type: 'OnOff', pass_opt: :PassengerResistDeploymentErrors},
+        'passenger_resolve_symlinks_in_document_root' => {type: 'OnOff', pass_opt: :PassengerResolveSymlinksInDocumentRoot},
+        'passenger_response_buffer_high_watermark' => {type: 'Integer', pass_opt: :PassengerResponseBufferHighWatermark},
+        'passenger_restart_dir' => {type: 'Path', pass_opt: :PassengerRestartDir},
+        'passenger_rolling_restarts' => {type: 'OnOff', pass_opt: :PassengerRollingRestarts},
+        'passenger_root' => {type: 'FullPath', pass_opt: :PassengerRoot},
+        'passenger_ruby' => {type: 'FullPath', pass_opt: :PassengerRuby},
+        'passenger_security_update_check_proxy' => {type: 'URI', pass_opt: :PassengerSecurityUpdateCheckProxy},
+        'passenger_show_version_in_header' => {type: 'OnOff', pass_opt: :PassengerShowVersionInHeader},
+        'passenger_socket_backlog' => {type: 'Integer', pass_opt: :PassengerSocketBacklog},
+        'passenger_spawn_method' => {type: ["smart", "direct"], pass_opt: :PassengerSpawnMethod},
+        'passenger_start_timeout' => {type: 'Integer', pass_opt: :PassengerStartTimeout},
+        'passenger_startup_file' => {type: 'RelPath', pass_opt: :PassengerStartupFile},
+        'passenger_stat_throttle_rate' => {type: 'Integer', pass_opt: :PassengerStatThrottleRate},
+        'passenger_sticky_sessions' => {type: 'OnOff', pass_opt: :PassengerStickySessions},
+        'passenger_sticky_sessions_cookie_name' => {type: 'String', pass_opt: :PassengerStickySessionsCookieName},
+        'passenger_thread_count' => {type: 'Integer', pass_opt: :PassengerThreadCount},
+        'passenger_use_global_queue' => {type: 'String', pass_opt: :PassengerUseGlobalQueue},
+        'passenger_user' => {type: 'String', pass_opt: :PassengerUser},
+        'passenger_user_switching' => {type: 'OnOff', pass_opt: :PassengerUserSwitching},
+        'rack_auto_detect' => {type: 'String', pass_opt: :RackAutoDetect},
+        'rack_autodetect' => {type: 'String', pass_opt: :RackAutoDetect},
+        'rack_base_uri' => {type: 'String', pass_opt: :RackBaseURI},
+        'rack_env' => {type: 'String', pass_opt: :RackEnv},
+        'rails_allow_mod_rewrite' => {type: 'String', pass_opt: :RailsAllowModRewrite},
+        'rails_app_spawner_idle_time' => {type: 'String', pass_opt: :RailsAppSpawnerIdleTime},
+        'rails_auto_detect' => {type: 'String', pass_opt: :RailsAutoDetect},
+        'rails_autodetect' => {type: 'String', pass_opt: :RailsAutoDetect},
+        'rails_base_uri' => {type: 'String', pass_opt: :RailsBaseURI},
+        'rails_default_user' => {type: 'String', pass_opt: :RailsDefaultUser},
+        'rails_env' => {type: 'String', pass_opt: :RailsEnv},
+        'rails_framework_spawner_idle_time' => {type: 'String', pass_opt: :RailsFrameworkSpawnerIdleTime},
+        'rails_ruby' => {type: 'String', pass_opt: :RailsRuby},
+        'rails_spawn_method' => {type: 'String', pass_opt: :RailsSpawnMethod},
+        'rails_user_switching' => {type: 'String', pass_opt: :RailsUserSwitching},
+        'wsgi_auto_detect' => {type: 'String', pass_opt: :WsgiAutoDetect},
+    }
+    passenger_config_options.each do |config_option, config_hash|
+      puppetized_config_option = config_option
+      valid_config_values = []
+      case config_hash[:type]
+        # UnionStationFilter values are quoted strings
+        when 'QuotedString'
+          valid_config_values = ['"a quoted string"']
+          valid_config_values.each do |valid_value|
+            describe "with #{puppetized_config_option} => '#{valid_value.gsub(/\"/, '')}'" do
+              let :params do
+                { puppetized_config_option.to_sym => valid_value }
+              end
+              it { is_expected.to contain_file('passenger.conf').with_content(/^  #{config_hash[:pass_opt]} "#{valid_value}"$/) }
+            end
+          end
+        when 'FullPath', 'RelPath', 'Path'
+          valid_config_values = ['/some/path/to/somewhere']
+          valid_config_values.each do |valid_value|
+            describe "with #{puppetized_config_option} => #{valid_value}" do
+              let :params do
+                { puppetized_config_option.to_sym => valid_value }
+              end
+              it { is_expected.to contain_file('passenger.conf').with_content(/^  #{config_hash[:pass_opt]} "#{valid_value}"$/) }
+            end
+          end
+        when 'URI', 'String', 'Integer'
+          valid_config_values = ['some_value_for_you']
+          valid_config_values.each do |valid_value|
+            describe "with #{puppetized_config_option} => #{valid_value}" do
+              let :params do
+                { puppetized_config_option.to_sym => valid_value }
+              end
+              it { is_expected.to contain_file('passenger.conf').with_content(/^  #{config_hash[:pass_opt]} #{valid_value}$/) }
+            end
+          end
+       when 'OnOff'
+          valid_config_values = ['on', 'off']
+          valid_config_values.each do |valid_value|
+            describe "with #{puppetized_config_option} => '#{valid_value}'" do
+              let :params do
+                { puppetized_config_option.to_sym => valid_value }
+              end
+              it { is_expected.to contain_file('passenger.conf').with_content(/^  #{config_hash[:pass_opt]} #{valid_value}$/) }
+            end
+          end
+        else
+          valid_config_values = config_hash[:type]
+          valid_config_values.each do |valid_value|
+            describe "with #{puppetized_config_option} => '#{valid_value}'" do
+              let :params do
+                { puppetized_config_option.to_sym => valid_value }
+              end
+              it { is_expected.to contain_file('passenger.conf').with_content(/^  #{config_hash[:pass_opt]} #{valid_value}$/) }
+            end
+          end
+      end
+    end
+  end
   context "on a Debian OS" do
     let :facts do
       {
@@ -126,7 +289,7 @@ describe 'apache::mod::passenger', :type => :class do
       let :params do
         { :passenger_log_file => '/var/log/apache2/passenger.log' }
       end
-      it { is_expected.to contain_file('passenger.conf').with_content(%r{^  PassengerLogFile /var/log/apache2/passenger.log$}) }
+      it { is_expected.to contain_file('passenger.conf').with_content(%r{^  PassengerLogFile "/var/log/apache2/passenger.log"$}) }
     end
     describe "with passenger_log_level => 3" do
       let :params do

--- a/spec/classes/mod/prefork_spec.rb
+++ b/spec/classes/mod/prefork_spec.rb
@@ -79,12 +79,16 @@ describe 'apache::mod::prefork', :type => :class do
         'require' => 'Package[httpd]',
         })
       }
+      it { is_expected.to contain_file("/etc/httpd/conf.d/prefork.conf").without({ 'content' => /MaxRequestWorkers/ }) }
+      it { is_expected.to contain_file("/etc/httpd/conf.d/prefork.conf").without({ 'content' => /MaxConnectionsPerChild/ }) }
     end
 
     context "with Apache version >= 2.4" do
       let :params do
         {
-          :apache_version => '2.4',
+          :apache_version         => '2.4',
+          :maxrequestworkers      => '512',
+          :maxconnectionsperchild => '4000'
         }
       end
 
@@ -95,6 +99,8 @@ describe 'apache::mod::prefork', :type => :class do
         'content' => "LoadModule mpm_prefork_module modules/mod_mpm_prefork.so\n",
         })
       }
+      it { is_expected.to contain_file("/etc/httpd/conf.d/prefork.conf").without({ 'content' => /MaxClients/ }) }
+      it { is_expected.to contain_file("/etc/httpd/conf.d/prefork.conf").without({ 'content' => /MaxRequestsPerChild/ }) }
     end
   end
   context "on a FreeBSD OS" do

--- a/spec/classes/mod/userdir_spec.rb
+++ b/spec/classes/mod/userdir_spec.rb
@@ -32,6 +32,7 @@ describe 'apache::mod::userdir', :type => :class do
         }
       end
       it { should contain_file("userdir.conf").with_content(%r{^\s*UserDir\s+/home/\*/hi$})}
+      it { should contain_file("userdir.conf").with_content(%r{^\s*\<Directory\s+\"/home/\*/hi\"\>$})}
     end
     context "with home set to something" do
       let :params do
@@ -40,6 +41,7 @@ describe 'apache::mod::userdir', :type => :class do
         }
       end
       it { should contain_file("userdir.conf").with_content(%r{^\s*UserDir\s+/u/\*/public_html$})}
+      it { should contain_file("userdir.conf").with_content(%r{^\s*\<Directory\s+\"/u/\*/public_html"\>$})}
     end
     context "with path set to something" do
       let :params do
@@ -48,6 +50,7 @@ describe 'apache::mod::userdir', :type => :class do
         }
       end
       it { should contain_file("userdir.conf").with_content(%r{^\s*UserDir\s+public_html /usr/web http://www\.example\.com/$})}
+      it { should contain_file("userdir.conf").with_content(%r{^\s*\<Directory\s+\"public_html /usr/web http://www\.example\.com/\"\>$})}
     end
   end
 end

--- a/spec/defines/fastcgi_server_spec.rb
+++ b/spec/defines/fastcgi_server_spec.rb
@@ -25,7 +25,7 @@ describe 'apache::fastcgi::server', :type => :define do
       it { should contain_class("apache") }
       it { should contain_class("apache::mod::fastcgi") }
       it { should contain_file("fastcgi-pool-#{title}.conf").with(
-        :ensure => 'present',
+        :ensure => 'file',
         :path => "/etc/httpd/conf.d/fastcgi-pool-#{title}.conf"
       ) }
     end
@@ -47,7 +47,7 @@ describe 'apache::fastcgi::server', :type => :define do
       it { should contain_class("apache") }
       it { should contain_class("apache::mod::fastcgi") }
       it { should contain_file("fastcgi-pool-#{title}.conf").with(
-        :ensure => 'present',
+        :ensure => 'file',
         :path   => "/etc/apache2/conf.d/fastcgi-pool-#{title}.conf"
       ) }
     end
@@ -68,7 +68,7 @@ describe 'apache::fastcgi::server', :type => :define do
       it { should contain_class("apache") }
       it { should contain_class("apache::mod::fastcgi") }
       it { should contain_file("fastcgi-pool-#{title}.conf").with(
-        :ensure => 'present',
+        :ensure => 'file',
         :path   => "/usr/local/etc/apache24/Includes/fastcgi-pool-#{title}.conf"
       ) }
     end
@@ -89,7 +89,7 @@ describe 'apache::fastcgi::server', :type => :define do
       it { should contain_class("apache") }
       it { should contain_class("apache::mod::fastcgi") }
       it { should contain_file("fastcgi-pool-#{title}.conf").with(
-        :ensure => 'present',
+        :ensure => 'file',
         :path   => "/etc/apache2/conf.d/fastcgi-pool-#{title}.conf"
       ) }
     end

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -392,6 +392,7 @@ describe 'apache::vhost', :type => :define do
           'use_optional_includes'       => true,
           'suexec_user_group'           => 'root root',
           'allow_encoded_slashes'       => 'nodecode',
+          'passenger_spawn_method'      => 'direct',
           'passenger_app_root'          => '/usr/share/myapp',
           'passenger_app_env'           => 'test',
           'passenger_ruby'              => '/usr/bin/ruby1.9.1',

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -992,6 +992,96 @@ describe 'apache::vhost', :type => :define do
       it { is_expected.to_not contain_concat__fragment('rspec.example.com-limits') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-file_footer') }
     end
+    context 'wsgi_application_group should set apache::mod::wsgi' do
+      let :params do
+        {
+            'docroot'                    => '/rspec/docroot',
+            'wsgi_application_group'     => '%{GLOBAL}',
+        }
+      end
+      it { is_expected.to contain_class("apache::mod::wsgi") }
+    end
+    context 'wsgi_daemon_process should set apache::mod::wsgi' do
+      let :params do
+        {
+           'docroot'                    => '/rspec/docroot',
+           'wsgi_daemon_process'        => 'wsgi',
+        }
+      end
+      it { is_expected.to contain_class("apache::mod::wsgi") }
+    end
+    context 'wsgi_import_script on its own should not set apache::mod::wsgi' do
+      let :params do
+        {
+            'docroot'                    => '/rspec/docroot',
+            'wsgi_import_script'         => '/var/www/demo.wsgi',
+        }
+      end
+      it { is_expected.not_to contain_class("apache::mod::wsgi") }
+    end
+    context 'wsgi_import_script_options on its own should not set apache::mod::wsgi' do
+      let :params do
+        {
+            'docroot'                     => '/rspec/docroot',
+            'wsgi_import_script_options'  => {
+                'process-group'           => 'wsgi',
+                'application-group'       => '%{GLOBAL}'
+            },
+        }
+      end
+      it { is_expected.not_to contain_class("apache::mod::wsgi") }
+    end
+    context 'wsgi_import_script and wsgi_import_script_options should set apache::mod::wsgi' do
+      let :params do
+        {
+            'docroot'                     => '/rspec/docroot',
+            'wsgi_import_script'          => '/var/www/demo.wsgi',
+            'wsgi_import_script_options'  => {
+                'process-group'           => 'wsgi',
+                'application-group'       => '%{GLOBAL}'
+            },
+        }
+      end
+      it { is_expected.to contain_class("apache::mod::wsgi") }
+    end
+    context 'wsgi_process_group should set apache::mod::wsgi' do
+      let :params do
+        {
+            'docroot'                    => '/rspec/docroot',
+            'wsgi_daemon_process'        => 'wsgi',
+        }
+      end
+      it { is_expected.to contain_class("apache::mod::wsgi") }
+    end
+    context 'wsgi_script_aliases with non-empty aliases should set apache::mod::wsgi' do
+      let :params do
+        {
+            'docroot'                    => '/rspec/docroot',
+            'wsgi_script_aliases'        => {
+                '/' => '/var/www/demo.wsgi'
+            },
+        }
+      end
+      it { is_expected.to contain_class("apache::mod::wsgi") }
+    end
+    context 'wsgi_script_aliases with empty aliases should set apache::mod::wsgi' do
+      let :params do
+        {
+            'docroot'                    => '/rspec/docroot',
+            'wsgi_script_aliases'        => { },
+        }
+      end
+      it { is_expected.not_to contain_class("apache::mod::wsgi") }
+    end
+    context 'wsgi_pass_authorization should set apache::mod::wsgi' do
+      let :params do
+        {
+            'docroot'                    => '/rspec/docroot',
+            'wsgi_pass_authorization'    => 'On',
+        }
+      end
+      it { is_expected.to contain_class("apache::mod::wsgi") }
+    end
     context 'when not setting nor managing the docroot' do
       let :params do
         {

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -1397,5 +1397,41 @@ describe 'apache::vhost', :type => :define do
         :content => /^\s+Require all granted$/ )
       }
     end
+    describe "redirectmatch_*" do
+      let :facts do
+        {
+          :osfamily               => 'RedHat',
+          :operatingsystemrelease => '6',
+          :concat_basedir         => '/dne',
+          :operatingsystem        => 'RedHat',
+          :id                     => 'root',
+          :kernel                 => 'Linux',
+          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :is_pe                  => false,
+        }
+      end
+      let :dparams do
+        {
+          :docroot => '/rspec/docroot',
+          :port    => '84',
+        }
+      end
+      context "status" do
+        let (:params) { dparams.merge({:redirectmatch_status => "404"}) }
+        it { is_expected.to contain_class("apache::mod::alias")}
+      end
+      context "dest" do
+        let (:params) { dparams.merge({:redirectmatch_dest => "http://other.example.com$1.jpg"}) }
+        it { is_expected.to contain_class("apache::mod::alias")}
+      end
+      context "regexp" do
+        let (:params) { dparams.merge({:redirectmatch_regexp => "(.*)\.gif$"}) }
+        it { is_expected.to contain_class("apache::mod::alias")}
+      end
+      context "none" do
+        let (:params) { dparams }
+        it { is_expected.to_not contain_class("apache::mod::alias") }
+      end
+    end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -3,9 +3,54 @@ require 'beaker-rspec/helpers/serverspec'
 require 'beaker/puppet_install_helper'
 require 'beaker/module_install_helper'
 
+def install_bolt_on(hosts)
+  on(hosts, "/opt/puppetlabs/puppet/bin/gem install --source http://rubygems.delivery.puppetlabs.net bolt -v '> 0.0.1'", acceptable_exit_codes: [0, 1]).stdout
+end
+
+def pe_install?
+  ENV['PUPPET_INSTALL_TYPE'] =~ %r{pe}i
+end
+
+def puppet_version
+  (on default, puppet('--version')).output.chomp
+end
+
 run_puppet_install_helper
+install_bolt_on(hosts) unless pe_install?
 install_module_on(hosts)
 install_module_dependencies_on(hosts)
+
+DEFAULT_PASSWORD = if default[:hypervisor] == 'vagrant'
+                     'vagrant'
+                   elsif default[:hypervisor] == 'vcloud'
+                     'Qu@lity!'
+                   end
+
+def run_puppet_access_login(user:, password: '~!@#$%^*-/ aZ', lifetime: '5y')
+  on(master, puppet('access', 'login', '--username', user, '--lifetime', lifetime), stdin: password)
+end
+
+def run_task(task_name:, params: nil, password: DEFAULT_PASSWORD)
+  if pe_install?
+    run_puppet_task(task_name: task_name, params: params)
+  else
+    run_bolt_task(task_name: task_name, params: params, password: password)
+  end
+end
+
+def run_bolt_task(task_name:, params: nil, password: DEFAULT_PASSWORD)
+  on(master, "/opt/puppetlabs/puppet/bin/bolt task run #{task_name} --modules /etc/puppetlabs/code/modules/service --nodes localhost --password #{password} #{params}", acceptable_exit_codes: [0, 1]).stdout # rubocop:disable Metrics/LineLength
+end
+
+def run_puppet_task(task_name:, params: nil)
+  on(master, puppet('task', 'run', task_name, '--nodes', fact_on(master, 'fqdn'), params.to_s), acceptable_exit_codes: [0, 1]).stdout
+end
+
+def expect_multiple_regexes(result:, regexes:)
+  regexes.each do |regex|
+    expect(result).to match(regex)
+  end
+end
 
 RSpec.configure do |c|
   c.filter_run :focus => true
@@ -26,6 +71,7 @@ RSpec.configure do |c|
 
   # Configure all nodes in nodeset
   c.before :suite do
+    run_puppet_access_login(user: 'admin') if pe_install?
     # net-tools required for netstat utility being used by be_listening
     if fact('osfamily') == 'RedHat' && fact('operatingsystemmajrelease') == '7'
       pp = <<-EOS

--- a/tasks/init.json
+++ b/tasks/init.json
@@ -1,0 +1,10 @@
+{
+  "description": "Allows you to perform apache service functions",
+  "input_method": "stdin",
+  "parameters": {
+    "action": {
+      "description": "Action to perform ",
+      "type": "Enum[reload]"
+    }
+  }
+}

--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -1,0 +1,23 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+require 'json'
+require 'open3'
+require 'puppet'
+
+def service(action)
+  cmd_string = "service apache2 #{action}"
+  stdout, stderr, status = Open3.capture3(cmd_string)
+  raise Puppet::Error, stderr if status != 0
+  { status: "#{action} successful" }
+end
+
+params = JSON.parse(STDIN.read)
+action = params['action']
+
+begin
+  result = service(action)
+  puts result.to_json
+  exit 0
+rescue Puppet::Error => e
+  puts({ status: 'failure', error: e.message }.to_json)
+  exit 1
+end

--- a/templates/mod/passenger.conf.erb
+++ b/templates/mod/passenger.conf.erb
@@ -1,61 +1,242 @@
 # The Passenger Apache module configuration file is being
 # managed by Puppet and changes will be overwritten.
 <IfModule mod_passenger.c>
+  <%- if @passenger_allow_encoded_slashes -%>
+  PassengerAllowEncodedSlashes <%= @passenger_allow_encoded_slashes %>
+  <%- end -%>
+  <%- if @passenger_app_env -%>
+  PassengerAppEnv <%= @passenger_app_env %>
+  <%- end -%>
+  <%- if @passenger_app_group_name -%>
+  PassengerAppGroupName <%= @passenger_app_group_name %>
+  <%- end -%>
+  <%- if @passenger_app_root -%>
+  PassengerAppRoot "<%= @passenger_app_root %>"
+  <%- end -%>
+  <%- if @passenger_app_type -%>
+  PassengerAppType <%= @passenger_app_type %>
+  <%- end -%>
+  <%- if @passenger_base_uri -%>
+  PassengerBaseURI <%= @passenger_base_uri %>
+  <%- end -%>
+  <%- if @passenger_buffer_response -%>
+  PassengerBufferResponse <%= @passenger_buffer_response %>
+  <%- end -%>
+  <%- if @passenger_buffer_upload -%>
+  PassengerBufferUpload <%= @passenger_buffer_upload %>
+  <%- end -%>
+  <%- if @passenger_concurrency_model -%>
+  PassengerConcurrencyModel <%= @passenger_concurrency_model %>
+  <%- end -%>
+  <%- if @passenger_data_buffer_dir -%>
+  PassengerDataBufferDir "<%= @passenger_data_buffer_dir %>"
+  <%- end -%>
+  <%- if @passenger_debug_log_file -%>
+  PassengerDebugLogFile <%= @passenger_debug_log_file %>
+  <%- end -%>
+  <%- if @passenger_debugger -%>
+  PassengerDebugger <%= @passenger_debugger %>
+  <%- end -%>
+  <%- if @passenger_default_group -%>
+  PassengerDefaultGroup <%= @passenger_default_group %>
+  <%- end -%>
+  <%- if @passenger_default_ruby -%>
+  PassengerDefaultRuby "<%= @passenger_default_ruby %>"
+  <%- end -%>
+  <%- if @passenger_default_user -%>
+  PassengerDefaultUser <%= @passenger_default_user %>
+  <%- end -%>
+  <%- if @passenger_disable_security_update_check -%>
+  PassengerDisableSecurityUpdateCheck <%= @passenger_disable_security_update_check %>
+  <%- end -%>
+  <%- if @passenger_enabled -%>
+  PassengerEnabled <%= @passenger_enabled %>
+  <%- end -%>
+  <%- if @passenger_error_override -%>
+  PassengerErrorOverride <%= @passenger_error_override %>
+  <%- end -%>
+  <%- if @passenger_file_descriptor_log_file -%>
+  PassengerFileDescriptorLogFile "<%= @passenger_file_descriptor_log_file %>"
+  <%- end -%>
+  <%- if @passenger_fly_with -%>
+  PassengerFlyWith "<%= @passenger_fly_with %>"
+  <%- end -%>
+  <%- if @passenger_force_max_concurrent_requests_per_process -%>
+  PassengerForceMaxConcurrentRequestsPerProcess <%= @passenger_force_max_concurrent_requests_per_process %>
+  <%- end -%>
+  <%- if @passenger_friendly_error_pages -%>
+  PassengerFriendlyErrorPages <%= @passenger_friendly_error_pages %>
+  <%- end -%>
+  <%- if @passenger_group -%>
+  PassengerGroup <%= @passenger_group %>
+  <%- end -%>
+  <%- if @passenger_high_performance -%>
+  PassengerHighPerformance <%= @passenger_high_performance %>
+  <%- end -%>
+  <%- if @passenger_instance_registry_dir -%>
+  PassengerInstanceRegistryDir "<%= @passenger_instance_registry_dir %>"
+  <%- end -%>
+  <%- if @passenger_load_shell_envvars -%>
+  PassengerLoadShellEnvvars <%= @passenger_load_shell_envvars %>
+  <%- end -%>
+  <%- if @passenger_log_file -%>
+  PassengerLogFile "<%= @passenger_log_file %>"
+  <%- end -%>
+  <%- if @passenger_log_level -%>
+  PassengerLogLevel <%= @passenger_log_level %>
+  <%- end -%>
+  <%- if @passenger_lve_min_uid -%>
+  PassengerLveMinUid <%= @passenger_lve_min_uid %>
+  <%- end -%>
+  <%- if @passenger_max_instances -%>
+  PassengerMaxInstances <%= @passenger_max_instances %>
+  <%- end -%>
+  <%- if @passenger_max_instances_per_app -%>
+  PassengerMaxInstancesPerApp <%= @passenger_max_instances_per_app %>
+  <%- end -%>
+  <%- if @passenger_max_pool_size -%>
+  PassengerMaxPoolSize <%= @passenger_max_pool_size %>
+  <%- end -%>
+  <%- if @passenger_max_preloader_idle_time -%>
+  PassengerMaxPreloaderIdleTime <%= @passenger_max_preloader_idle_time %>
+  <%- end -%>
+  <%- if @passenger_max_request_queue_size -%>
+  PassengerMaxRequestQueueSize <%= @passenger_max_request_queue_size %>
+  <%- end -%>
+  <%- if @passenger_max_request_time -%>
+  PassengerMaxRequestTime <%= @passenger_max_request_time %>
+  <%- end -%>
+  <%- if @passenger_max_requests -%>
+  PassengerMaxRequests <%= @passenger_max_requests %>
+  <%- end -%>
+  <%- if @passenger_memory_limit -%>
+  PassengerMemoryLimit <%= @passenger_memory_limit %>
+  <%- end -%>
+  <%- if @passenger_meteor_app_settings -%>
+  PassengerMeteorAppSettings "<%= @passenger_meteor_app_settings %>"
+  <%- end -%>
+  <%- if @passenger_min_instances -%>
+  PassengerMinInstances <%= @passenger_min_instances %>
+  <%- end -%>
+  <%- if @passenger_nodejs -%>
+  PassengerNodejs "<%= @passenger_nodejs %>"
+  <%- end -%>
+  <%- if @passenger_pool_idle_time -%>
+  PassengerPoolIdleTime <%= @passenger_pool_idle_time %>
+  <%- end -%>
+  <%- if @passenger_pre_start -%>
+  PassengerPreStart <%= @passenger_pre_start %>
+  <%- end -%>
+  <%- if @passenger_python -%>
+  PassengerPython "<%= @passenger_python %>"
+  <%- end -%>
+  <%- if @passenger_resist_deployment_errors -%>
+  PassengerResistDeploymentErrors <%= @passenger_resist_deployment_errors %>
+  <%- end -%>
+  <%- if @passenger_resolve_symlinks_in_document_root -%>
+  PassengerResolveSymlinksInDocumentRoot <%= @passenger_resolve_symlinks_in_document_root %>
+  <%- end -%>
+  <%- if @passenger_response_buffer_high_watermark -%>
+  PassengerResponseBufferHighWatermark <%= @passenger_response_buffer_high_watermark %>
+  <%- end -%>
+  <%- if @passenger_restart_dir -%>
+  PassengerRestartDir "<%= @passenger_restart_dir %>"
+  <%- end -%>
+  <%- if @passenger_rolling_restarts -%>
+  PassengerRollingRestarts <%= @passenger_rolling_restarts %>
+  <%- end -%>
   <%- if @passenger_root -%>
   PassengerRoot "<%= @passenger_root %>"
   <%- end -%>
   <%- if @passenger_ruby -%>
   PassengerRuby "<%= @passenger_ruby %>"
   <%- end -%>
-  <%- if @passenger_default_ruby -%>
-  PassengerDefaultRuby "<%= @passenger_default_ruby %>"
+  <%- if @passenger_security_update_check_proxy -%>
+  PassengerSecurityUpdateCheckProxy <%= @passenger_security_update_check_proxy %>
   <%- end -%>
-  <%- if @passenger_high_performance -%>
-  PassengerHighPerformance <%= @passenger_high_performance %>
+  <%- if @passenger_show_version_in_header -%>
+  PassengerShowVersionInHeader <%= @passenger_show_version_in_header %>
   <%- end -%>
-  <%- if @passenger_max_pool_size -%>
-  PassengerMaxPoolSize <%= @passenger_max_pool_size %>
-  <%- end -%>
-  <%- if @passenger_min_instances -%>
-  PassengerMinInstances <%= @passenger_min_instances %>
-  <%- end -%>
-  <%- if @passenger_max_instances_per_app -%>
-  PassengerMaxInstancesPerApp <%= @passenger_max_instances_per_app %>
-  <%- end -%>
-  <%- if @passenger_pool_idle_time -%>
-  PassengerPoolIdleTime <%= @passenger_pool_idle_time %>
-  <%- end -%>
-  <%- if @passenger_max_request_queue_size -%>
-  PassengerMaxRequestQueueSize <%= @passenger_max_request_queue_size %>
-  <%- end -%>
-  <%- if @passenger_max_requests -%>
-  PassengerMaxRequests <%= @passenger_max_requests %>
+  <%- if @passenger_socket_backlog -%>
+  PassengerSocketBacklog <%= @passenger_socket_backlog %>
   <%- end -%>
   <%- if @passenger_spawn_method -%>
   PassengerSpawnMethod <%= @passenger_spawn_method %>
   <%- end -%>
+  <%- if @passenger_start_timeout -%>
+  PassengerStartTimeout <%= @passenger_start_timeout %>
+  <%- end -%>
+  <%- if @passenger_startup_file -%>
+  PassengerStartupFile "<%= @passenger_startup_file %>"
+  <%- end -%>
   <%- if @passenger_stat_throttle_rate -%>
   PassengerStatThrottleRate <%= @passenger_stat_throttle_rate %>
   <%- end -%>
-  <%- if @rack_autodetect -%>
-  RackAutoDetect <%= @rack_autodetect %>
+  <%- if @passenger_sticky_sessions -%>
+  PassengerStickySessions <%= @passenger_sticky_sessions %>
   <%- end -%>
-  <%- if @rails_autodetect -%>
-  RailsAutoDetect <%= @rails_autodetect %>
+  <%- if @passenger_sticky_sessions_cookie_name -%>
+  PassengerStickySessionsCookieName <%= @passenger_sticky_sessions_cookie_name %>
+  <%- end -%>
+  <%- if @passenger_thread_count -%>
+  PassengerThreadCount <%= @passenger_thread_count %>
   <%- end -%>
   <%- if @passenger_use_global_queue -%>
   PassengerUseGlobalQueue <%= @passenger_use_global_queue %>
   <%- end -%>
-  <%- if @passenger_app_env -%>
-  PassengerAppEnv <%= @passenger_app_env %>
+  <%- if @passenger_user -%>
+  PassengerUser <%= @passenger_user %>
   <%- end -%>
-  <%- if @passenger_log_file -%>
-  PassengerLogFile <%= @passenger_log_file %>
+  <%- if @passenger_user_switching -%>
+  PassengerUserSwitching <%= @passenger_user_switching %>
   <%- end -%>
-  <%- if @passenger_log_level -%>
-  PassengerLogLevel <%= @passenger_log_level %>
+  <%- if @rack_auto_detect -%>
+  RackAutoDetect <%= @rack_auto_detect %>
   <%- end -%>
-  <%- if @passenger_data_buffer_dir -%>
-  PassengerDataBufferDir <%= @passenger_data_buffer_dir %>
+  <%- if @rack_base_uri -%>
+  RackBaseURI <%= @rack_base_uri %>
   <%- end -%>
+  <%- if @rack_env -%>
+  RackEnv <%= @rack_env %>
+  <%- end -%>
+  <%- if @rails_allow_mod_rewrite -%>
+  RailsAllowModRewrite <%= @rails_allow_mod_rewrite %>
+  <%- end -%>
+  <%- if @rails_app_spawner_idle_time -%>
+  RailsAppSpawnerIdleTime <%= @rails_app_spawner_idle_time %>
+  <%- end -%>
+  <%- if @rails_auto_detect -%>
+  RailsAutoDetect <%= @rails_auto_detect %>
+  <%- end -%>
+  <%- if @rails_base_uri -%>
+  RailsBaseURI <%= @rails_base_uri %>
+  <%- end -%>
+  <%- if @rails_default_user -%>
+  RailsDefaultUser <%= @rails_default_user %>
+  <%- end -%>
+  <%- if @rails_env -%>
+  RailsEnv <%= @rails_env %>
+  <%- end -%>
+  <%- if @rails_framework_spawner_idle_time -%>
+  RailsFrameworkSpawnerIdleTime <%= @rails_framework_spawner_idle_time %>
+  <%- end -%>
+  <%- if @rails_ruby -%>
+  RailsRuby <%= @rails_ruby %>
+  <%- end -%>
+  <%- if @rails_spawn_method -%>
+  RailsSpawnMethod <%= @rails_spawn_method %>
+  <%- end -%>
+  <%- if @rails_user_switching -%>
+  RailsUserSwitching <%= @rails_user_switching %>
+  <%- end -%>
+  <%- if @wsgi_auto_detect -%>
+  WsgiAutoDetect <%= @wsgi_auto_detect %>
+  <%- end -%>
+  <%- if @rails_autodetect -%>
+  RailsAutoDetect <%= @rails_autodetect %>
+  <%- end -%>
+  <%- if @rack_autodetect -%>
+  RackAutoDetect <%= @rack_autodetect %>
+  <%- end -%>
+
 </IfModule>

--- a/templates/mod/prefork.conf.erb
+++ b/templates/mod/prefork.conf.erb
@@ -3,6 +3,14 @@
   MinSpareServers     <%= @minspareservers %>
   MaxSpareServers     <%= @maxspareservers %>
   ServerLimit         <%= @serverlimit %>
-  MaxClients          <%= @maxclients %>
-  MaxRequestsPerChild <%= @maxrequestsperchild %>
+  <%- if @maxrequestworkers -%>
+  MaxRequestWorkers      <%= @maxrequestworkers %>
+  <%- elsif @maxclients -%>
+  MaxClients             <%= @maxclients %>
+  <%- end -%>
+  <%- if @maxconnectionsperchild -%>
+  MaxConnectionsPerChild <%= @maxconnectionsperchild %>
+  <%- elsif @maxrequestsperchild -%>
+  MaxRequestsPerChild    <%= @maxrequestsperchild %>
+  <%- end -%>
 </IfModule>

--- a/templates/mod/prefork.conf.erb
+++ b/templates/mod/prefork.conf.erb
@@ -13,4 +13,5 @@
   <%- elsif @maxrequestsperchild -%>
   MaxRequestsPerChild    <%= @maxrequestsperchild %>
   <%- end -%>
+  ListenBacklog       <%= @listenbacklog %>
 </IfModule>

--- a/templates/mod/userdir.conf.erb
+++ b/templates/mod/userdir.conf.erb
@@ -4,7 +4,7 @@
 <% end -%>
   UserDir <%= @_path %>
 
-  <Directory "<%= @home %>/*/<%= @dir %>">
+  <Directory "<%= @_path %>">
     AllowOverride <%= @overrides.join(' ') %>
     Options <%= @options.join(' ') %>
     <Limit GET POST OPTIONS>

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -85,9 +85,7 @@
     <%- if directory['sethandler'] and directory['sethandler'] != '' -%>
     SetHandler <%= directory['sethandler'] %>
     <%- end -%>
-    <%- if directory['passenger_enabled'] and directory['passenger_enabled'] != '' -%>
-    PassengerEnabled <%= directory['passenger_enabled'] %>
-    <%- end -%>
+    <%= scope.function_template(["apache/vhost/_passenger_directory.erb"]) -%>
     <%- if directory['php_flags'] and ! directory['php_flags'].empty? -%>
       <%- directory['php_flags'].sort.each do |flag,value| -%>
         <%- value = if value =~ /true|yes|on|1/i then 'on' else 'off' end -%>

--- a/templates/vhost/_passenger.erb
+++ b/templates/vhost/_passenger.erb
@@ -1,3 +1,6 @@
+<% if @passenger_spawn_method -%>
+  PassengerSpawnMethod <%= @passenger_spawn_method %>
+<% end -%>
 <% if @passenger_app_root -%>
   PassengerAppRoot <%= @passenger_app_root %>
 <% end -%>

--- a/templates/vhost/_passenger_directory.erb
+++ b/templates/vhost/_passenger_directory.erb
@@ -1,0 +1,127 @@
+<%- _item = scope.lookupvar('_template_scope')[:item] -%>
+<%- if _item['passenger_allow_encoded_slashes'] and _item['passenger_allow_encoded_slashes'] != '' -%>
+    PassengerAllowEncodedSlashes <%= _item['passenger_allow_encoded_slashes'] %>
+<%- end -%>
+<%- if _item['passenger_app_env'] and _item['passenger_app_env'] != '' -%>
+    PassengerAppEnv <%= _item['passenger_app_env'] %>
+<%- end -%>
+<%- if _item['passenger_app_group_name'] and _item['passenger_app_group_name'] != '' -%>
+    PassengerAppGroupName <%= _item['passenger_app_group_name'] %>
+<%- end -%>
+<%- if _item['passenger_app_root'] and _item['passenger_app_root'] != '' -%>
+    PassengerAppRoot "<%= _item['passenger_app_root'] %>"
+<%- end -%>
+<%- if _item['passenger_app_type'] and _item['passenger_app_type'] != '' -%>
+    PassengerAppType <%= _item['passenger_app_type'] %>
+<%- end -%>
+<%- if _item['passenger_base_uri'] and _item['passenger_base_uri'] != '' -%>
+    PassengerBaseURI <%= _item['passenger_base_uri'] %>
+<%- end -%>
+<%- if _item['passenger_buffer_response'] and _item['passenger_buffer_response'] != '' -%>
+    PassengerBufferResponse <%= _item['passenger_buffer_response'] %>
+<%- end -%>
+<%- if _item['passenger_buffer_upload'] and _item['passenger_buffer_upload'] != '' -%>
+    PassengerBufferUpload <%= _item['passenger_buffer_upload'] %>
+<%- end -%>
+<%- if _item['passenger_concurrency_model'] and _item['passenger_concurrency_model'] != '' -%>
+    PassengerConcurrencyModel <%= _item['passenger_concurrency_model'] %>
+<%- end -%>
+<%- if _item['passenger_debugger'] and _item['passenger_debugger'] != '' -%>
+    PassengerDebugger <%= _item['passenger_debugger'] %>
+<%- end -%>
+<%- if _item['passenger_enabled'] and _item['passenger_enabled'] != '' -%>
+    PassengerEnabled <%= _item['passenger_enabled'] %>
+<%- end -%>
+<%- if _item['passenger_error_override'] and _item['passenger_error_override'] != '' -%>
+    PassengerErrorOverride <%= _item['passenger_error_override'] %>
+<%- end -%>
+<%- if _item['passenger_force_max_concurrent_requests_per_process'] and _item['passenger_force_max_concurrent_requests_per_process'] != '' -%>
+    PassengerForceMaxConcurrentRequestsPerProcess <%= _item['passenger_force_max_concurrent_requests_per_process'] %>
+<%- end -%>
+<%- if _item['passenger_friendly_error_pages'] and _item['passenger_friendly_error_pages'] != '' -%>
+    PassengerFriendlyErrorPages <%= _item['passenger_friendly_error_pages'] %>
+<%- end -%>
+<%- if _item['passenger_group'] and _item['passenger_group'] != '' -%>
+    PassengerGroup <%= _item['passenger_group'] %>
+<%- end -%>
+<%- if _item['passenger_high_performance'] and _item['passenger_high_performance'] != '' -%>
+    PassengerHighPerformance <%= _item['passenger_high_performance'] %>
+<%- end -%>
+<%- if _item['passenger_load_shell_envvars'] and _item['passenger_load_shell_envvars'] != '' -%>
+    PassengerLoadShellEnvvars <%= _item['passenger_load_shell_envvars'] %>
+<%- end -%>
+<%- if _item['passenger_max_instances'] and _item['passenger_max_instances'] != '' -%>
+    PassengerMaxInstances <%= _item['passenger_max_instances'] %>
+<%- end -%>
+<%- if _item['passenger_max_request_queue_size'] and _item['passenger_max_request_queue_size'] != '' -%>
+    PassengerMaxRequestQueueSize <%= _item['passenger_max_request_queue_size'] %>
+<%- end -%>
+<%- if _item['passenger_max_request_time'] and _item['passenger_max_request_time'] != '' -%>
+    PassengerMaxRequestTime <%= _item['passenger_max_request_time'] %>
+<%- end -%>
+<%- if _item['passenger_max_requests'] and _item['passenger_max_requests'] != '' -%>
+    PassengerMaxRequests <%= _item['passenger_max_requests'] %>
+<%- end -%>
+<%- if _item['passenger_memory_limit'] and _item['passenger_memory_limit'] != '' -%>
+    PassengerMemoryLimit <%= _item['passenger_memory_limit'] %>
+<%- end -%>
+<%- if _item['passenger_meteor_app_settings'] and _item['passenger_meteor_app_settings'] != '' -%>
+    PassengerMeteorAppSettings "<%= _item['passenger_meteor_app_settings'] %>"
+<%- end -%>
+<%- if _item['passenger_min_instances'] and _item['passenger_min_instances'] != '' -%>
+    PassengerMinInstances <%= _item['passenger_min_instances'] %>
+<%- end -%>
+<%- if _item['passenger_nodejs'] and _item['passenger_nodejs'] != '' -%>
+    PassengerNodejs "<%= _item['passenger_nodejs'] %>"
+<%- end -%>
+<%- if _item['passenger_python'] and _item['passenger_python'] != '' -%>
+    PassengerPython "<%= _item['passenger_python'] %>"
+<%- end -%>
+<%- if _item['passenger_resist_deployment_errors'] and _item['passenger_resist_deployment_errors'] != '' -%>
+    PassengerResistDeploymentErrors <%= _item['passenger_resist_deployment_errors'] %>
+<%- end -%>
+<%- if _item['passenger_resolve_symlinks_in_document_root'] and _item['passenger_resolve_symlinks_in_document_root'] != '' -%>
+    PassengerResolveSymlinksInDocumentRoot <%= _item['passenger_resolve_symlinks_in_document_root'] %>
+<%- end -%>
+<%- if _item['passenger_restart_dir'] and _item['passenger_restart_dir'] != '' -%>
+    PassengerRestartDir "<%= _item['passenger_restart_dir'] %>"
+<%- end -%>
+<%- if _item['passenger_rolling_restarts'] and _item['passenger_rolling_restarts'] != '' -%>
+    PassengerRollingRestarts <%= _item['passenger_rolling_restarts'] %>
+<%- end -%>
+<%- if _item['passenger_ruby'] and _item['passenger_ruby'] != '' -%>
+    PassengerRuby "<%= _item['passenger_ruby'] %>"
+<%- end -%>
+<%- if _item['passenger_start_timeout'] and _item['passenger_start_timeout'] != '' -%>
+    PassengerStartTimeout <%= _item['passenger_start_timeout'] %>
+<%- end -%>
+<%- if _item['passenger_startup_file'] and _item['passenger_startup_file'] != '' -%>
+    PassengerStartupFile "<%= _item['passenger_startup_file'] %>"
+<%- end -%>
+<%- if _item['passenger_sticky_sessions'] and _item['passenger_sticky_sessions'] != '' -%>
+    PassengerStickySessions <%= _item['passenger_sticky_sessions'] %>
+<%- end -%>
+<%- if _item['passenger_sticky_sessions_cookie_name'] and _item['passenger_sticky_sessions_cookie_name'] != '' -%>
+    PassengerStickySessionsCookieName <%= _item['passenger_sticky_sessions_cookie_name'] %>
+<%- end -%>
+<%- if _item['passenger_thread_count'] and _item['passenger_thread_count'] != '' -%>
+    PassengerThreadCount <%= _item['passenger_thread_count'] %>
+<%- end -%>
+<%- if _item['passenger_user'] and _item['passenger_user'] != '' -%>
+    PassengerUser <%= _item['passenger_user'] %>
+<%- end -%>
+<%- if _item['rack_env'] and _item['rack_env'] != '' -%>
+    RackEnv <%= _item['rack_env'] %>
+<%- end -%>
+<%- if _item['rails_env'] and _item['rails_env'] != '' -%>
+    RailsEnv <%= _item['rails_env'] %>
+<%- end -%>
+<%- if _item['union_station_filter'] and _item['union_station_filter'] != '' -%>
+    UnionStationFilter "<%= _item['union_station_filter'] %>"
+<%- end -%>
+<%- if _item['union_station_key'] and _item['union_station_key'] != '' -%>
+    UnionStationKey <%= _item['union_station_key'] %>
+<%- end -%>
+<%- if _item['union_station_support'] and _item['union_station_support'] != '' -%>
+    UnionStationSupport <%= _item['union_station_support'] %>
+<%- end -%>

--- a/templates/vhost/_ssl.erb
+++ b/templates/vhost/_ssl.erb
@@ -7,6 +7,17 @@
   <%- if @ssl_chain -%>
   SSLCertificateChainFile "<%= @ssl_chain %>"
   <%- end -%>
+  <%- if @ssl_protocol -%>
+  SSLProtocol             <%= [@ssl_protocol].flatten.compact.join(' ') %>
+  <%- end -%>
+  <%- if @ssl_cipher -%>
+  SSLCipherSuite          <%= @ssl_cipher %>
+  <%- end -%>
+  <%- if @ssl_honorcipherorder -%>
+  SSLHonorCipherOrder     <%= @ssl_honorcipherorder %>
+  <%- end -%>
+  <%- if @ssl_verify_client -%>
+  SSLVerifyClient         <%= @ssl_verify_client %>
   <%- if @ssl_certs_dir && @ssl_certs_dir != '' -%>
   SSLCACertificatePath    "<%= @ssl_certs_dir %>"
   <%- end -%>
@@ -19,23 +30,12 @@
   <%- if @ssl_crl -%>
   SSLCARevocationFile     "<%= @ssl_crl %>"
   <%- end -%>
+  <%- if @ssl_verify_depth -%>
+  SSLVerifyDepth          <%= @ssl_verify_depth %>
+  <%- end -%>
   <%- if @ssl_crl_check && scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
   SSLCARevocationCheck    "<%= @ssl_crl_check %>"
   <%- end -%>
-  <%- if @ssl_protocol -%>
-  SSLProtocol             <%= [@ssl_protocol].flatten.compact.join(' ') %>
-  <%- end -%>
-  <%- if @ssl_cipher -%>
-  SSLCipherSuite          <%= @ssl_cipher %>
-  <%- end -%>
-  <%- if @ssl_honorcipherorder -%>
-  SSLHonorCipherOrder     <%= @ssl_honorcipherorder %>
-  <%- end -%>
-  <%- if @ssl_verify_client -%>
-  SSLVerifyClient         <%= @ssl_verify_client %>
-  <%- end -%>
-  <%- if @ssl_verify_depth -%>
-  SSLVerifyDepth          <%= @ssl_verify_depth %>
   <%- end -%>
   <%- if @ssl_options -%>
   SSLOptions <%= Array(@ssl_options).join(' ') %>


### PR DESCRIPTION
I added support for the passenger settings you can use inside Directory as they are documented at https://www.phusionpassenger.com/library/config/apache/reference/. 

* This branched off of master and not the other passenger feature branch I created.
* The README.md changes are more detailed in this pull request as it also details which passenger options are supported where. ( It may not be appropriate to to have the 'context' column inside the documentation for the mod::passenger class.