### PR TITLE
[Modules 5385] Include support for Apache 2.4 mod_authz_host directives in apache::mod::status

### DIFF
--- a/README.md
+++ b/README.md
@@ -2791,6 +2791,24 @@ Installs [`mod_status`][] and uses the `status.conf.erb` template to generate it
 * `allow_from`: An [array][] of IPv4 or IPv6 addresses that can access `/server-status`.
 
   Default: ['127.0.0.1','::1'].
+
+* `requires`: A string, an [array][] or a [hash][], of IPs and/or names that can/can't access `/server-status`, using Apache v. >= 2.4 `mod_authz_host` directives (`require ip`, `require host`, etc.). This parameter should follow one of the structures below:
+
+  > Only used if Apache version >= 2.4
+
+  - `undef` - Uses `allow_from` and old directive syntax (`Allow from <List of IPs and/or names>`). Issues deprecation warning.
+  - String
+    - `''` or `'unmanaged'` - No auth directives (access controlled elsewhere)
+    - `'ip <List of IPs>'` - IPs/ranges allowed to access `/server-status`
+    - `'host <List of names>'` - Names/domains allowed to access `/server-status`
+    - `'all [granted|denied]'` - Allow / block everyone
+  - Array - Each item should be a string from those described above. Results in one directive per array item.
+  - Hash with structure below (shown as key => value, where keys are strings):
+    - `'requires'` => Array as above - Same effect as the array
+    - `'enforce'`  => String `'Any'`, `'All'` or `'None'` (optional) - Encloses all directives from `'requires'` key in a `<Require(Any|All|None)>` block
+
+  Default: 'ip 127.0.0.1 ::1'
+
 * `extended_status`: Determines whether to track extended status information for each request, via the [`ExtendedStatus`][] directive.
 
   Values: 'Off', 'On'.

--- a/manifests/mod/status.pp
+++ b/manifests/mod/status.pp
@@ -7,6 +7,20 @@
 # - $allow_from is an array of hosts, ip addresses, partial network numbers
 #   or networks in CIDR notation specifying what hosts can view the special
 #   /server-status URL.  Defaults to ['127.0.0.1', '::1'].
+#   > Creates Apache < 2.4 directive "Allow from"
+# - $requires is either a:
+#   - String with:
+#     - '' or 'unmanaged' - Host auth control done elsewhere
+#     - 'ip <List of IPs>' - Allowed IPs/ranges
+#     - 'host <List of names>' - Allowed names/domains
+#     - 'all [granted|denied]'
+#   - Array of strings with ip or host as above
+#   - Hash with following keys:
+#     - 'requires' - Value => Array as above
+#     - 'enforce' - Value => String 'Any', 'All' or 'None'
+#       This encloses "Require" directives in "<Require(Any|All|None)>" block
+#       Optional - If unspecified, "Require" directives follow current flow
+#   > Creates Apache >= 2.4 directives "Require"
 # - $extended_status track and display extended status information. Valid
 #   values are 'On' or 'Off'.  Defaults to 'On'.
 # - $status_path is the path assigned to the Location directive which
@@ -26,15 +40,21 @@
 #  }
 #
 class apache::mod::status (
-  Array $allow_from                               = ['127.0.0.1','::1'],
-  Enum['On', 'Off', 'on', 'off'] $extended_status = 'On',
-  $apache_version                                 = undef,
-  $status_path                                    = '/server-status',
+  Optional[Array] $allow_from                      = undef,
+  Optional[Variant[String, Array, Hash]] $requires = undef,
+  Enum['On', 'Off', 'on', 'off'] $extended_status  = 'On',
+  $apache_version                                  = undef,
+  $status_path                                     = '/server-status',
 ) inherits ::apache::params {
 
   include ::apache
   $_apache_version = pick($apache_version, $apache::apache_version)
   ::apache::mod { 'status': }
+
+  # Defaults for "Allow from" or "Require" directives
+  $allow_defaults = ['127.0.0.1','::1']
+  $requires_defaults = 'ip 127.0.0.1 ::1'
+
   # Template uses $allow_from, $extended_status, $_apache_version, $status_path
   file { 'status.conf':
     ensure  => file,

--- a/spec/classes/mod/status_spec.rb
+++ b/spec/classes/mod/status_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 # Helper function for testing the contents of `status.conf`
+# Apache < 2.4
 def status_conf_spec(allow_from, extended_status, status_path)
   it do
     is_expected.to contain_file("status.conf").with_content(
@@ -19,12 +20,51 @@ def status_conf_spec(allow_from, extended_status, status_path)
     )
   end
 end
+# Apache >= 2.4
+def require_directives(requires)
+  if requires == :undef
+    return "    Require ip 127.0.0.1 ::1\n"
+  elsif requires.is_a?(String)
+    if ['','unmanaged'].include?requires.downcase
+      return ''
+    else
+      return "    Require #{requires}\n"
+    end
+  elsif requires.is_a?(Array)
+    return requires.map { |req| "    Require #{req}\n" }.join('')
+  elsif requires.is_a?(Hash)
+    unless requires.has_key?(:enforce)
+      return requires[:requires].map { |req| "    Require #{req}\n" }.join('')
+    else
+      return \
+        "    <Require#{requires[:enforce].capitalize}>\n" + \
+        requires[:requires].map { |req| "        Require #{req}\n" }.join('') + \
+        "    </Require#{requires[:enforce].capitalize}>\n"
+    end
+  end
+end
+def status_conf_spec_require(requires, extended_status, status_path)
+  it do
+    is_expected.to contain_file("status.conf").with_content(
+      "<Location #{status_path}>\n"\
+      "    SetHandler server-status\n"\
+      "#{require_directives(requires)}"\
+      "</Location>\n"\
+      "ExtendedStatus #{extended_status}\n"\
+      "\n"\
+      "<IfModule mod_proxy.c>\n"\
+      "    # Show Proxy LoadBalancer status in mod_status\n"\
+      "    ProxyStatus On\n"\
+      "</IfModule>\n"
+    )
+  end
+end
 
 describe 'apache::mod::status', :type => :class do
   it_behaves_like "a mod class, without including apache"
-  
+
   context "default configuration with parameters" do
-    context "on a Debian OS with default params" do
+    context "on a Debian 6 OS with default params" do
       let :facts do
         {
           :osfamily               => 'Debian',
@@ -55,7 +95,7 @@ describe 'apache::mod::status', :type => :class do
 
     end
 
-    context "on a RedHat OS with default params" do
+    context "on a RedHat 6 OS with default params" do
       let :facts do
         {
           :osfamily               => 'RedHat',
@@ -75,6 +115,97 @@ describe 'apache::mod::status', :type => :class do
 
       it { is_expected.to contain_file("status.conf").with_path("/etc/httpd/conf.d/status.conf") }
 
+    end
+
+    valid_requires = {
+      :undef     => :undef,
+      :empty     => '',
+      :unmanaged => 'unmanaged',
+      :string    => 'ip 127.0.0.1 192.168',
+      :array     => [
+        'ip 127.0.0.1',
+        'ip ::1',
+        'host localhost',
+      ],
+      :hash      => {
+        :requires => [
+          'ip 10.1',
+          'host somehost',
+        ],
+      },
+      :enforce   => {
+        :enforce => 'all',
+        :requires => [
+          'ip 127.0.0.1',
+          'host localhost',
+        ],
+      },
+    }
+    valid_requires.each do |req_key, req_value|
+      context "on a Debian 8 OS with default params and #{req_key} requires" do
+        let :facts do
+          {
+            :osfamily               => 'Debian',
+            :operatingsystemrelease => '8',
+            :concat_basedir         => '/dne',
+            :lsbdistcodename        => 'squeeze',
+            :operatingsystem        => 'Debian',
+            :id                     => 'root',
+            :kernel                 => 'Linux',
+            :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+            :is_pe                  => false,
+          }
+        end
+
+        let :params do
+          {
+            :requires => req_value,
+          }
+        end
+
+        it { is_expected.to contain_apache__mod("status") }
+
+        status_conf_spec_require(req_value, "On", "/server-status")
+
+        it { is_expected.to contain_file("status.conf").with({
+          :ensure => 'file',
+          :path   => '/etc/apache2/mods-available/status.conf',
+        } ) }
+
+        it { is_expected.to contain_file("status.conf symlink").with({
+          :ensure => 'link',
+          :path   => '/etc/apache2/mods-enabled/status.conf',
+        } ) }
+
+      end
+
+      context "on a RedHat 7 OS with default params and #{req_key} requires" do
+        let :facts do
+          {
+            :osfamily               => 'RedHat',
+            :operatingsystemrelease => '7',
+            :concat_basedir         => '/dne',
+            :operatingsystem        => 'RedHat',
+            :id                     => 'root',
+            :kernel                 => 'Linux',
+            :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+            :is_pe                  => false,
+          }
+        end
+
+        let :params do
+          {
+            :requires => req_value,
+          }
+        end
+
+        it { is_expected.to contain_apache__mod("status") }
+
+        status_conf_spec_require(req_value, "On", "/server-status")
+
+        it { is_expected.to contain_file("status.conf").with_path("/etc/httpd/conf.modules.d/status.conf") }
+
+      end
     end
 
     context "with custom parameters $allow_from => ['10.10.10.10','11.11.11.11'], $extended_status => 'Off', $status_path => '/custom-status'" do

--- a/templates/mod/_allow.erb
+++ b/templates/mod/_allow.erb
@@ -1,0 +1,7 @@
+    Order deny,allow
+    Deny from all
+<% if @allow_from != nil and ! @allow_from.empty? -%>
+    Allow from <%= Array(@allow_from).join(" ") %>
+<% else -%>
+    Allow from <%= Array(@allow_defaults).join(" ") %>
+<% end -%>

--- a/templates/mod/_require.erb
+++ b/templates/mod/_require.erb
@@ -1,0 +1,44 @@
+<% if @requires != nil -%>
+  <%- _requires = @requires -%>
+<% elsif @allow_from != nil and ! @allow_from.empty? -%>
+  <%- scope.function_warning(["Class #{@title}: Using Allow"]) -%>
+  <%- scope.function_warning(["is deprecated in Apache #{@_apache_version}"]) -%>
+  <%- _requires = 'ip ' + Array(@allow_from).join(" ") -%>
+<% else -%>
+  <%- _requires = @requires_defaults -%>
+<% end -%>
+<%-# -%>
+<% if _requires.is_a?(String) -%>
+  <%- if ! ['', 'unmanaged'].include?_requires.downcase -%>
+    Require <%= _requires %>
+  <%- end -%>
+<% elsif _requires.is_a?(Array) -%>
+  <%- _requires.each do |req| -%>
+    Require <%= req %>
+  <%- end -%>
+<% elsif _requires.is_a?(Hash) -%>
+  <%- if _requires.has_key?('enforce') and ['all', 'none', 'any'].include?_requires['enforce'].downcase -%>
+    <%- enforce_str = "Require#{_requires['enforce'].capitalize}>\n" -%>
+    <%- enforce_open = "    <#{enforce_str}" -%>
+    <%- enforce_close = "    </#{enforce_str}" -%>
+    <%- indentation = '    ' -%>
+  <%- else -%>
+    <%- if _requires.has_key?('enforce') -%>
+      <%- scope.function_warning(["Class #{@title}: Require can only"]) -%>
+      <%- scope.function_warning(["be overwritten with all, none or any."]) -%>
+    <%- end -%>
+    <%- enforce_open = '' -%>
+    <%- enforce_close = '' -%>
+    <%- indentation = '' -%>
+  <%- end -%>
+  <%- if _requires.has_key?('requires') and _requires['requires'].is_a?(Array) -%>
+<%# %><%= enforce_open -%>
+      <%- _requires['requires'].each do |req| -%>
+<%# %>    <%= indentation -%>Require <%= req %>
+      <%- end -%>
+<%# %><%= enforce_close -%>
+  <%- else -%>
+    <%- scope.function_warning(["Class #{@title}: Require hash must have"]) -%>
+    <%- scope.function_warning(["a key named \"requires\" with array value"]) -%>
+  <%- end -%>
+<% end -%>

--- a/templates/mod/status.conf.erb
+++ b/templates/mod/status.conf.erb
@@ -1,11 +1,13 @@
 <Location <%= @status_path %>>
     SetHandler server-status
+    <%-# From Puppet 4.2 up, replace: -%>
+    <%-# "scope.function_template(["apache/mod/<Template>"])" -%>
+    <%-# with: -%>
+    <%-# "scope.call_function('template', ["apache/mod/<Template>"])" -%>
     <%- if scope.function_versioncmp([@_apache_version, '2.4']) >= 0 -%>
-    Require ip <%= Array(@allow_from).join(" ") %>
+<%= scope.function_template(["apache/mod/_require.erb"]) -%>
     <%- else -%>
-    Order deny,allow
-    Deny from all
-    Allow from <%= Array(@allow_from).join(" ") %>
+<%= scope.function_template(["apache/mod/_allow.erb"]) -%>
     <%- end -%>
 </Location>
 ExtendedStatus <%= @extended_status %>


### PR DESCRIPTION
In the current state, creates helper templates `mod/_allow` and `mod/_require` with, respectively, Apache 2.2 and 2.4 host authorization logic. These aim to be used by various templates in `mod/`. Then, template `mod/status.conf.erb` is modified to use one of these helper templates depending on Apache version.
The `_require` helper template implements "Require" directives from the parameter `requires` provided by the calling class. If this is `undef`, then uses variable `requires_defaults`, also provided by the calling class. In order not to break existing systems, if `requires == undef` but `allow_from` is defined, uses the latter and issue a deprecation warning.

`requires` parameter can be either of:
- `undef`
- '' or 'unmanaged' (No "Require" directive)
- String (`ip <list>`, `host <list>`, `not <something>`, etc.)
- Array of strings (each with same syntax as standalone string)
- Hash
  - Key `requires` - Array of strings (same rule as standalone array)
  - Key `enforce` (optional) - Either of "Any|All|None" for `<Require*></Require*>` block

Tested on RHEL 6 and 7 and Debian 7 and 8, but only in Puppet 3 (unfortunately, it's what I have here for the moment)
Test specs were not updated yet