### PR TITLE
MODULES-5452 - add $options to `balancer` type

### DIFF
--- a/README.md
+++ b/README.md
@@ -2814,6 +2814,12 @@ Configures key-value pairs as [`ProxySet`][] lines. Values: a [hash][].
 
 Default: '{}'.
 
+##### `options`
+
+Specifies an [array][] of [options](https://httpd.apache.org/docs/current/mod/mod_proxy.html#balancermember) after the balancer URL, and accepts any key-value pairs available to [`ProxyPass`][].
+
+Default: [].
+
 ##### `collect_exported`
 
 Determines whether to use [exported resources][].

--- a/manifests/balancer.pp
+++ b/manifests/balancer.pp
@@ -35,6 +35,9 @@
 # apache::balancermember with array arguments, which allows you to deploy
 # everything in 1 run)
 #
+# [*options*]
+# Array, default empty. If given, additional directives may be added to the
+# <Proxy balancer://xyz OPTIONS> block.
 #
 # === Examples
 #
@@ -46,6 +49,7 @@ define apache::balancer (
   $proxy_set = {},
   $collect_exported = true,
   $target = undef,
+  $options = [],
 ) {
   include ::apache::mod::proxy_balancer
 
@@ -63,6 +67,12 @@ define apache::balancer (
     $_target = "${::apache::confd_dir}/balancer_${name}.conf"
   }
 
+  if !empty($options) {
+    $_options = " ${join($options, ' ')}"
+  } else {
+    $_options = ''
+  }
+
   concat { "apache_balancer_${name}":
     owner  => '0',
     group  => '0',
@@ -74,7 +84,7 @@ define apache::balancer (
   concat::fragment { "00-${name}-header":
     target  => "apache_balancer_${name}",
     order   => '01',
-    content => "<Proxy balancer://${name}>\n",
+    content => "<Proxy balancer://${name}${_options}>\n",
   }
 
   if $collect_exported {

--- a/spec/defines/balancer_spec.rb
+++ b/spec/defines/balancer_spec.rb
@@ -21,6 +21,12 @@ describe 'apache::balancer', :type => :define do
     let :pre_condition do
       'include apache'
     end
+    describe "works when only declaring resource title" do
+      it { should contain_concat('apache_balancer_myapp') }
+      it { should_not contain_apache__mod('slotmem_shm') }
+      it { should_not contain_apache__mod('lbmethod_byrequests') }
+      it { should contain_concat__fragment('00-myapp-header').with_content(%r{^<Proxy balancer://myapp>$}) }
+    end
     describe "accept a target parameter and use it" do
       let :params do
         {
@@ -32,6 +38,16 @@ describe 'apache::balancer', :type => :define do
       })}
       it { should_not contain_apache__mod('slotmem_shm') }
       it { should_not contain_apache__mod('lbmethod_byrequests') }
+    end
+    describe "accept an options parameter and use it" do
+      let :params do
+        {
+          :options => ['timeout=0', 'nonce=none'],
+        }
+      end
+      it { should contain_concat__fragment('00-myapp-header').with_content(
+        %r{^<Proxy balancer://myapp timeout=0 nonce=none>$}
+      )}
     end
     context "on jessie" do
       let(:facts) { super().merge({


### PR DESCRIPTION
- New param `$options` to `apache::balancer` defined type so that it is
  possible to create Proxy block such as:

  ```puppet
  # Note the additional options 'timeout=4' and 'nonce=none':
  <Proxy balancer://foobar timeout=4 nonce=none>
      BalancerMember ajp://spam:8009 retry=30
      ...
  </Proxy>
  ```