### PR TITLE
Replace deprecated type checking with Puppet 4 types

### DIFF
--- a/manifests/fastcgi/server.pp
+++ b/manifests/fastcgi/server.pp
@@ -11,12 +11,12 @@ define apache::fastcgi::server (
 
   Apache::Mod['fastcgi'] -> Apache::Fastcgi::Server[$title]
 
-  if is_absolute_path($host) {
+  if $host =~ Stdlib::Absolutepath {
     $socket = $host
   }
 
   file { "fastcgi-pool-${name}.conf":
-    ensure  => present,
+    ensure  => file,
     path    => "${::apache::confd_dir}/fastcgi-pool-${name}.conf",
     owner   => 'root',
     group   => $::apache::params::root_group,

--- a/spec/defines/fastcgi_server_spec.rb
+++ b/spec/defines/fastcgi_server_spec.rb
@@ -25,7 +25,7 @@ describe 'apache::fastcgi::server', :type => :define do
       it { should contain_class("apache") }
       it { should contain_class("apache::mod::fastcgi") }
       it { should contain_file("fastcgi-pool-#{title}.conf").with(
-        :ensure => 'present',
+        :ensure => 'file',
         :path => "/etc/httpd/conf.d/fastcgi-pool-#{title}.conf"
       ) }
     end
@@ -47,7 +47,7 @@ describe 'apache::fastcgi::server', :type => :define do
       it { should contain_class("apache") }
       it { should contain_class("apache::mod::fastcgi") }
       it { should contain_file("fastcgi-pool-#{title}.conf").with(
-        :ensure => 'present',
+        :ensure => 'file',
         :path   => "/etc/apache2/conf.d/fastcgi-pool-#{title}.conf"
       ) }
     end
@@ -68,7 +68,7 @@ describe 'apache::fastcgi::server', :type => :define do
       it { should contain_class("apache") }
       it { should contain_class("apache::mod::fastcgi") }
       it { should contain_file("fastcgi-pool-#{title}.conf").with(
-        :ensure => 'present',
+        :ensure => 'file',
         :path   => "/usr/local/etc/apache24/Includes/fastcgi-pool-#{title}.conf"
       ) }
     end
@@ -89,7 +89,7 @@ describe 'apache::fastcgi::server', :type => :define do
       it { should contain_class("apache") }
       it { should contain_class("apache::mod::fastcgi") }
       it { should contain_file("fastcgi-pool-#{title}.conf").with(
-        :ensure => 'present',
+        :ensure => 'file',
         :path   => "/etc/apache2/conf.d/fastcgi-pool-#{title}.conf"
       ) }
     end


### PR DESCRIPTION
This and https://github.com/puppetlabs/puppetlabs-apache/pull/1664 should remove all deprecation warnings users might see.