### PR TITLE
(maint) Improve version matching fact

### DIFF
--- a/lib/facter/apache_version.rb
+++ b/lib/facter/apache_version.rb
@@ -3,11 +3,11 @@ Facter.add(:apache_version) do
     if Facter::Util::Resolution.which('apachectl')
       apache_version = Facter::Util::Resolution.exec('apachectl -v 2>&1')
       Facter.debug "Matching apachectl '#{apache_version}'"
-      %r{^Server version: Apache\/(\d+.\d+(.\d+)?)}.match(apache_version)[1]
+      %r{^Server version: Apache/(\d+\.\d+(\.\d+)?)}.match(apache_version)[1]
     elsif Facter::Util::Resolution.which('apache2ctl')
       apache_version = Facter::Util::Resolution.exec('apache2ctl -v 2>&1')
       Facter.debug "Matching apache2ctl '#{apache_version}'"
-      %r{^Server version: Apache\/(\d+.\d+(.\d+)?)}.match(apache_version)[1]
+      %r{^Server version: Apache/(\d+\.\d+(\.\d+)?)}.match(apache_version)[1]
     end
   end
 end


### PR DESCRIPTION
* `/` not being a special char, there is no need to escape it (removed preceding `\`);
* `.` matching *any* char, escaping it is required so that it matches a dot char (added preceding `\`).