### PR TITLE
(MODULES-3942) make sure mod_alias is loaded with redirectmatch

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -410,7 +410,10 @@ define apache::vhost(
   }
 
   # Load mod_alias if needed and not yet loaded
-  if ($scriptalias or $scriptaliases != []) or ($aliases and $aliases != []) or ($redirect_source and $redirect_dest) {
+  if ($scriptalias or $scriptaliases != [])
+    or ($aliases and $aliases != [])
+    or ($redirect_source and $redirect_dest)
+    or ($redirectmatch_regexp or $redirectmatch_status or $redirectmatch_dest){
     if ! defined(Class['apache::mod::alias'])  and ($ensure == 'present') {
       include ::apache::mod::alias
     }

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -1397,5 +1397,41 @@ describe 'apache::vhost', :type => :define do
         :content => /^\s+Require all granted$/ )
       }
     end
+    describe "redirectmatch_*" do
+      let :facts do
+        {
+          :osfamily               => 'RedHat',
+          :operatingsystemrelease => '6',
+          :concat_basedir         => '/dne',
+          :operatingsystem        => 'RedHat',
+          :id                     => 'root',
+          :kernel                 => 'Linux',
+          :path                   => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          :is_pe                  => false,
+        }
+      end
+      let :dparams do
+        {
+          :docroot => '/rspec/docroot',
+          :port    => '84',
+        }
+      end
+      context "status" do
+        let (:params) { dparams.merge({:redirectmatch_status => "404"}) }
+        it { is_expected.to contain_class("apache::mod::alias")}
+      end
+      context "dest" do
+        let (:params) { dparams.merge({:redirectmatch_dest => "http://other.example.com$1.jpg"}) }
+        it { is_expected.to contain_class("apache::mod::alias")}
+      end
+      context "regexp" do
+        let (:params) { dparams.merge({:redirectmatch_regexp => "(.*)\.gif$"}) }
+        it { is_expected.to contain_class("apache::mod::alias")}
+      end
+      context "none" do
+        let (:params) { dparams }
+        it { is_expected.to_not contain_class("apache::mod::alias") }
+      end
+    end
   end
 end


### PR DESCRIPTION
previously, when redirectmatch_* parameters were included, the RedirectMatch directive would be added to the vhost without mod_alias loaded. Since RedirectMatch is part of mod_alias, mod_alias is required. This change makes sure this happens whenever any of the three parameters are used.