### PR TITLE
Setup SSL/TLS client auth without overly broad trusts for client certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1369,7 +1369,7 @@ Default: `undef`.
 
 ##### `ssl_ca`
 
-Specifies the SSL certificate authority. [SSLCACertificateFile](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcacertificatefile).
+Specifies the SSL certificate authority. [SSLCACertificateFile](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcacertificatefile) to use to verify certificate used in ssl client authentication.
 
 It is possible to override this on a vhost level.
 
@@ -4913,7 +4913,7 @@ Default: `false`.
 
 ##### `ssl_ca`
 
-Specifies the SSL certificate authority.
+Specifies the SSL certificate authority to be used to verify client certificates used for authentication. You must also set `ssl_verify_client` to use this.
 
 Default: `undef`.
 
@@ -4950,14 +4950,9 @@ Default: `true`.
 
 ##### `ssl_certs_dir`
 
-Specifies the location of the SSL certification directory.
+Specifies the location of the SSL certification directory to verify client certs. Will not be used unless `ssl_verify_client` is also set (see below).
 
-Default: Depends on operating system.
-
-- Debian: '/etc/ssl/certs'
-- Red Hat: '/etc/pki/tls/certs'
-- FreeBSD: `undef`
-- Gentoo: '/etc/ssl/apache2'
+Default: undef
 
 ##### `ssl_chain`
 
@@ -4973,13 +4968,13 @@ Default: `undef`.
 
 ##### `ssl_crl_path`
 
-Specifies the location of the certificate revocation list. (This default works out of the box but must be updated in the base `apache` class with your specific certificate information before being used in production.)
+Specifies the location of the certificate revocation list to verify certificates for client authentication with. (This default works out of the box but must be updated in the base `apache` class with your specific certificate information before being used in production.)
 
 Default: `undef`.
 
 ##### `ssl_crl_check`
 
-Sets the certificate revocation check level via the [SSLCARevocationCheck directive](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcarevocationcheck). The default works out of the box but must be specified when using CRLs in production. Only applicable to Apache 2.4 or higher; the value is ignored on older versions.
+Sets the certificate revocation check level via the [SSLCARevocationCheck directive] for ssl client authentication (https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcarevocationcheck). The default works out of the box but must be specified when using CRLs in production. Only applicable to Apache 2.4 or higher; the value is ignored on older versions.
 
 Default: `undef`.
 
@@ -5012,11 +5007,12 @@ Default: `undef`.
 
 ##### `ssl_verify_depth`
 
-Sets the [SSLVerifyDepth](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslverifydepth) directive, which specifies the maximum depth of CA certificates in client certificate verification.
+Sets the [SSLVerifyDepth](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslverifydepth) directive, which specifies the maximum depth of CA certificates in client certificate verification. You must set `ssl_verify_client` for it to take effect.
 
 ``` puppet
 apache::vhost { 'sample.example.net':
   …
+  ssl_verify_client => 'require',
   ssl_verify_depth => 1,
 }
 ```

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -49,6 +49,9 @@ class apache::params inherits ::apache::version {
 
   $modsec_audit_log_parts = 'ABIJDEFHZ'
 
+  # no client certs should be trusted for auth by default.
+  $ssl_certs_dir          = undef
+
   if ($::operatingsystem == 'Ubuntu' and $::lsbdistrelease == '10.04') or ($::operatingsystem == 'SLES') {
     $verify_command = '/usr/sbin/apache2ctl -t'
   } elsif $::operatingsystem == 'FreeBSD' {
@@ -83,7 +86,6 @@ class apache::params inherits ::apache::version {
     $dev_packages         = 'httpd-devel'
     $default_ssl_cert     = '/etc/pki/tls/certs/localhost.crt'
     $default_ssl_key      = '/etc/pki/tls/private/localhost.key'
-    $ssl_certs_dir        = '/etc/pki/tls/certs'
     $ssl_sessioncache     = '/var/cache/mod_ssl/scache(512000)'
     $passenger_conf_file  = 'passenger_extra.conf'
     $passenger_conf_package_file = 'passenger.conf'
@@ -223,7 +225,6 @@ class apache::params inherits ::apache::version {
     $mpm_module          = 'worker'
     $default_ssl_cert    = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
     $default_ssl_key     = '/etc/ssl/private/ssl-cert-snakeoil.key'
-    $ssl_certs_dir       = '/etc/ssl/certs'
     $ssl_sessioncache    = "\${APACHE_RUN_DIR}/ssl_scache(512000)"
     $suphp_addhandler    = 'x-httpd-php'
     $suphp_engine        = 'off'
@@ -389,7 +390,6 @@ class apache::params inherits ::apache::version {
     $dev_packages     = undef
     $default_ssl_cert = '/usr/local/etc/apache24/server.crt'
     $default_ssl_key  = '/usr/local/etc/apache24/server.key'
-    $ssl_certs_dir    = undef
     $ssl_sessioncache  = '/var/run/ssl_scache(512000)'
     $passenger_conf_file = 'passenger.conf'
     $passenger_conf_package_file = undef
@@ -459,7 +459,6 @@ class apache::params inherits ::apache::version {
     $dev_packages     = undef
     $default_ssl_cert = '/etc/ssl/apache2/server.crt'
     $default_ssl_key  = '/etc/ssl/apache2/server.key'
-    $ssl_certs_dir    = '/etc/ssl/apache2'
     $ssl_sessioncache  = '/var/run/ssl_scache(512000)'
     $passenger_root   = '/usr'
     $passenger_ruby   = '/usr/bin/ruby'
@@ -528,7 +527,6 @@ class apache::params inherits ::apache::version {
     $mpm_module          = 'prefork'
     $default_ssl_cert    = '/etc/apache2/ssl.crt/server.crt'
     $default_ssl_key     = '/etc/apache2/ssl.key/server.key'
-    $ssl_certs_dir       = '/etc/ssl/certs'
     $ssl_sessioncache    = '/var/lib/apache2/ssl_scache(512000)'
     $suphp_addhandler    = 'x-httpd-php'
     $suphp_engine        = 'off'

--- a/templates/vhost/_ssl.erb
+++ b/templates/vhost/_ssl.erb
@@ -7,6 +7,17 @@
   <%- if @ssl_chain -%>
   SSLCertificateChainFile "<%= @ssl_chain %>"
   <%- end -%>
+  <%- if @ssl_protocol -%>
+  SSLProtocol             <%= [@ssl_protocol].flatten.compact.join(' ') %>
+  <%- end -%>
+  <%- if @ssl_cipher -%>
+  SSLCipherSuite          <%= @ssl_cipher %>
+  <%- end -%>
+  <%- if @ssl_honorcipherorder -%>
+  SSLHonorCipherOrder     <%= @ssl_honorcipherorder %>
+  <%- end -%>
+  <%- if @ssl_verify_client -%>
+  SSLVerifyClient         <%= @ssl_verify_client %>
   <%- if @ssl_certs_dir && @ssl_certs_dir != '' -%>
   SSLCACertificatePath    "<%= @ssl_certs_dir %>"
   <%- end -%>
@@ -19,23 +30,12 @@
   <%- if @ssl_crl -%>
   SSLCARevocationFile     "<%= @ssl_crl %>"
   <%- end -%>
+  <%- if @ssl_verify_depth -%>
+  SSLVerifyDepth          <%= @ssl_verify_depth %>
+  <%- end -%>
   <%- if @ssl_crl_check && scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
   SSLCARevocationCheck    "<%= @ssl_crl_check %>"
   <%- end -%>
-  <%- if @ssl_protocol -%>
-  SSLProtocol             <%= [@ssl_protocol].flatten.compact.join(' ') %>
-  <%- end -%>
-  <%- if @ssl_cipher -%>
-  SSLCipherSuite          <%= @ssl_cipher %>
-  <%- end -%>
-  <%- if @ssl_honorcipherorder -%>
-  SSLHonorCipherOrder     <%= @ssl_honorcipherorder %>
-  <%- end -%>
-  <%- if @ssl_verify_client -%>
-  SSLVerifyClient         <%= @ssl_verify_client %>
-  <%- end -%>
-  <%- if @ssl_verify_depth -%>
-  SSLVerifyDepth          <%= @ssl_verify_depth %>
   <%- end -%>
   <%- if @ssl_options -%>
   SSLOptions <%= Array(@ssl_options).join(' ') %>


### PR DESCRIPTION
If `$ssl_certs_dir` defaults to a location that contains certificates, apache will trust implicitly all the certificates presented by the client for auth that were issues by *any* certificates in that location. Setting the default to the location where all root certificates is stored enabled anyone with a key and cert from any of the SSL certificate provider to connect.

Note: 
 * In Gentoo, `$ssl_certs_dir` was pointing to /etc/apache2/ssl, which may have been safe, or used for storing CA certs to check client auth. Gentoo users may need to set that value explicitly depending on how it was used in prior versions.

For more details, see [MODULE-5471]