### PR TITLE
(maint) allow arrays of arrays for $directories

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -61,7 +61,7 @@ define apache::vhost(
   $access_log_env_var                                                               = false,
   Optional[Array] $access_logs                                                      = undef,
   $aliases                                                                          = undef,
-  Optional[Variant[Hash, Array[Hash]]] $directories                                 = undef,
+  Optional[Variant[Hash, Array[Variant[Array,Hash]]]] $directories                  = undef,
   Boolean $error_log                                                                = true,
   $error_log_file                                                                   = undef,
   $error_log_pipe                                                                   = undef,


### PR DESCRIPTION
recently, $directories in vhost.pp was puppet4-ized. because we still support Apache 2.2, we need to continue to allow $directories to have nested arrays so that users can pass arrays of allow/deny rules for each directory.