### PR TITLE
remoteip: Notify apache::service instead of service['httpd']

### DIFF
--- a/manifests/mod/remoteip.pp
+++ b/manifests/mod/remoteip.pp
@@ -25,6 +25,6 @@ class apache::mod::remoteip (
     content => template('apache/mod/remoteip.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],
-    notify  => Service['httpd'],
+    notify  => Class['apache::service'],
   }
 }


### PR DESCRIPTION
Otherwise service is restarted even if service_manage=false

Signed-off-by: Sergii Kipot <kipot.sergey@gmail.com>