### PR TITLE
(MODULES-2062) updates prefork.conf params for apache 2.4

### DIFF
--- a/manifests/mod/prefork.pp
+++ b/manifests/mod/prefork.pp
@@ -1,11 +1,13 @@
 class apache::mod::prefork (
-  $startservers        = '8',
-  $minspareservers     = '5',
-  $maxspareservers     = '20',
-  $serverlimit         = '256',
-  $maxclients          = '256',
-  $maxrequestsperchild = '4000',
-  $apache_version      = undef,
+  $startservers           = '8',
+  $minspareservers        = '5',
+  $maxspareservers        = '20',
+  $serverlimit            = '256',
+  $maxclients             = '256',
+  $maxrequestworkers      = undef,
+  $maxrequestsperchild    = '4000',
+  $maxconnectionsperchild = undef,
+  $apache_version         = undef,
 ) {
   include ::apache
   $_apache_version = pick($apache_version, $apache::apache_version)
@@ -23,6 +25,15 @@ class apache::mod::prefork (
   if defined(Class['apache::mod::worker']) {
     fail('May not include both apache::mod::prefork and apache::mod::worker on the same node')
   }
+
+  if versioncmp($_apache_version, '2.3.13') < 0 {
+    if $maxrequestworkers == undef {
+      warning("For newer versions of Apache, \$maxclients is deprecated, please use \$maxrequestworkers.")
+    } elsif $maxconnectionsperchild == undef {
+      warning("For newer versions of Apache, \$maxrequestsperchild is deprecated, please use \$maxconnectionsperchild.")
+    }
+  }
+
   File {
     owner => 'root',
     group => $::apache::params::root_group,
@@ -35,7 +46,9 @@ class apache::mod::prefork (
   # - $maxspareservers
   # - $serverlimit
   # - $maxclients
+  # - $maxrequestworkers
   # - $maxrequestsperchild
+  # - $maxconnectionsperchild
   file { "${::apache::mod_dir}/prefork.conf":
     ensure  => file,
     content => template('apache/mod/prefork.conf.erb'),

--- a/spec/classes/mod/prefork_spec.rb
+++ b/spec/classes/mod/prefork_spec.rb
@@ -79,12 +79,16 @@ describe 'apache::mod::prefork', :type => :class do
         'require' => 'Package[httpd]',
         })
       }
+      it { is_expected.to contain_file("/etc/httpd/conf.d/prefork.conf").without({ 'content' => /MaxRequestWorkers/ }) }
+      it { is_expected.to contain_file("/etc/httpd/conf.d/prefork.conf").without({ 'content' => /MaxConnectionsPerChild/ }) }
     end
 
     context "with Apache version >= 2.4" do
       let :params do
         {
-          :apache_version => '2.4',
+          :apache_version         => '2.4',
+          :maxrequestworkers      => '512',
+          :maxconnectionsperchild => '4000'
         }
       end
 
@@ -95,6 +99,8 @@ describe 'apache::mod::prefork', :type => :class do
         'content' => "LoadModule mpm_prefork_module modules/mod_mpm_prefork.so\n",
         })
       }
+      it { is_expected.to contain_file("/etc/httpd/conf.d/prefork.conf").without({ 'content' => /MaxClients/ }) }
+      it { is_expected.to contain_file("/etc/httpd/conf.d/prefork.conf").without({ 'content' => /MaxRequestsPerChild/ }) }
     end
   end
   context "on a FreeBSD OS" do

--- a/templates/mod/prefork.conf.erb
+++ b/templates/mod/prefork.conf.erb
@@ -3,6 +3,14 @@
   MinSpareServers     <%= @minspareservers %>
   MaxSpareServers     <%= @maxspareservers %>
   ServerLimit         <%= @serverlimit %>
-  MaxClients          <%= @maxclients %>
-  MaxRequestsPerChild <%= @maxrequestsperchild %>
+  <%- if @maxrequestworkers -%>
+  MaxRequestWorkers      <%= @maxrequestworkers %>
+  <%- elsif @maxclients -%>
+  MaxClients             <%= @maxclients %>
+  <%- end -%>
+  <%- if @maxconnectionsperchild -%>
+  MaxConnectionsPerChild <%= @maxconnectionsperchild %>
+  <%- elsif @maxrequestsperchild -%>
+  MaxRequestsPerChild    <%= @maxrequestsperchild %>
+  <%- end -%>
 </IfModule>


### PR DESCRIPTION
MaxClients is now MaxRequestWorkers and MaxRequestsPerChild is now MaxConnectionsPerChild. This updates the manifest, template, and adds a couple unit tests. Unit tests for every OS did not seem necessary since all that is being tested is an if block.