### PR TITLE
Add enable capabilities to itk

### DIFF
--- a/README.md
+++ b/README.md
@@ -2146,6 +2146,54 @@ Installs and manages [`mod_info`][], which provides a comprehensive overview of 
 
   Default: `true`.
 
+##### Class: `apache::mod::itk`
+
+Installs and manages [`mod_itk`][], which is an (MPM) that is loaded and configured for the HTTPD process. [official documentation](http://mpm-itk.sesse.net/)
+
+**Parameters**:
+
+* `startservers`: The number of child server processes created on startup.
+
+  Values: Integer.
+
+  Default: `8`.
+
+* `minspareservers`: The desired minimum number of idle child server processes.
+
+  Values: Integer.
+
+  Default: `5`.
+
+* `maxspareservers`: The desired maximum number of idle child server processes.
+
+  Values: Integer.
+
+  Default: `20`.
+
+* `serverlimit`: The maximum configured value for MaxRequestWorkers for the lifetime of the Apache httpd process.
+
+  Values: Integer.
+
+  Default: `256`.
+
+* `maxclients`: The limit on the number of simultaneous requests that will be served.
+
+  Values: Integer.
+
+  Default: `256`.
+
+* `maxrequestsperchild`: The limit on the number of connections that an individual child server process will handle.
+
+  Values: Integer.
+
+  Default: `4000`.
+
+* `enablecapabilities`: Drop most root capabilities in the parent process, and instead run as the user given by the User/Group directives with some extra capabilities (in particular setuid). Somewhat more secure, but can cause problems when serving from filesystems that do not honor capabilities, such as NFS.
+
+  Values: Boolean.
+
+  Default: `undef`.
+
 ##### Class: `apache::mod::jk`
 
 Installs and manages `mod_jk`, a connector for Apache httpd redirection to old versions of TomCat and JBoss

--- a/manifests/mod/itk.pp
+++ b/manifests/mod/itk.pp
@@ -5,6 +5,7 @@ class apache::mod::itk (
   $serverlimit         = '256',
   $maxclients          = '256',
   $maxrequestsperchild = '4000',
+  $enablecapabilities  = undef,
   $apache_version      = undef,
 ) {
   include ::apache

--- a/spec/classes/mod/itk_spec.rb
+++ b/spec/classes/mod/itk_spec.rb
@@ -34,6 +34,15 @@ describe 'apache::mod::itk', :type => :class do
       it { is_expected.not_to contain_file("/etc/apache2/mods-enabled/itk.load") }
 
       it { is_expected.to contain_package("apache2-mpm-itk") }
+
+      context "with enablecapabilities set" do
+        let :params do
+          super().merge({:enablecapabilities => true})
+        end
+
+        it { is_expected.not_to contain_file('/etc/apache2/mods-available/itk.conf').with_content(
+                /EnableCapabilities/) }
+      end
     end
 
     context "with Apache version >= 2.4" do
@@ -53,6 +62,11 @@ describe 'apache::mod::itk', :type => :class do
         })
       }
       it { is_expected.to contain_file("/etc/apache2/mods-enabled/itk.load").with_ensure('link') }
+
+      context "with enablecapabilities not set" do
+        it { is_expected.not_to contain_file('/etc/apache2/mods-available/itk.conf').with_content(
+                /EnableCapabilities/) }
+      end
     end
   end
   context "on a RedHat OS" do
@@ -84,6 +98,15 @@ describe 'apache::mod::itk', :type => :class do
         'require' => 'Package[httpd]',
         })
       }
+
+      context "with enablecapabilities set" do
+        let :params do
+          super().merge({:enablecapabilities => 'On'})
+        end
+
+        it { is_expected.not_to contain_file('/etc/httpd/conf.d/itk.conf').with_content(
+                /EnableCapabilities/) }
+      end
     end
 
     context "with Apache version >= 2.4" do
@@ -102,6 +125,15 @@ describe 'apache::mod::itk', :type => :class do
         'content' => "LoadModule mpm_itk_module modules/mod_mpm_itk.so\n"
         })
       }
+
+      context "with enablecapabilities set" do
+        let :params do
+          super().merge({:enablecapabilities => false})
+        end
+
+        it { is_expected.to contain_file('/etc/httpd/conf.d/itk.conf').with_content(
+                /EnableCapabilities  Off/) }
+      end
     end
   end
   context "on a FreeBSD OS" do
@@ -126,5 +158,35 @@ describe 'apache::mod::itk', :type => :class do
     it { is_expected.not_to contain_apache__mod('itk') }
     it { is_expected.to contain_file("/usr/local/etc/apache24/Modules/itk.conf").with_ensure('file') }
     it { is_expected.to contain_package("www/mod_mpm_itk") }
+
+    context "with Apache version < 2.4" do
+      let :params do
+        {
+          :apache_version => '2.2',
+        }
+      end
+
+      context "with enablecapabilities not set" do
+        it { is_expected.not_to contain_file('/usr/local/etc/apache24/Modules/itk.conf').with_content(
+                /EnableCapabilities/) }
+      end
+    end
+
+    context "with Apache version >= 2.4" do
+      let :params do
+        {
+          :apache_version => '2.4',
+        }
+      end
+
+      context "with enablecapabilities set" do
+        let :params do
+          super().merge({:enablecapabilities => true})
+        end
+
+        it { is_expected.to contain_file('/usr/local/etc/apache24/Modules/itk.conf').with_content(
+                /EnableCapabilities  On/) }
+      end
+    end
   end
 end

--- a/templates/mod/itk.conf.erb
+++ b/templates/mod/itk.conf.erb
@@ -5,4 +5,7 @@
   ServerLimit         <%= @serverlimit %>
   MaxClients          <%= @maxclients %>
   MaxRequestsPerChild <%= @maxrequestsperchild %>
+  <%- if (not @enablecapabilities.nil?) && (scope.function_versioncmp([@_apache_version, '2.4']) >= 0) -%>
+  EnableCapabilities  <%= scope.function_bool2httpd([@enablecapabilities]) %>
+  <%- end -%>
 </IfModule>


### PR DESCRIPTION
Recently epel has updated the mod_itk package for RedHat:  https://bugzilla.redhat.com/show_bug.cgi?id=1432881

They have compiled with Linux capabilities support, which is enabled by default.
This breaks many existing setups that were using nfs etc that does not support Linux capabilities.

This adds the ability to turn off Linux capabilities and restore functionality on these setups.
