### PR TITLE
(maint) - Removing Debian 6 Support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -47,7 +47,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "6",
         "7",
         "8"
       ]


### PR DESCRIPTION
Removing Debian 6 from metadata. According to
https://docs.puppet.com/pe/latest/sys_req_os.html Debian 6 is no longer
supported.