### PR TITLE
Added listenbacklog to prefork module

### DIFF
--- a/manifests/mod/prefork.pp
+++ b/manifests/mod/prefork.pp
@@ -8,6 +8,7 @@ class apache::mod::prefork (
   $maxrequestsperchild    = '4000',
   $maxconnectionsperchild = undef,
   $apache_version         = undef,
+  $listenbacklog          = '511'
 ) {
   include ::apache
   $_apache_version = pick($apache_version, $apache::apache_version)

--- a/templates/mod/prefork.conf.erb
+++ b/templates/mod/prefork.conf.erb
@@ -13,4 +13,5 @@
   <%- elsif @maxrequestsperchild -%>
   MaxRequestsPerChild    <%= @maxrequestsperchild %>
   <%- end -%>
+  ListenBacklog       <%= @listenbacklog %>
 </IfModule>


### PR DESCRIPTION
worker module has $listenbacklog          = '511',
event module has $listenbacklog          = '511',

I use prefork and I would like to use listenbacklog too.