### PR TITLE
(MODULES-5148) - Add `ldap_trusted_mode` parameter to mod_ldap config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2337,6 +2337,7 @@ Installs and configures [`mod_ldap`][], and allows you to modify the
 class { 'apache::mod::ldap':
   ldap_trusted_global_cert_file => '/etc/pki/tls/certs/ldap-trust.crt',
   ldap_trusted_global_cert_type => 'CA_DER',
+  ldap_trusted_mode             => 'TLS',
   ldap_shared_cache_size        => '500000',
   ldap_cache_entries            => '1024',
   ldap_cache_ttl                => '600',
@@ -2356,6 +2357,8 @@ class { 'apache::mod::ldap':
 * `ldap_trusted_global_cert_type`: Specifies the global trust certificate format.
 
   Default: 'CA_BASE64'.
+
+* `ldap_trusted_mode`: Specifies the SSL/TLS mode to be used when connecting to an LDAP server.
 
 * `ldap_shared_cache_size`: Specifies the size, in bytes, of the shared memory cache.
 

--- a/manifests/mod/ldap.pp
+++ b/manifests/mod/ldap.pp
@@ -8,6 +8,7 @@ class apache::mod::ldap (
   $ldap_cache_ttl                                  = undef,
   $ldap_opcache_entries                            = undef,
   $ldap_opcache_ttl                                = undef,
+  $ldap_trusted_mode                               = undef,
 ){
 
   include ::apache

--- a/spec/classes/mod/ldap_spec.rb
+++ b/spec/classes/mod/ldap_spec.rb
@@ -34,6 +34,7 @@ describe 'apache::mod::ldap', :type => :class do
       let(:params) {{
         :ldap_trusted_global_cert_file => 'ca.pem',
         :ldap_trusted_global_cert_type => 'CA_DER',
+        :ldap_trusted_mode             => 'TLS',
         :ldap_shared_cache_size        => '500000',
         :ldap_cache_entries            => '1024',
         :ldap_cache_ttl                => '600',
@@ -41,6 +42,7 @@ describe 'apache::mod::ldap', :type => :class do
         :ldap_opcache_ttl              => '600'
       }}
       it { is_expected.to contain_file('ldap.conf').with_content(/^LDAPTrustedGlobalCert CA_DER ca\.pem$/) }
+      it { is_expected.to contain_file('ldap.conf').with_content(/^LDAPTrustedMode TLS$/) }
       it { is_expected.to contain_file('ldap.conf').with_content(/^LDAPSharedCacheSize 500000$/) }
       it { is_expected.to contain_file('ldap.conf').with_content(/^LDAPCacheEntries 1024$/) }
       it { is_expected.to contain_file('ldap.conf').with_content(/^LDAPCacheTTL 600$/) }

--- a/templates/mod/ldap.conf.erb
+++ b/templates/mod/ldap.conf.erb
@@ -12,6 +12,9 @@
 <% if @ldap_trusted_global_cert_file -%>
 LDAPTrustedGlobalCert <%= @ldap_trusted_global_cert_type %> <%= @ldap_trusted_global_cert_file %>
 <% end -%>
+<% if @ldap_trusted_mode -%>
+LDAPTrustedMode <%= @ldap_trusted_mode %>
+<% end -%>
 <%- if @ldap_shared_cache_size -%>
 LDAPSharedCacheSize <%= @ldap_shared_cache_size %>
 <%- end -%>


### PR DESCRIPTION
* New param `$ldap_trusted_mode` adding to the `apache::mod::ldap` sub-module.