### PR TITLE
Support for UseCanonicalName On | on | Off | off | DNS | dns

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@
 [template]: http://docs.puppet.com/puppet/latest/reference/lang_template.html
 [`TraceEnable`]: https://httpd.apache.org/docs/current/mod/core.html#traceenable
 
+[`UseCanonicalName`]: https://httpd.apache.org/docs/current/mod/core.html#usecanonicalname
+
 [`verify_config`]: #verify_config
 [`vhost`]: #defined-type-apachevhost
 [`vhost_dir`]: #vhost_dir
@@ -1389,6 +1391,14 @@ Controls how Apache handles `TRACE` requests (per [RFC 2616][]) via the [`TraceE
 Values: 'Off', 'On'.
 
 Default: 'On'.
+
+##### `use_canonical_name`
+
+Controls Apache's [`UseCanonicalName`][] directive which controls how Apache handles self-referential URLs. If not specified, this parameter omits the declaration from the server's configuration and uses Apache's default setting of 'off'.
+
+Values: 'On', 'on', 'Off', 'off', 'DNS', 'dns'.
+
+Default: `undef`.
 
 ##### `use_systemd`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -80,6 +80,8 @@ class apache (
   $trace_enable                                                  = 'On',
   Optional[Enum['on', 'off', 'nodecode']] $allow_encoded_slashes = undef,
   $file_e_tag                                                    = undef,
+  Optional[Enum['On', 'on', 'Off', 'off', 'DNS', 'dns']]
+    $use_canonical_name                                          = undef,
   $package_ensure                                                = 'installed',
   Boolean $use_optional_includes                                 = $::apache::params::use_optional_includes,
   $use_systemd                                                   = $::apache::params::use_systemd,

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -175,6 +175,7 @@ define apache::vhost(
   $cas_login_url                                                                    = undef,
   $cas_validate_url                                                                 = undef,
   $cas_validate_saml                                                                = undef,
+  Optional[Enum['On', 'on', 'Off', 'off', 'DNS', 'dns']] $use_canonical_name        = undef,
 ) {
 
   # The base class must be included first because it is used by parameter defaults
@@ -1064,6 +1065,16 @@ define apache::vhost(
       target  => "${priority_real}${filename}.conf",
       order   => 350,
       content => template('apache/vhost/_http_protocol_options.erb'),
+    }
+  }
+
+  # Template uses:
+  # - $use_canonical_name
+  if $use_canonical_name {
+    concat::fragment { "${name}-use_canonical_name":
+      target  => "${priority_real}${filename}.conf",
+      order   => 360,
+      content => template('apache/vhost/_use_canonical_name.erb'),
     }
   }
 

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -118,6 +118,14 @@ describe 'apache', :type => :class do
       it { is_expected.to contain_file("/etc/apache2/apache2.conf").with_content %r{^FileETag None$} }
     end
 
+    context "when specifying canonical name behaviour" do
+      let :params do
+        { :use_canonical_name => 'dns' }
+      end
+
+      it { is_expected.to contain_file("/etc/apache2/apache2.conf").with_content %r{^UseCanonicalName dns$} }
+    end
+
     context "when specifying default character set" do
       let :params do
         { :default_charset => 'none' }

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -392,6 +392,7 @@ describe 'apache::vhost', :type => :define do
           'use_optional_includes'       => true,
           'suexec_user_group'           => 'root root',
           'allow_encoded_slashes'       => 'nodecode',
+          'use_canonical_name'          => 'dns',
           'passenger_spawn_method'      => 'direct',
           'passenger_app_root'          => '/usr/share/myapp',
           'passenger_app_env'           => 'test',

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -68,6 +68,9 @@ AllowEncodedSlashes <%= @allow_encoded_slashes %>
 <%- if @file_e_tag -%>
 FileETag <%= @file_e_tag %>
 <%- end -%>
+<%- if @use_canonical_name -%>
+UseCanonicalName <%= @use_canonical_name %>
+<%- end -%>
 
 #Listen 80
 

--- a/templates/vhost/_use_canonical_name.erb
+++ b/templates/vhost/_use_canonical_name.erb
@@ -1,0 +1,4 @@
+<%- if @use_canonical_name -%>
+
+  UseCanonicalName <%= @use_canonical_name %>
+<%- end -%>


### PR DESCRIPTION
apache and apache::vhost support for UseCanonicalName. This directive
controls how Apache uses self-referential URLs.