### PR TITLE
Reduce Travis test parallelism

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ script: "bundle exec rake release_checks"
 #Inserting below due to the following issue: https://github.com/travis-ci/travis-ci/issues/3531#issuecomment-88311203
 before_install:
   - gem update bundler
+# Reduce load on Travis servers to prevent tests from being killed
+env:
+  global:
+  - PARALLEL_TEST_PROCESSORS=16
 matrix:
   fast_finish: true
   include:


### PR DESCRIPTION
Set the maximum parallel test processors to 16, to reduce the load on the Travis servers and prevent tests from being killed.

(This is needed in order for the tests for #1659 to not fail, but is not directly related to that PR, so I'm introducing it in an independent PR)