### PR TITLE
Add attributes owner and group to apache::custom_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -3042,6 +3042,20 @@ Boolean.
 
 Default: `true`.
 
+##### `owner`
+
+Specifies the owner of the configuration file. Default: 'root'.
+
+##### `group`
+
+Specifies the group of the configuration file. Default: Depends on your operating system.
+
+- **Debian**: `root`
+- **FreeBSD**: `wheel`
+- **Gentoo**: `wheel`
+- **Red Hat**: `root`
+- **Suse**: `root`
+
 #### Defined type: `apache::fastcgi::server`
 
 Defines one or more external FastCGI servers to handle specific file types. Use this defined type with [`mod_fastcgi`][FastCGI].

--- a/manifests/custom_config.pp
+++ b/manifests/custom_config.pp
@@ -8,6 +8,8 @@ define apache::custom_config (
   $verify_command                   = $::apache::params::verify_command,
   Boolean $verify_config            = true,
   $filename                         = undef,
+  $owner                            = 'root',
+  $group                            = $::apache::params::root_group,
 ) {
 
   if $content and $source {
@@ -45,6 +47,8 @@ define apache::custom_config (
     source  => $source,
     require => Package['httpd'],
     notify  => $notifies,
+    owner   => $owner,
+    group   => $group,
   }
 
   if $ensure == 'present' and $verify_config {


### PR DESCRIPTION
If the file is owned by user bob UID 1005 on the Puppet server, then it will be owned by the user with UID 1005 on the node where the file is deployed. But on that node maybe UID 1005 is Max. That can lead to a security risk.
So it would be nice to be able to specify the owner (and group) of the file in the class apache::custom_config.