### PR TITLE
Fix case of setting apache::mpm_module to false

### DIFF
--- a/manifests/mod/cgi.pp
+++ b/manifests/mod/cgi.pp
@@ -1,9 +1,14 @@
 class apache::mod::cgi {
+  include ::apache
   case $::osfamily {
     'FreeBSD': {}
     default: {
-      if $::apache::mpm_module =~ /^(itk|peruser|prefork)$/ {
-        Class["::apache::mod::${::apache::mpm_module}"] -> Class['::apache::mod::cgi']
+      if defined(Class['::apache::mod::itk']) {
+        Class['::apache::mod::itk'] -> Class['::apache::mod::cgi']
+      } elsif defined(Class['::apache::mod::peruser']) {
+        Class['::apache::mod::peruser'] -> Class['::apache::mod::cgi']
+      } else {
+        Class['::apache::mod::prefork'] -> Class['::apache::mod::cgi']
       }
     }
   }


### PR DESCRIPTION
This commit: https://github.com/puppetlabs/puppetlabs-apache/commit/0dcfa2a0109fc98a5fae76fb55cc9f4dbbb1c48c#diff-2c378354f8ec309dd88357170e38035d

Breaks a common setup of setting  $::apache::mpm_module to false and declaring your own mpm module to set params etc. and results in the following error:
```

Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Left match operand must result in a String value. Got a Boolean. at /etc/puppetlabs/code/environments/production/modules/apache/manifests/mod/cgi.pp:5:10
```

This restores that functionality while still maintaining the intent of the original commit.
The net effect should be the same, but it handles more cases better.