### PR TITLE
[MODULES-5644] Package name is libapache2-mpm-itk for Debian 9

### DIFF
--- a/manifests/mpm.pp
+++ b/manifests/mpm.pp
@@ -83,7 +83,7 @@ define apache::mpm (
         }
       }
 
-      if $mpm == 'itk' and $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '16.04' {
+      if $mpm == 'itk' and ( ( $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '16.04' ) or ( $::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '9.0.0') >= 0 ) ) {
         $packagename = 'libapache2-mpm-itk'
       } else {
         $packagename = "apache2-mpm-${mpm}"


### PR DESCRIPTION
This PR superseeds #1699 and #1713 

It does basically the same as #1699 but 
* without introducing fact operatingsystemmajrelease instead it uses operatingsystemrelease so the tests do not have to be altered…
* using versioncmp for robustness