### PR TITLE
Dont run task setup on LTS

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -28,7 +28,7 @@ RSpec.configure do |c|
 
   # Configure all nodes in nodeset
   c.before :suite do
-    run_puppet_access_login(user: 'admin') if pe_install?
+    run_puppet_access_login(user: 'admin') if pe_install? && puppet_version =~ %r{(5\.\d\.\d)}
     # net-tools required for netstat utility being used by be_listening
     if fact('osfamily') == 'RedHat' && fact('operatingsystemmajrelease') == '7'
       pp = <<-EOS


### PR DESCRIPTION
Tasks only work on builds with a puppet agent version of 5 or greater.
Adding logic to skip the task setup.