### PR TITLE
Set default keepalive to on in all distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -1095,7 +1095,7 @@ Determines whether to enable persistent HTTP connections with the [`KeepAlive`][
 
 Values: 'Off', 'On'.
 
-Default: 'Off'.
+Default: 'On'.
 
 ##### `keepalive_timeout`
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -151,7 +151,7 @@ class apache::params inherits ::apache::version {
     }
     $conf_template        = 'apache/httpd.conf.erb'
     $http_protocol_options  = undef
-    $keepalive            = 'On'
+    $keepalive            = 'Off'
     $keepalive_timeout    = 15
     $max_keepalive_requests = 100
     $fastcgi_lib_path     = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -302,7 +302,7 @@ class apache::params inherits ::apache::version {
     }
     $conf_template          = 'apache/httpd.conf.erb'
     $http_protocol_options  = undef
-    $keepalive              = 'Off'
+    $keepalive              = 'On'
     $keepalive_timeout      = 15
     $max_keepalive_requests = 100
     $fastcgi_lib_path       = '/var/lib/apache2/fastcgi'
@@ -427,7 +427,7 @@ class apache::params inherits ::apache::version {
     }
     $conf_template        = 'apache/httpd.conf.erb'
     $http_protocol_options = undef
-    $keepalive            = 'Off'
+    $keepalive            = 'On'
     $keepalive_timeout    = 15
     $max_keepalive_requests = 100
     $fastcgi_lib_path     = undef # TODO: revisit
@@ -494,7 +494,7 @@ class apache::params inherits ::apache::version {
     }
     $conf_template        = 'apache/httpd.conf.erb'
     $http_protocol_options = undef
-    $keepalive            = 'Off'
+    $keepalive            = 'On'
     $keepalive_timeout    = 15
     $max_keepalive_requests = 100
     $fastcgi_lib_path     = undef # TODO: revisit
@@ -560,7 +560,7 @@ class apache::params inherits ::apache::version {
     }
     $conf_template          = 'apache/httpd.conf.erb'
     $http_protocol_options  = undef
-    $keepalive              = 'Off'
+    $keepalive              = 'On'
     $keepalive_timeout      = 15
     $max_keepalive_requests = 100
     $fastcgi_lib_path       = '/var/lib/apache2/fastcgi'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -151,7 +151,7 @@ class apache::params inherits ::apache::version {
     }
     $conf_template        = 'apache/httpd.conf.erb'
     $http_protocol_options  = undef
-    $keepalive            = 'Off'
+    $keepalive            = 'On'
     $keepalive_timeout    = 15
     $max_keepalive_requests = 100
     $fastcgi_lib_path     = undef


### PR DESCRIPTION
According to README, $keepalive is off by default but only RedHat and Amazon are set to on.