### PR TITLE
Actually create CASScrubRequestHeaders setting in _auth_cas.erb

### DIFF
--- a/templates/vhost/_auth_cas.erb
+++ b/templates/vhost/_auth_cas.erb
@@ -60,6 +60,6 @@
   CASAttributeDelimiter <%= @cas_attribute_delimiter %>
   <%- end -%>
   <%- if @cas_scrub_request_headers -%>
-  CASAttributeDelimiter On
+  CASScrubRequestHeaders On
   <%- end -%>
 <%- end -%>


### PR DESCRIPTION
Fix `templates/vhost/_auth_cas.erb` to create the proper `CASScrubRequestHeaders` setting when passed `@cas_scrub_request_headers`, rather than (re-)creating `CASAttributeDelimiter`.