### PR TITLE
MODULES-6224: rename apache mod ldap file

### DIFF
--- a/manifests/mod/ldap.pp
+++ b/manifests/mod/ldap.pp
@@ -17,7 +17,7 @@ class apache::mod::ldap (
     package => $package_name,
   }
   # Template uses $_apache_version
-  file { 'ldap.conf':
+  file { 'apache-mod-ldap.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/ldap.conf",
     mode    => $::apache::file_mode,

--- a/spec/classes/mod/ldap_spec.rb
+++ b/spec/classes/mod/ldap_spec.rb
@@ -22,12 +22,12 @@ describe 'apache::mod::ldap', :type => :class do
     it { is_expected.to contain_apache__mod('ldap') }
 
     context 'default ldap_trusted_global_cert_file' do
-      it { is_expected.to contain_file('ldap.conf').without_content(/^LDAPTrustedGlobalCert/) }
+      it { is_expected.to contain_file('apache-mod-ldap.conf').without_content(/^LDAPTrustedGlobalCert/) }
     end
 
     context 'ldap_trusted_global_cert_file param' do
       let(:params) { { :ldap_trusted_global_cert_file => 'ca.pem' } }
-      it { is_expected.to contain_file('ldap.conf').with_content(/^LDAPTrustedGlobalCert CA_BASE64 ca\.pem$/) }
+      it { is_expected.to contain_file('apache-mod-ldap.conf').with_content(/^LDAPTrustedGlobalCert CA_BASE64 ca\.pem$/) }
     end
 
     context 'set multiple ldap params' do
@@ -41,13 +41,13 @@ describe 'apache::mod::ldap', :type => :class do
         :ldap_opcache_entries          => '1024',
         :ldap_opcache_ttl              => '600'
       }}
-      it { is_expected.to contain_file('ldap.conf').with_content(/^LDAPTrustedGlobalCert CA_DER ca\.pem$/) }
-      it { is_expected.to contain_file('ldap.conf').with_content(/^LDAPTrustedMode TLS$/) }
-      it { is_expected.to contain_file('ldap.conf').with_content(/^LDAPSharedCacheSize 500000$/) }
-      it { is_expected.to contain_file('ldap.conf').with_content(/^LDAPCacheEntries 1024$/) }
-      it { is_expected.to contain_file('ldap.conf').with_content(/^LDAPCacheTTL 600$/) }
-      it { is_expected.to contain_file('ldap.conf').with_content(/^LDAPOpCacheEntries 1024$/) }
-      it { is_expected.to contain_file('ldap.conf').with_content(/^LDAPOpCacheTTL 600$/) }
+      it { is_expected.to contain_file('apache-mod-ldap.conf').with_content(/^LDAPTrustedGlobalCert CA_DER ca\.pem$/) }
+      it { is_expected.to contain_file('apache-mod-ldap.conf').with_content(/^LDAPTrustedMode TLS$/) }
+      it { is_expected.to contain_file('apache-mod-ldap.conf').with_content(/^LDAPSharedCacheSize 500000$/) }
+      it { is_expected.to contain_file('apache-mod-ldap.conf').with_content(/^LDAPCacheEntries 1024$/) }
+      it { is_expected.to contain_file('apache-mod-ldap.conf').with_content(/^LDAPCacheTTL 600$/) }
+      it { is_expected.to contain_file('apache-mod-ldap.conf').with_content(/^LDAPOpCacheEntries 1024$/) }
+      it { is_expected.to contain_file('apache-mod-ldap.conf').with_content(/^LDAPOpCacheTTL 600$/) }
     end
   end #Debian
 
@@ -69,12 +69,12 @@ describe 'apache::mod::ldap', :type => :class do
     it { is_expected.to contain_apache__mod('ldap') }
 
     context 'default ldap_trusted_global_cert_file' do
-      it { is_expected.to contain_file('ldap.conf').without_content(/^LDAPTrustedGlobalCert/) }
+      it { is_expected.to contain_file('apache-mod-ldap.conf').without_content(/^LDAPTrustedGlobalCert/) }
     end
 
     context 'ldap_trusted_global_cert_file param' do
       let(:params) { { :ldap_trusted_global_cert_file => 'ca.pem' } }
-      it { is_expected.to contain_file('ldap.conf').with_content(/^LDAPTrustedGlobalCert CA_BASE64 ca\.pem$/) }
+      it { is_expected.to contain_file('apache-mod-ldap.conf').with_content(/^LDAPTrustedGlobalCert CA_BASE64 ca\.pem$/) }
     end
 
     context 'ldap_trusted_global_cert_file and ldap_trusted_global_cert_type params' do
@@ -82,7 +82,7 @@ describe 'apache::mod::ldap', :type => :class do
         :ldap_trusted_global_cert_file => 'ca.pem',
         :ldap_trusted_global_cert_type => 'CA_DER'
       }}
-      it { is_expected.to contain_file('ldap.conf').with_content(/^LDAPTrustedGlobalCert CA_DER ca\.pem$/) }
+      it { is_expected.to contain_file('apache-mod-ldap.conf').with_content(/^LDAPTrustedGlobalCert CA_DER ca\.pem$/) }
     end
   end # Redhat
 end


### PR DESCRIPTION
I consider config file for apache mod ldap `file` resource to have an "out of scope" name `ldap.conf` which may collide with the client-side config file ldap.conf (i.e. located in `/etc/ldap.conf` or `/etc/openldap/ldap.conf`).

My suggestion: renaming this file resource into `apache-mod-ldap.conf` in `manifests/mod/ldap.pp` and into the related `spec/classes/mod/ldap_spec.rb` file.

Here is the link to the [JIra issue](https://tickets.puppetlabs.com/browse/MODULES-6224)