### PR TITLE
#puppethack Reduce Travis test parallelism, take 2

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -6,3 +6,7 @@ Rakefile:
   - 'disable_only_variable_string'
 spec/spec_helper.rb:
   allow_deprecations: true
+.travis.yml:
+  env:
+    global:
+      - "PARALLEL_TEST_PROCESSORS=16 # reduce test parallelism to prevent overloading containers"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ script: "bundle exec rake release_checks"
 #Inserting below due to the following issue: https://github.com/travis-ci/travis-ci/issues/3531#issuecomment-88311203
 before_install:
   - gem update bundler
+env:
+  global:
+    - PARALLEL_TEST_PROCESSORS=16 # reduce test parallelism to prevent overloading containers
 matrix:
   fast_finish: true
   include:


### PR DESCRIPTION
Set the environment variable `PARALLEL_TEST_PROCESSOR` in the global `env` section to avoid overloading the Travis testing containers and killing the tests.
Also add this to `.sync.yml` so it will be permanent (unlike my previous attempt at this).