### PR TITLE
Make section discussing php_values parameter a little more clear.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3945,11 +3945,16 @@ Default: `undef`.
 
 Sets the [`PassengerStartupFile`](https://www.phusionpassenger.com/library/config/apache/reference/#passengerstartupfile) path. This path is relative to the application root.
 
-##### `php_flags & values`
+##### `php_values & php_flags`
 
 Allows per-virtual host setting [`php_value`s or `php_flag`s](http://php.net/manual/en/configuration.changes.php). These flags or values can be overwritten by a user or an application.
 
 Default: '{}'.
+
+Within a vhost declaration:
+``` puppet
+  php_values    => [ 'include_path ".:/usr/local/example-app/include"' ],
+```
 
 ##### `php_admin_flags & values`
 


### PR DESCRIPTION
Minor README.md tweak for php_values, along with example usage.