### PR TITLE
Add LimitRequestFields parameter in main configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1517,7 +1517,7 @@ Default: Depends on operating system:
 
 ##### `limitreqfields`
 
-The [limitreqfields][] parameter sets the maximum number of request header fields in an HTTP request. This directive gives the server administrator greater control over abnormal client request behavior, which may be useful for avoiding some forms of denial-of-service attacks. The value should be increased if normal clients see an error response from the server that indicates too many fields were sent in the request.
+The [`limitreqfields`][] parameter sets the maximum number of request header fields in an HTTP request. This directive gives the server administrator greater control over abnormal client request behavior, which may be useful for avoiding some forms of denial-of-service attacks. The value should be increased if normal clients see an error response from the server that indicates too many fields were sent in the request.
 
 Default: '100'
 

--- a/README.md
+++ b/README.md
@@ -1517,7 +1517,7 @@ Default: Depends on operating system:
 
 ##### `limitreqfields`
 
-The [limitreqfieldsize][] parameter sets the maximum number of request header fields in an HTTP request. This directive gives the server administrator greater control over abnormal client request behavior, which may be useful for avoiding some forms of denial-of-service attacks. The value should be increased if normal clients see an error response from the server that indicates too many fields were sent in the request.
+The [limitreqfields][] parameter sets the maximum number of request header fields in an HTTP request. This directive gives the server administrator greater control over abnormal client request behavior, which may be useful for avoiding some forms of denial-of-service attacks. The value should be increased if normal clients see an error response from the server that indicates too many fields were sent in the request.
 
 Default: '100'
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@
 [`keepalive` parameter]: #keepalive
 [`keepalive_timeout`]: #keepalive_timeout
 [`limitreqfieldsize`]: https://httpd.apache.org/docs/current/mod/core.html#limitrequestfieldsize
+[`limitreqfields`]: http://httpd.apache.org/docs/current/mod/core.html#limitrequestfields
 
 [`lib`]: #lib
 [`lib_path`]: #lib_path
@@ -1513,6 +1514,12 @@ Default: Depends on operating system:
 - **Gentoo**: 'access.log'
 - **Red Hat**: 'access_log'
 - **Suse**: 'access.log'
+
+##### `limitreqfields`
+
+The [limitreqfieldsize][] parameter sets the maximum number of request header fields in an HTTP request. This directive gives the server administrator greater control over abnormal client request behavior, which may be useful for avoiding some forms of denial-of-service attacks. The value should be increased if normal clients see an error response from the server that indicates too many fields were sent in the request.
+
+Default: '100'
 
 #### Class: `apache::dev`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,6 +67,7 @@ class apache (
   $keepalive_timeout                                             = $::apache::params::keepalive_timeout,
   $max_keepalive_requests                                        = $::apache::params::max_keepalive_requests,
   $limitreqfieldsize                                             = '8190',
+  $limitreqfields                                                = '100',
   $logroot                                                       = $::apache::params::logroot,
   $logroot_mode                                                  = $::apache::params::logroot_mode,
   $log_level                                                     = $::apache::params::log_level,

--- a/spec/acceptance/apache_parameters_spec.rb
+++ b/spec/acceptance/apache_parameters_spec.rb
@@ -399,6 +399,20 @@ describe 'apache parameters' do
     end
   end
 
+  describe 'limitrequestfields' do
+    describe 'setup' do
+      it 'applies cleanly' do
+        pp = "class { 'apache': limitreqfields => '120' }"
+        apply_manifest(pp, :catch_failures => true)
+      end
+    end
+
+    describe file($conf_file) do
+      it { is_expected.to be_file }
+      it { is_expected.to contain 'LimitRequestFields 120' }
+    end
+  end
+
   describe 'logging' do
     describe 'setup' do
       it 'applies cleanly' do

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -11,6 +11,7 @@ KeepAlive <%= @keepalive %>
 MaxKeepAliveRequests <%= @max_keepalive_requests %>
 KeepAliveTimeout <%= @keepalive_timeout %>
 LimitRequestFieldSize <%= @limitreqfieldsize %>
+LimitRequestFields <%= @limitreqfields %>
 <%# Actually >= 2.4.24, but the minor version is not provided -%>
 <%- if @http_protocol_options and scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
 HttpProtocolOptions <%= @http_protocol_options %>


### PR DESCRIPTION
Hello,

I need to configure this parameter : LimitRequestFields (http://httpd.apache.org/docs/current/mod/core.html#limitrequestfields) but it is not managed by your module yet.

So I took the liberty to add this parameter in the init.pp file (with a value at '100', which is the default value in apache) and in the httpd.conf template.

Successfully tested on Debian 8.9 and apache 2.4.10.

Thanks