### PR TITLE
use of puppet4 functions-api

### DIFF
--- a/lib/puppet/functions/apache/apache_pw_hash.rb
+++ b/lib/puppet/functions/apache/apache_pw_hash.rb
@@ -1,0 +1,15 @@
+# Hashes a password in a format suitable for htpasswd files read by apache.
+#
+# Currently uses SHA-hashes, because although this format is considered insecure, its the
+# most secure format supported by the most platforms.
+Puppet::Functions.create_function(:'apache::apache_pw_hash') do
+  dispatch :apache_pw_hash do
+    required_param 'String[1]', :password
+    return_type 'String'
+  end
+
+  def apache_pw_hash(password)
+    require 'base64'
+    return '{SHA}' + Base64.strict_encode64(Digest::SHA1.digest(password))
+  end
+end

--- a/lib/puppet/functions/apache/bool2httpd.rb
+++ b/lib/puppet/functions/apache/bool2httpd.rb
@@ -1,0 +1,25 @@
+# Transform a supposed boolean to On or Off. Pass all other values through.
+# Given a nil value (undef), bool2httpd will return 'Off'
+#
+# Example:
+#
+#    $trace_enable     = false
+#    $server_signature = 'mail'
+#
+#    bool2httpd($trace_enable)
+#    # => 'Off'
+#    bool2httpd($server_signature)
+#    # => 'mail'
+#    bool2httpd(undef)
+#    # => 'Off'
+Puppet::Functions.create_function(:'apache::bool2httpd') do
+  def bool2httpd(arg)
+    if arg.nil? or arg == false or arg =~ /false/i or arg == :undef
+      return 'Off'
+    elsif arg == true or arg =~ /true/i
+      return 'On'
+    end
+
+    return arg.to_s
+  end
+end

--- a/lib/puppet/functions/apache/validate_apache_log_level.rb
+++ b/lib/puppet/functions/apache/validate_apache_log_level.rb
@@ -1,0 +1,22 @@
+#    Perform simple validation of a string against the list of known log
+#    levels as per http://httpd.apache.org/docs/current/mod/core.html#loglevel
+#        validate_apache_loglevel('info')
+#
+#    Modules maybe specified with their own levels like these:
+#        validate_apache_loglevel('warn ssl:info')
+#        validate_apache_loglevel('warn mod_ssl.c:info')
+#        validate_apache_loglevel('warn ssl_module:info')
+#
+#    Expected to be used from the main or vhost.
+#    
+#    Might be used from directory too later as apache supports that
+Puppet::Functions.create_function(:'apache::validate_apache_log_level') do
+  dispatch :validate_apache_log_level do
+    required_param 'String', :log_level
+  end
+
+  def validate_apache_log_level (log_level)
+    msg = "Log level '${log_level}' is not one of the supported Apache HTTP Server log levels."
+    raise Puppet::ParseError, (msg) unless log_level =~ Regexp.compile('(emerg|alert|crit|error|warn|notice|info|debug|trace[1-8])')
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -147,7 +147,7 @@ class apache (
     }
   }
 
-  validate_apache_log_level($log_level)
+  apache::validate_apache_log_level($log_level)
 
   class { '::apache::service':
     service_name    => $service_name,

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -194,7 +194,7 @@ define apache::vhost(
   # Input validation begins
 
   if $log_level {
-    validate_apache_log_level($log_level)
+    apache::validate_apache_log_level($log_level)
   }
 
   if $access_log_file and $access_log_pipe {

--- a/spec/functions/apache_pw_hash_spec.rb
+++ b/spec/functions/apache_pw_hash_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'apache::apache_pw_hash' do
+
+  it { is_expected.not_to eq(nil) }
+  it { is_expected.to run.with_params.and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params("").and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params(1).and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params(true).and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params({}).and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params([]).and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params("test").and_return('{SHA}qUqP5cyxm6YcTAhz05Hph5gvu9M=') }
+end

--- a/spec/functions/bool2httpd_spec.rb
+++ b/spec/functions/bool2httpd_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe 'apache::bool2httpd' do
+
+  it { is_expected.not_to eq(nil) }
+  it { is_expected.to run.with_params.and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params('1', '2').and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params(true).and_return('On') }
+  it 'should return a string "On"' do
+    expect(subject.execute(true)).to be_an_instance_of(String)
+  end
+  it { is_expected.to run.with_params(false).and_return('Off') }
+  it 'should return a string "Off"' do
+    expect(subject.execute(false)).to be_an_instance_of(String)
+  end
+  it { is_expected.to run.with_params('mail').and_return('mail') }
+  it { is_expected.to run.with_params(nil).and_return('Off') }
+  it { is_expected.to run.with_params(:undef).and_return('Off') }
+  it { is_expected.to run.with_params('foo').and_return('foo') }
+end

--- a/spec/functions/validate_apache_log_level_spec.rb
+++ b/spec/functions/validate_apache_log_level_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'apache::validate_apache_log_level' do
+
+  it { is_expected.not_to eq(nil) }
+  it { is_expected.to run.with_params.and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params('garbage').and_raise_error(Puppet::ParseError) }
+  it { is_expected.to run.with_params('info') }
+  it { is_expected.to run.with_params('warn ssl:info') }
+  it { is_expected.to run.with_params('warn mod_ssl.c:info') }
+  it { is_expected.to run.with_params('warn ssl_module:info') }
+  it { is_expected.to run.with_params('trace4') }
+end

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -1,7 +1,7 @@
 # Security
 ServerTokens <%= @server_tokens %>
-ServerSignature <%= scope.function_bool2httpd([@server_signature]) %>
-TraceEnable <%= scope.function_bool2httpd([@trace_enable]) %>
+ServerSignature <%= scope.call_function('apache::bool2httpd', [@server_signature]) %>
+TraceEnable <%= scope.call_function('apache::bool2httpd', [@trace_enable]) %>
 
 ServerName "<%= @servername %>"
 ServerRoot "<%= @server_root %>"

--- a/templates/mod/cluster.conf.erb
+++ b/templates/mod/cluster.conf.erb
@@ -8,10 +8,10 @@ Listen <%= @ip %>:<%= @port %>
 
   KeepAliveTimeout <%= @keep_alive_timeout %>
   MaxKeepAliveRequests <%= @max_keep_alive_requests %>
-  EnableMCPMReceive <%= scope.function_bool2httpd([@enable_mcpm_receive]) %>
+  EnableMCPMReceive <%= scope.call_function('apache::bool2httpd', [@enable_mcpm_receive]) %>
 
   ManagerBalancerName <%= @balancer_name %>
-  ServerAdvertise <%= scope.function_bool2httpd([@server_advertise]) %>
+  ServerAdvertise <%= scope.call_function('apache::bool2httpd', [@server_advertise]) %>
   <%- if @server_advertise == true and @advertise_frequency != nil -%>
   AdvertiseFrequency <%= @advertise_frequency %>
   <%- end -%>

--- a/templates/mod/expires.conf.erb
+++ b/templates/mod/expires.conf.erb
@@ -1,4 +1,4 @@
-ExpiresActive <%= scope.function_bool2httpd([@expires_active]) %>
+ExpiresActive <%= scope.call_function('apache::bool2httpd', [@expires_active]) %>
 <%- if ! @expires_default.nil? and ! @expires_default.empty? -%>
 ExpiresDefault "<%= @expires_default %>"
 <%- end -%>

--- a/templates/mod/geoip.conf.erb
+++ b/templates/mod/geoip.conf.erb
@@ -1,4 +1,4 @@
-GeoIPEnable <%= scope.function_bool2httpd([@enable]) %>
+GeoIPEnable <%= scope.call_function('apache::bool2httpd', [@enable]) %>
 
 <%- if @db_file and ! [ false, 'false', '' ].include?(@db_file) -%>
     <%- if @db_file.kind_of?(Array) -%>
@@ -11,7 +11,7 @@ GeoIPDBFile <%= @db_file %> <%= @flag %>
 <%- end -%>
 GeoIPOutput <%= @output %>
 <% if ! @enable_utf8.nil? -%>
-GeoIPEnableUTF8 <%= scope.function_bool2httpd([@enable_utf8]) %>
+GeoIPEnableUTF8 <%= scope.call_function('apache::bool2httpd', [@enable_utf8]) %>
 <% end -%>
 <% if ! @scan_proxy_headers.nil? -%>
 GeoIPScanProxyHeaders <%= scope.function_bool2httpd([@scan_proxy_headers]) %>

--- a/templates/mod/ssl.conf.erb
+++ b/templates/mod/ssl.conf.erb
@@ -13,20 +13,20 @@
   <%- if scope.function_versioncmp([@_apache_version, '2.4']) >= 0 -%>
   Mutex <%= @_ssl_mutex %>
     <%- if @ssl_compression -%>
-  SSLCompression <%= scope.function_bool2httpd([@ssl_compression]) %>
+  SSLCompression <%= scope.call_function('apache::bool2httpd', [@ssl_compression]) %>
     <%- end -%>
   <%- else -%>
   SSLMutex <%= @_ssl_mutex %>
   <%- end -%>
   SSLCryptoDevice <%= @ssl_cryptodevice %>
-  SSLHonorCipherOrder <%= scope.function_bool2httpd([@_ssl_honorcipherorder]) %>
+  SSLHonorCipherOrder <%= scope.call_function('apache::bool2httpd', [@_ssl_honorcipherorder]) %>
   <%- if @ssl_ca -%>
   SSLCACertificateFile    "<%= @ssl_ca %>"
   <%- end -%>
 <% if scope.function_versioncmp([@_apache_version, '2.4']) >= 0 -%>
-  SSLUseStapling <%= scope.function_bool2httpd([@ssl_stapling]) %>
+  SSLUseStapling <%= scope.call_function('apache::bool2httpd', [@ssl_stapling]) %>
   <%- if not @ssl_stapling_return_errors.nil? -%>
-  SSLStaplingReturnResponderErrors <%= scope.function_bool2httpd([@ssl_stapling_return_errors]) %>
+  SSLStaplingReturnResponderErrors <%= scope.call_function('apache::bool2httpd', [@ssl_stapling_return_errors]) %>
   <%- end -%>
   SSLStaplingCache "shmcb:<%= @stapling_cache %>"
 <% end -%>

--- a/templates/mod/wsgi.conf.erb
+++ b/templates/mod/wsgi.conf.erb
@@ -2,7 +2,7 @@
 # managed by Puppet an changes will be overwritten.
 <IfModule mod_wsgi.c>
   <%- if @wsgi_restrict_embedded -%>
-  WSGIRestrictEmbedded <%= scope.function_bool2httpd([@wsgi_restrict_embedded]) %>
+  WSGIRestrictEmbedded <%= scope.call_function('apache::bool2httpd', [@wsgi_restrict_embedded]) %>
   <%- end -%>
   <%- if @wsgi_socket_prefix -%>
   WSGISocketPrefix <%= @wsgi_socket_prefix %>

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -36,7 +36,7 @@
       <%- end -%>
     <%- end -%>
     <%- if ! directory['geoip_enable'].nil? -%>
-    GeoIPEnable <%= scope.function_bool2httpd([directory['geoip_enable']]) %>
+    GeoIPEnable <%= scope.call_function('apache::bool2httpd', [directory['geoip_enable']]) %>
     <%- end -%>
     <%- if directory['options'] -%>
     Options <%= Array(directory['options']).join(' ') %>
@@ -126,7 +126,7 @@
     <%- if directory['dav'] -%>
     Dav <%= directory['dav'] %>
     <%- if directory['dav_depth_infinity'] -%>
-    DavDepthInfinity <%= scope.function_bool2httpd([directory['dav_depth_infinity']]) %>
+    DavDepthInfinity <%= scope.call_function('apache::bool2httpd', [directory['dav_depth_infinity']]) %>
     <%- end -%>
     <%- if directory['dav_min_timeout'] -%>
     DavMinTimeout <%= directory['dav_min_timeout'] %>

--- a/templates/vhost/_passenger.erb
+++ b/templates/vhost/_passenger.erb
@@ -26,13 +26,13 @@
   PassengerUser <%= @passenger_user %>
 <% end -%>
 <% if @passenger_high_performance -%>
-  PassengerHighPerformance <%= scope.function_bool2httpd([@passenger_high_performance]) %>
+  PassengerHighPerformance <%= scope.call_function('apache::bool2httpd', [@passenger_high_performance]) %>
 <% end -%>
 <% if @passenger_nodejs -%>
   PassengerNodejs <%= @passenger_nodejs -%>
 <% end -%>
 <% if @passenger_sticky_sessions -%>
-  PassengerStickySessions <%= scope.function_bool2httpd([@passenger_sticky_sessions]) %>
+  PassengerStickySessions <%= scope.call_function('apache::bool2httpd', [@passenger_sticky_sessions]) %>
 <% end -%>
 <% if @passenger_startup_file -%>
   PassengerStartupFile <%= @passenger_startup_file -%>

--- a/templates/vhost/_ssl.erb
+++ b/templates/vhost/_ssl.erb
@@ -44,12 +44,12 @@
   SSLOpenSSLConfCmd       <%= @ssl_openssl_conf_cmd %>
   <%- end -%>
   <%- if (not @ssl_stapling.nil?) && (scope.function_versioncmp([@apache_version, '2.4']) >= 0) -%>
-  SSLUseStapling <%= scope.function_bool2httpd([@ssl_stapling]) %>
+  SSLUseStapling <%= scope.call_function('apache::bool2httpd', [@ssl_stapling]) %>
   <%- end -%>
   <%- if @ssl_stapling_timeout && scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
   SSLStaplingResponderTimeout <%= @ssl_stapling_timeout %>
   <%- end -%>
   <%- if (not @ssl_stapling_return_errors.nil?) && (scope.function_versioncmp([@apache_version, '2.4']) >= 0) -%>
-  SSLStaplingReturnResponderErrors <%= scope.function_bool2httpd([@ssl_stapling_return_errors]) %>
+  SSLStaplingReturnResponderErrors <%= scope.call_function('apache::bool2httpd', [@ssl_stapling_return_errors]) %>
   <%- end -%>
 <% end -%>


### PR DESCRIPTION
The legacy puppet3 functions-api should be avoided.
This migrates the existing functions to the new api and uses it in the module. It also adds the tests for the new functions based on those for the olds.
We should keep the legacy functions for now to allow compatibility for those using the functions outside out this module.