### PR TITLE
(maint) Disable shibb testing on redhats and ipv6 testing without ipv6

### DIFF
--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -1714,7 +1714,7 @@ describe 'apache::vhost define' do
     end
   end
 
-  describe 'shibboleth parameters' do
+  describe 'shibboleth parameters', :unless => fact('osfamily') == 'RedHat' do
     it 'applies cleanly' do
       pp = <<-EOS
         class { 'apache': }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -16,6 +16,10 @@ RSpec.configure do |c|
   if fact('operatingsystem') == 'Ubuntu' and (fact('operatingsystemrelease') == '10.04' or fact('operatingsystemrelease') == '12.04')
     c.filter_run_excluding :ipv6 => true
   end
+  # IPv6 is not enabled by default in the new travis-ci Trusty environment (see https://github.com/travis-ci/travis-ci/issues/8891 )
+  if fact('network6_lo') != '::1'
+    c.filter_run_excluding :ipv6 => true
+  end
 
   # Readable test descriptions
   c.formatter = :documentation


### PR DESCRIPTION
The shibb package is not in the default repos; broken by #1657

On Dec 12th 2017 travis-ci updated their trusty environment and disabled
ipv6. This causes ipv6 tests to fail.