### PR TITLE
Security HTTP headers

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -100,7 +100,24 @@ define apache::vhost(
   $redirectmatch_dest                                                               = undef,
   $rack_base_uris                                                                   = undef,
   $passenger_base_uris                                                              = undef,
-  $headers                                                                          = undef,
+## FIXME! how to ensure those headers are not overwrited too easily?
+  $headers                                                                          = [
+    'set X-Content-Type-Options "nosniff"',
+    'set X-Frame-Options "sameorigin"',
+    "set Strict-Transport-Security \"max-age=16070400; includeSubDomains\"",
+    ## https://www.w3.org/TR/upgrade-insecure-requests/
+    "set Upgrade-Insecure-Requests \"1\"",
+    "set X-XSS-Protection \"1; mode=block\"",
+    "set Content-Security-Policy \"default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self'; style-src 'self' 'unsafe-inline'; object-src 'self'; upgrade-insecure-requests; report-uri /csp/report.php\"",
+    "set Referrer-Policy \"origin\"",
+    "set Expect-CT \"max-age=0, report-uri,report-uri=/csp/report.php\"",
+    # Note: might break some app... need Apache 2.2.4+
+    # https://scotthelme.co.uk/csrf-is-dead/
+    'edit Set-Cookie ^(.*)$ $1;HttpOnly;Secure;SameSite',
+    # want to be indexed by search engine?
+    'set X-Robots-Tag none',
+#    'Set X-Robots-Tag "noindex, noarchive, nosnippet"',
+    ],
   $request_headers                                                                  = undef,
   $filters                                                                          = undef,
   Optional[Array] $rewrites                                                         = undef,

--- a/templates/vhost/_securityheader.erb
+++ b/templates/vhost/_securityheader.erb
@@ -1,0 +1,9 @@
+<% if @security_headers and ! @security_headers.empty? -%>
+
+  ## Security header rules
+  <%- Array(@security_headers).each do |security_statement| -%>
+    <%- if security_statement != '' -%>
+  Header <%= security_statement %>
+    <%- end -%>
+  <%- end -%>
+<% end -%>


### PR DESCRIPTION
Goal: provide a sane & secure default configuration for modern webserver

This adds all usual Security HTTP headers that are usually advised for a modern website. see also securityheaders.io

1 failure I didn't fix or understand in travis
```
Failures:
  1) apache::vhost os-independent items not everything can be set together... should not contain Class[apache::mod::headers]
     Failure/Error: it { is_expected.to_not contain_class('apache::mod::headers') }
       expected that the catalogue would not contain Class[apache::mod::headers]
     # ./spec/defines/vhost_spec.rb:939:in `block (4 levels) in <top (required)>'
Finished in 4 minutes 8.2 seconds (files took 16.06 seconds to load)
290 examples, 1 failure
```

Can you point me what needs to be fixed?

Thanks