### PR TITLE
security.txt configuration - https://securitytxt.org/

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -150,6 +150,8 @@ class apache::params inherits ::apache::version {
       'nss' => 'libmodnss.so',
     }
     $conf_template        = 'apache/httpd.conf.erb'
+    $security_txt         = true
+    $security_txt_template  = 'apache/vhost/security.txt.erb'
     $http_protocol_options  = undef
     $keepalive            = 'On'
     $keepalive_timeout    = 15
@@ -301,6 +303,8 @@ class apache::params inherits ::apache::version {
       'shib2' => $shib2_lib,
     }
     $conf_template          = 'apache/httpd.conf.erb'
+    $security_txt           = true
+    $security_txt_template  = 'apache/vhost/security.txt.erb'
     $http_protocol_options  = undef
     $keepalive              = 'On'
     $keepalive_timeout      = 15
@@ -426,6 +430,8 @@ class apache::params inherits ::apache::version {
     $mod_libs         = {
     }
     $conf_template        = 'apache/httpd.conf.erb'
+    $security_txt         = true
+    $security_txt_template = 'apache/vhost/security.txt.erb'
     $http_protocol_options = undef
     $keepalive            = 'On'
     $keepalive_timeout    = 15
@@ -493,6 +499,8 @@ class apache::params inherits ::apache::version {
     $mod_libs         = {
     }
     $conf_template        = 'apache/httpd.conf.erb'
+    $security_txt         = true
+    $security_txt_template = 'apache/vhost/security.txt.erb'
     $http_protocol_options = undef
     $keepalive            = 'On'
     $keepalive_timeout    = 15
@@ -559,6 +567,8 @@ class apache::params inherits ::apache::version {
       'php53'          => '/usr/lib64/apache2/mod_php5.so',
     }
     $conf_template          = 'apache/httpd.conf.erb'
+    $security_txt           = true
+    $security_txt_template  = 'apache/vhost/security.txt.erb'
     $http_protocol_options  = undef
     $keepalive              = 'On'
     $keepalive_timeout      = 15

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -176,6 +176,8 @@ define apache::vhost(
   $cas_login_url                                                                    = undef,
   $cas_validate_url                                                                 = undef,
   $cas_validate_saml                                                                = undef,
+  $security_txt                                                                     = $::apache::params::security_txt,
+  $security_txt_value                                                               = $::apache::params::security_txt_template,
   Optional[String] $shib_compat_valid_user                                          = undef,
   Optional[Enum['On', 'on', 'Off', 'off', 'DNS', 'dns']] $use_canonical_name        = undef,
 ) {
@@ -1081,4 +1083,19 @@ define apache::vhost(
     order   => 999,
     content => template('apache/vhost/_file_footer.erb'),
   }
+
+  # Template uses no variables
+  if $security_txt {
+    file { "${docroot}/${name}-security.txt":
+# FIXME! puppet complain if file exists because of another vhost...
+#   Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Resource Statement, Duplicate declaration: File[/var/www/html/security.txt] is already declared in file /tmp/kitchen/modules/apache/manifests/vhost.pp:1099; cannot redeclare at /tmp/kitchen/modules/apache/manifests/vhost.pp:1099 at /tmp/kitchen/modules/apache/manifests/vhost.pp:1099:3  at /tmp/kitchen/modules/apache/manifests/init.pp:380 on node 51a0780bb787
+#    file { "${docroot}/security.txt":
+      ensure  => 'present',
+      owner   => $docroot_owner,
+      group   => $docroot_group,
+      mode    => '0444',
+      content => template("${security_txt_value}"),
+    }
+  }
+
 }

--- a/templates/vhost/security.txt.erb
+++ b/templates/vhost/security.txt.erb
@@ -1,0 +1,6 @@
+Contact: security@example.com
+Contact: +1-201-555-0123
+Contact: https://example.com/security
+Encryption: https://example.com/pgp-key.txt
+Disclosure: Full
+Acknowledgement: https://example.com/hall-of-fame.html


### PR DESCRIPTION
Goal: provide a sane & secure default configuration for modern webserver

This adds support for security.txt, a file like robots.txt bug giving contact information if vulnerabilities are found on the website or subdomains.

1 failure in travis that I didn't find how to solve if you can help
```
1) apache::vhost os-independent items when not setting nor managing the docroot should compile into a catalogue without dependency cycles
     Failure/Error: it { is_expected.to compile }
       error during compilation: Parameter path failed on File[false/rspec.example.com-security.txt]: File paths must be fully qualified, not 'false/rspec.example.com-security.txt' at /home/travis/build/juju4/puppetlabs-apache/spec/fixtures/modules/apache/manifests/vhost.pp:1089
     # ./spec/defines/vhost_spec.rb:1096:in `block (4 levels) in <top (required)>'
Finished in 5 minutes 57 seconds (files took 17.28 seconds to load)
290 examples, 1 failure
```

Thanks