### PR TITLE
php config hardening

### DIFF
--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -8,6 +8,18 @@ class apache::mod::php (
   $source           = undef,
   $root_group       = $::apache::params::root_group,
   $php_version      = $::apache::params::php_version,
+  # php security settings
+  $php_date_timezone = 'UTC',
+  $php_expose_php   = 'Off',
+  $php_allow_url_fopen    = 'Off',
+  $php_disable_functions  = 'pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,chown,diskfreespace,disk_free_space,disk_total_space,dl,exec,escapeshellarg,escapeshellcmd,fileinode,highlight_file,max_execution_time,passthru,pclose,phpinfo,popen,proc_close,proc_open,proc_get_status,proc_nice,proc_open,proc_terminate,set_time_limit,shell_exec,show_source,system,serialize,unserialize,__construct, __destruct, __call,__wakeup',
+  $php_memory_limit       = '128M',
+  $php_include_path       = '/usr/share/pear:/usr/share/php',
+  $php_session_use_strict_mode    = 1,
+  $php_session_cookie_secure      = true,
+  $php_session_cookie_httponly    = true,
+  $php_assert_active      = 'Off',
+  $php_file_uploads       = 'Off',
 ) inherits apache::params {
 
   include ::apache
@@ -91,4 +103,77 @@ class apache::mod::php (
     before  => File[$::apache::mod_dir],
     notify  => Class['apache::service'],
   }
+
+  # Harden apache php.ini config
+  # FIXME! is it applied before package installation? worked on second converge
+  file { "${apache::mod::php::php_ini}":
+    ensure => present,
+  }
+  file_line { 'php.ini: Configure timezone':
+    path   => "${apache::mod::php::php_ini}",
+    line   => "date.timezone = '${apache::mod::php::php_date_timezone}'",
+    match  => '^date.timezone = .*',
+    notify => Class['apache::service'],
+  }
+  file_line { 'php.ini: Configure expose_php':
+    path   => "${apache::mod::php::php_ini}",
+    line   => "expose_php = ${apache::mod::php::php_expose_php}",
+    match  => '^expose_php = .*',
+    notify => Class['apache::service'],
+  }
+  file_line { 'php.ini: Configure allow_url_fopen':
+    path   => "${apache::mod::php::php_ini}",
+    line   => "allow_url_fopen = ${apache::mod::php::php_allow_url_fopen}",
+    match  => '^allow_url_fopen = .*',
+    notify => Class['apache::service'],
+  }
+  file_line { 'php.ini: Configure disable_functions':
+    path   => "${apache::mod::php::php_ini}",
+    line   => "disable_functions = ${apache::mod::php::php_disable_functions}",
+    match  => '^disable_functions =.*',
+    notify => Class['apache::service'],
+  }
+  file_line { 'php.ini: Configure memory_limit':
+    path   => "${apache::mod::php::php_ini}",
+    line   => "memory_limit = ${apache::mod::php::php_memory_limit}",
+    match  => '^memory_limit = .*',
+    notify => Class['apache::service'],
+  }
+  file_line { 'php.ini: Configure include_path':
+    path   => "${apache::mod::php::php_ini}",
+    line   => "include_path = ${apache::mod::php::php_include_path}",
+    match  => '^include_path = .*',
+    notify => Class['apache::service'],
+  }
+  file_line { 'php.ini: Configure session.use_strict_mode':
+    path   => "${apache::mod::php::php_ini}",
+    line   => "session.use_strict_mode = ${apache::mod::php::php_session_use_strict_mode}",
+    match  => '^session.use_strict_mode = .*',
+    notify => Class['apache::service'],
+  }
+  file_line { 'php.ini: Configure session.cookie_secure':
+    path   => "${apache::mod::php::php_ini}",
+    line   => "session.cookie_secure = ${apache::mod::php::php_session_cookie_secure}",
+    match  => '^session.cookie_secure = .*',
+    notify => Class['apache::service'],
+  }
+  file_line { 'php.ini: Configure session.cookie_httponly':
+    path   => "${apache::mod::php::php_ini}",
+    line   => "session.cookie_httponly = ${apache::mod::php::php_session_cookie_httponly}",
+    match  => '^session.cookie_httponly = .*',
+    notify => Class['apache::service'],
+  }
+  file_line { 'php.ini: Configure assert.active':
+    path   => "${apache::mod::php::php_ini}",
+    line   => "assert.active = ${apache::mod::php::php_assert_active}",
+    match  => '^assert.active = .*',
+    notify => Class['apache::service'],
+  }
+  file_line { 'php.ini: Configure file_uploads':
+    path   => "${apache::mod::php::php_ini}",
+    line   => "file_uploads = ${apache::mod::php::php_file_uploads}",
+    match  => '^file_uploads = .*',
+    notify => Class['apache::service'],
+  }
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -96,6 +96,7 @@ class apache::params inherits ::apache::version {
     $suphp_engine         = 'off'
     $suphp_configpath     = undef
     $php_version          = '5'
+    $php_ini              = '/etc/php.ini'
     $mod_packages         = {
       # NOTE: The auth_cas module isn't available on RH/CentOS without providing dependency packages provided by EPEL.
       'auth_cas'              => 'mod_auth_cas',
@@ -236,6 +237,7 @@ class apache::params inherits ::apache::version {
     if ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') < 0) or ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '9') < 0) {
       # Only the major version is used here
       $php_version = '5'
+      $php_ini     = '/etc/php5/apache2/php.ini'
       $mod_packages = {
         'auth_cas'              => 'libapache2-mod-auth-cas',
         'auth_kerb'             => 'libapache2-mod-auth-kerb',
@@ -264,6 +266,7 @@ class apache::params inherits ::apache::version {
     } else {
       # major.minor version used since Debian stretch and Ubuntu Xenial
       $php_version = '7.0'
+      $php_ini     = '/etc/php/7.0/apache2/php.ini'
       $mod_packages = {
         'auth_cas'              => 'libapache2-mod-auth-cas',
         'auth_kerb'             => 'libapache2-mod-auth-kerb',
@@ -404,6 +407,7 @@ class apache::params inherits ::apache::version {
     $suphp_engine     = 'off'
     $suphp_configpath = undef
     $php_version      = '5'
+    $php_ini          = '/usr/local/etc/php.ini'
     $mod_packages     = {
       # NOTE: I list here only modules that are not included in www/apache24
       # NOTE: 'passenger' needs to enable APACHE_SUPPORT in make config
@@ -473,6 +477,7 @@ class apache::params inherits ::apache::version {
     $suphp_engine     = 'off'
     $suphp_configpath = '/etc/php5/apache2'
     $php_version      = '5'
+    $php_ini          = '/etc/php5/apache2/php.ini'
     $mod_packages     = {
       # NOTE: I list here only modules that are not included in www-servers/apache
       'auth_kerb'       => 'www-apache/mod_auth_kerb',
@@ -536,6 +541,7 @@ class apache::params inherits ::apache::version {
     $suphp_engine        = 'off'
     $suphp_configpath    = '/etc/php5/apache2'
     $php_version         = '5'
+    $php_ini             = '/etc/php5/apache2/php.ini'
     if $::operatingsystemrelease < '11' or $::operatingsystemrelease >= '12' {
       $mod_packages      = {
         'auth_kerb'   => 'apache2-mod_auth_kerb',

--- a/spec/acceptance/mod_php_spec.rb
+++ b/spec/acceptance/mod_php_spec.rb
@@ -9,7 +9,9 @@ unless (fact('operatingsystem') == 'SLES' && fact('operatingsystemmajrelease') =
           class { 'apache':
             mpm_module => 'prefork',
           }
-          class { 'apache::mod::php': }
+          class { 'apache::mod::php':
+            php_disable_functions  => 'pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,chown,diskfreespace,disk_free_space,disk_total_space,dl,exec,escapeshellarg,escapeshellcmd,fileinode,highlight_file,max_execution_time,passthru,pclose,popen,proc_close,proc_open,proc_get_status,proc_nice,proc_open,proc_terminate,set_time_limit,shell_exec,show_source,system,serialize,unserialize,__construct, __destruct, __call,__wakeup',
+          }
           apache::vhost { 'php.example.com':
             port    => '80',
             docroot => '#{$doc_root}/php',
@@ -58,11 +60,12 @@ unless (fact('operatingsystem') == 'SLES' && fact('operatingsystemmajrelease') =
           }
           class { 'apache::mod::php':
             extensions => ['.php','.php5'],
+            php_disable_functions  => 'pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,chown,diskfreespace,disk_free_space,disk_total_space,dl,exec,escapeshellarg,escapeshellcmd,fileinode,highlight_file,max_execution_time,passthru,pclose,popen,proc_close,proc_open,proc_get_status,proc_nice,proc_open,proc_terminate,set_time_limit,shell_exec,show_source,system,serialize,unserialize,__construct, __destruct, __call,__wakeup',
           }
           apache::vhost { 'php.example.com':
             port             => '80',
             docroot          => '#{$doc_root}/php',
-            php_values       => { 'include_path' => '.:/usr/share/pear:/usr/bin/php', },
+            php_values       => { 'include_path' => '/usr/share/pear:/usr/share/php', },
             php_flags        => { 'display_errors' => 'on', },
             php_admin_values => { 'open_basedir' => '/var/www/php/:/usr/share/pear/', },
             php_admin_flags  => { 'engine' => 'on', },
@@ -87,7 +90,7 @@ unless (fact('operatingsystem') == 'SLES' && fact('operatingsystemmajrelease') =
 
       describe file("#{$vhost_dir}/25-php.example.com.conf") do
         it { is_expected.to contain "  php_flag display_errors on" }
-        it { is_expected.to contain "  php_value include_path \".:/usr/share/pear:/usr/bin/php\"" }
+        it { is_expected.to contain "  php_value include_path \"/usr/share/pear:/usr/bin/php\"" }
         it { is_expected.to contain "  php_admin_flag engine on" }
         it { is_expected.to contain "  php_admin_value open_basedir /var/www/php/:/usr/share/pear/" }
       end


### PR DESCRIPTION
Goal: provide a sane & secure default configuration for modern webserver

Customizable options for php with sane and secure defaults

See also
* https://github.com/sensiolabs/security-checker
* https://github.com/sektioneins/pcc
* https://github.com/psecio/iniscan

1 failure for unknown reason
```
Failures:

  1) apache::mod::php class custom extensions, php_flag, php_value, php_admin_flag, and php_admin_value File "/etc/httpd/conf.d/25-php.example.com.conf" should contain "  php_value include_path \"/usr/share/pear:/usr/bin/php\""
     [31mFailure/Error: [0m[32mit[0m { is_expected.to contain [31m[1;31m"[0m[31m  php_value include_path [1;35m\"[0m[31m/usr/share/pear:/usr/bin/php[1;35m\"[0m[31m[1;31m"[0m[31m[0m }[0m
     [31m  expected File "/etc/httpd/conf.d/25-php.example.com.conf" to contain "  php_value include_path \"/usr/share/pear:/usr/bin/php\""[0m
     [31m  [0m
     [36m# ./spec/acceptance/mod_php_spec.rb:93:in `block (4 levels) in <top (required)>'[0m

Finished in 17 minutes 31 seconds (files took 2 minutes 17.3 seconds to load)
[31m528 examples, 1 failure[0m
```