### PR TITLE
SCL support for httpd and php7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,6 +795,7 @@ Load balancing scheduler algorithms (`lbmethod`) are listed [in mod_proxy_balanc
 
 - [**Public classes**](#public-classes)
     - [Class: apache](#class-apache)
+    - [Class: apache::globals](#class-apacheglobals)
     - [Class: apache::dev](#class-apachedev)
     - [Class: apache::vhosts](#class-apachevhosts)
     - [Classes: apache::mod::\*](#classes-apachemodname)
@@ -825,6 +826,36 @@ Load balancing scheduler algorithms (`lbmethod`) are listed [in mod_proxy_balanc
 - [**Tasks**](#tasks)
 
 ### Public Classes
+
+#### Class: `apache::globals`
+
+Global configurations for Apache. These values has to be set before apache is included.
+
+##### `scl`
+
+**Experimental!**
+Enables Software Collections on RHEL / CentOS. If this is enabled Apache Httpd is installed from [Software Collections](https://www.softwarecollections.org/en/).
+These packages allow for newer Apache and PHP amongst other packages.
+
+The repository is not managed by this module yet. For CentOS you can enable the repo by installing the package: centos-release-scl-rh
+
+Values: false, true
+
+Default: false
+
+##### `scl_httpd`
+
+The name of the httpd to install.
+
+Example: 'httpd24' for httpd24, it is.
+
+
+##### `scl_php_version`
+
+Version of PHP to use.
+
+Example: '7.1'
+
 
 #### Class: `apache`
 
@@ -1472,7 +1503,8 @@ To prevent Puppet from managing the user, set the [`manage_user`][] parameter to
 
 ##### `apache_name`
 
-The name of the Apache package to install. If you are using a non-standard Apache package, such as those from Red Hat's software collections, you might need to override the default setting.
+The name of the Apache package to install. If you are using a non-standard Apache package. 
+For Red Hat's software collections, you can also use apache::globals::scl_httpd.
 
 Default: Depends on the user set by [`apache::params`][] class, based on your operating system:
 
@@ -3026,7 +3058,35 @@ Manages the Apache daemon.
 
 #### Class: `apache::version`
 
-Attempts to automatically detect the Apache version based on the operating system.
+Automatically detect the Apache version based on the operating system.
+
+For RedHat Enterprise Linux and distros based of this, it is possible to use Software Collections instead. This is configured here.
+
+##### `scl`
+
+**Experimental!**
+Enables Software Collections on RHEL / CentOS. If this is enabled Apache Httpd is installed from [Software Collections](https://www.softwarecollections.org/en/).
+These packages allow for newer Apache and PHP amongst other packages.
+
+The repository is not managed by this module yet. For CentOS you can enable the repo by installing the package: centos-release-scl-rh
+
+Values: false, true
+
+Default: false
+
+##### `scl_httpd`
+
+The name of the httpd to install.
+
+Example: 'httpd24' for httpd24, it is.
+
+
+##### `scl_php_version`
+
+Version of PHP to use.
+
+Example: '7.1'
+
 
 ### Public defined types
 

--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -12,7 +12,12 @@ class apache::mod::php (
 
   include ::apache
   $mod = "php${php_version}"
-
+  if $::apache::params::scl_httpd != undef and  $::apache::params::scl_php_version == undef {
+    fail("If you define apache::scl_httpd, then you also need to specify apache::scl_php_version")
+  }
+  if $::apache::params::scl_httpd == undef and  $::apache::params::scl_php_version != undef {
+    fail("If you define apache::scl_php_version, then you also need to specify apache::scl_httpd")
+  }
   if defined(Class['::apache::mod::prefork']) {
     Class['::apache::mod::prefork']->File["${mod}.conf"]
   }
@@ -49,27 +54,31 @@ class apache::mod::php (
     $_package_name = undef
   }
 
-  $_lib = "libphp${php_version}.so"
   $_php_major = regsubst($php_version, '^(\d+)\..*$', '\1')
+  $_php_version_no_dot = regsubst($php_version, '\.', '')
+  if $apache::version::scl_httpd {
+    $_lib = "librh-php${_php_version_no_dot}-php${_php_major}.so"
+  } else {
+    $_lib = "libphp${php_version}.so"
+  }
 
   if $::operatingsystem == 'SLES' {
-      ::apache::mod { $mod:
-        package        => $_package_name,
-        package_ensure => $package_ensure,
-        lib            => 'mod_php5.so',
-        id             => "php${_php_major}_module",
-        path           => "${::apache::lib_path}/mod_php5.so",
-      }
-    } else {
-      ::apache::mod { $mod:
-        package        => $_package_name,
-        package_ensure => $package_ensure,
-        lib            => $_lib,
-        id             => "php${_php_major}_module",
-        path           => $path,
-      }
-
+    ::apache::mod { $mod:
+      package        => $_package_name,
+      package_ensure => $package_ensure,
+      lib            => 'mod_php5.so',
+      id             => "php${_php_major}_module",
+      path           => "${::apache::lib_path}/mod_php5.so",
     }
+  } else {
+    ::apache::mod { $mod:
+      package        => $_package_name,
+      package_ensure => $package_ensure,
+      lib            => $_lib,
+      id             => "php${_php_major}_module",
+      path           => $path,
+    }
+  }
 
 
   include ::apache::mod::mime

--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -2,7 +2,10 @@
 #
 # Try to automatically detect the version by OS
 #
-class apache::version {
+class apache::version(
+  Optional[String] $scl_httpd       = undef,
+  Optional[String] $scl_php_version = undef,
+) {
   # This will be 5 or 6 on RedHat, 6 or wheezy on Debian, 12 or quantal on Ubuntu, etc.
   $osr_array = split($::operatingsystemrelease,'[\/\.]')
   $distrelease = $osr_array[0]


### PR DESCRIPTION
* SCL is short for Software Collections on CentOS and RHEL.
* Only preliminary / experimental support for php and apache.
* Activaed by adding parameters for apache::params like this (hiera):
	apache::params::scl: true
	apache::params::scl_httpd: 'httpd24'
	apache::params::scl_php_version: '7.1'

**I would like feedback on whether this is a good way to implement support for SCL.** 