### PR TITLE
MODULES-6225 :  fix worker mantain typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2276,14 +2276,14 @@ Default: '80'
 **workers\_file\_content**
 
 Each directive has the format `worker.<Worker name>.<Property>=<Value>`. This maps as a hash of hashes, where the outer hash specifies workers, and each inner hash specifies each worker properties and values.
-Plus, there are two global directives, 'worker.list' and 'worker.mantain'
+Plus, there are two global directives, 'worker.list' and 'worker.maintain'
 For example, the workers file below:
 
 ```
 worker.list = status
 worker.list = some_name,other_name
 
-worker.mantain = 60
+worker.maintain = 60
 
 # Optional comment
 worker.some_name.type=ajp13
@@ -2298,14 +2298,14 @@ Should be parameterized as:
 
 ```
 $workers_file_content = {
-  worker_lists   => ['status', 'some_name,other_name'],
-  worker_mantain => '60',
-  some_name      => {
+  worker_lists    => ['status', 'some_name,other_name'],
+  worker_maintain => '60',
+  some_name       => {
     comment          => 'Optional comment',
     type             => 'ajp13',
     socket_keepalive => 'true',
   },
-  other_name     => {
+  other_name      => {
     comment          => 'I just like comments',
     type             => 'ajp12',
     socket_keepalive => 'false',

--- a/manifests/mod/jk.pp
+++ b/manifests/mod/jk.pp
@@ -67,6 +67,13 @@ class apache::mod::jk (
   # Manages basic module config
   ::apache::mod { 'jk': }
 
+  # Ensure that we are not using variables with the typo fixed by MODULES-6225
+  # anymore:
+  if !empty($workers_file_content) and has_key($workers_file_content, 'worker_mantain') {
+    fail('Please replace $workers_file_content[\'worker_mantain\'] by $workers_file_content[\'worker_maintain\']. See MODULES-6225 for details.')
+  }
+
+
   # Binding to mod_jk
   if $add_listen {
     $_ip = $ip ? {

--- a/readmes/README_ja_JP.md
+++ b/readmes/README_ja_JP.md
@@ -2196,14 +2196,14 @@ class { '::apache::mod::jk':
 **workers\_file\_content**
 
 各ディレクティブにはフォーマット`worker.<Worker name>.<Property>=<Value>`があります。このマップは複数ハッシュのハッシュとして表され、外側のハッシュはワーカーを指定し、内側の各ハッシュは各ワーカーのプロパティと値を指定します。
-また、2つのグローバルディレクティブ 'worker.list'および'worker.mantain'もあります。  
+また、2つのグローバルディレクティブ 'worker.list'および'worker.maintain'もあります。  
 例えば、ワーカーファイルは以下のようになります。
 
 ```
 worker.list = status
 worker.list = some_name,other_name
 
-worker.mantain = 60
+worker.maintain = 60
 
 # Optional comment
 worker.some_name.type=ajp13
@@ -2218,14 +2218,14 @@ worker.other_name.socket_keepalive=false
 
 ```
 $workers_file_content = {
-  worker_lists   => ['status', 'some_name,other_name'],
-  worker_mantain => '60',
-  some_name      => {
+  worker_lists    => ['status', 'some_name,other_name'],
+  worker_maintain => '60',
+  some_name       => {
     comment          => 'Optional comment',
     type             => 'ajp13',
     socket_keepalive => 'true',
   },
-  other_name     => {
+  other_name      => {
     comment          => 'I just like comments',
     type             => 'ajp12',
     socket_keepalive => 'false',

--- a/spec/classes/mod/jk_spec.rb
+++ b/spec/classes/mod/jk_spec.rb
@@ -31,7 +31,7 @@ describe 'apache::mod::jk', :type => :class do
             'socket_keepalive' => 'true',
             'comment'          => 'This is worker B',
           },
-          'worker_mantain' => 40,
+          'worker_maintain' => 40,
           'worker_lists' => ['worker_a,worker_b'],
         },
       }

--- a/templates/mod/jk/workers.properties.erb
+++ b/templates/mod/jk/workers.properties.erb
@@ -6,12 +6,12 @@
 <%# Two keys are special (and reserved!): -%>
 <%# worker_lists - Array of comma-separated worker names lists -%>
 <%# Each list is an item of the array and will be placed in one line -%>
-<%# worker_mantain - Numeric string -%>
+<%# worker_maintain - Numeric string -%>
 <%# -%>
 <%# Example: -%>
 <%# worker.list = status -%>
 <%# worker.list = some_name,other_name -%>
-<%# worker.mantain = 60 -%>
+<%# worker.maintain = 60 -%>
 <%# # Optional comment -%>
 <%# worker.some_name.type=ajp13 -%>
 <%# worker.some_name.socket_keepalive=true -%>
@@ -21,14 +21,14 @@
 <%# -%>
 <%# should be parameterized as: -%>
 <%# $workers_file_content = { -%>
-<%#   worker_lists => ['status', 'some_name,other_name'], -%>
-<%#   worker_mantain => '60', -%>
-<%#   some_name => { -%>
+<%#   worker_lists    => ['status', 'some_name,other_name'], -%>
+<%#   worker_maintain => '60', -%>
+<%#   some_name       => { -%>
 <%#     type             => 'ajp13', -%>
 <%#     socket_keepalive => 'true', -%>
 <%#     comment          => 'Optional comment', -%>
 <%#   }, -%>
-<%#   other_name => { -%>
+<%#   other_name      => { -%>
 <%#     type             => 'ajp12', -%>
 <%#     socket_keepalive => 'false', -%>
 <%#     comment          => 'I just like comments', -%>
@@ -41,13 +41,13 @@
 worker.list = <%= list %>
 <% end -%>
 <% end -%>
-<% if @workers_file_content.has_key?('worker_mantain') -%>
+<% if @workers_file_content.has_key?('worker_maintain') -%>
 
-worker.maintain = <%= @workers_file_content['worker_mantain'] %>
+worker.maintain = <%= @workers_file_content['worker_maintain'] %>
 <% end -%>
 <% @workers_file_content.sort.each do |name,directives| -%>
 <%# Skip hash items with the reserved keys -%>
-<% if not ['worker_lists', 'worker_mantain'].include?(name) -%>
+<% if not ['worker_lists', 'worker_maintain'].include?(name) -%>
 
 <%# Places comment before worker directives -%>
 <% if directives.has_key?('comment') -%>


### PR DESCRIPTION
Fix key 'worker_mantain' in $workers_file_content

- Add spec tests for advanced mod_jk configuration
- Fix *worker_mantain* typo (see below)
- Call `fail()` function when using the deprecated *worker_mantain* key

Original comment in worker.properties.erb reference a key
*worker_mantain* in the `$workers_file_content` hash.

From the original Apache's mod_jk documentation [1], the parameter name is
`worker.maintain` and has been mistyped as `worker.mantain` (note the
missing *i* letter).

[1] https://tomcat.apache.org/connectors-doc/reference/workers.html

Here is the [Reference in Jira](https://tickets.puppetlabs.com/browse/MODULES-6225)