### PR TITLE
(MODULES-6608) - Adding puppet requirement for tasks versioncmp in beaker-task_helper

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,3 +1,4 @@
+require 'puppet'
 require 'beaker-rspec/spec_helper'
 require 'beaker-rspec/helpers/serverspec'
 require 'beaker/puppet_install_helper'


### PR DESCRIPTION
[A change in the new beaker-task_helper uses versioncmp.](https://github.com/puppetlabs/beaker-task_helper/pull/16) Therefore adding
a puppet requirement in the spec_helper_acceptance to access versioncmp.