### PR TITLE
ensure mpm_event is disabled under debian 9 if mpm itk is used

### DIFF
--- a/manifests/mpm.pp
+++ b/manifests/mpm.pp
@@ -73,20 +73,19 @@ define apache::mpm (
         }
       }
 
-      if $mpm == 'itk' and $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '14.04' {
-        # workaround https://bugs.launchpad.net/ubuntu/+source/mpm-itk/+bug/1286882
-        exec {
-          '/usr/sbin/a2dismod mpm_event':
-            onlyif  => '/usr/bin/test -e /etc/apache2/mods-enabled/mpm_event.load',
-            require => Package['httpd'],
-            before  => Package['apache2-mpm-itk'],
-        }
-      }
-
       if $mpm == 'itk' and ( ( $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '16.04' ) or ( $::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '9.0.0') >= 0 ) ) {
         $packagename = 'libapache2-mpm-itk'
       } else {
         $packagename = "apache2-mpm-${mpm}"
+      }
+
+      if $mpm == 'itk' and ( ( $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '14.04' ) or ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '9.0.0') >= 0 ) ) {
+        # workaround https://bugs.launchpad.net/ubuntu/+source/mpm-itk/+bug/1286882
+        exec { '/usr/sbin/a2dismod mpm_event':
+          onlyif  => '/usr/bin/test -e /etc/apache2/mods-enabled/mpm_event.load',
+          require => Package['httpd'],
+          before  => Package[$packagename],
+        }
       }
 
       if versioncmp($apache_version, '2.4') < 0 or $mpm == 'itk' {


### PR DESCRIPTION
On debian 9 using mod_itk as mpm with: 
apache 2.4.25-3+deb9u3 and 
libapache2-mpm-itk 2.4.7-04-1

You have to disable mpm_event before installing libapache2-mpm-itk …

smells a bit like https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=734865 although it should be fixed…
