### PR TITLE
(MODULES-6677) make sure event mpm is disabled

### DIFF
--- a/manifests/mpm.pp
+++ b/manifests/mpm.pp
@@ -73,20 +73,19 @@ define apache::mpm (
         }
       }
 
-      if $mpm == 'itk' and $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '14.04' {
-        # workaround https://bugs.launchpad.net/ubuntu/+source/mpm-itk/+bug/1286882
-        exec {
-          '/usr/sbin/a2dismod mpm_event':
-            onlyif  => '/usr/bin/test -e /etc/apache2/mods-enabled/mpm_event.load',
-            require => Package['httpd'],
-            before  => Package['apache2-mpm-itk'],
-        }
-      }
-
       if $mpm == 'itk' and ( ( $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '16.04' ) or ( $::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '9.0.0') >= 0 ) ) {
         $packagename = 'libapache2-mpm-itk'
       } else {
         $packagename = "apache2-mpm-${mpm}"
+      }
+
+      if $mpm == 'itk' and ( ( $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '14.04' ) or ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '9.0.0') >= 0 ) ) {
+        # workaround https://bugs.launchpad.net/ubuntu/+source/mpm-itk/+bug/1286882
+        exec { '/usr/sbin/a2dismod mpm_event':
+          onlyif  => '/usr/bin/test -e /etc/apache2/mods-enabled/mpm_event.load',
+          require => Package['httpd'],
+          before  => Package[$packagename],
+        }
       }
 
       if versioncmp($apache_version, '2.4') < 0 or $mpm == 'itk' {

--- a/manifests/mpm.pp
+++ b/manifests/mpm.pp
@@ -79,10 +79,20 @@ define apache::mpm (
         $packagename = "apache2-mpm-${mpm}"
       }
 
+      $mod_enabled_dir = $::apache::mod_enable_dir
+
+      if $mpm == 'prefork' and ( $::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '9.0.0') >= 0 ) {
+        exec { '/usr/sbin/a2dismod mpm_event':
+          onlyif  => "/usr/bin/test -e ${mod_enabled_dir}/mpm_event.load",
+          require => Package['httpd'],
+          before  => Package[$packagename],
+        }
+      }
+
       if $mpm == 'itk' and ( ( $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '14.04' ) or ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '9.0.0') >= 0 ) ) {
         # workaround https://bugs.launchpad.net/ubuntu/+source/mpm-itk/+bug/1286882
         exec { '/usr/sbin/a2dismod mpm_event':
-          onlyif  => '/usr/bin/test -e /etc/apache2/mods-enabled/mpm_event.load',
+          onlyif  => "/usr/bin/test -e ${mod_enabled_dir}/mpm_event.load",
           require => Package['httpd'],
           before  => Package[$packagename],
         }


### PR DESCRIPTION
Currently, on Debian 9 specifically, the event mod may be enabled when trying to use a different mpm. This ensures event is disabled if another mpm is chosen. Also closes #1766