### PR TITLE
Allow overriding passenger_group in apache::vhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -4059,6 +4059,10 @@ Sets [PassengerPreStart](https://www.phusionpassenger.com/library/config/apache/
 
 Sets [PassengerUser](https://www.phusionpassenger.com/library/config/apache/reference/#passengeruser), the running user for sandboxing applications.
 
+##### `passenger_group`
+
+Sets [PassengerGroup](https://www.phusionpassenger.com/library/config/apache/reference/#passengergroup), the running group for sandboxing applications.
+
 ##### `passenger_high_performance`
 
 Sets the [`PassengerHighPerformance`](https://www.phusionpassenger.com/library/config/apache/reference/#passengerhighperformance) parameter.

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -144,6 +144,7 @@ define apache::vhost(
   $passenger_start_timeout                                                          = undef,
   $passenger_pre_start                                                              = undef,
   $passenger_user                                                                   = undef,
+  $passenger_group                                                                  = undef,
   $passenger_high_performance                                                       = undef,
   $passenger_nodejs                                                                 = undef,
   Optional[Boolean] $passenger_sticky_sessions                                      = undef,
@@ -236,7 +237,7 @@ define apache::vhost(
     include ::apache::mod::suexec
   }
 
-  if $passenger_spawn_method or $passenger_app_root or $passenger_app_env or $passenger_ruby or $passenger_min_instances or $passenger_max_requests or $passenger_start_timeout or $passenger_pre_start or $passenger_user or $passenger_high_performance or $passenger_nodejs or $passenger_sticky_sessions or $passenger_startup_file {
+  if $passenger_spawn_method or $passenger_app_root or $passenger_app_env or $passenger_ruby or $passenger_min_instances or $passenger_max_requests or $passenger_start_timeout or $passenger_pre_start or $passenger_user or $passenger_group or $passenger_high_performance or $passenger_nodejs or $passenger_sticky_sessions or $passenger_startup_file {
     include ::apache::mod::passenger
   }
 
@@ -967,10 +968,11 @@ define apache::vhost(
   # - $passenger_start_timeout
   # - $passenger_pre_start
   # - $passenger_user
+  # - $passenger_group
   # - $passenger_nodejs
   # - $passenger_sticky_sessions
   # - $passenger_startup_file
-  if $passenger_spawn_method or $passenger_app_root or $passenger_app_env or $passenger_ruby or $passenger_min_instances or $passenger_start_timeout or $passenger_pre_start or $passenger_user or $passenger_nodejs or $passenger_sticky_sessions or $passenger_startup_file{
+  if $passenger_spawn_method or $passenger_app_root or $passenger_app_env or $passenger_ruby or $passenger_min_instances or $passenger_start_timeout or $passenger_pre_start or $passenger_user or $passenger_group or $passenger_nodejs or $passenger_sticky_sessions or $passenger_startup_file{
     concat::fragment { "${name}-passenger":
       target  => "${priority_real}${filename}.conf",
       order   => 300,

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -854,7 +854,72 @@ describe 'apache::vhost', type: :define do
       }
       it {
         is_expected.to contain_concat__fragment('rspec.example.com-passenger').with(
+          content: %r{^\s+PassengerSpawnMethod\sdirect$},
+        )
+      }
+      it {
+        is_expected.to contain_concat__fragment('rspec.example.com-passenger').with(
+          content: %r{^\s+PassengerAppRoot\s/usr/share/myapp$},
+        )
+      }
+      it {
+        is_expected.to contain_concat__fragment('rspec.example.com-passenger').with(
+          content: %r{^\s+PassengerAppEnv\stest$},
+        )
+      }
+      it {
+        is_expected.to contain_concat__fragment('rspec.example.com-passenger').with(
+          content: %r{^\s+PassengerRuby\s/usr/bin/ruby1\.9\.1$},
+        )
+      }
+      it {
+        is_expected.to contain_concat__fragment('rspec.example.com-passenger').with(
+          content: %r{^\s+PassengerMinInstances\s1$},
+        )
+      }
+      it {
+        is_expected.to contain_concat__fragment('rspec.example.com-passenger').with(
+          content: %r{^\s+PassengerMaxRequests\s1000$},
+        )
+      }
+      it {
+        is_expected.to contain_concat__fragment('rspec.example.com-passenger').with(
+          content: %r{^\s+PassengerStartTimeout\s600$},
+        )
+      }
+      it {
+        is_expected.to contain_concat__fragment('rspec.example.com-passenger').with(
+          content: %r{^\s+PassengerPreStart\shttp://localhost/myapp$},
+        )
+      }
+      it {
+        is_expected.to contain_concat__fragment('rspec.example.com-passenger').with(
+          content: %r{^\s+PassengerHighPerformance\sOn$},
+        )
+      }
+      it {
+        is_expected.to contain_concat__fragment('rspec.example.com-passenger').with(
+          content: %r{^\s+PassengerUser\ssandbox$},
+        )
+      }
+      it {
+        is_expected.to contain_concat__fragment('rspec.example.com-passenger').with(
           content: %r{^\s+PassengerGroup\ssandbox$},
+        )
+      }
+      it {
+        is_expected.to contain_concat__fragment('rspec.example.com-passenger').with(
+          content: %r{^\s+PassengerNodejs\s/usr/bin/node$},
+        )
+      }
+      it {
+        is_expected.to contain_concat__fragment('rspec.example.com-passenger').with(
+          content: %r{^\s+PassengerStickySessions\sOn$},
+        )
+      }
+      it {
+        is_expected.to contain_concat__fragment('rspec.example.com-passenger').with(
+          content: %r{^\s+PassengerStartupFile\sbin/www$},
         )
       }
     end

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -412,6 +412,7 @@ describe 'apache::vhost', type: :define do
           'passenger_pre_start'         => 'http://localhost/myapp',
           'passenger_high_performance'  => true,
           'passenger_user'              => 'sandbox',
+          'passenger_group'             => 'sandbox',
           'passenger_nodejs'            => '/usr/bin/node',
           'passenger_sticky_sessions'   => true,
           'passenger_startup_file'      => 'bin/www',
@@ -849,6 +850,11 @@ describe 'apache::vhost', type: :define do
       it {
         is_expected.to contain_concat__fragment('rspec.example.com-keepalive_options').with(
           content: %r{^\s+MaxKeepAliveRequests\s1000$},
+        )
+      }
+      it {
+        is_expected.to contain_concat__fragment('rspec.example.com-passenger').with(
+          content: %r{^\s+PassengerGroup\ssandbox$},
         )
       }
     end

--- a/templates/vhost/_passenger.erb
+++ b/templates/vhost/_passenger.erb
@@ -32,7 +32,7 @@
   PassengerHighPerformance <%= scope.call_function('apache::bool2httpd', [@passenger_high_performance]) %>
 <% end -%>
 <% if @passenger_nodejs -%>
-  PassengerNodejs <%= @passenger_nodejs -%>
+  PassengerNodejs <%= @passenger_nodejs %>
 <% end -%>
 <% if @passenger_sticky_sessions -%>
   PassengerStickySessions <%= scope.call_function('apache::bool2httpd', [@passenger_sticky_sessions]) %>

--- a/templates/vhost/_passenger.erb
+++ b/templates/vhost/_passenger.erb
@@ -25,6 +25,9 @@
 <% if @passenger_user -%>
   PassengerUser <%= @passenger_user %>
 <% end -%>
+<% if @passenger_group -%>
+  PassengerGroup <%= @passenger_group %>
+<% end -%>
 <% if @passenger_high_performance -%>
   PassengerHighPerformance <%= scope.call_function('apache::bool2httpd', [@passenger_high_performance]) %>
 <% end -%>


### PR DESCRIPTION
Just like we can use `passenger_user` in a VHost, allow setting `passenger_group`.