### PR TITLE
Rework PassengerPreStart

### DIFF
--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -64,7 +64,7 @@ class apache::mod::passenger (
   $passenger_min_instances                                                                   = undef,
   $passenger_nodejs                                                                          = undef,
   $passenger_pool_idle_time                                                                  = undef,
-  $passenger_pre_start                                                                       = undef,
+  Optional[Variant[String,Array[String]]] $passenger_pre_start                               = undef,
   $passenger_python                                                                          = undef,
   $passenger_resist_deployment_errors                                                        = undef,
   $passenger_resolve_symlinks_in_document_root                                               = undef,

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -967,13 +967,12 @@ define apache::vhost(
   # - $passenger_min_instances
   # - $passenger_max_requests
   # - $passenger_start_timeout
-  # - $passenger_pre_start
   # - $passenger_user
   # - $passenger_group
   # - $passenger_nodejs
   # - $passenger_sticky_sessions
   # - $passenger_startup_file
-  if $passenger_spawn_method or $passenger_app_root or $passenger_app_env or $passenger_ruby or $passenger_min_instances or $passenger_start_timeout or $passenger_pre_start or $passenger_user or $passenger_group or $passenger_nodejs or $passenger_sticky_sessions or $passenger_startup_file{
+  if $passenger_spawn_method or $passenger_app_root or $passenger_app_env or $passenger_ruby or $passenger_min_instances or $passenger_start_timeout or $passenger_user or $passenger_group or $passenger_nodejs or $passenger_sticky_sessions or $passenger_startup_file{
     concat::fragment { "${name}-passenger":
       target  => "${priority_real}${filename}.conf",
       order   => 300,

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -142,7 +142,7 @@ define apache::vhost(
   $passenger_min_instances                                                          = undef,
   $passenger_max_requests                                                           = undef,
   $passenger_start_timeout                                                          = undef,
-  $passenger_pre_start                                                              = undef,
+  Optional[Variant[String,Array[String]]] $passenger_pre_start                      = undef,
   $passenger_user                                                                   = undef,
   $passenger_group                                                                  = undef,
   $passenger_high_performance                                                       = undef,

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -888,8 +888,8 @@ describe 'apache::vhost', type: :define do
         )
       }
       it {
-        is_expected.to contain_concat__fragment('rspec.example.com-passenger').with(
-          content: %r{^\s+PassengerPreStart\shttp://localhost/myapp$},
+        is_expected.to contain_concat__fragment('rspec.example.com-file_footer').with(
+          content: %r{^PassengerPreStart\shttp://localhost/myapp$},
         )
       }
       it {

--- a/templates/mod/passenger.conf.erb
+++ b/templates/mod/passenger.conf.erb
@@ -125,7 +125,9 @@
   PassengerPoolIdleTime <%= @passenger_pool_idle_time %>
   <%- end -%>
   <%- if @passenger_pre_start -%>
-  PassengerPreStart <%= @passenger_pre_start %>
+    <%- [@passenger_pre_start].flatten.compact.each do |passenger_pre_start| -%>
+  PassengerPreStart <%= passenger_pre_start %>
+    <%- end -%>
   <%- end -%>
   <%- if @passenger_python -%>
   PassengerPython "<%= @passenger_python %>"

--- a/templates/vhost/_file_footer.erb
+++ b/templates/vhost/_file_footer.erb
@@ -1,4 +1,6 @@
 </VirtualHost>
 <% if @passenger_pre_start -%>
-PassengerPreStart <%= @passenger_pre_start %>
+  <%- [@passenger_pre_start].flatten.compact.each do |passenger_pre_start| -%>
+PassengerPreStart <%= passenger_pre_start %>
+  <%- end -%>
 <% end -%>

--- a/templates/vhost/_file_footer.erb
+++ b/templates/vhost/_file_footer.erb
@@ -1,1 +1,4 @@
 </VirtualHost>
+<% if @passenger_pre_start -%>
+PassengerPreStart <%= @passenger_pre_start %>
+<% end -%>

--- a/templates/vhost/_passenger.erb
+++ b/templates/vhost/_passenger.erb
@@ -19,9 +19,6 @@
 <% if @passenger_start_timeout -%>
   PassengerStartTimeout <%= @passenger_start_timeout %>
 <% end -%>
-<% if @passenger_pre_start -%>
-  PassengerPreStart <%= @passenger_pre_start %>
-<% end -%>
 <% if @passenger_user -%>
   PassengerUser <%= @passenger_user %>
 <% end -%>


### PR DESCRIPTION
These commits improve usage of `passenger_pre_start` by:

* Outputting `PassengerPreStart` outside the `<VirtualHost>` block (using this directive inside is not supported and produce a warning with (at least) passenger-5.2.1);
* Allowing to set multiple URIs (to start multiple applications served within a single VirutalHost).

Only the generated configuration is affected, existing puppet code does not need to be modified for the fix to take effect (`passenger_pre_start` is still a parameter of `apache::vhost`).