### PR TITLE
Re-enable the apache_version fact on FreeBSD

### DIFF
--- a/lib/facter/apache_version.rb
+++ b/lib/facter/apache_version.rb
@@ -1,5 +1,5 @@
 Facter.add(:apache_version) do
-  confine kernel: 'Linux'
+  confine kernel: %w[FreeBSD Linux]
   setcode do
     if Facter::Util::Resolution.which('apachectl')
       apache_version = Facter::Util::Resolution.exec('apachectl -v 2>&1')


### PR DESCRIPTION
The fact was confined in 783729a5f2e348a4728f3ce29f0b58c7e0a425dd but running the test suite on FreeBSD will fail because the fact is confined to Linux.

Instead of simulating Linux when testing on FreeBSD, enable the fact on FreeBSD so that the apache version is available in Puppet manifests on this platform.