### PR TITLE
(Maint) Fix `release_checks` Travis matrix to work with Puppet 5.5.1

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -13,7 +13,7 @@
     - release
   extras:
     - env: CHECK=release_checks
-      rvm: 2.1.9
+      rvm: 2.3.4
 
 Gemfile:
   required:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ matrix:
       rvm: 2.1.9
     -
       env: CHECK=release_checks
-      rvm: 2.1.9
+      rvm: 2.3.4
 branches:
   only:
     - master


### PR DESCRIPTION
Puppet 5.5.1 changed the deprecated Ruby versions to anything < 2.3.0.
This means, with `release_checks` running in ruby version 2.1.9,
deprecation warnings are emitted, and the `puppet-syntax` task fails
due to deprecations being considered failures by default.