### PR TITLE
Remove insecure/bad SSL example

### DIFF
--- a/examples/vhost.pp
+++ b/examples/vhost.pp
@@ -231,15 +231,15 @@ apache::vhost { 'subdomain.loc':
 
 # Vhost with SSL (SSLProtocol, SSLCipherSuite & SSLHonorCipherOrder from default)
 apache::vhost { 'securedomain.com':
-        priority             => '10',
-        vhost_name           => 'www.securedomain.com',
-        port                 => '443',
-        docroot              => '/var/www/secure',
-        ssl                  => true,
-        ssl_cert             => '/etc/ssl/securedomain.cert',
-        ssl_key              => '/etc/ssl/securedomain.key',
-        ssl_chain            => '/etc/ssl/securedomain.crt',
-        add_listen           => false,
+  priority   => '10',
+  vhost_name => 'www.securedomain.com',
+  port       => '443',
+  docroot    => '/var/www/secure',
+  ssl        => true,
+  ssl_cert   => '/etc/ssl/securedomain.cert',
+  ssl_key    => '/etc/ssl/securedomain.key',
+  ssl_chain  => '/etc/ssl/securedomain.crt',
+  add_listen => false,
 }
 
 # Vhost with access log environment variables writing control

--- a/examples/vhost.pp
+++ b/examples/vhost.pp
@@ -229,7 +229,7 @@ apache::vhost { 'subdomain.loc':
   serveraliases   => ['*.loc',],
 }
 
-# Vhost with SSLProtocol,SSLCipherSuite, SSLHonorCipherOrder
+# Vhost with SSL (SSLProtocol, SSLCipherSuite & SSLHonorCipherOrder from default)
 apache::vhost { 'securedomain.com':
         priority             => '10',
         vhost_name           => 'www.securedomain.com',
@@ -239,9 +239,6 @@ apache::vhost { 'securedomain.com':
         ssl_cert             => '/etc/ssl/securedomain.cert',
         ssl_key              => '/etc/ssl/securedomain.key',
         ssl_chain            => '/etc/ssl/securedomain.crt',
-        ssl_protocol         => '-ALL +TLSv1',
-        ssl_cipher           => 'ALL:!aNULL:!ADH:!eNULL:!LOW:!EXP:RC4+RSA:+HIGH:+MEDIUM',
-        ssl_honorcipherorder => 'On',
         add_listen           => false,
 }
 


### PR DESCRIPTION
These SSL settings are worse than the default one:
- It only enables TLS1, no 1.1 or 1.2
- It enables RC4, which is supposed to be forbidden nowadays (http://www.ietf.org/rfc/rfc7465.txt)