### PR TITLE
(maint) - Re-adding PARALLEL_TEST_PROCESSORS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 ---
+env:
+  global:
+    - PARALLEL_TEST_PROCESSORS=16 # reduce test parallelism to prevent overloading containers
 sudo: false
 dist: trusty
 language: ruby


### PR DESCRIPTION
When using the pdk all additional configurations are put into the `.sync.yml` Currently there is no method to put this in the `.sync.yml` and populate via the pdk-template. Manually adding back in and have a ticket on the backlog to address this issue.