### PR TITLE
added $ to replacment param

### DIFF
--- a/README.md
+++ b/README.md
@@ -4230,7 +4230,7 @@ apache::vhost { 'site.name.fdqn':
   …
   redirectmatch_status => ['404','404'],
   redirectmatch_regexp => ['\.git(/.*|$)/','\.svn(/.*|$)'],
-  redirectmatch_dest => ['http://www.example.com/1','http://www.example.com/2'],
+  redirectmatch_dest => ['http://www.example.com/$1','http://www.example.com/$2'],
 }
 ```
 


### PR DESCRIPTION
According to the apache documentation https://httpd.apache.org/docs/2.4/rewrite/remapping.html a $ sign is need before the numbered replacment param in the redirectmatch section.

Mine is working with the $ sign. I did not test without.