### PR TITLE
(MODULES-7196) Allow setting CASRootProxiedAs per virtualhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -1850,7 +1850,7 @@ The `cas_login_url` and `cas_validate_url` parameters are required; several othe
 
   Default: `undef`.
 
-- `cas_root_proxied_as`: Sets the URL end users see when access to this Apache server is proxied.
+- `cas_root_proxied_as`: Sets the URL end users see when access to this Apache server is proxied. This URL should not include a trailing slash.
 
   Default: `undef`.
 

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -172,6 +172,7 @@ define apache::vhost(
   $max_keepalive_requests                                                           = undef,
   $cas_attribute_prefix                                                             = undef,
   $cas_attribute_delimiter                                                          = undef,
+  $cas_root_proxied_as                                                              = undef,
   $cas_scrub_request_headers                                                        = undef,
   $cas_sso_enabled                                                                  = undef,
   $cas_login_url                                                                    = undef,


### PR DESCRIPTION
The README doesn't say much about the use of CASRootProxiedAs, but it makes more sense to set it per vhost. This patch allows that.