### PR TITLE
add ssl_verify_client option to directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -5157,6 +5157,27 @@ apache::vhost { 'secure.example.net':
 }
 ```
 
+##### `ssl_verify_client`
+
+Exactly as with the top-level (VHost) `ssl_verify_client` directive, permits user to set [client certificate verification](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslverifyclient) level for this directory. 
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  …
+  directories => [
+	{ 	path				=> '/path/to/directory',
+		ssl_verify_client 	=> 'optional',
+	},
+  ],
+}
+```
+
+SSL renegotiation will occur if a session already exists at a lower verification level.
+
+Values: 'none', 'optional', 'require', and 'optional_no_ca'.
+
+Default: `undef`.
+
 ##### `suphp`
 
 A hash containing the 'user' and 'group' keys for the [suPHP_UserGroup](http://www.suphp.org/DocumentationView.html?file=apache/CONFIG) setting. It must be used with `suphp_engine => on` in the virtual host declaration, and can only be passed within `directories`.

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -220,6 +220,9 @@
     <%- if directory['ssl_options'] -%>
     SSLOptions <%= Array(directory['ssl_options']).join(' ') %>
     <%- end -%>
+    <%- if directory['ssl_verify_client'] -%>
+    SSLVerifyClient <%= directory['ssl_verify_client'] %>
+    <%- end -%>
     <%- if directory['suphp'] and @suphp_engine == 'on' -%>
     suPHP_UserGroup <%= directory['suphp']['user'] %> <%= directory['suphp']['group'] %>
     <%- end -%>

--- a/templates/vhost/_ssl.erb
+++ b/templates/vhost/_ssl.erb
@@ -16,8 +16,6 @@
   <%- if @ssl_honorcipherorder -%>
   SSLHonorCipherOrder     <%= @ssl_honorcipherorder %>
   <%- end -%>
-  <%- if @ssl_verify_client -%>
-  SSLVerifyClient         <%= @ssl_verify_client %>
   <%- if @ssl_certs_dir && @ssl_certs_dir != '' -%>
   SSLCACertificatePath    "<%= @ssl_certs_dir %>"
   <%- end -%>
@@ -36,6 +34,8 @@
   <%- if @ssl_crl_check && scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
   SSLCARevocationCheck    "<%= @ssl_crl_check %>"
   <%- end -%>
+  <%- if @ssl_verify_client -%>
+  SSLVerifyClient         <%= @ssl_verify_client %>
   <%- end -%>
   <%- if @ssl_options -%>
   SSLOptions <%= Array(@ssl_options).join(' ') %>


### PR DESCRIPTION
MODULES-7227
([link to Jira ticket](https://tickets.puppetlabs.com/browse/MODULES-7227))
Currently SSLVerifyClient can only be specified at VHost root.
**Change** to allow SSLVerifyClient to be specified inside Directory/Location (as per [spec](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslverifyclient)).