### PR TITLE
Add mod::auth_gssapi manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@
 [`mod_alias`]: https://httpd.apache.org/docs/current/mod/mod_alias.html
 [`mod_auth_cas`]: https://github.com/Jasig/mod_auth_cas
 [`mod_auth_kerb`]: http://modauthkerb.sourceforge.net/configure.html
+[`mod_auth_gssapi`]: https://github.com/modauthgssapi/mod_auth_gssapi
 [`mod_authnz_external`]: https://github.com/phokz/mod-auth-external
 [`mod_auth_dbd`]: http://httpd.apache.org/docs/current/mod/mod_authn_dbd.html
 [`mod_auth_mellon`]: https://github.com/UNINETT/mod_auth_mellon
@@ -1597,6 +1598,7 @@ The following Apache modules have supported classes, many of which allow for par
 * `auth_cas`\* (see [`apache::mod::auth_cas`][])
 * `auth_mellon`\* (see [`apache::mod::auth_mellon`][])
 * `auth_kerb`
+* `auth_gssapi`
 * `authn_core`
 * `authn_dbd`\* (see [`apache::mod::authn_dbd`][])
 * `authn_file`

--- a/manifests/mod/auth_gssapi.pp
+++ b/manifests/mod/auth_gssapi.pp
@@ -1,0 +1,5 @@
+class apache::mod::auth_gssapi {
+  include apache
+  include apache::mod::authn_core
+  apache::mod { 'auth_gssapi': }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -100,6 +100,7 @@ class apache::params inherits ::apache::version {
       # NOTE: The auth_cas module isn't available on RH/CentOS without providing dependency packages provided by EPEL.
       'auth_cas'              => 'mod_auth_cas',
       'auth_kerb'             => 'mod_auth_kerb',
+      'auth_gssapi'           => 'mod_auth_gssapi',
       'auth_mellon'           => 'mod_auth_mellon',
       'authnz_ldap'           => $::apache::version::distrelease ? {
         '7'     => 'mod_ldap',
@@ -239,6 +240,7 @@ class apache::params inherits ::apache::version {
       $mod_packages = {
         'auth_cas'              => 'libapache2-mod-auth-cas',
         'auth_kerb'             => 'libapache2-mod-auth-kerb',
+        'auth_gssapi'           => 'libapache2-mod-auth-gssapi',
         'auth_mellon'           => 'libapache2-mod-auth-mellon',
         'authnz_pam'            => 'libapache2-mod-authnz-pam',
         'dav_svn'               => 'libapache2-svn',
@@ -267,6 +269,7 @@ class apache::params inherits ::apache::version {
       $mod_packages = {
         'auth_cas'              => 'libapache2-mod-auth-cas',
         'auth_kerb'             => 'libapache2-mod-auth-kerb',
+        'auth_gssapi'           => 'libapache2-mod-auth-gssapi',
         'auth_mellon'           => 'libapache2-mod-auth-mellon',
         'authnz_pam'            => 'libapache2-mod-authnz-pam',
         'dav_svn'               => 'libapache2-svn',
@@ -410,18 +413,19 @@ class apache::params inherits ::apache::version {
       # NOTE: 'php' needs to enable APACHE option in make config
       # NOTE: 'dav_svn' needs to enable MOD_DAV_SVN make config
       # NOTE: not sure where the shibboleth should come from
-      'auth_kerb'  => 'www/mod_auth_kerb2',
-      'fcgid'      => 'www/mod_fcgid',
-      'passenger'  => 'www/rubygem-passenger',
-      'perl'       => 'www/mod_perl2',
-      'phpXXX'     => 'www/mod_phpXXX',
-      'proxy_html' => 'www/mod_proxy_html',
-      'python'     => 'www/mod_python3',
-      'wsgi'       => 'www/mod_wsgi',
-      'dav_svn'    => 'devel/subversion',
-      'xsendfile'  => 'www/mod_xsendfile',
-      'rpaf'       => 'www/mod_rpaf2',
-      'shib2'      => 'security/shibboleth2-sp',
+      'auth_kerb'   => 'www/mod_auth_kerb2',
+      'auth_gssapi' => 'www/mod_auth_gssapi',
+      'fcgid'       => 'www/mod_fcgid',
+      'passenger'   => 'www/rubygem-passenger',
+      'perl'        => 'www/mod_perl2',
+      'phpXXX'      => 'www/mod_phpXXX',
+      'proxy_html'  => 'www/mod_proxy_html',
+      'python'      => 'www/mod_python3',
+      'wsgi'        => 'www/mod_wsgi',
+      'dav_svn'     => 'devel/subversion',
+      'xsendfile'   => 'www/mod_xsendfile',
+      'rpaf'        => 'www/mod_rpaf2',
+      'shib2'       => 'security/shibboleth2-sp',
     }
     $mod_libs         = {
     }
@@ -476,6 +480,7 @@ class apache::params inherits ::apache::version {
     $mod_packages     = {
       # NOTE: I list here only modules that are not included in www-servers/apache
       'auth_kerb'       => 'www-apache/mod_auth_kerb',
+      'auth_gssapi'     => 'www-apache/mod_auth_gssapi',
       'authnz_external' => 'www-apache/mod_authnz_external',
       'fcgid'           => 'www-apache/mod_fcgid',
       'passenger'       => 'www-apache/passenger',
@@ -539,6 +544,7 @@ class apache::params inherits ::apache::version {
     if $::operatingsystemrelease < '11' or $::operatingsystemrelease >= '12' {
       $mod_packages      = {
         'auth_kerb'   => 'apache2-mod_auth_kerb',
+        'auth_gssapi' => 'apache2-mod_auth_gssapi',
         'dav_svn'     => 'subversion-server',
         'perl'        => 'apache2-mod_perl',
         'php5'        => 'apache2-mod_php5',
@@ -549,6 +555,7 @@ class apache::params inherits ::apache::version {
     } else {
       $mod_packages        = {
         'auth_kerb'   => 'apache2-mod_auth_kerb',
+        'auth_gssapi' => 'apache2-mod_auth_gssapi',
         'dav_svn'     => 'subversion-server',
         'perl'        => 'apache2-mod_perl',
         'php5'        => 'apache2-mod_php53',

--- a/spec/classes/mod/auth_gssapi_spec.rb
+++ b/spec/classes/mod/auth_gssapi_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+describe 'apache::mod::auth_gssapi', type: :class do
+  it_behaves_like 'a mod class, without including apache'
+
+  context 'default configuration with parameters' do
+    context 'on a Debian OS', :compile do
+      let :facts do
+        {
+          id: 'root',
+          kernel: 'Linux',
+          lsbdistcodename: 'squeeze',
+          osfamily: 'Debian',
+          operatingsystem: 'Debian',
+          operatingsystemrelease: '6',
+          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          concat_basedir: '/dne',
+          is_pe: false,
+        }
+      end
+
+      it { is_expected.to contain_class('apache::params') }
+      it { is_expected.to contain_apache__mod('auth_gssapi') }
+      it { is_expected.to contain_package('libapache2-mod-auth-gssapi') }
+    end
+    context 'on a RedHat OS', :compile do
+      let :facts do
+        {
+          id: 'root',
+          kernel: 'Linux',
+          osfamily: 'RedHat',
+          operatingsystem: 'RedHat',
+          operatingsystemrelease: '6',
+          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          concat_basedir: '/dne',
+          is_pe: false,
+        }
+      end
+
+      it { is_expected.to contain_class('apache::params') }
+      it { is_expected.to contain_apache__mod('auth_gssapi') }
+      it { is_expected.to contain_package('mod_auth_gssapi') }
+    end
+    context 'on a FreeBSD OS', :compile do
+      let :facts do
+        {
+          id: 'root',
+          kernel: 'FreeBSD',
+          osfamily: 'FreeBSD',
+          operatingsystem: 'FreeBSD',
+          operatingsystemrelease: '9',
+          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          concat_basedir: '/dne',
+          is_pe: false,
+        }
+      end
+
+      it { is_expected.to contain_class('apache::params') }
+      it { is_expected.to contain_apache__mod('auth_gssapi') }
+      it { is_expected.to contain_package('www/mod_auth_gssapi') }
+    end
+    context 'on a Gentoo OS', :compile do
+      let :facts do
+        {
+          id: 'root',
+          kernel: 'Linux',
+          osfamily: 'Gentoo',
+          operatingsystem: 'Gentoo',
+          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
+          operatingsystemrelease: '3.16.1-gentoo',
+          concat_basedir: '/dne',
+          is_pe: false,
+        }
+      end
+
+      it { is_expected.to contain_class('apache::params') }
+      it { is_expected.to contain_apache__mod('auth_gssapi') }
+      it { is_expected.to contain_package('www-apache/mod_auth_gssapi') }
+    end
+  end
+end


### PR DESCRIPTION
mod_auth_gssapi has a similar functionality to mod_auth_kerb, and is the
recommended way to deploy authorization with kerberos, through GSSAPI.

This merely adds the necessary module.