### PR TITLE
(DOCUMENT-870) Updates ssl_proxyengine default

### DIFF
--- a/README.md
+++ b/README.md
@@ -5412,7 +5412,7 @@ Specifies whether or not to use [SSLProxyEngine](https://httpd.apache.org/docs/c
 
 Boolean.
 
-Default: `true`.
+Default: `false`.
 
 ##### `ssl_stapling`
 


### PR DESCRIPTION
Updates the documentation to match the code, which already is in line with Apache's default. Discussed briefly here: https://tickets.puppetlabs.com/browse/DOCUMENT-870