### PR TITLE
MODULES-7343: Allow overrides by adding mod_libs in apache class

### DIFF
--- a/README.md
+++ b/README.md
@@ -1212,6 +1212,21 @@ Default: Depends on operating system.
 - **Gentoo**: `/etc/apache2/modules.d`
 - **Red Hat**: `/etc/httpd/conf.d`
 
+##### `mod_libs`
+
+Allows the user to override default module library names.
+
+```puppet
+include apache::params
+class { 'apache':
+  mod_libs => merge($::apache::params::mod_libs, {
+    'wsgi' => 'mod_wsgi_python3.so',
+  })
+}
+```
+
+Hash. Default: `$apache::params::mod_libs`
+
 ##### `mod_packages`
 
 Allows the user to override default module package names.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,6 +47,7 @@ class apache (
   $confd_dir                                                     = $::apache::params::confd_dir,
   $vhost_dir                                                     = $::apache::params::vhost_dir,
   $vhost_enable_dir                                              = $::apache::params::vhost_enable_dir,
+  $mod_libs                                                      = $::apache::params::mod_libs,
   $mod_packages                                                  = $::apache::params::mod_packages,
   $vhost_include_pattern                                         = $::apache::params::vhost_include_pattern,
   $mod_dir                                                       = $::apache::params::mod_dir,

--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -17,7 +17,7 @@ define apache::mod (
   $mod_dir = $::apache::mod_dir
 
   # Determine if we have special lib
-  $mod_libs = $::apache::params::mod_libs
+  $mod_libs = $::apache::mod_libs
   if $lib {
     $_lib = $lib
   } elsif has_key($mod_libs, $mod) { # 2.6 compatibility hack

--- a/spec/classes/mod/wsgi_spec.rb
+++ b/spec/classes/mod/wsgi_spec.rb
@@ -160,4 +160,37 @@ describe 'apache::mod::wsgi', type: :class do
     }
     it { is_expected.to contain_package('www-apache/mod_wsgi') }
   end
+  context 'overriding mod_libs' do
+    context 'on a RedHat OS', :compile do
+      let :facts do
+        {
+          id: 'root',
+          kernel: 'Linux',
+          osfamily: 'RedHat',
+          operatingsystem: 'Fedora',
+          operatingsystemrelease: '28',
+          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          concat_basedir: '/dne',
+          is_pe: false,
+        }
+      end
+      let :pre_condition do
+        <<-MANIFEST
+        include apache::params
+        class { 'apache':
+          mod_packages => merge($::apache::params::mod_packages, {
+            'wsgi' => 'python3-mod_wsgi',
+          }),
+          mod_libs => merge($::apache::params::mod_libs, {
+            'wsgi' => 'mod_wsgi_python3.so',
+          })
+        }
+        MANIFEST
+      end
+
+      it { is_expected.to contain_class('apache::params') }
+      it { is_expected.to contain_file('wsgi.load').with_content(%r{LoadModule wsgi_module modules/mod_wsgi_python3.so}) }
+      it { is_expected.to contain_package('python3-mod_wsgi') }
+    end
+  end
 end


### PR DESCRIPTION
This commit allows to override 'mod_libs' similar to how 'mod_packages'
is currently overriden. All the references to apache::params::mod_libs
are changed to apache::mod_libs.