### PR TITLE
fix typo in the tests

### DIFF
--- a/spec/acceptance/mod_passenger_spec.rb
+++ b/spec/acceptance/mod_passenger_spec.rb
@@ -174,7 +174,7 @@ describe 'apache::mod::passenger class' do
       unless (fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '14.04') ||
              (fact('operatingsystem') == 'Ubuntu' && fact('operatingsystemrelease') == '16.04') ||
              (fact('operatingsystem') == 'Debian' && fact('operatingsystemmajrelease') == '8')
-        expected_one < [%r{### Processes: [0-9]+}, %r{### Total private dirty RSS: [0-9\.]+ MB}]
+        expected_one << [%r{### Processes: [0-9]+}, %r{### Total private dirty RSS: [0-9\.]+ MB}]
       end
       it 'outputs status via passenger-memory-stats #stdout' do
         expected_one.each do |expect|


### PR DESCRIPTION
This typo is present since ~ 7 months. https://github.com/puppetlabs/puppetlabs-apache/commit/02919a8295b31931efda728654ab1d69ac4771e7#diff-54659813dfca25ca1f5df88aaccb09ecL199
Nobody noticed it because there are no acceptance tests running for
everything where unless does not match. I discovered this in https://github.com/puppetlabs/puppetlabs-apache/pull/1809