### PR TITLE
apache + modphp on debian9.5 fix

### DIFF
--- a/manifests/mpm.pp
+++ b/manifests/mpm.pp
@@ -73,6 +73,14 @@ define apache::mpm (
         }
       }
 
+      if $mpm == 'prefork' and $::operatingsystem == 'Debian' and $::operatingsystemrelease == '9.5' {
+        exec {
+          '/usr/sbin/a2dismod mpm_event':
+            onlyif  => '/usr/bin/test -e /etc/apache2/mods-enabled/mpm_event.load',
+            require => Package['httpd'],
+        }
+      }
+
       if $mpm == 'itk' and $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '14.04' {
         # workaround https://bugs.launchpad.net/ubuntu/+source/mpm-itk/+bug/1286882
         exec {


### PR DESCRIPTION
Hi, this PR fixes an error when installing apache with mod::php on debian:

```pp
class {'::apache':
    mpm_module => 'prefork',
} 

class {'::apache::mod::php': }
```

Relevant error message:
```
Creating config file /etc/php/7.0/apache2/php.ini with new version
apache2_switch_mpm prefork: No action required
dpkg: error processing package libapache2-mod-php7.0 (--configure):
 subprocess installed post-installation script returned error exit status 1
Errors were encountered while processing:
 libapache2-mod-php7.0
E: Sub-process /usr/bin/dpkg returned an error code (1)
Error: /Stage[main]/Apache::Mod::Php/Apache::Mod[php7.0]/Package[libapache2-mod-php7.0]: Could not evaluate: Puppet::Util::Log requires a message

```

Thank you, regards