### PR TITLE
remove EOL RHEL 5 from metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -21,7 +21,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7"
       ]
@@ -29,7 +28,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "5",
         "6",
         "7"
       ]


### PR DESCRIPTION
RHEL 5 is dead since a long time. I cherry-picked this from https://github.com/puppetlabs/puppetlabs-apache/pull/1809