### PR TITLE
Add option to add comments to the header of a vhost file

### DIFF
--- a/README.md
+++ b/README.md
@@ -3482,6 +3482,28 @@ Sets the URL to use when validating a client-presented ticket in an HTTP query s
 
 Defaults to the value set by [`apache::mod::auth_cas`][].
 
+
+##### `comment`
+
+Adds comments to the header of the configuration file. Pass as string or an array of strings.
+
+Default: `undef`.
+
+For example:
+
+``` puppet
+comment => "Account number: 123B",
+```
+
+Or:
+
+``` puppet
+comment => [
+  "Customer: X",
+  "Frontend domain: x.example.org",
+]
+```
+
 ##### `custom_fragment`
 
 Passes a string of custom configuration directives to place at the end of the virtual host configuration.

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -205,6 +205,7 @@ define apache::vhost(
   $cas_validate_saml                                                                = undef,
   Optional[String] $shib_compat_valid_user                                          = undef,
   Optional[Enum['On', 'on', 'Off', 'off', 'DNS', 'dns']] $use_canonical_name        = undef,
+  Optional[Variant[String,Array[String]]] $comment                                  = undef,
 ) {
 
   # The base class must be included first because it is used by parameter defaults

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -493,6 +493,10 @@ describe 'apache::vhost', type: :define do
           'keepalive'                   => 'on',
           'keepalive_timeout'           => '100',
           'max_keepalive_requests'      => '1000',
+          'comment'                     => [
+            'Comment 1',
+            'Comment 2',
+          ],
         }
       end
       let :facts do
@@ -554,7 +558,11 @@ describe 'apache::vhost', type: :define do
         is_expected.to contain_file('30-rspec.example.com.conf symlink').with('ensure' => 'link',
                                                                               'path' => '/etc/apache2/sites-enabled/30-rspec.example.com.conf')
       }
-      it { is_expected.to contain_concat__fragment('rspec.example.com-apache-header') }
+      it {
+        is_expected.to contain_concat__fragment('rspec.example.com-apache-header').with(
+          content: %r{^# Comment 1$},
+        )
+      }
       it { is_expected.to contain_concat__fragment('rspec.example.com-docroot') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-aliases') }
       it { is_expected.to contain_concat__fragment('rspec.example.com-itk') }

--- a/templates/vhost/_file_header.erb
+++ b/templates/vhost/_file_header.erb
@@ -2,6 +2,7 @@
 # Vhost template in module puppetlabs-apache
 # Managed by Puppet
 # ************************************
+<%= [@comment].flatten.collect{|c| "# #{c}"}.join("\n") -%>
 
 <VirtualHost <%= [@nvh_addr_port].flatten.compact.join(' ') %>>
 <% if @servername and not @servername.empty? -%>


### PR DESCRIPTION
You can pass

```puppet
comment => 'My comment',
```

or
```puppet
comment => [
  'comment 1',
  'comment 2',
],
```

Each element from the array will be added as a separate line.