### PR TITLE
(MODULES-8429) Update GPG key for phusion passenger

### DIFF
--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -527,7 +527,7 @@ class apache::mod::passenger (
       descr         => 'passenger',
       enabled       => '1',
       gpgcheck      => '0',
-      gpgkey        => 'https://packagecloud.io/gpg.key',
+      gpgkey        => 'https://packagecloud.io/phusion/passenger/gpgkey',
       repo_gpgcheck => '1',
       sslcacert     => '/etc/pki/tls/certs/ca-bundle.crt',
       sslverify     => '1',


### PR DESCRIPTION
Prior to this commit, a GPG key mismatch prevented the phusion
passenger RPM from installing on RedHat based installs.  This
commit updates the GPGKey to match the one provided by the script
https://packagecloud.io/phusion/passenger/install#bash-rpm.