### PR TITLE
(MODULES-5990) Addition of 'IncludeOptional conf-enabled/*.conf' to '…

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -69,6 +69,7 @@ class apache::params inherits ::apache::version {
     $server_root          = '/etc/httpd'
     $conf_dir             = "${httpd_dir}/conf"
     $confd_dir            = "${httpd_dir}/conf.d"
+    $conf_enabled         = undef
     $mod_dir              = $::apache::version::distrelease ? {
       '7'     => "${httpd_dir}/conf.modules.d",
       default => "${httpd_dir}/conf.d",
@@ -217,6 +218,7 @@ class apache::params inherits ::apache::version {
     $server_root         = '/etc/apache2'
     $conf_dir            = $httpd_dir
     $confd_dir           = "${httpd_dir}/conf.d"
+    $conf_enabled        = "${httpd_dir}/conf-enabled"
     $mod_dir             = "${httpd_dir}/mods-available"
     $mod_enable_dir      = "${httpd_dir}/mods-enabled"
     $vhost_dir           = "${httpd_dir}/sites-available"
@@ -462,6 +464,7 @@ class apache::params inherits ::apache::version {
     $server_root      = '/usr/local'
     $conf_dir         = $httpd_dir
     $confd_dir        = "${httpd_dir}/Includes"
+    $conf_enabled     = undef
     $mod_dir          = "${httpd_dir}/Modules"
     $mod_enable_dir   = undef
     $vhost_dir        = "${httpd_dir}/Vhosts"
@@ -602,6 +605,7 @@ class apache::params inherits ::apache::version {
     $server_root         = '/etc/apache2'
     $conf_dir            = $httpd_dir
     $confd_dir           = "${httpd_dir}/conf.d"
+    $conf_enabled        = undef
     $mod_dir             = "${httpd_dir}/mods-available"
     $mod_enable_dir      = "${httpd_dir}/mods-enabled"
     $vhost_dir           = "${httpd_dir}/sites-available"

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -114,6 +114,9 @@ IncludeOptional "<%= @confd_dir %>/*.conf"
 <%- else -%>
 Include "<%= @confd_dir %>/*.conf"
 <%- end -%>
+<%- if @conf_enabled and scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
+IncludeOptional "<%= @conf_enabled %>/*.conf"
+<%- end -%>
 <% if @vhost_load_dir != @confd_dir -%>
 <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
 IncludeOptional "<%= @vhost_load_dir %>/<%= @vhost_include_pattern %>"


### PR DESCRIPTION
…apache2.conf' on Debian Family OS