### PR TITLE
(MODULES-7196) Allow setting CASRootProxiedAs per virtualhost (replaces #1794)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1867,7 +1867,7 @@ The `cas_login_url` and `cas_validate_url` parameters are required; several othe
 
   Default: `undef`.
 
-- `cas_root_proxied_as`: Sets the URL end users see when access to this Apache server is proxied.
+- `cas_root_proxied_as`: Sets the URL end users see when access to this Apache server is proxied. This URL should not include a trailing slash.
 
   Default: `undef`.
 

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -198,6 +198,7 @@ define apache::vhost(
   $max_keepalive_requests                                                           = undef,
   $cas_attribute_prefix                                                             = undef,
   $cas_attribute_delimiter                                                          = undef,
+  $cas_root_proxied_as                                                              = undef,
   $cas_scrub_request_headers                                                        = undef,
   $cas_sso_enabled                                                                  = undef,
   $cas_login_url                                                                    = undef,

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -1733,4 +1733,26 @@ describe 'apache::vhost define' do
       it { is_expected.to contain 'ShibCompatValidUser On' }
     end
   end
+
+  describe 'cas parameters' do
+    pp = <<-MANIFEST
+      class { 'apache': }
+      class {'::apache::mod::auth_cas':
+        cas_login_url    => 'https://login.example.com/cas/login',
+        cas_validate_url => 'https://login.example.com/cas/serviceValidate',
+      }
+      apache::vhost { 'test.server':
+        port    => '80',
+        docroot => '/var/www/html',
+        cas_root_proxied_as => 'http://test.server'
+      }
+    MANIFEST
+    it 'applies cleanly' do
+      apply_manifest(pp, catch_failures: true)
+    end
+    describe file("#{$vhost_dir}/25-test.server.conf") do
+      it { is_expected.to be_file }
+      it { is_expected.to contain 'CASRootProxiedAs http://test.server' }
+    end
+  end
 end


### PR DESCRIPTION
The README doesn't say much about the use of CASRootProxiedAs, but it makes more sense to set it per vhost. This patch allows that. Now includes a test for the new feature and rebased against master, but I can't reopen the old pull request.