### PR TITLE
Add support for mod_http2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1283,6 +1283,18 @@ Sets the path to the file containing Apache ports configuration.
 
 Default: '{$conf_dir}/ports.conf'.
 
+##### `protocols`
+
+Sets the [Protocols](https://httpd.apache.org/docs/current/en/mod/core.html#protocols) directive, which lists available protocols for the server.
+
+Default: `undef`
+
+##### `protocols_honor_order`
+
+Sets the [ProtocolsHonorOrder](https://httpd.apache.org/docs/current/en/mod/core.html#protocolshonororder) directive which determines if order of Protocols determines precedence during negotiation.
+
+Default: `undef`
+
 ##### `purge_configs`
 
 Removes all other Apache configs and virtual hosts.
@@ -4408,6 +4420,18 @@ If nothing matches the priority, the first name-based virtual host is used. Like
 To omit the priority prefix in file names, pass a priority of `false`.
 
 Default: '25'.
+
+##### `protocols`
+
+Sets the [Protocols](https://httpd.apache.org/docs/current/en/mod/core.html#protocols) directive, which lists available protocols for the virutal host.
+
+Default: `undef`
+
+##### `protocols_honor_order`
+
+Sets the [ProtocolsHonorOrder](https://httpd.apache.org/docs/current/en/mod/core.html#protocolshonororder) directive which determines if order of Protocols determines precedence during negotiation.
+
+Default: `undef`
 
 ##### `proxy_dest`
 

--- a/README.md
+++ b/README.md
@@ -5078,6 +5078,16 @@ apache::vhost { 'first.example.com':
 }
 ```
 
+##### `h2_copy_files`
+
+Sets the [H2CopyFiles](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2copyfiles) directive.
+Note that you must declare `class {'apache::mod::http2': }` before using this directive.
+
+##### `h2_push_resource`
+
+Sets the [H2PushResource](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2pushresource) directive.
+Note that you must declare `class {'apache::mod::http2': }` before using this directive.
+
 ##### `headers`
 
 Adds lines for [Header](https://httpd.apache.org/docs/current/mod/mod_headers.html#header) directives.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 [`apache::mod::event`]: #class-apachemodevent
 [`apache::mod::ext_filter`]: #class-apachemodext_filter
 [`apache::mod::geoip`]: #class-apachemodgeoip
+[`apache::mod::http2`]: #class-apachemodhttp2
 [`apache::mod::itk`]: #class-apachemoditk
 [`apache::mod::jk`]: #class-apachemodjk
 [`apache::mod::ldap`]: #class-apachemodldap
@@ -182,6 +183,7 @@
 [`mod_ext_filter`]: https://httpd.apache.org/docs/current/mod/mod_ext_filter.html
 [`mod_fcgid`]: https://httpd.apache.org/mod_fcgid/mod/mod_fcgid.html
 [`mod_geoip`]: http://dev.maxmind.com/geoip/legacy/mod_geoip2/
+[`mod_http2`]: https://httpd.apache.org/docs/current/mod/mod_http2.html
 [`mod_info`]: https://httpd.apache.org/docs/current/mod/mod_info.html
 [`mod_ldap`]: https://httpd.apache.org/docs/2.2/mod/mod_ldap.html
 [`mod_mpm_event`]: https://httpd.apache.org/docs/current/mod/event.html
@@ -1647,6 +1649,7 @@ The following Apache modules have supported classes, many of which allow for par
 * `filter`
 * `geoip` (see [`apache::mod::geoip`][])
 * `headers`
+* `http2` (see [`apache::mod::http2`][])
 * `include`
 * `info`\*
 * `intercept_form_submit`
@@ -2189,6 +2192,138 @@ Installs and manages [`mod_geoip`][].
   Boolean.
 
   Default: `undef`.
+
+##### Class: `apache::mod::http2`
+
+Installs and manages [`mod_http2`][].
+
+**Parameters**:
+
+* `h2_copy_files`: Determines if file handles or copies of file content are
+passed from the requestion processing down to the main connection.
+
+  Boolean.
+
+  Default: `undef`
+
+* `h2_direct`: Toggles the usage of the HTTP/2 Direct Mode.
+
+  Boolean.
+
+  Default: `undef`
+
+* `h2_early_hints`: Controls if HTTP status 103 interim responses are forwarded
+to the client or not.
+
+  Boolean.
+
+  Default: `undef`
+
+* `h2_max_session_streams`: Sets the maximum number of active streams per
+HTTP/2 session that the server allows.
+
+  Integer.
+
+  Default: `undef`
+
+* `h2_max_worker_idle_seconds`: Sets the maximum number of seconds a h2 worker
+  may idle until it shuts itself down.
+
+  Integer.
+
+  Default: `undef`
+
+* `h2_max_workers`: Sets the maximum number of worker threads to spawn per
+  child process for HTTP/2 processing.
+
+  Integer.
+
+  Default: `undef`
+
+* `h2_min_workers`: Sets the minimum number of worker threads to spawn per
+  child process for HTTP/2 processing.
+
+  Integer.
+
+  Default: `undef`
+
+* `h2_modern_tls_only`: Toggles the security checks on HTTP/2 connections in
+  TLS mode.
+
+  Boolean.
+
+  Default: `undef`
+
+* `h2_push`: Toggles the usage of the HTTP/2 server push protocol feature.
+
+  Boolean.
+
+  Default: `undef`
+
+* `h2_push_diary_size`: Toggles the maximum number of HTTP/2 server pushes that
+  are remembered per HTTP/2 connection.
+
+  Integer.
+
+  Default: `undef`
+
+* `h2_push_priority`: Defines the priority handling of pushed responses based
+  on the content-type of the response.
+
+  Values: An array of priority definitions.
+
+  Default: `[]`
+
+* `h2_push_resource`: Declares resources for early pushing to the client.
+
+  Values: An array of resources.
+
+  Default: `[]`
+
+* `h2_serialize_headers`: Toggles if HTTP/2 requests shall be serialized in
+  HTTP/1.1 format for processing by httpd core.
+
+  Boolean.
+
+  Default: `undef`
+
+* `h2_stream_max_mem_size`: Maximum number of outgoing data bytes buffered in
+  memory for an active streams.
+
+  Integer.
+
+  Default: `undef`
+
+* `h2_tls_cool_down_secs`: Sets the number of seconds of idle time on a TLS
+  connection before the TLS write size falls back to small (~1300 bytes)
+  length.
+
+  Integer.
+
+  Default: `undef`
+
+* `h2_tls_warm_up_size`: Sets the number of bytes to be sent in small TLS
+  records (~1300 bytes) until doing maximum sized writes (16k) on https: HTTP/2
+  connections.
+
+  Integer.
+
+  Default: `undef`
+
+* `h2_upgrade`: Toggles the usage of the HTTP/1.1 Upgrade method for switching
+  to HTTP/2.
+
+  Boolean.
+
+  Default: `undef`
+
+* `h2_window_size`: Sets the size of the window that is used for flow control
+  from client to server and limits the amount of data the server has to buffer.
+
+  Integer.
+
+  Default: `undef`
+
 
 ##### Class: `apache::mod::info`
 

--- a/README.md
+++ b/README.md
@@ -3831,6 +3831,93 @@ Sets the [`ForceType`][] directive, which forces Apache to serve all matching fi
 
 Lets Apache set custom content character sets per directory and/or file extension
 
+##### `h2_copy_files`
+
+Sets the [H2CopyFiles](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2copyfiles)
+directive which influences how the requestion process pass files to the main
+connection.
+
+##### `h2_direct`
+
+Sets the [H2Direct](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2direct)
+directive which toggles the usage of the HTTP/2 Direct Mode.
+
+##### `h2_early_hints`
+
+Sets the [H2EarlyHints](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2earlyhints)
+directive which controls if HTTP status 103 interim responses are forwarded to
+the client or not.
+
+##### `h2_max_session_streams`
+
+Sets the [H2MaxSessionStreams](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2maxsessionstreams)
+directive which sets the maximum number of active streams per HTTP/2 session
+that the server allows.
+
+##### `h2_modern_tls_only`
+
+Sets the [H2ModernTLSOnly](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2moderntlsonly)
+directive which toggles the security checks on HTTP/2 connections in TLS mode.
+
+##### `h2_push`
+
+Sets the [H2Push](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2push)
+directive which toggles the usage of the HTTP/2 server push protocol feature.
+
+##### `h2_push_diary_size`
+
+Sets the [H2PushDiarySize](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2pushdiarysize)
+directive which toggles the maximum number of HTTP/2 server pushes that are
+remembered per HTTP/2 connection.
+
+##### `h2_push_priority`
+
+Sets the [H2PushPriority](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2pushpriority)
+directive which defines the priority handling of pushed responses based on the
+content-type of the response.
+
+##### `h2_push_resource`
+
+Sets the [H2PushResource](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2pushresource)
+directive which declares resources for early pushing to the client.
+
+##### `h2_serialize_headers`
+
+Sets the [H2SerializeHeaders](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2serializeheaders)
+directive which toggles if HTTP/2 requests shall be serialized in HTTP/1.1
+format for processing by httpd core.
+
+##### `h2_stream_max_mem_size`
+
+Sets the [H2StreamMaxMemSize](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2streammaxmemsize)
+directive which sets the maximum number of outgoing data bytes buffered in
+memory for an active streams.
+
+##### `h2_tls_cool_down_secs`
+
+Sets the [H2TLSCoolDownSecs](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2tlscooldownsecs)
+directive which sets the number of seconds of idle time on a TLS connection
+before the TLS write size falls back to small (~1300 bytes) length.
+
+##### `h2_tls_warm_up_size`
+
+Sets the [H2TLSWarmUpSize](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2tlswarmupsize)
+directive which sets the number of bytes to be sent in small TLS records (~1300
+bytes) until doing maximum sized writes (16k) on https: HTTP/2 connections.
+
+##### `h2_upgrade`
+
+Sets the [H2Upgrade](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2upgrade)
+directive which toggles the usage of the HTTP/1.1 Upgrade method for switching
+to HTTP/2.
+
+##### `h2_window_size`
+
+Sets the [H2WindowSize](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2windowsize)
+directive which sets the size of the window that is used for flow control from
+client to server and limits the amount of data the server has to buffer.
+
+
 ##### `headers`
 
 Adds lines to replace, merge, or remove response headers. See [Apache's mod_headers documentation](https://httpd.apache.org/docs/current/mod/mod_headers.html#header) for more information.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,6 +94,8 @@ class apache (
   $error_log                                                     = $::apache::params::error_log,
   $scriptalias                                                   = $::apache::params::scriptalias,
   $access_log_file                                               = $::apache::params::access_log_file,
+  Array[Enum['h2', 'h2c', 'http/1.1']] $protocols                = [],
+  Optional[Boolean] $protocols_honor_order                       = undef,
 ) inherits ::apache::params {
 
   $valid_mpms_re = $apache_version ? {

--- a/manifests/mod/http2.pp
+++ b/manifests/mod/http2.pp
@@ -1,0 +1,38 @@
+class apache::mod::http2 (
+  Optional[Boolean] $h2_copy_files              = undef,
+  Optional[Boolean] $h2_direct                  = undef,
+  Optional[Boolean] $h2_early_hints             = undef,
+  Optional[Integer] $h2_max_session_streams     = undef,
+  Optional[Integer] $h2_max_worker_idle_seconds = undef,
+  Optional[Integer] $h2_max_workers             = undef,
+  Optional[Integer] $h2_min_workers             = undef,
+  Optional[Boolean] $h2_modern_tls_only         = undef,
+  Optional[Boolean] $h2_push                    = undef,
+  Optional[Integer] $h2_push_diary_size         = undef,
+  Array[String]     $h2_push_priority           = [],
+  Array[String]     $h2_push_resource           = [],
+  Optional[Boolean] $h2_serialize_headers       = undef,
+  Optional[Integer] $h2_stream_max_mem_size     = undef,
+  Optional[Integer] $h2_tls_cool_down_secs      = undef,
+  Optional[Integer] $h2_tls_warm_up_size        = undef,
+  Optional[Boolean] $h2_upgrade                 = undef,
+  Optional[Integer] $h2_window_size             = undef,
+  Optional[String]  $apache_version             = undef,
+) {
+  include ::apache
+  apache::mod { 'http2': }
+
+  $_apache_version = pick($apache_version, $apache::apache_version)
+
+  file { 'http2.conf':
+    ensure  => file,
+    content => template('apache/mod/http2.conf.erb'),
+    mode    => $::apache::file_mode,
+    path    => "${::apache::mod_dir}/http2.conf",
+    owner   => $::apache::params::user,
+    group   => $::apache::params::group,
+    require => Exec["mkdir ${::apache::mod_dir}"],
+    before  => File[$::apache::mod_dir],
+    notify  => Class['apache::service'],
+  }
+}

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -133,6 +133,23 @@ define apache::vhost(
   $apache_version                                                                   = $::apache::apache_version,
   Optional[Enum['on', 'off', 'nodecode']] $allow_encoded_slashes                    = undef,
   Optional[Pattern[/^[\w-]+ [\w-]+$/]] $suexec_user_group                           = undef,
+
+  Optional[Boolean] $h2_copy_files                                                  = undef,
+  Optional[Boolean] $h2_direct                                                      = undef,
+  Optional[Boolean] $h2_early_hints                                                 = undef,
+  Optional[Integer] $h2_max_session_streams                                         = undef,
+  Optional[Boolean] $h2_modern_tls_only                                             = undef,
+  Optional[Boolean] $h2_push                                                        = undef,
+  Optional[Integer] $h2_push_diary_size                                             = undef,
+  Array[String]     $h2_push_priority                                               = [],
+  Array[String]     $h2_push_resource                                               = [],
+  Optional[Boolean] $h2_serialize_headers                                           = undef,
+  Optional[Integer] $h2_stream_max_mem_size                                         = undef,
+  Optional[Integer] $h2_tls_cool_down_secs                                          = undef,
+  Optional[Integer] $h2_tls_warm_up_size                                            = undef,
+  Optional[Boolean] $h2_upgrade                                                     = undef,
+  Optional[Integer] $h2_window_size                                                 = undef,
+
   Optional[Boolean] $passenger_enabled                                              = undef,
   Optional[String] $passenger_base_uri                                              = undef,
   Optional[Stdlib::Absolutepath] $passenger_ruby                                    = undef,
@@ -947,6 +964,16 @@ define apache::vhost(
       target  => "${priority_real}${filename}.conf",
       order   => 290,
       content => template('apache/vhost/_suexec.erb'),
+    }
+  }
+
+  if $h2_copy_files != undef or $h2_direct != undef or $h2_early_hints != undef or $h2_max_session_streams != undef or $h2_modern_tls_only != undef or $h2_push != undef or $h2_push_diary_size != undef or $h2_push_priority != [] or $h2_push_resource != [] or $h2_serialize_headers != undef or $h2_stream_max_mem_size != undef or $h2_tls_cool_down_secs != undef or $h2_tls_warm_up_size != undef or $h2_upgrade != undef or $h2_window_size != undef {
+    include ::apache::mod::http2
+
+    concat::fragment { "${name}-http2":
+      target  => "${priority_real}${filename}.conf",
+      order   => 300,
+      content => template('apache/vhost/_http2.erb'),
     }
   }
 

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -570,6 +570,7 @@ define apache::vhost(
   }
 
   # Template uses:
+  # - $comment
   # - $nvh_addr_port
   # - $servername
   # - $serveradmin

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -10,6 +10,8 @@ define apache::vhost(
   $docroot_owner                                                                    = 'root',
   $docroot_group                                                                    = $::apache::params::root_group,
   $docroot_mode                                                                     = undef,
+  Array[Enum['h2', 'h2c', 'http/1.1']] $protocols                                   = [],
+  Optional[Boolean] $protocols_honor_order                                          = undef,
   $serveradmin                                                                      = undef,
   Boolean $ssl                                                                      = false,
   $ssl_cert                                                                         = $::apache::default_ssl_cert,
@@ -571,6 +573,9 @@ define apache::vhost(
   # - $nvh_addr_port
   # - $servername
   # - $serveradmin
+  # - $protocols
+  # - $protocols_honor_order
+  # - $apache_version
   concat::fragment { "${name}-apache-header":
     target  => "${priority_real}${filename}.conf",
     order   => 0,

--- a/spec/classes/mod/http2_spec.rb
+++ b/spec/classes/mod/http2_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+describe 'apache::mod::http2', type: :class do
+  it_behaves_like 'a mod class, without including apache'
+
+  context 'default configuration with parameters on a Debian OS' do
+    let :facts do
+      {
+        lsbdistcodename: 'jessie',
+        osfamily: 'Debian',
+        operatingsystemrelease: '8',
+        id: 'root',
+        kernel: 'Linux',
+        operatingsystem: 'Debian',
+        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        is_pe: false,
+      }
+    end
+
+    it { is_expected.to contain_class('apache::mod::http2') }
+    context 'with default values' do
+      let(:expected_content) do
+        <<EOT
+# The http2 Apache module configuration file is being
+# managed by Puppet and changes will be overwritten.
+
+EOT
+      end
+
+      it { is_expected.to contain_file('http2.conf').with(content: expected_content) }
+    end
+
+    context 'with all values set' do
+      let(:params) do
+        {
+          h2_copy_files: false,
+          h2_direct: true,
+          h2_early_hints: false,
+          h2_max_session_streams: 100,
+          h2_max_worker_idle_seconds: 600,
+          h2_max_workers: 20,
+          h2_min_workers: 10,
+          h2_modern_tls_only: true,
+          h2_push: true,
+          h2_push_diary_size: 256,
+          h2_push_priority: [
+            'application/json 32',
+            'image/jpeg before',
+            'text/css   interleaved',
+          ],
+          h2_push_resource: [
+            '/xxx.css',
+            '/xxx.js',
+          ],
+          h2_serialize_headers: true,
+          h2_stream_max_mem_size: 128_000,
+          h2_tls_cool_down_secs: 0,
+          h2_tls_warm_up_size: 0,
+          h2_upgrade: false,
+          h2_window_size: 128_000,
+
+          apache_version: '2.4',
+        }
+      end
+
+      let(:expected_content) do
+        <<EOT
+# The http2 Apache module configuration file is being
+# managed by Puppet and changes will be overwritten.
+
+H2CopyFiles Off
+H2Direct On
+H2EarlyHints Off
+H2MaxSessionStreams 100
+H2MaxWorkerIdleSeconds 600
+H2MaxWorkers 20
+H2MinWorkers 10
+H2ModernTLSOnly On
+H2Push On
+H2PushDiarySize 256
+H2PushPriority application/json 32
+H2PushPriority image/jpeg before
+H2PushPriority text/css   interleaved
+H2PushResource /xxx.css
+H2PushResource /xxx.js
+H2SerializeHeaders On
+H2StreamMaxMemSize 128000
+H2TLSCoolDownSecs 0
+H2TLSWarmUpSize 0
+H2Upgrade Off
+H2WindowSize 128000
+EOT
+      end
+
+      it { is_expected.to contain_file('http2.conf').with(content: expected_content) }
+    end
+  end
+end

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -349,6 +349,28 @@ describe 'apache::vhost', type: :define do
               'suexec_user_group'           => 'root root',
               'allow_encoded_slashes'       => 'nodecode',
               'use_canonical_name'          => 'dns',
+
+              'h2_copy_files'               => false,
+              'h2_direct'                   => true,
+              'h2_early_hints'              => false,
+              'h2_max_session_streams'      => 100,
+              'h2_modern_tls_only'          => true,
+              'h2_push'                     => true,
+              'h2_push_diary_size'          => 256,
+              'h2_push_priority'            => [
+                'application/json 32',
+              ],
+              'h2_push_resource' => [
+                '/css/main.css',
+                '/js/main.js',
+              ],
+              'h2_serialize_headers'        => false,
+              'h2_stream_max_mem_size'      => 65_536,
+              'h2_tls_cool_down_secs'       => 1,
+              'h2_tls_warm_up_size'         => 1_048_576,
+              'h2_upgrade'                  => true,
+              'h2_window_size'              => 65_535,
+
               'passenger_enabled'                     => false,
               'passenger_base_uri'                    => '/app',
               'passenger_ruby'                        => '/usr/bin/ruby1.9.1',
@@ -1000,6 +1022,88 @@ describe 'apache::vhost', type: :define do
               content: %r{^\s+MaxKeepAliveRequests\s1000$},
             )
           }
+
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-http2').with(
+              content: %r{^\s+H2CopyFiles\sOff$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-http2').with(
+              content: %r{^\s+H2Direct\sOn$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-http2').with(
+              content: %r{^\s+H2EarlyHints\sOff$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-http2').with(
+              content: %r{^\s+H2MaxSessionStreams\s100$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-http2').with(
+              content: %r{^\s+H2ModernTLSOnly\sOn$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-http2').with(
+              content: %r{^\s+H2Push\sOn$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-http2').with(
+              content: %r{^\s+H2PushDiarySize\s256$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-http2').with(
+              content: %r{^\s+H2PushPriority\sapplication/json 32$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-http2').with(
+              content: %r{^\s+H2PushResource\s/css/main.css$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-http2').with(
+              content: %r{^\s+H2PushResource\s/js/main.js$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-http2').with(
+              content: %r{^\s+H2SerializeHeaders\sOff$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-http2').with(
+              content: %r{^\s+H2StreamMaxMemSize\s65536$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-http2').with(
+              content: %r{^\s+H2TLSCoolDownSecs\s1$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-http2').with(
+              content: %r{^\s+H2TLSWarmUpSize\s1048576$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-http2').with(
+              content: %r{^\s+H2Upgrade\sOn$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-http2').with(
+              content: %r{^\s+H2WindowSize\s65535$},
+            )
+          }
+
           it {
             is_expected.to contain_concat__fragment('rspec.example.com-passenger').with(
               content: %r{^\s+PassengerEnabled\sOff$},

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -437,6 +437,8 @@ describe 'apache::vhost', type: :define do
               'keepalive'                   => 'on',
               'keepalive_timeout'           => '100',
               'max_keepalive_requests'      => '1000',
+              'protocols'                   => ['h2', 'http/1.1'],
+              'protocols_honor_order'       => true,
             }
           end
 
@@ -1043,6 +1045,16 @@ describe 'apache::vhost', type: :define do
           it {
             is_expected.to contain_concat__fragment('rspec.example.com-keepalive_options').with(
               content: %r{^\s+MaxKeepAliveRequests\s1000$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-apache-header').with(
+              content: %r{^\s+Protocols\sh2 http/1.1$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-apache-header').with(
+              content: %r{^\s+ProtocolsHonorOrder\sOn$},
             )
           }
 

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -177,6 +177,14 @@ describe 'apache::vhost', type: :define do
                   'dav_depth_infinity' => true,
                   'dav_min_timeout'    => '600' },
                 {
+                  'path'             => '/var/www/http2',
+                  'h2_copy_files'    => true,
+                  'h2_push_resource' => [
+                    '/foo.css',
+                    '/foo.js',
+                  ],
+                },
+                {
                   'path'                                                => '/var/www/node-app/public',
                   'passenger_enabled'                                   => true,
                   'passenger_base_uri'                                  => '/app',
@@ -499,6 +507,21 @@ describe 'apache::vhost', type: :define do
           it {
             is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
               content: %r{^\s+Include\s'\/custom\/path\/another_includes'$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
+              content: %r{^\s+H2CopyFiles\sOn$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
+              content: %r{^\s+H2PushResource\s/foo.css$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
+              content: %r{^\s+H2PushResource\s/foo.js$},
             )
           }
           it {

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -17,6 +17,16 @@ LimitRequestFields <%= @limitreqfields %>
 HttpProtocolOptions <%= @http_protocol_options %>
 <%- end -%>
 
+<%# Actually >= 2.4.17, but the minor version is not provided -%>
+<%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
+  <%- unless @protocols.empty? -%>
+Protocols <%= @protocols.join(' ') %>
+  <%- end -%>
+  <%- unless @protocols_honor_order.nil? -%>
+ProtocolsHonorOrder <%= scope.call_function('apache::bool2httpd', [@protocols_honor_order]) %>
+  <%- end -%>
+<%- end -%>
+
 <%- if @rewrite_lock and scope.function_versioncmp([@apache_version, '2.2']) <= 0 -%>
 RewriteLock <%= @rewrite_lock %>
 <%- end -%>

--- a/templates/mod/http2.conf.erb
+++ b/templates/mod/http2.conf.erb
@@ -1,0 +1,65 @@
+# The http2 Apache module configuration file is being
+# managed by Puppet and changes will be overwritten.
+
+<%# Actually >= 2.4.24, but the minor version is not provided -%>
+<% if !@h2_copy_files.nil? && scope.function_versioncmp([@_apache_version, '2.4']) >= 0 -%>
+H2CopyFiles <%= scope.call_function('apache::bool2httpd', [@h2_copy_files]) %>
+<% end -%>
+<% unless @h2_direct.nil? -%>
+H2Direct <%= scope.call_function('apache::bool2httpd', [@h2_direct]) %>
+<% end -%>
+<%# Actually >= 2.4.24, but the minor version is not provided -%>
+<% if !@h2_early_hints.nil? && scope.function_versioncmp([@_apache_version, '2.4']) >= 0 -%>
+H2EarlyHints <%= scope.call_function('apache::bool2httpd', [@h2_early_hints]) %>
+<% end -%>
+<% unless @h2_max_session_streams.nil? -%>
+H2MaxSessionStreams <%= @h2_max_session_streams %>
+<% end -%>
+<% unless @h2_max_worker_idle_seconds.nil? -%>
+H2MaxWorkerIdleSeconds <%= @h2_max_worker_idle_seconds %>
+<% end -%>
+<% unless @h2_max_workers.nil? -%>
+H2MaxWorkers <%= @h2_max_workers %>
+<% end -%>
+<% unless @h2_min_workers.nil? -%>
+H2MinWorkers <%= @h2_min_workers %>
+<% end -%>
+<%# Actually >= 2.4.24, but the minor version is not provided -%>
+<% if scope.function_versioncmp([@_apache_version, '2.4']) >= 0 -%>
+    <%- unless @h2_modern_tls_only.nil? -%>
+H2ModernTLSOnly <%= scope.call_function('apache::bool2httpd', [@h2_modern_tls_only]) %>
+    <%- end -%>
+    <%- unless @h2_push.nil? -%>
+H2Push <%= scope.call_function('apache::bool2httpd', [@h2_push]) %>
+    <%- end -%>
+    <%- unless @h2_push_diary_size.nil? -%>
+H2PushDiarySize <%= @h2_push_diary_size %>
+    <%- end -%>
+    <%- @h2_push_priority.each do |expr| -%>
+H2PushPriority <%= expr %>
+    <%- end -%>
+    <%- @h2_push_resource.each do |expr| -%>
+H2PushResource <%= expr %>
+    <%- end -%>
+<% end -%>
+<% unless @h2_serialize_headers.nil? -%>
+H2SerializeHeaders <%= scope.call_function('apache::bool2httpd', [@h2_serialize_headers]) %>
+<% end -%>
+<% unless @h2_stream_max_mem_size.nil? -%>
+H2StreamMaxMemSize <%= @h2_stream_max_mem_size %>
+<% end -%>
+<%# Actually >= 2.4.24, but the minor version is not provided -%>
+<% if scope.function_versioncmp([@_apache_version, '2.4']) >= 0 -%>
+    <%- unless @h2_tls_cool_down_secs.nil? -%>
+H2TLSCoolDownSecs <%= @h2_tls_cool_down_secs %>
+    <%- end -%>
+    <%- unless @h2_tls_warm_up_size.nil? -%>
+H2TLSWarmUpSize <%= @h2_tls_warm_up_size %>
+    <%- end -%>
+<% end -%>
+<% unless @h2_upgrade.nil? -%>
+H2Upgrade <%= scope.call_function('apache::bool2httpd', [@h2_upgrade]) %>
+<% end -%>
+<% unless @h2_window_size.nil? -%>
+H2WindowSize <%= @h2_window_size %>
+<% end -%>

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -85,6 +85,14 @@
     <%- if directory['sethandler'] and directory['sethandler'] != '' -%>
     SetHandler <%= directory['sethandler'] %>
     <%- end -%>
+    <%- unless directory['h2_copy_files'].nil? -%>
+    H2CopyFiles <%= scope.call_function('apache::bool2httpd', [directory['h2_copy_files']]) %>
+    <%- end -%>
+    <%- if directory['h2_push_resource'] && ! directory['h2_push_resource'].empty? -%>
+      <%- [directory['h2_push_resource']].flatten.compact.each do |h2_push_resource| -%>
+    H2PushResource <%= h2_push_resource %>
+      <%- end -%>
+    <%- end -%>
     <%- unless directory['passenger_enabled'].nil? -%>
     PassengerEnabled <%= scope.call_function('apache::bool2httpd', [directory['passenger_enabled']]) %>
     <%- end -%>

--- a/templates/vhost/_file_header.erb
+++ b/templates/vhost/_file_header.erb
@@ -11,3 +11,12 @@
 <% if @serveradmin -%>
   ServerAdmin <%= @serveradmin %>
 <% end -%>
+<%# Actually >= 2.4.17, but the minor version is not provided -%>
+<% if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
+  <%- unless @protocols.empty? -%>
+  Protocols <%= @protocols.join(' ') %>
+  <%- end -%>
+  <%- unless @protocols_honor_order.nil? -%>
+  ProtocolsHonorOrder <%= scope.call_function('apache::bool2httpd', [@protocols_honor_order]) %>
+  <%- end -%>
+<% end -%>

--- a/templates/vhost/_http2.erb
+++ b/templates/vhost/_http2.erb
@@ -1,0 +1,53 @@
+<%# Actually >= 2.4.24, but the minor version is not provided -%>
+<% if !@h2_copy_files.nil? && scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
+  H2CopyFiles <%= scope.call_function('apache::bool2httpd', [@h2_copy_files]) %>
+<% end -%>
+<% unless @h2_direct.nil? -%>
+  H2Direct <%= scope.call_function('apache::bool2httpd', [@h2_direct]) %>
+<% end -%>
+<%# Actually >= 2.4.24, but the minor version is not provided -%>
+<% if !@h2_early_hints.nil? && scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
+  H2EarlyHints <%= scope.call_function('apache::bool2httpd', [@h2_early_hints]) %>
+<% end -%>
+<% unless @h2_max_session_streams.nil? -%>
+  H2MaxSessionStreams <%= @h2_max_session_streams %>
+<% end -%>
+<%# Actually >= 2.4.24, but the minor version is not provided -%>
+<% if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
+    <%- unless @h2_modern_tls_only.nil? -%>
+  H2ModernTLSOnly <%= scope.call_function('apache::bool2httpd', [@h2_modern_tls_only]) %>
+    <%- end -%>
+    <%- unless @h2_push.nil? -%>
+  H2Push <%= scope.call_function('apache::bool2httpd', [@h2_push]) %>
+    <%- end -%>
+    <%- unless @h2_push_diary_size.nil? -%>
+  H2PushDiarySize <%= @h2_push_diary_size %>
+    <%- end -%>
+    <%- @h2_push_priority.each do |expr| -%>
+  H2PushPriority <%= expr %>
+    <%- end -%>
+    <%- @h2_push_resource.each do |expr| -%>
+  H2PushResource <%= expr %>
+    <%- end -%>
+<% end -%>
+<% unless @h2_serialize_headers.nil? -%>
+  H2SerializeHeaders <%= scope.call_function('apache::bool2httpd', [@h2_serialize_headers]) %>
+<% end -%>
+<% unless @h2_stream_max_mem_size.nil? -%>
+  H2StreamMaxMemSize <%= @h2_stream_max_mem_size %>
+<% end -%>
+<%# Actually >= 2.4.24, but the minor version is not provided -%>
+<% if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
+    <%- unless @h2_tls_cool_down_secs.nil? -%>
+  H2TLSCoolDownSecs <%= @h2_tls_cool_down_secs %>
+    <%- end -%>
+    <%- unless @h2_tls_warm_up_size.nil? -%>
+  H2TLSWarmUpSize <%= @h2_tls_warm_up_size %>
+    <%- end -%>
+<% end -%>
+<% unless @h2_upgrade.nil? -%>
+  H2Upgrade <%= scope.call_function('apache::bool2httpd', [@h2_upgrade]) %>
+<% end -%>
+<% unless @h2_window_size.nil? -%>
+  H2WindowSize <%= @h2_window_size %>
+<% end -%>


### PR DESCRIPTION
[`mod_http2`](https://httpd.apache.org/docs/current/mod/mod_http2.html) was introduced in Apache 2.4.17 and provides HTTP/2 ([RFC 7540](https://tools.ietf.org/html/rfc7540)) support.

This pull request allows configuring HTTP/2 websites using the apache module.