### PR TITLE
MODULES-8541 : Allow HostnameLookups to be modified

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,7 @@ class apache (
   $service_ensure                                                = 'running',
   $service_restart                                               = undef,
   $purge_configs                                                 = true,
+  $host_namelookups                                              = $::apache::params::host_namelookups,
   $purge_vhost_dir                                               = undef,
   $purge_vdir                                                    = false,
   $serveradmin                                                   = 'root@localhost',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,6 +28,9 @@ class apache::params inherits ::apache::version {
   # The default error log level
   $log_level = 'warn'
   $use_optional_includes = false
+  
+  # The default value for host hame lookup
+  $host_namelookups = 'Off'
 
   # Default mime types settings
   $mime_types_additional = {

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -55,7 +55,7 @@ AddDefaultCharset <%= @default_charset %>
 <%- if scope.function_versioncmp([@apache_version, '2.4']) < 0 -%>
 DefaultType <%= @default_type %>
 <%- end -%>
-HostnameLookups Off
+HostnameLookups "<%= @host_namelookups %>"
 <%- if /^[|\/]/.match(@error_log) || /^syslog:/.match(@error_log) -%>
 ErrorLog "<%= @error_log %>"
 <%- else -%>


### PR DESCRIPTION
https://tickets.puppetlabs.com/projects/MODULES/issues/MODULES-8541

Apache variable HostnameLookups should be allowed to configured, as many of the configuration behind proxy require the domain name lookup in conditional statements. It should be default value set to Off, but it should be allowed to configured.
