### PR TITLE
Fix wsgi_daemon_process to support hash data type

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,11 +561,13 @@ apache::vhost { 'wsgi.example.com':
   port                        => '80',
   docroot                     => '/var/www/pythonapp',
   wsgi_application_group      => '%{GLOBAL}',
-  wsgi_daemon_process         => 'wsgi',
-  wsgi_daemon_process_options => {
-    processes    => '2',
-    threads      => '15',
-    display-name => '%{GROUP}',
+  wsgi_daemon_process         => {
+    'wsgi' => {
+      processes    => '2',
+      threads      => '15',
+      display-name => '%{GROUP}',
+    },
+    'foo' => {},
   },
   wsgi_import_script          => '/var/www/demo.wsgi',
   wsgi_import_script_options  => {
@@ -4853,7 +4855,7 @@ apache::vhost { 'subdomain.loc':
 Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi).
 
 * `wsgi_daemon_process`: A hash that sets the name of the WSGI daemon, accepting [certain keys](http://modwsgi.readthedocs.org/en/latest/configuration-directives/WSGIDaemonProcess.html). Default: `undef`.
-* `wsgi_daemon_process_options`. _Optional._ Default: `undef`.
+* `wsgi_daemon_process_options`. _Optional._ Default: `undef`. **Deprecated:** Please add values inside Hash `wsgi_daemon_process`.
 * `wsgi_process_group`: Sets the group ID that the virtual host runs under. Default: `undef`.
 * `wsgi_script_aliases`: Requires a hash of web paths to filesystem .wsgi paths. Default: `undef`.
 * `wsgi_script_aliases_match`: Requires a hash of web path regexes to filesystem .wsgi paths. Default: `undef`
@@ -4866,12 +4868,14 @@ An example virtual host configuration with WSGI:
 apache::vhost { 'wsgi.example.com':
   port                        => '80',
   docroot                     => '/var/www/pythonapp',
-  wsgi_daemon_process         => 'wsgi',
-  wsgi_daemon_process_options =>
-    { processes    => '2',
+  wsgi_daemon_process         => {
+    'wsgi' => {
+      processes    => '2',
       threads      => '15',
       display-name => '%{GROUP}',
-     },
+    },
+    'foo' => {},
+  },
   wsgi_process_group          => 'wsgi',
   wsgi_script_aliases         => { '/' => '/var/www/demo.wsgi' },
   wsgi_chunked_request        => 'On',

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -114,7 +114,7 @@ define apache::vhost(
   $block                                                                            = [],
   Enum['absent', 'present'] $ensure                                                 = 'present',
   $wsgi_application_group                                                           = undef,
-  $wsgi_daemon_process                                                              = undef,
+  Optional[Variant[String,Hash]] $wsgi_daemon_process                               = undef,
   Optional[Hash] $wsgi_daemon_process_options                                       = undef,
   $wsgi_import_script                                                               = undef,
   Optional[Hash] $wsgi_import_script_options                                        = undef,
@@ -933,6 +933,9 @@ define apache::vhost(
   # - $wsgi_process_group
   # - $wsgi_script_aliases
   # - $wsgi_pass_authorization
+  if $wsgi_daemon_process_options {
+    deprecation('apache::vhost::wsgi_daemon_process_options', 'This parameter is deprecated. Please add values inside Hash `wsgi_daemon_process`.')
+  }
   if $wsgi_application_group or $wsgi_daemon_process or ($wsgi_import_script and $wsgi_import_script_options) or $wsgi_process_group or ($wsgi_script_aliases and ! empty($wsgi_script_aliases)) or $wsgi_pass_authorization {
     concat::fragment { "${name}-wsgi":
       target  => "${priority_real}${filename}.conf",

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -1510,7 +1510,7 @@ describe 'apache::vhost define' do
           apache::vhost { 'test.server':
             docroot                     => '/tmp',
             wsgi_application_group      => '%{GLOBAL}',
-            wsgi_daemon_process         => 'wsgi',
+            wsgi_daemon_process         => { 'foo' => { 'python-home' => '/usr' }, 'bar' => {} },
             wsgi_daemon_process_options => {processes => '2'},
             wsgi_process_group          => 'nobody',
             wsgi_script_aliases         => { '/test' => '/test1' },
@@ -1531,7 +1531,7 @@ describe 'apache::vhost define' do
         apache::vhost { 'test.server':
           docroot                     => '/tmp',
           wsgi_application_group      => '%{GLOBAL}',
-          wsgi_daemon_process         => 'wsgi',
+          wsgi_daemon_process         => { 'wsgi' => { 'python-home' => '/usr' }, 'foo' => {} },
           wsgi_daemon_process_options => {processes => '2'},
           wsgi_import_script          => '/test1',
           wsgi_import_script_options  => { application-group => '%{GLOBAL}', process-group => 'wsgi' },
@@ -1549,7 +1549,8 @@ describe 'apache::vhost define' do
         describe file("#{$vhost_dir}/25-test.server.conf") do
           it { is_expected.to be_file }
           it { is_expected.to contain 'WSGIApplicationGroup %{GLOBAL}' }
-          it { is_expected.to contain 'WSGIDaemonProcess wsgi processes=2' }
+          it { is_expected.to contain 'WSGIDaemonProcess foo' }
+          it { is_expected.to contain 'WSGIDaemonProcess wsgi python-home=/usr' }
           it { is_expected.to contain 'WSGIImportScript /test1 application-group=%{GLOBAL} process-group=wsgi' }
           it { is_expected.to contain 'WSGIProcessGroup nobody' }
           it { is_expected.to contain 'WSGIScriptAlias /test "/test1"' }

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -320,7 +320,7 @@ describe 'apache::vhost', type: :define do
               'setenvifnocase'              => 'REMOTE_ADDR ^127.0.0.1 localhost=true',
               'block'                       => 'scm',
               'wsgi_application_group'      => '%{GLOBAL}',
-              'wsgi_daemon_process'         => 'wsgi',
+              'wsgi_daemon_process'         => { 'foo' => { 'python-home' => '/usr' }, 'bar' => {} },
               'wsgi_daemon_process_options' => {
                 'processes'    => '2',
                 'threads'      => '15',
@@ -1691,7 +1691,7 @@ describe 'apache::vhost', type: :define do
           let :params do
             {
               'docroot'                    => '/rspec/docroot',
-              'wsgi_daemon_process' => 'wsgi',
+              'wsgi_daemon_process' => { 'foo' => { 'python-home' => '/usr' }, 'bar' => {} },
             }
           end
 

--- a/templates/vhost/_wsgi.erb
+++ b/templates/vhost/_wsgi.erb
@@ -5,10 +5,18 @@
 <% if @wsgi_application_group -%>
   WSGIApplicationGroup <%= @wsgi_application_group %>
 <% end -%>
-<% if @wsgi_daemon_process and @wsgi_daemon_process_options -%>
+<% if @wsgi_daemon_process.is_a? String and @wsgi_daemon_process_options -%>
   WSGIDaemonProcess <%= @wsgi_daemon_process %> <%= @wsgi_daemon_process_options.collect { |k,v| "#{k}=#{v}"}.sort.join(' ') %>
-<% elsif @wsgi_daemon_process and !@wsgi_daemon_process_options -%>
+<% elsif @wsgi_daemon_process.is_a? String and !@wsgi_daemon_process_options -%>
   WSGIDaemonProcess <%= @wsgi_daemon_process %>
+<% elsif @wsgi_daemon_process.is_a? Hash -%>
+  <%- @wsgi_daemon_process.each do |key, val| -%>
+    <%- if val.empty? -%>
+  WSGIDaemonProcess <%= key %>
+    <%- else -%>
+  WSGIDaemonProcess <%= key %> <%= val.collect { |k,v| "#{k}=#{v}"}.sort.join(' ') %>
+<% end -%>
+<% end -%>
 <% end -%>
 <% if @wsgi_import_script and @wsgi_import_script_options -%>
   WSGIImportScript <%= @wsgi_import_script %> <%= @wsgi_import_script_options.collect { |k,v| "#{k}=#{v}"}.sort.join(' ') %>


### PR DESCRIPTION
The README states wsgi_daemon_process is a hash data type however the
ERB template interpolates it as a string. As this type it currently
cannot accept multiple daemon processes per vhost, and requires
wsgi_daemon_process_options to manage parameters.

This commit adds logic to the parameter to support this data type while
maintaining original functionality. The data type allows for multiple
daemons per vhost, and deprecates wsgi_daemon_process_options.