### PR TITLE
Logging bug: prevent upcoming log events from getting lost

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -304,6 +304,7 @@ define apache::vhost(
       mode    => $logroot_mode,
       require => Package['httpd'],
       before  => Concat["${priority_real}${filename}.conf"],
+      notify  => Class['Apache::Service'],
     }
   }
 


### PR DESCRIPTION
This pull request fixes a problematic situation regarding logging.
Specifically, when Apache service starts up, it opens log files (e.g.,`/var/log/apache2/access.log`) through the following system call:
```
open("/var/log/apache2/access.log", O_WRONLY|O_CREAT|O_APPEND|O_CLOEXEC) = 7
```
While Apache service is up, those files remain open for efficiency.

Consider this scenario: If the log directory (i.e, `/var/log/apache2`) misses from the host, applying the catalog creates the directory again. The issue is that the service is unaffected. Specifically, the Apache server still handles a file descriptor that corresponds to the original log file (`/var/log/apache2/access.log`), i.e., the open file descriptor points to the inode which the initial log file was pointing to.

When we remove a file, which is open, the underlying system call (`unlink()`) does not affect the file descriptors of the file. In other words, any open file descriptor still refers to the inode of the removed file. However, the inode becomes *orphaned*; thus it becomes non-accessible.

Therefore, in the case of a missing notifier, the log history of the upcoming events is *lost* because the service writes to an orphaned inode.

To fix that issue, the log file should notify the service so that Apache opens the freshly-created log file. This prevents any upcoming log events from getting lost.