### PR TITLE
(MODULES-8731) Allow CIDRs for proxy_ips/internal_proxy in remoteip

### DIFF
--- a/manifests/mod/remoteip.pp
+++ b/manifests/mod/remoteip.pp
@@ -51,17 +51,17 @@
 #   `mod_remoteip`. If not specified, `$::apache::apache_version` is used.
 #
 class apache::mod::remoteip (
-  String                         $header                    = 'X-Forwarded-For',
-  Optional[Array[Stdlib::Host]]  $internal_proxy            = undef,
-  Optional[Array[Stdlib::Host]]  $proxy_ips                 = undef,
-  Optional[Stdlib::Absolutepath] $internal_proxy_list       = undef,
-  Optional[String]               $proxies_header            = undef,
-  Boolean                        $proxy_protocol            = false,
-  Optional[Array[Stdlib::Host]]  $proxy_protocol_exceptions = undef,
-  Optional[Array[Stdlib::Host]]  $trusted_proxy             = undef,
-  Optional[Array[Stdlib::Host]]  $trusted_proxy_ips         = undef,
-  Optional[Stdlib::Absolutepath] $trusted_proxy_list        = undef,
-  Optional[String]               $apache_version            = undef,
+  String                                                      $header                    = 'X-Forwarded-For',
+  Optional[Array[Variant[Stdlib::Host,Stdlib::IP::Address]]]  $internal_proxy            = undef,
+  Optional[Array[Variant[Stdlib::Host,Stdlib::IP::Address]]]  $proxy_ips                 = undef,
+  Optional[Stdlib::Absolutepath]                              $internal_proxy_list       = undef,
+  Optional[String]                                            $proxies_header            = undef,
+  Boolean                                                     $proxy_protocol            = false,
+  Optional[Array[Stdlib::Host]]                               $proxy_protocol_exceptions = undef,
+  Optional[Array[Stdlib::Host]]                               $trusted_proxy             = undef,
+  Optional[Array[Stdlib::Host]]                               $trusted_proxy_ips         = undef,
+  Optional[Stdlib::Absolutepath]                              $trusted_proxy_list        = undef,
+  Optional[String]                                            $apache_version            = undef,
 ) {
   include ::apache
 

--- a/manifests/mod/remoteip.pp
+++ b/manifests/mod/remoteip.pp
@@ -51,17 +51,17 @@
 #   `mod_remoteip`. If not specified, `$::apache::apache_version` is used.
 #
 class apache::mod::remoteip (
-  String                                                      $header                    = 'X-Forwarded-For',
-  Optional[Array[Variant[Stdlib::Host,Stdlib::IP::Address]]]  $internal_proxy            = undef,
-  Optional[Array[Variant[Stdlib::Host,Stdlib::IP::Address]]]  $proxy_ips                 = undef,
-  Optional[Stdlib::Absolutepath]                              $internal_proxy_list       = undef,
-  Optional[String]                                            $proxies_header            = undef,
-  Boolean                                                     $proxy_protocol            = false,
-  Optional[Array[Stdlib::Host]]                               $proxy_protocol_exceptions = undef,
-  Optional[Array[Stdlib::Host]]                               $trusted_proxy             = undef,
-  Optional[Array[Stdlib::Host]]                               $trusted_proxy_ips         = undef,
-  Optional[Stdlib::Absolutepath]                              $trusted_proxy_list        = undef,
-  Optional[String]                                            $apache_version            = undef,
+  String                                                     $header                    = 'X-Forwarded-For',
+  Optional[Array[Variant[Stdlib::Host,Stdlib::IP::Address]]] $internal_proxy            = undef,
+  Optional[Array[Variant[Stdlib::Host,Stdlib::IP::Address]]] $proxy_ips                 = undef,
+  Optional[Stdlib::Absolutepath]                             $internal_proxy_list       = undef,
+  Optional[String]                                           $proxies_header            = undef,
+  Boolean                                                    $proxy_protocol            = false,
+  Optional[Array[Stdlib::Host]]                              $proxy_protocol_exceptions = undef,
+  Optional[Array[Stdlib::Host]]                              $trusted_proxy             = undef,
+  Optional[Array[Stdlib::Host]]                              $trusted_proxy_ips         = undef,
+  Optional[Stdlib::Absolutepath]                             $trusted_proxy_list        = undef,
+  Optional[String]                                           $apache_version            = undef,
 ) {
   include ::apache
 

--- a/spec/classes/mod/remoteip_spec.rb
+++ b/spec/classes/mod/remoteip_spec.rb
@@ -38,6 +38,20 @@ describe 'apache::mod::remoteip', type: :class do
       it { is_expected.to contain_file('remoteip.conf').with_content(%r{^RemoteIPInternalProxy 10.42.17.8$}) }
       it { is_expected.to contain_file('remoteip.conf').with_content(%r{^RemoteIPInternalProxy 10.42.18.99$}) }
     end
+    describe 'with IPv4 CIDR in internal_proxy => [ 192.168.1.0/24 ]' do
+      let :params do
+        { internal_proxy: ['192.168.1.0/24'] }
+      end
+
+      it { is_expected.to contain_file('remoteip.conf').with_content(%r{^RemoteIPInternalProxy 192.168.1.0/24$}) }
+    end
+    describe 'with IPv6 CIDR in internal_proxy => [ fd00:fd00:fd00:2000::/64 ]' do
+      let :params do
+        { internal_proxy: ['fd00:fd00:fd00:2000::/64'] }
+      end
+
+      it { is_expected.to contain_file('remoteip.conf').with_content(%r{^RemoteIPInternalProxy fd00:fd00:fd00:2000::/64$}) }
+    end
     describe 'with proxy_ips => [ 10.42.17.8, 10.42.18.99 ]' do
       let :params do
         { proxy_ips: ['10.42.17.8', '10.42.18.99'] }
@@ -45,6 +59,20 @@ describe 'apache::mod::remoteip', type: :class do
 
       it { is_expected.to contain_file('remoteip.conf').with_content(%r{^RemoteIPInternalProxy 10.42.17.8$}) }
       it { is_expected.to contain_file('remoteip.conf').with_content(%r{^RemoteIPInternalProxy 10.42.18.99$}) }
+    end
+    describe 'with IPv4 CIDR in proxy_ips => [ 192.168.1.0/24 ]' do
+      let :params do
+        { proxy_ips: ['192.168.1.0/24'] }
+      end
+
+      it { is_expected.to contain_file('remoteip.conf').with_content(%r{^RemoteIPInternalProxy 192.168.1.0/24$}) }
+    end
+    describe 'with IPv6 CIDR in proxy_ips => [ fd00:fd00:fd00:2000::/64 ]' do
+      let :params do
+        { proxy_ips: ['fd00:fd00:fd00:2000::/64'] }
+      end
+
+      it { is_expected.to contain_file('remoteip.conf').with_content(%r{^RemoteIPInternalProxy fd00:fd00:fd00:2000::/64$}) }
     end
     describe 'with trusted_proxy => [ 10.42.17.8, 10.42.18.99 ]' do
       let :params do

--- a/templates/mod/remoteip.conf.epp
+++ b/templates/mod/remoteip.conf.epp
@@ -1,12 +1,12 @@
 <%- |
-  String                               $header,
-  Optional[Array[Stdlib::IP::Address]] $internal_proxy            = undef,
-  Optional[Stdlib::Absolutepath]       $internal_proxy_list       = undef,
-  Optional[String]                     $proxies_header            = undef,
-  Boolean                              $proxy_protocol            = undef,
-  Optional[Array[Stdlib::IP::Address]] $proxy_protocol_exceptions = undef,
-  Optional[Array[Stdlib::IP::Address]] $trusted_proxy             = undef,
-  Optional[Stdlib::Absolutepath]       $trusted_proxy_list        = undef,
+  String                                                     $header,
+  Optional[Array[Variant[Stdlib::Host,Stdlib::IP::Address]]] $internal_proxy            = undef,
+  Optional[Stdlib::Absolutepath]                             $internal_proxy_list       = undef,
+  Optional[String]                                           $proxies_header            = undef,
+  Boolean                                                    $proxy_protocol            = undef,
+  Optional[Array[Stdlib::IP::Address]]                       $proxy_protocol_exceptions = undef,
+  Optional[Array[Stdlib::IP::Address]]                       $trusted_proxy             = undef,
+  Optional[Stdlib::Absolutepath]                             $trusted_proxy_list        = undef,
 | -%>
 # Declare the header field which should be parsed for useragent IP addresses
 RemoteIPHeader <%= $header %>


### PR DESCRIPTION
The recent addition of data types for this module [1] introduced an
issue, where CIDRs are no longer allowed. This allows those sort of
values.

This addresses https://tickets.puppetlabs.com/browse/MODULES-8731

[1] https://github.com/puppetlabs/puppetlabs-apache/commit/1503035d788f9fdaa2bab9cdaabfb66e858c2c39#diff-c2ea3c67760696a0d67bab9fb81757c6