### PR TITLE
(feat) - Amazon Linux 2 compatibility added

### DIFF
--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -18,6 +18,9 @@ class apache::default_mods (
             ::apache::mod { 'systemd': }
           }
         }
+        if ($::operatingsystem == 'Amazon' and $::operatingsystemrelease == '2') {
+          ::apache::mod { 'systemd': }
+        }
         ::apache::mod { 'unixd': }
       }
     }

--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -50,7 +50,7 @@ define apache::mod (
   if $package {
     $_package = $package
   } elsif has_key($mod_packages, $mod) { # 2.6 compatibility hack
-    if ($::apache::apache_version == '2.4' and $::operatingsystem =~ /^[Aa]mazon$/) {
+    if ($::apache::apache_version == '2.4' and $::operatingsystem =~ /^[Aa]mazon$/ and $::operatingsystemmajrelease != '2') {
       # On amazon linux we need to prefix our package name with mod24 instead of mod to support apache 2.4
       $_package = regsubst($mod_packages[$mod],'^(mod_)?(.*)','mod24_\2')
     } else {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -173,9 +173,14 @@ class apache::params inherits ::apache::version {
     $conf_dir             = "${httpd_dir}/conf"
     $confd_dir            = "${httpd_dir}/conf.d"
     $conf_enabled         = undef
-    $mod_dir              = $::apache::version::distrelease ? {
-      '7'     => "${httpd_dir}/conf.modules.d",
-      default => "${httpd_dir}/conf.d",
+    if $::operatingsystem =~ /^[Aa]mazon$/ and $::operatingsystemmajrelease == '2' {
+      # Amazon Linux 2 uses the /conf.modules.d/ dir
+      $mod_dir            = "${httpd_dir}/conf.modules.d"
+    } else {
+      $mod_dir              = $::apache::version::distrelease ? {
+        '7'     => "${httpd_dir}/conf.modules.d",
+        default => "${httpd_dir}/conf.d",
+      }
     }
     $mod_enable_dir       = undef
     $vhost_dir            = "${httpd_dir}/conf.d"


### PR DESCRIPTION
Rebase of PR ('https://github.com/puppetlabs/puppetlabs-apache/pull/1845') made to add compatibility for Amazon Linux 2, thank you @engshine for the work that you have done.
The changes on this PR all originate from @engshine.
Please note that this does not mean that Amazon Linux 2 is supported.