### PR TITLE
Remove mod_ldap dependency from mod_authz_ldap module

### DIFF
--- a/manifests/mod/authnz_ldap.pp
+++ b/manifests/mod/authnz_ldap.pp
@@ -4,7 +4,6 @@ class apache::mod::authnz_ldap (
 ) {
 
   include ::apache
-  include '::apache::mod::ldap'
   ::apache::mod { 'authnz_ldap':
     package => $package_name,
   }

--- a/spec/classes/mod/authnz_ldap_spec.rb
+++ b/spec/classes/mod/authnz_ldap_spec.rb
@@ -18,7 +18,6 @@ describe 'apache::mod::authnz_ldap', type: :class do
     end
 
     it { is_expected.to contain_class('apache::params') }
-    it { is_expected.to contain_class('apache::mod::ldap') }
     it { is_expected.to contain_apache__mod('authnz_ldap') }
 
     context 'default verify_server_cert' do
@@ -54,7 +53,6 @@ describe 'apache::mod::authnz_ldap', type: :class do
     end
 
     it { is_expected.to contain_class('apache::params') }
-    it { is_expected.to contain_class('apache::mod::ldap') }
     it { is_expected.to contain_apache__mod('authnz_ldap') }
 
     context 'default verify_server_cert' do


### PR DESCRIPTION
An error occurs when using the mod_authz_ldap module.

`ESC[1;31mError: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, 'regsubst' parameter 'target' expects a value of type Array or String, got Undef (file: /etc/puppetlabs/code/modules/apache/manifests/mod.pp, line: 55, column: 19) (file: /etc/puppetlabs/code/modules/apache/manifests/mod/ldap.pp, line: 16) on node *******[0m`