### PR TITLE
(MODULES-9014) Add SSLSessionTickets parameter

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -5338,6 +5338,15 @@ Enable compression on the SSL level.
 
 Default value: `false`
 
+##### `ssl_sessiontickets`
+
+Data type: `Boolean`
+
+Enable the use of TLS session tickets (RFC 5077).
+Ignored on Ubuntu 14.04 since Apache 2.4.11 or newer is needed.
+
+Default: `true`.
+
 ##### `ssl_cryptodevice`
 
 Data type: `Any`

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -76,6 +76,7 @@
 #
 class apache::mod::ssl (
   Boolean $ssl_compression                                  = false,
+  Boolean $ssl_sessiontickets                               = true,
   $ssl_cryptodevice                                         = 'builtin',
   $ssl_options                                              = [ 'StdEnvVars' ],
   $ssl_openssl_conf_cmd                                     = undef,
@@ -165,6 +166,12 @@ class apache::mod::ssl (
     }
   }
 
+  if $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '14.04' {
+    $_ssl_sessiontickets = undef
+  } else {
+    $_ssl_sessiontickets = $ssl_sessiontickets
+  }
+
   if versioncmp($_apache_version, '2.4') >= 0 {
     include ::apache::mod::socache_shmcb
   }
@@ -172,6 +179,7 @@ class apache::mod::ssl (
   # Template uses
   #
   # $ssl_compression
+  # $_ssl_sessiontickets
   # $ssl_cryptodevice
   # $ssl_ca
   # $ssl_cipher

--- a/spec/classes/mod/ssl_spec.rb
+++ b/spec/classes/mod/ssl_spec.rb
@@ -255,6 +255,27 @@ describe 'apache::mod::ssl', type: :class do
 
       it { is_expected.to contain_file('ssl.conf').with_content(%r{^  SSLCompression On$}) }
     end
+
+    context 'with Apache version >= 2.4 - ssl_sessiontickets with default value' do
+      let :params do
+        {
+          apache_version: '2.4',
+        }
+      end
+
+      it { is_expected.to contain_file('ssl.conf').with_content(%r{^  SSLSessionTickets On$}) }
+    end
+    context 'with Apache version >= 2.4 - setting ssl_sessiontickets to false' do
+      let :params do
+        {
+          apache_version: '2.4',
+          ssl_sessiontickets: false,
+        }
+      end
+
+      it { is_expected.to contain_file('ssl.conf').with_content(%r{^  SSLSessionTickets Off$}) }
+    end
+
     context 'with Apache version >= 2.4 - setting ssl_stapling to true' do
       let :params do
         {
@@ -332,6 +353,31 @@ describe 'apache::mod::ssl', type: :class do
       end
 
       it { is_expected.to contain_file('ssl.conf').with_content(%r{^  SSLProxyProtocol -ALL \+TLSv1$}) }
+    end
+  end
+  # Template config parts varying by distro
+  context 'on Ubuntu 14.04' do
+    let :facts do
+      {
+        osfamily: 'Debian',
+        operatingsystem: 'Ubuntu',
+        operatingsystemrelease: '14.04',
+        lsbdistrelease: '14.04',
+        kernel: 'Linux',
+        id: 'root',
+        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        is_pe: false,
+      }
+    end
+
+    context 'with Apache version >= 2.4 - setting ssl_sessiontickets to false' do
+      let :params do
+        {
+          apache_version: '2.4',
+        }
+      end
+
+      it { is_expected.not_to contain_file('ssl.conf').with_content(%r{^  SSLSessionTickets Off$}) }
     end
   end
 end

--- a/templates/mod/ssl.conf.erb
+++ b/templates/mod/ssl.conf.erb
@@ -15,6 +15,9 @@
     <%- if @ssl_compression -%>
   SSLCompression <%= scope.call_function('apache::bool2httpd', [@ssl_compression]) %>
     <%- end -%>
+    <%- unless @_ssl_sessiontickets.nil? -%>
+  SSLSessionTickets <%= scope.call_function('apache::bool2httpd', [@_ssl_sessiontickets]) %>
+    <%- end -%>
   <%- else -%>
   SSLMutex <%= @_ssl_mutex %>
   <%- end -%>


### PR DESCRIPTION
Add the boolean parameter ssl_sessiontickets to apache::mod::ssl
Use parameter ssl_sessiontickets in ssl.conf.erb
Add unit tests for parameter ssl_sessiontickets
Document the parameter ssl_sessiontickets