### PR TITLE
(MODULES-9018) Customize SSLStaplingCache parameter

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -5466,6 +5466,20 @@ Pass stapling related OCSP errors on to client.
 
 Default value: `undef`
 
+##### `stapling_cache`
+
+Data type: `String`
+
+Configures the storage type of the global/inter-process SSL Stapling Cache.
+Only cache type 'shmcb' is supported.
+Default based on the OS:
+- Debian/Ubuntu: '${APACHE_RUN_DIR}/ocsp(32768)'.
+- RedHat: '/run/httpd/ssl_stapling(32768)'.
+- FreeBSD/Gentoo: '/var/run/ssl_stapling(32768)'.
+- Suse: '/var/lib/apache2/ssl_stapling(32768)'.
+
+Default value: `undef`
+
 ##### `ssl_mutex`
 
 Data type: `Any`

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -91,6 +91,7 @@ class apache::mod::ssl (
   String $ssl_sessioncache                                  = $::apache::params::ssl_sessioncache,
   $ssl_sessioncachetimeout                                  = '300',
   Boolean $ssl_stapling                                     = false,
+  Optional[String] $stapling_cache                          = undef,
   Optional[Boolean] $ssl_stapling_return_errors             = undef,
   $ssl_mutex                                                = undef,
   $apache_version                                           = undef,
@@ -141,12 +142,16 @@ class apache::mod::ssl (
     }
   }
 
-  $stapling_cache = $::osfamily ? {
-    'debian'  => "\${APACHE_RUN_DIR}/ocsp(32768)",
-    'redhat'  => '/run/httpd/ssl_stapling(32768)',
-    'freebsd' => '/var/run/ssl_stapling(32768)',
-    'gentoo'  => '/var/run/ssl_stapling(32768)',
-    'Suse'    => '/var/lib/apache2/ssl_stapling(32768)',
+  if $stapling_cache =~ Undef {
+    $_stapling_cache = $::osfamily ? {
+      'debian'  => "\${APACHE_RUN_DIR}/ocsp(32768)",
+      'redhat'  => '/run/httpd/ssl_stapling(32768)',
+      'freebsd' => '/var/run/ssl_stapling(32768)',
+      'gentoo'  => '/var/run/ssl_stapling(32768)',
+      'Suse'    => '/var/lib/apache2/ssl_stapling(32768)',
+    }
+  } else {
+    $_stapling_cache = $stapling_cache
   }
 
   if $::osfamily == 'Suse' {
@@ -179,7 +184,7 @@ class apache::mod::ssl (
   # $ssl_options
   # $ssl_openssl_conf_cmd
   # $ssl_sessioncache
-  # $stapling_cache
+  # $_stapling_cache
   # $ssl_mutex
   # $ssl_random_seed_bytes
   # $ssl_sessioncachetimeout

--- a/spec/classes/mod/ssl_spec.rb
+++ b/spec/classes/mod/ssl_spec.rb
@@ -275,6 +275,16 @@ describe 'apache::mod::ssl', type: :class do
 
       it { is_expected.to contain_file('ssl.conf').with_content(%r{^  SSLStaplingReturnResponderErrors On$}) }
     end
+    context 'with Apache version >= 2.4 - setting stapling_cache' do
+      let :params do
+        {
+          apache_version: '2.4',
+          stapling_cache: '/tmp/customstaplingcache(51200)',
+        }
+      end
+
+      it { is_expected.to contain_file('ssl.conf').with_content(%r{^  SSLStaplingCache "shmcb:/tmp/customstaplingcache\(51200\)"$}) }
+    end
 
     context 'setting ssl_pass_phrase_dialog' do
       let :params do

--- a/templates/mod/ssl.conf.erb
+++ b/templates/mod/ssl.conf.erb
@@ -34,7 +34,7 @@
   <%- if not @ssl_stapling_return_errors.nil? -%>
   SSLStaplingReturnResponderErrors <%= scope.call_function('apache::bool2httpd', [@ssl_stapling_return_errors]) %>
   <%- end -%>
-  SSLStaplingCache "shmcb:<%= @stapling_cache %>"
+  SSLStaplingCache "shmcb:<%= @_stapling_cache %>"
 <% end -%>
   SSLCipherSuite <%= @ssl_cipher %>
   SSLProtocol <%= @ssl_protocol.compact.join(' ') %>


### PR DESCRIPTION
- Add a stapling_cache parameter to apache::mod::ssl
  * if it is set to undef (the default value), the actual behavior will
    take place (SSLStaplingCache will be set to a value based on the OS)
  * if is is set to a string, this string will used as a value for
    SSLStaplingCache.
- Adapt template ssl.conf.erb accordingly
- Add unit tests got the stapling_cache parameter
- Document the stapling_cache parameter