### PR TITLE
(MODULES-9104) Add file_mode to config files.

### DIFF
--- a/manifests/custom_config.pp
+++ b/manifests/custom_config.pp
@@ -78,6 +78,7 @@ define apache::custom_config (
   file { "apache_${name}":
     ensure  => $ensure,
     path    => "${confdir}/${_filename}",
+    mode    => $::apache::file_mode,
     content => $content,
     source  => $source,
     require => Package['httpd'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -776,6 +776,7 @@ class apache (
     # - $root_directory_secured
     file { "${::apache::conf_dir}/${::apache::params::conf_file}":
       ensure  => file,
+      mode    => $::apache::file_mode,
       content => template($conf_template),
       notify  => Class['Apache::Service'],
       require => [Package['httpd'], Concat[$ports_file]],

--- a/manifests/mod/reqtimeout.pp
+++ b/manifests/mod/reqtimeout.pp
@@ -15,6 +15,7 @@ class apache::mod::reqtimeout (
   file { 'reqtimeout.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/reqtimeout.conf",
+    mode    => $::apache::file_mode,
     content => template('apache/mod/reqtimeout.conf.erb'),
     require => Exec["mkdir ${::apache::mod_dir}"],
     before  => File[$::apache::mod_dir],


### PR DESCRIPTION
- `::apache::file_mode` attribute is missing from several config files, including the main config file in `::apache`, any custom config files managed by `apache::custom_config`, and reqtimeout.conf managed by `apache::mod::reqtimeout`
- Add `mode => $::apache::file_mode` to `::apache`, `apache::custom_config`, and `apache::mod::reqtimeout` to correct the inability to manage the mode of these config files.