### PR TITLE
(MODULES-9014) Improve SSLSessionTickets handling

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -5340,12 +5340,12 @@ Default value: `false`
 
 ##### `ssl_sessiontickets`
 
-Data type: `Boolean`
+Data type: `Optional[Boolean]`
 
 Enable the use of TLS session tickets (RFC 5077).
-Ignored on Ubuntu 14.04 since Apache 2.4.11 or newer is needed.
+Available since Apache 2.4.11.
 
-Default: `true`.
+Default: `undef`.
 
 ##### `ssl_cryptodevice`
 

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -76,7 +76,7 @@
 #
 class apache::mod::ssl (
   Boolean $ssl_compression                                  = false,
-  Boolean $ssl_sessiontickets                               = true,
+  Optional[Boolean] $ssl_sessiontickets                     = undef,
   $ssl_cryptodevice                                         = 'builtin',
   $ssl_options                                              = [ 'StdEnvVars' ],
   $ssl_openssl_conf_cmd                                     = undef,
@@ -171,12 +171,6 @@ class apache::mod::ssl (
     }
   }
 
-  if $::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '14.04' {
-    $_ssl_sessiontickets = undef
-  } else {
-    $_ssl_sessiontickets = $ssl_sessiontickets
-  }
-
   if versioncmp($_apache_version, '2.4') >= 0 {
     include ::apache::mod::socache_shmcb
   }
@@ -184,7 +178,7 @@ class apache::mod::ssl (
   # Template uses
   #
   # $ssl_compression
-  # $_ssl_sessiontickets
+  # $ssl_sessiontickets
   # $ssl_cryptodevice
   # $ssl_ca
   # $ssl_cipher

--- a/spec/classes/mod/ssl_spec.rb
+++ b/spec/classes/mod/ssl_spec.rb
@@ -263,7 +263,7 @@ describe 'apache::mod::ssl', type: :class do
         }
       end
 
-      it { is_expected.to contain_file('ssl.conf').with_content(%r{^  SSLSessionTickets On$}) }
+      it { is_expected.not_to contain_file('ssl.conf').with_content(%r{^  SSLSessionTickets (Off|On)$}) }
     end
     context 'with Apache version >= 2.4 - setting ssl_sessiontickets to false' do
       let :params do
@@ -363,31 +363,6 @@ describe 'apache::mod::ssl', type: :class do
       end
 
       it { is_expected.to contain_file('ssl.conf').with_content(%r{^  SSLProxyProtocol -ALL \+TLSv1$}) }
-    end
-  end
-  # Template config parts varying by distro
-  context 'on Ubuntu 14.04' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystem: 'Ubuntu',
-        operatingsystemrelease: '14.04',
-        lsbdistrelease: '14.04',
-        kernel: 'Linux',
-        id: 'root',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
-
-    context 'with Apache version >= 2.4 - setting ssl_sessiontickets to false' do
-      let :params do
-        {
-          apache_version: '2.4',
-        }
-      end
-
-      it { is_expected.not_to contain_file('ssl.conf').with_content(%r{^  SSLSessionTickets Off$}) }
     end
   end
 end

--- a/templates/mod/ssl.conf.erb
+++ b/templates/mod/ssl.conf.erb
@@ -15,8 +15,8 @@
     <%- if @ssl_compression -%>
   SSLCompression <%= scope.call_function('apache::bool2httpd', [@ssl_compression]) %>
     <%- end -%>
-    <%- unless @_ssl_sessiontickets.nil? -%>
-  SSLSessionTickets <%= scope.call_function('apache::bool2httpd', [@_ssl_sessiontickets]) %>
+    <%- unless @ssl_sessiontickets.nil? -%>
+  SSLSessionTickets <%= scope.call_function('apache::bool2httpd', [@ssl_sessiontickets]) %>
     <%- end -%>
   <%- else -%>
   SSLMutex <%= @_ssl_mutex %>


### PR DESCRIPTION
- Make ssl_sessiontickets parameter optional
- Set default value for ssl_sessiontickets to undef (Compatible
  with all Apache versions)
- Update documentation and unit tests accordingly

@sheenaajay Here the the pull request with the fixes you expected.  ssl_sessiontickets is now optional with the default value set to undef. So, by default, the parameter will not be set and nothing will break on older distributions.  Moreover it simplifies the code, which is always a good thing.