### PR TITLE
Add LDAPReferrals configuration parameter

### DIFF
--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -184,6 +184,11 @@ describe 'apache::vhost', type: :define do
                   ],
                 },
                 {
+                  'path'                => '/',
+                  'provider'            => 'location',
+                  'auth_ldap_referrals' => 'off',
+                },
+                {
                   'path'                                                => '/var/www/node-app/public',
                   'passenger_enabled'                                   => true,
                   'passenger_base_uri'                                  => '/app',
@@ -598,6 +603,11 @@ describe 'apache::vhost', type: :define do
           it {
             is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
               content: %r{^\s+Require any-valid2$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
+              content: %r{^\s+LDAPReferrals off$},
             )
           }
           it {

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -290,6 +290,9 @@
     <%- if directory['auth_merging'] -%>
     AuthMerging <%= directory['auth_merging'] %>
     <%- end -%>
+    <%- if directory['auth_ldap_referrals'] -%>
+    LDAPReferrals <%= directory['auth_ldap_referrals'] %>
+    <%- end -%>
     <%- if directory['auth_ldap_url'] -%>
     AuthLDAPURL <%= directory['auth_ldap_url'] %>
     <%- end -%>


### PR DESCRIPTION
This PR adds support for the [LDAPReferrals](https://httpd.apache.org/docs/2.4/mod/mod_ldap.html#ldapreferrals) parameter. I could not find any documentation regarding all the possible values for the `directories` hash. If I missed this, I will add some documentation.