### PR TITLE
Added unmanaged_path and custom_fragment options to userdir

### DIFF
--- a/manifests/mod/userdir.pp
+++ b/manifests/mod/userdir.pp
@@ -21,6 +21,12 @@
 # 
 # @param options
 #   Configures what features are available in a particular directory.
+#
+# @param unmanaged_path
+#   Toggles whether to manage path in userdir.conf
+#
+# @param custom_fragment
+#   Custom configuration to be added to userdir.conf
 # 
 # @see https://httpd.apache.org/docs/current/mod/mod_userdir.html for additional documentation.
 #
@@ -32,6 +38,8 @@ class apache::mod::userdir (
   $path = '/home/*/public_html',
   $overrides = [ 'FileInfo', 'AuthConfig', 'Limit', 'Indexes' ],
   $options = [ 'MultiViews', 'Indexes', 'SymLinksIfOwnerMatch', 'IncludesNoExec' ],
+  $unmanaged_path = false,
+  $custom_fragment = undef,
 ) {
   include ::apache
   $_apache_version = pick($apache_version, $apache::apache_version)

--- a/spec/classes/mod/userdir_spec.rb
+++ b/spec/classes/mod/userdir_spec.rb
@@ -62,7 +62,7 @@ describe 'apache::mod::userdir', type: :class do
         }
       end
 
-      it { is_expected.to contain_file('userdir.conf').with_content(%r{^\s*UserDir\s+$/home/\*/public_html$}) }
+      it { is_expected.to contain_file('userdir.conf').with_content(%r{^\s*UserDir\s+/home/\*/public_html$}) }
       it { is_expected.not_to contain_file('userdir.conf').with_content(%r{^\s*\<Directory }) }
     end
     context 'with custom_fragment set to something' do

--- a/spec/classes/mod/userdir_spec.rb
+++ b/spec/classes/mod/userdir_spec.rb
@@ -55,5 +55,24 @@ describe 'apache::mod::userdir', type: :class do
       it { is_expected.to contain_file('userdir.conf').with_content(%r{^\s*UserDir\s+public_html /usr/web http://www\.example\.com/$}) }
       it { is_expected.to contain_file('userdir.conf').with_content(%r{^\s*\<Directory\s+\"public_html /usr/web http://www\.example\.com/\"\>$}) }
     end
+    context 'with unmanaged_path set to true' do
+      let :params do
+        {
+          unmanaged_path: true,
+        }
+      end
+
+      it { is_expected.to contain_file('userdir.conf').with_content(%r{^\s*UserDir\s+$/home/\*/public_html$}) }
+      it { is_expected.not_to contain_file('userdir.conf').with_content(%r{^\s*\<Directory }) }
+    end
+    context 'with custom_fragment set to something' do
+      let :params do
+        {
+          custom_fragment: 'custom_test_string',
+        }
+      end
+
+      it { is_expected.to contain_file('userdir.conf').with_content(%r{custom_test_string}) }
+    end
   end
 end

--- a/templates/mod/userdir.conf.erb
+++ b/templates/mod/userdir.conf.erb
@@ -4,6 +4,7 @@
 <% end -%>
   UserDir <%= @_path %>
 
+<%- if ! @unmanaged_path -%>
   <Directory "<%= @_path %>">
     AllowOverride <%= @overrides.join(' ') %>
     Options <%= @options.join(' ') %>
@@ -24,4 +25,8 @@
       <%- end -%>
     </LimitExcept>
   </Directory>
+<%- end -%>
+<%- if @custom_fragment -%>
+<%= @custom_fragment %>
+<%- end -%>
 </IfModule>


### PR DESCRIPTION
The unmanged_path option stops the template from configuring the directory permissions in userdir.conf, this is useful if you want to have path set as 'public_html' or 'https://mysite/*' etc.

The custom_fragment option allows you to add your own config to userdir.conf, useful when using the unmanaged_path option.