### PR TITLE
(MODULES-9668 ) Please make ProxyRequests setting in vhost.pp configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -808,6 +808,7 @@ This release features many improvements and bugfixes, including several new defi
   - passenger_ruby
   - passenger_start_timeout
   - proxy_preserve_host
+  - proxy_requests
   - redirectmatch_dest
   - ssl_crl_check
   - wsgi_chunked_request

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -698,6 +698,7 @@ This release features many improvements and bugfixes, including several new defi
   - passenger_ruby
   - passenger_start_timeout
   - proxy_preserve_host
+  - proxy_requests
   - redirectmatch_dest
   - ssl_crl_check
   - wsgi_chunked_request

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -4657,7 +4657,7 @@ The following parameters are available in the `apache::mod::proxy` class.
 
 ##### `proxy_requests`
 
-Data type: `Any`
+Data type: `Boolean`
 
 Enables forward (standard) proxy requests.
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7369,6 +7369,16 @@ X-Forwarded-Host and X-Forwarded-Server) get sent to the backend server.
 
 Default value: `undef`
 
+##### `proxy_requests`
+
+Data type: `Any`
+
+Sets the [ProxyErrorOverride Directive](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxyrequests).
+This prarmeter allows or prevents Apache httpd from functioning as a forward proxy server.
+(Setting ProxyRequests to Off does not disable use of the ProxyPass directive.)
+
+Default value: `false`
+
 ##### `proxy_error_override`
 
 Data type: `Any`

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7373,7 +7373,7 @@ Default value: `undef`
 
 Data type: `Boolean`
 
-Sets the [ProxyErrorOverride Directive](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxyrequests).
+Sets the [ProxyRequests Directive](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxyrequests).
 This prarmeter allows or prevents Apache httpd from functioning as a forward proxy server.
 (Setting ProxyRequests to Off does not disable use of the ProxyPass directive.)
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7371,7 +7371,7 @@ Default value: `undef`
 
 ##### `proxy_requests`
 
-Data type: `Any`
+Data type: `Boolean`
 
 Sets the [ProxyErrorOverride Directive](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxyrequests).
 This prarmeter allows or prevents Apache httpd from functioning as a forward proxy server.

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1705,7 +1705,7 @@ define apache::vhost(
   $proxy_dest_reverse_match                                                         = undef,
   $proxy_pass                                                                       = undef,
   $proxy_pass_match                                                                 = undef,
-  Optional[Boolean] $proxy_requests                                                 = false,
+  Boolean $proxy_requests                                                           = false,
   $suphp_addhandler                                                                 = $::apache::params::suphp_addhandler,
   Enum['on', 'off'] $suphp_engine                                                   = $::apache::params::suphp_engine,
   $suphp_configpath                                                                 = $::apache::params::suphp_configpath,

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1705,7 +1705,7 @@ define apache::vhost(
   $proxy_dest_reverse_match                                                         = undef,
   $proxy_pass                                                                       = undef,
   $proxy_pass_match                                                                 = undef,
-  $proxy_requests                                                                   = false,
+  Optional[Boolean] $proxy_requests                                                 = false,
   $suphp_addhandler                                                                 = $::apache::params::suphp_addhandler,
   Enum['on', 'off'] $suphp_engine                                                   = $::apache::params::suphp_engine,
   $suphp_configpath                                                                 = $::apache::params::suphp_configpath,

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1705,6 +1705,7 @@ define apache::vhost(
   $proxy_dest_reverse_match                                                         = undef,
   $proxy_pass                                                                       = undef,
   $proxy_pass_match                                                                 = undef,
+  $proxy_requests                                                                   = false,
   $suphp_addhandler                                                                 = $::apache::params::suphp_addhandler,
   Enum['on', 'off'] $suphp_engine                                                   = $::apache::params::suphp_engine,
   $suphp_configpath                                                                 = $::apache::params::suphp_configpath,

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -279,6 +279,7 @@ describe 'apache::vhost', type: :define do
                   'setenv' => ['proxy-nokeepalive 1', 'force-proxy-request-1.0 1'],
                 },
               ],
+              'proxy_requests'              => false,
               'suphp_addhandler'            => 'foo',
               'suphp_engine'                => 'on',
               'suphp_configpath'            => '/var/www/html',

--- a/templates/vhost/_proxy.erb
+++ b/templates/vhost/_proxy.erb
@@ -1,11 +1,11 @@
 <% if @proxy_dest or @proxy_pass or @proxy_pass_match or @proxy_dest_match -%>
 
   ## Proxy rules
-  <% if @proxy_requests -%>
+<% if @proxy_requests -%>
   ProxyRequests On
-  <% else -%>
+<% else -%>
   ProxyRequests Off
-  <%- end -%>
+<%- end -%>
 <%- end -%>
 <% if @proxy_preserve_host -%>
   ProxyPreserveHost On

--- a/templates/vhost/_proxy.erb
+++ b/templates/vhost/_proxy.erb
@@ -1,7 +1,11 @@
 <% if @proxy_dest or @proxy_pass or @proxy_pass_match or @proxy_dest_match -%>
 
   ## Proxy rules
-  ProxyRequests Off
+  <% if @proxy_requests -%>
+    ProxyRequests On
+  <% else -%>
+    ProxyRequests Off
+  <%- end -%>
 <%- end -%>
 <% if @proxy_preserve_host -%>
   ProxyPreserveHost On

--- a/templates/vhost/_proxy.erb
+++ b/templates/vhost/_proxy.erb
@@ -2,9 +2,9 @@
 
   ## Proxy rules
   <% if @proxy_requests -%>
-    ProxyRequests On
+  ProxyRequests On
   <% else -%>
-    ProxyRequests Off
+  ProxyRequests Off
   <%- end -%>
 <%- end -%>
 <% if @proxy_preserve_host -%>


### PR DESCRIPTION
This fork and change makes 'ProxyRequests' in Apache vhost sections managed by puppetlabs-apache configurable. I created a Jira ticket as well (MODULES-9668)