### PR TITLE
MODULES-9083: remove double quotes to allow flags in SSLCARevocationCheck

### DIFF
--- a/spec/acceptance/apache_ssl_spec.rb
+++ b/spec/acceptance/apache_ssl_spec.rb
@@ -50,7 +50,7 @@ describe 'apache ssl' do
           ssl_ca               => '/tmp/ssl_ca',
           ssl_crl_path         => '/tmp/ssl_crl_path',
           ssl_crl              => '/tmp/ssl_crl',
-          ssl_crl_check        => 'chain',
+          ssl_crl_check        => 'chain flag',
           ssl_certs_dir        => '/tmp',
           ssl_protocol         => 'test',
           ssl_cipher           => 'test',
@@ -83,7 +83,7 @@ describe 'apache ssl' do
       it { is_expected.to contain 'SSLVerifyDepth          test' }
       it { is_expected.to contain 'SSLOptions test test1' }
       if apache_hash['version'] == '2.4'
-        it { is_expected.to contain 'SSLCARevocationCheck    "chain"' }
+        it { is_expected.to contain 'SSLCARevocationCheck    chain flag' }
       else
         it { is_expected.not_to contain 'SSLCARevocationCheck' }
       end

--- a/templates/vhost/_ssl.erb
+++ b/templates/vhost/_ssl.erb
@@ -34,7 +34,7 @@
   SSLVerifyDepth          <%= @ssl_verify_depth %>
   <%- end -%>
   <%- if @ssl_crl_check && scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
-  SSLCARevocationCheck    "<%= @ssl_crl_check %>"
+  SSLCARevocationCheck    <%= @ssl_crl_check %>
   <%- end -%>
   <%- end -%>
   <%- if @ssl_options -%>


### PR DESCRIPTION
This is a solution to solve the bug I have submitted ([MODULES-9083](https://tickets.puppetlabs.com/browse/MODULES-9083)).
I hope it can help.
It is a rebase onto master of this [PR 1920](https://github.com/puppetlabs/puppetlabs-apache/pull/1920). Thus, the PR1920 can be cancelled.

Best Regards