### PR TITLE
add possibility to define variables inside VirtualHost definition

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1622,6 +1622,10 @@
 #   Specifies whether to use the [`UseCanonicalName directive`](https://httpd.apache.org/docs/2.4/mod/core.html#usecanonicalname),
 #   which allows you to configure how the server determines it's own name and port.
 # 
+# @param define
+#   this lets you define configuration variables inside a vhost using [`Define`](https://httpd.apache.org/docs/2.4/mod/core.html#define),
+#   these can then be used to replace configuration values. All Defines are Undefined at the end of the VirtualHost.
+#
 define apache::vhost(
   Variant[Boolean,String] $docroot,
   $manage_docroot                                                                   = true,
@@ -1850,6 +1854,7 @@ define apache::vhost(
   Optional[String] $shib_compat_valid_user                                          = undef,
   Optional[Enum['On', 'on', 'Off', 'off', 'DNS', 'dns']] $use_canonical_name        = undef,
   Optional[Variant[String,Array[String]]] $comment                                  = undef,
+  Hash $define                                                                      = {},
 ) {
 
   # The base class must be included first because it is used by parameter defaults

--- a/templates/vhost/_file_footer.erb
+++ b/templates/vhost/_file_footer.erb
@@ -1,3 +1,6 @@
+<% @define.each do | k, v| -%>
+  Undefine <%= k %>
+<% end -%>
 </VirtualHost>
 <% if @passenger_pre_start -%>
   <%- [@passenger_pre_start].flatten.compact.each do |passenger_pre_start| -%>

--- a/templates/vhost/_file_header.erb
+++ b/templates/vhost/_file_header.erb
@@ -5,6 +5,9 @@
 <%= [@comment].flatten.collect{|c| "# #{c}"}.join("\n") -%>
 
 <VirtualHost <%= [@nvh_addr_port].flatten.compact.join(' ') %>>
+<% @define.each do | k, v| -%>
+  Define <%= k %> <%= v %>
+<% end -%>
 <% if @servername and not @servername.empty? -%>
   ServerName <%= @servername %>
 <% end -%>


### PR DESCRIPTION
The variable can them be used inside the vhost tag as a variable.
At the footer, the variable is undefined to avoid side effects
in other vhosts.

also see https://httpd.apache.org/docs/2.4/mod/core.html#define