### PR TITLE
Add parameter version for mod security

### DIFF
--- a/manifests/mod/security.pp
+++ b/manifests/mod/security.pp
@@ -2,6 +2,9 @@
 # @summary
 #   Installs and configures `mod_security`.
 # 
+# @param version
+#   Manage mod_security or mod_security2
+#
 # @param logroot
 #   Configures the location of audit and debug logs.
 # 
@@ -86,6 +89,7 @@
 #
 class apache::mod::security (
   $logroot                    = $::apache::params::logroot,
+  $version                     = $::apache::params::modsec_version,
   $crs_package                 = $::apache::params::modsec_crs_package,
   $activated_rules             = $::apache::params::modsec_default_rules,
   $modsec_dir                  = $::apache::params::modsec_dir,
@@ -127,7 +131,20 @@ class apache::mod::security (
     fail('SLES 10 is not currently supported.')
   }
 
-  ::apache::mod { 'security':
+  case $version {
+    1: {
+      $mod_name = 'security'
+      $mod_conf_name = 'security.conf'
+    }
+    2: {
+      $mod_name = 'security2'
+      $mod_conf_name = 'security2.conf'
+    }
+    default: {
+      fail('Unsuported version for mod security')
+    }
+  }
+  ::apache::mod { $mod_name:
     id  => 'security2_module',
     lib => 'mod_security2.so',
   }
@@ -161,7 +178,7 @@ class apache::mod::security (
     ensure  => file,
     content => template('apache/mod/security.conf.erb'),
     mode    => $::apache::file_mode,
-    path    => "${::apache::mod_dir}/security.conf",
+    path    => "${::apache::mod_dir}/${mod_conf_name}",
     owner   => $::apache::params::user,
     group   => $::apache::params::group,
     require => Exec["mkdir ${::apache::mod_dir}"],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -120,6 +120,7 @@ class apache::params inherits ::apache::version {
     $mellon_lock_file     = '/run/mod_auth_mellon/lock'
     $mellon_cache_size    = 100
     $mellon_post_directory = undef
+    $modsec_version       = 1
     $modsec_crs_package   = 'mod_security_crs'
     $modsec_crs_path      = '/usr/lib/modsecurity.d'
     $modsec_dir           = '/etc/httpd/modsecurity.d'
@@ -272,6 +273,7 @@ class apache::params inherits ::apache::version {
     $mellon_lock_file     = '/run/mod_auth_mellon/lock'
     $mellon_cache_size    = 100
     $mellon_post_directory = undef
+    $modsec_version       = 1
     $modsec_crs_package   = 'mod_security_crs'
     $modsec_crs_path      = '/usr/lib/modsecurity.d'
     $modsec_dir           = '/etc/httpd/modsecurity.d'
@@ -449,6 +451,7 @@ class apache::params inherits ::apache::version {
     $mellon_lock_file     = undef
     $mellon_cache_size    = undef
     $mellon_post_directory = '/var/cache/apache2/mod_auth_mellon/'
+    $modsec_version       = 1
     $modsec_crs_package   = 'modsecurity-crs'
     $modsec_crs_path      = '/usr/share/modsecurity-crs'
     $modsec_dir           = '/etc/modsecurity'
@@ -745,6 +748,7 @@ class apache::params inherits ::apache::version {
     $alias_icons_path     = '/usr/share/apache2/icons'
     $error_documents_path = '/usr/share/apache2/error'
     $dev_packages        = ['libapr-util1-devel', 'libapr1-devel', 'libcurl-devel']
+    $modsec_version       = 1
     $modsec_crs_package   = undef
     $modsec_crs_path      = undef
     $modsec_default_rules = undef

--- a/spec/classes/mod/security_spec.rb
+++ b/spec/classes/mod/security_spec.rb
@@ -182,6 +182,21 @@ describe 'apache::mod::security', type: :class do
               }
             end
           end
+
+          describe 'with mod security version' do
+            let :params do
+              {
+                version: 2,
+              }
+            end
+
+            it { is_expected.to contain_apache__mod('security2') }
+            it {
+              is_expected.to contain_file('security.conf').with(
+                path: '/etc/apache2/mods-available/security2.conf',
+              )
+            }
+          end
         end
       end
     end


### PR DESCRIPTION
We want to be able to select mod security 1 or 2.
Depending on Version, package names and config files are different.

Fixes: https://tickets.puppetlabs.com/browse/MODULES-9947