### PR TITLE
MODULES-9904 Fix lbmethod module load order

### DIFF
--- a/manifests/balancer.pp
+++ b/manifests/balancer.pp
@@ -55,7 +55,9 @@ define apache::balancer (
       undef   => 'byrequests',
       default => $proxy_set['lbmethod'],
     }
-    ensure_resource('apache::mod', "lbmethod_${lbmethod}")
+    ensure_resource('apache::mod', "lbmethod_${lbmethod}", {
+      'loadfile_name' => "proxy_balancer_lbmethod_${lbmethod}.load"
+    })
   }
 
   if $target {


### PR DESCRIPTION
Under recent apache versions (not sure when changed, but certainly
in 2.4.34), the lbmethod modules depend on symbols present in either
the mod_proxy or mod_proxy_balancer modules. Prior to this commit,
this module creates an `lbmethod_${method}.load` file which comes
alphabetically before `proxy.load` and `proxy_balancer.load`.
Under these recent apache versions, the daemon will therefore fail
to configtest or startup due to the invalid configuration.

This commit adjusts the module load order so that the lbmethod module
is loaded after those its dependent upon.