### PR TITLE
always quote ExpiresDefault in vhost::directories

### DIFF
--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -320,7 +320,7 @@
     ExpiresActive <%= directory['expires_active'] %>
     <%- end -%>
     <%- if directory['expires_default'] -%>
-    ExpiresDefault <%= directory['expires_default'] %>
+    ExpiresDefault "<%= directory['expires_default'] %>"
     <%- end -%>
     <%- if directory['expires_by_type'] -%>
     <%- Array(directory['expires_by_type']).each do |rule| -%>


### PR DESCRIPTION
this was already done in expires.conf, but not in a vhost