### PR TITLE
(MODULES-9948) Allow switching of thread modules

### DIFF
--- a/manifests/mpm.pp
+++ b/manifests/mpm.pp
@@ -109,6 +109,7 @@ define apache::mpm (
       if $mpm == 'worker' {
         if ( ( $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease,'18.04') >= 0 ) or ( $::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '8.0.0') >= 0 ) ) {
           include apache::mpm::disable_mpm_event
+          include apache::mpm::disable_mpm_prefork
         }
       }
 

--- a/manifests/mpm/disable_mpm_event.pp
+++ b/manifests/mpm/disable_mpm_event.pp
@@ -1,6 +1,6 @@
 class apache::mpm::disable_mpm_event {
-  exec { '/usr/sbin/a2dismod mpm_event':
-    onlyif  => "/usr/bin/test -e ${apache::mod_enable_dir}/mpm_event.load",
+  exec { '/usr/sbin/a2dismod event':
+    onlyif  => "/usr/bin/test -e ${apache::mod_enable_dir}/event.load",
     require => Package['httpd'],
     before  => Class['apache::service'],
   }

--- a/manifests/mpm/disable_mpm_prefork.pp
+++ b/manifests/mpm/disable_mpm_prefork.pp
@@ -1,0 +1,8 @@
+class apache::mpm::disable_mpm_prefork {
+  exec { '/usr/sbin/a2dismod prefork':
+    onlyif  => "/usr/bin/test -e ${apache::mod_enable_dir}/prefork.load",
+    require => Package['httpd'],
+    before  => Class['apache::service'],
+  }
+
+}

--- a/manifests/mpm/disable_mpm_worker.pp
+++ b/manifests/mpm/disable_mpm_worker.pp
@@ -1,6 +1,6 @@
 class apache::mpm::disable_mpm_worker {
-  exec { '/usr/sbin/a2dismod mpm_worker':
-    onlyif  => "/usr/bin/test -e ${apache::mod_enable_dir}/mpm_worker.load",
+  exec { '/usr/sbin/a2dismod worker':
+    onlyif  => "/usr/bin/test -e ${apache::mod_enable_dir}/worker.load",
     require => Package['httpd'],
     before  => Class['apache::service'],
   }

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -260,7 +260,8 @@ describe 'apache', type: :class do
           { mpm_module: 'worker' }
         end
 
-        it { is_expected.to contain_exec('/usr/sbin/a2dismod mpm_event') }
+        it { is_expected.to contain_exec('/usr/sbin/a2dismod event') }
+        it { is_expected.to contain_exec('/usr/sbin/a2dismod prefork') }
       end
     end
 


### PR DESCRIPTION
On Debian based systems (I have not tested behavior on other OS) you can have multiple thread modules installed in parallel. An admin must ensure that only one thread module is active by disabling any old thread module when adding a new one.

Changing thread module was not possible in Puppet Apache Module.
Once a thread module was active it never got disabled when switching to another one, causing the apache process to not be able to start.

This PR adds the capability to switch thread modules on existing, Puppet managed apache installations on Debian based systems.

Usual thread modules are: prefork, event or worker.
When switching from one thread module to another we must ensure that the
old, no longer to use, thread module gets disabled.

Puppet Apache module will always use the new mpm base thread modules and place
them in files without mpm_ prefix.
The a2dismod utility only checks for file names, not the real thread
module.