### PR TITLE
(FM-8662) Correct  in manifests/mod/ssl.pp for SLES 11

### DIFF
--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -159,7 +159,7 @@ class apache::mod::ssl (
     if defined(Class['::apache::mod::worker']){
       $suse_path = '/usr/lib64/apache2-worker'
     } else {
-      $suse_path = '/usr/lib64/apache2-worker'
+      $suse_path = '/usr/lib64/apache2-prefork'
     }
     ::apache::mod { 'ssl':
       package  => $package_name,


### PR DESCRIPTION
## Description

There were Pipelines CI test failures being caused by Apache not being able to load the SSL module on SLES 11: 

https://pipelines.puppet.com/team-modules/builds/599671

```ruby
      2) apache::vhost define parameter tests applies cleanly
         On host `j3ye05rmc16s212.delivery.puppetlabs.net'
         Failure/Error: apply_manifest(pp, catch_failures: true)
         RuntimeError:
           apply manifest failed
           ` puppet apply /tmp/manifest_20191029_43621_1a8n2bk.pp --detailed-exitcodes`
           with exit code 6 (expected: [0, 2])
           ====== Start output of failed Puppet apply ======
           Warning: Scope(Class[Apache::Mod::Prefork]): For newer versions of Apache, $maxclients is deprecated, please use $maxrequestworkers.
           Error: /Stage[main]/Apache::Service/Service[httpd]: Failed to call refresh: Could not restart Service[httpd]: Execution of '/sbin/service apache2 restart' returned 1: httpd2-prefork: Syntax error on line 43 of /etc/apache2/httpd.conf: Syntax error on line 1 of /etc/apache2/mods-enabled/ssl.load: Cannot load /usr/lib64/apache2-worker/mod_ssl.so into server: /usr/lib64/apache2-worker/mod_ssl.so: cannot open shared object file: No such file or directory
           Error: /Stage[main]/Apache::Service/Service[httpd]: Could not restart Service[httpd]: Execution of '/sbin/service apache2 restart' returned 1: httpd2-prefork: Syntax error on line 43 of /etc/apache2/httpd.conf: Syntax error on line 1 of /etc/apache2/mods-enabled/ssl.load: Cannot load /usr/lib64/apache2-worker/mod_ssl.so into server: /usr/lib64/apache2-worker/mod_ssl.so: cannot open shared object file: No such file or directory 
```

Upon investigation, it appears as though the path to the mod_ssl.so is incorrect: https://github.com/cmccrisken-puppet/puppetlabs-apache/blob/caf1c141d9a3820ba1b74469241eee6c2feeb332/manifests/mod/ssl.pp#L162

It appears to have been updated correctly in other places in our code base:

https://github.com/search?q=org%3Apuppetlabs+%2Fusr%2Flib64%2Fapache2-prefork&type=Code

Making the same change to manifests/mod/ssl.pp results in the test passing.