### PR TITLE
(FM-8721) fix php version and ssl error on redhat8

### DIFF
--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -85,7 +85,7 @@ class apache::mod::ssl (
   $ssl_ca                                                   = undef,
   $ssl_cipher                                               = 'HIGH:MEDIUM:!aNULL:!MD5:!RC4:!3DES',
   Variant[Boolean, Enum['on', 'off']] $ssl_honorcipherorder = true,
-  $ssl_protocol                                             = [ 'all', '-SSLv2', '-SSLv3' ],
+  $ssl_protocol                                             = ['all'],   # Implementations of the SSLv2 and SSLv3 protocol versions have been removed from OpenSSL (and hence mod_ssl) because these are no longer considered secure. For additional documentation https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/deploying_different_types_of_servers/setting-apache-web-server_deploying-different-types-of-servers
   Array $ssl_proxy_protocol                                 = [],
   $ssl_pass_phrase_dialog                                   = 'builtin',
   $ssl_random_seed_bytes                                    = '512',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -195,7 +195,10 @@ class apache::params inherits ::apache::version {
     $suphp_addhandler     = 'php5-script'
     $suphp_engine         = 'off'
     $suphp_configpath     = undef
-    $php_version          = '5'
+    $php_version = $facts['operatingsystemmajrelease'] ? {
+        '8'     => '7', # RedHat8
+        default => '5', # RedHat5, RedHat6, RedHat7 
+      }
     $mod_packages         = {
       # NOTE: The auth_cas module isn't available on RH/CentOS without providing dependency packages provided by EPEL.
       'auth_cas'              => 'mod_auth_cas',

--- a/spec/acceptance/mod_php_spec.rb
+++ b/spec/acceptance/mod_php_spec.rb
@@ -35,6 +35,10 @@ unless os[:family] == 'sles' && os[:release].to_i >= 12
         describe file("#{apache_hash['mod_dir']}/php7.2.conf") do
           it { is_expected.to contain 'DirectoryIndex index.php' }
         end
+      elsif os[:family] == 'redhat' && os[:release] =~ %r{^8}
+        describe file("#{apache_hash['mod_dir']}/php7.conf") do
+          it { is_expected.to contain 'DirectoryIndex index.php' }
+        end
       else
         describe file("#{apache_hash['mod_dir']}/php5.conf") do
           it { is_expected.to contain 'DirectoryIndex index.php' }

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -49,7 +49,7 @@ describe 'apache::vhost define' do
     end
   end
 
-  context 'default vhost with ssl' do
+  context 'default vhost with ssl', unless: (os[:family] =~ %r{redhat} && os[:release].to_i == 8) do
     pp = <<-MANIFEST
       file { '#{apache_hash['run_dir']}':
         ensure  => 'directory',
@@ -752,7 +752,7 @@ describe 'apache::vhost define' do
     end
   end
 
-  describe 'parameter tests' do
+  describe 'parameter tests', unless: (os[:family] =~ %r{redhat} && os[:release].to_i == 8) do
     pp = <<-MANIFEST
       class { 'apache': }
       host { 'test.itk': ip => '127.0.0.1' }

--- a/spec/classes/mod/php_spec.rb
+++ b/spec/classes/mod/php_spec.rb
@@ -86,13 +86,10 @@ describe 'apache::mod::php', type: :class do
             end
 
             it { is_expected.to contain_class('apache::params') }
-            it { is_expected.to contain_apache__mod('php5') }
+            it { is_expected.to contain_apache__mod('php5') } if facts[:os]['release']['major'].to_i < 8
             it { is_expected.to contain_package('php') } if facts[:os]['release']['major'].to_i > 5
-            it {
-              is_expected.to contain_file('php5.load').with(
-                content: "LoadModule php5_module modules/libphp5.so\n",
-              )
-            }
+            it { is_expected.to contain_file('php5.load').with(content: "LoadModule php5_module modules/libphp5.so\n") } if facts[:os]['release']['major'].to_i < 8
+            it { is_expected.to contain_file('php7.load').with(content: "LoadModule php7_module modules/libphp7.so\n") } if facts[:os]['release']['major'].to_i >= 8
           end
           context 'with alternative package name' do
             let :pre_condition do
@@ -112,11 +109,8 @@ describe 'apache::mod::php', type: :class do
               { path: 'alternative-path' }
             end
 
-            it {
-              is_expected.to contain_file('php5.load').with(
-                content: "LoadModule php5_module alternative-path\n",
-              )
-            }
+            it { is_expected.to contain_file('php5.load').with(content: "LoadModule php5_module alternative-path\n") } if facts[:os]['release']['major'].to_i < 8
+            it { is_expected.to contain_file('php7.load').with(content: "LoadModule php7_module alternative-path\n") } if facts[:os]['release']['major'].to_i >= 8
           end
           context 'with alternative extensions' do
             let :pre_condition do
@@ -128,7 +122,7 @@ describe 'apache::mod::php', type: :class do
               }
             end
 
-            it { is_expected.to contain_file('php5.conf').with_content(Regexp.new(Regexp.escape('<FilesMatch ".+(\.php|\.php5)$">'))) }
+            it { is_expected.to contain_file('php5.conf').with_content(Regexp.new(Regexp.escape('<FilesMatch ".+(\.php|\.php5)$">'))) } if facts[:os]['release']['major'].to_i < 8
           end
           if facts[:os]['release']['major'].to_i > 5
             context 'with specific version' do
@@ -149,13 +143,10 @@ describe 'apache::mod::php', type: :class do
           context 'with mpm_module => prefork' do
             it { is_expected.to contain_class('apache::params') }
             it { is_expected.to contain_class('apache::mod::prefork') }
-            it { is_expected.to contain_apache__mod('php5') }
+            it { is_expected.to contain_apache__mod('php5') } if facts[:os]['release']['major'].to_i < 8
             it { is_expected.to contain_package('php') } if facts[:os]['release']['major'].to_i > 5
-            it {
-              is_expected.to contain_file('php5.load').with(
-                content: "LoadModule php5_module modules/libphp5.so\n",
-              )
-            }
+            it { is_expected.to contain_file('php5.load').with(content: "LoadModule php5_module modules/libphp5.so\n") } if facts[:os]['release']['major'].to_i < 8
+            it { is_expected.to contain_file('php7.load').with(content: "LoadModule php7_module modules/libphp7.so\n") } if facts[:os]['release']['major'].to_i >= 8
           end
           context 'with mpm_module => itk' do
             let :pre_condition do
@@ -164,13 +155,10 @@ describe 'apache::mod::php', type: :class do
 
             it { is_expected.to contain_class('apache::params') }
             it { is_expected.to contain_class('apache::mod::itk') }
-            it { is_expected.to contain_apache__mod('php5') }
+            it { is_expected.to contain_apache__mod('php5') } if facts[:os]['release']['major'].to_i < 8
             it { is_expected.to contain_package('php') } if facts[:os]['release']['major'].to_i > 5
-            it {
-              is_expected.to contain_file('php5.load').with(
-                content: "LoadModule php5_module modules/libphp5.so\n",
-              )
-            }
+            it { is_expected.to contain_file('php5.load').with(content: "LoadModule php5_module modules/libphp5.so\n") } if facts[:os]['release']['major'].to_i < 8
+            it { is_expected.to contain_file('php7.load').with(content: "LoadModule php7_module modules/libphp7.so\n") } if facts[:os]['release']['major'].to_i >= 8
           end
         end
       when 'FreeBSD'
@@ -215,9 +203,10 @@ describe 'apache::mod::php', type: :class do
         end
       end
 
-      # all the following tests are for legacy php/apache versions. They don't work on modern ubuntu
+      # all the following tests are for legacy php/apache versions. They don't work on modern ubuntu and redhat 8
       next if (facts[:os]['release']['major'].to_i > 15 && facts[:os]['name'] == 'Ubuntu') ||
-              (facts[:os]['release']['major'].to_i >= 9 && facts[:os]['name'] == 'Debian')
+              (facts[:os]['release']['major'].to_i >= 9 && facts[:os]['name'] == 'Debian') ||
+              (facts[:os]['release']['major'].to_i >= 8 && facts[:os]['name'] == 'RedHat')
 
       describe 'OS independent tests' do
         context 'with content param' do


### PR DESCRIPTION
Request for a review
Fixed the following
Updated the PHP default version from 5 to 7 for redhat8 
Updated the unit test cases for the verification
Fixed the SSL certificate error on redhat8. The protocol is removed for security reasons.
Testcases run on release checks and all are running clean.

![Screen Shot 2019-11-11 at 14 24 03](https://user-images.githubusercontent.com/20660680/68594284-1f4a0300-048f-11ea-9f1c-659ab941f6ed.png)
