### PR TITLE
Change mod_proxy's ProxyTimeout to follow Apache's global timeout

### DIFF
--- a/manifests/mod/proxy.pp
+++ b/manifests/mod/proxy.pp
@@ -27,9 +27,10 @@ class apache::mod::proxy (
   $apache_version = undef,
   $package_name   = undef,
   $proxy_via      = 'On',
-  $proxy_timeout  = $apache::timeout,
+  $proxy_timeout  = undef,
 ) {
   include ::apache
+  $_proxy_timeout = $apache::timeout
   $_apache_version = pick($apache_version, $apache::apache_version)
   ::apache::mod { 'proxy':
     package => $package_name,

--- a/manifests/mod/proxy.pp
+++ b/manifests/mod/proxy.pp
@@ -27,7 +27,7 @@ class apache::mod::proxy (
   $apache_version = undef,
   $package_name   = undef,
   $proxy_via      = 'On',
-  $proxy_timeout  = '60',
+  $proxy_timeout  = $::apache::timeout,
 ) {
   include ::apache
   $_apache_version = pick($apache_version, $apache::apache_version)

--- a/manifests/mod/proxy.pp
+++ b/manifests/mod/proxy.pp
@@ -27,7 +27,7 @@ class apache::mod::proxy (
   $apache_version = undef,
   $package_name   = undef,
   $proxy_via      = 'On',
-  $proxy_timeout  = $::apache::timeout,
+  $proxy_timeout  = $apache::timeout,
 ) {
   include ::apache
   $_apache_version = pick($apache_version, $apache::apache_version)

--- a/templates/mod/proxy.conf.erb
+++ b/templates/mod/proxy.conf.erb
@@ -25,5 +25,7 @@
   # Set to one of: Off | On | Full | Block
   ProxyVia <%= @proxy_via %>
 
+  <%- if @proxy_timeout -%>
   ProxyTimeout <%= @proxy_timeout %>
+  <%- end -%>
 </IfModule>


### PR DESCRIPTION
[apache docs](https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#proxytimeout) for ProxyTimeout indicate that the default timeout tracks the global Timeout.  The code introduced in #1805 for `apache::mod::proxy` codes in '60' seconds for `proxy_timeout`.  While 60 is the normal default for the global `timeout` 'out of the box', it means that 60 becomes hard-specified and no longer tracks the global timeout.  This leads to a surprise when $apache::timeout is raised to 300 and proxied requests bomb out at 60.  Not that I know anyone who went through that, no ma'am.

The change edits the default of ProxyTimeout to track along with the global timeout unless told otherwise.

- Without a global `timeout` set, the `proxy_timeout` parameter will default to the global (undef) and lead to the `ProxyTimeout` config line disappearing. (minor config file change, no net apache behavior change).

- With a global `timeout` parameter, `proxy_timeout` will track to the global number instead of being 60 (my desired change.  config files and operations will change to line up with apache docs, under 'principle of least surprise').

- Specifying different numbers between `timeout` and `proxy_timeout` is still possible, and behavior is unchanged from the current world.