### PR TITLE
move unless into manage_security_corerules

### DIFF
--- a/manifests/mod/security.pp
+++ b/manifests/mod/security.pp
@@ -229,10 +229,10 @@ class apache::mod::security (
       require => File[$modsec_dir],
       notify  => Class['apache::service'],
     }
-  }
 
-  # Debian 9 has a different rule setup
-  unless $::operatingsystem == 'SLES' or ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '9') >= 0) or ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '18.04') >= 0) {
-    apache::security::rule_link { $activated_rules: }
+    # Debian 9 has a different rule setup
+    unless $::operatingsystem == 'SLES' or ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '9') >= 0) or ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '18.04') >= 0) {
+      apache::security::rule_link { $activated_rules: }
+    }
   }
 }


### PR DESCRIPTION
This PR moves the unless block inside the manage manage_security_corerules block because it is only needed if core rules are there. It also prevents the apache::security::rule_link define to be called if security core rules are not managed