### PR TITLE
Add an apache::vhost::fragment define

### DIFF
--- a/manifests/vhost/fragment.pp
+++ b/manifests/vhost/fragment.pp
@@ -1,0 +1,80 @@
+# @summary Define a fragment within a vhost
+#
+# @param vhost
+#   The title of the vhost resource to append to
+#
+# @param priority
+#   Set the priority to match the one `apache::vhost` sets. This must match the
+#   one `apache::vhost` sets or else the concat fragment won't be found.
+#
+# @param content
+#   The content to put in the fragment. Only when it's non-empty the actual
+#   fragment will be created.
+#
+# @param order
+#   The order to insert the fragment at
+#
+# @example With a vhost without priority
+#   include apache
+#   apache::vhost { 'myvhost':
+#   }
+#   apache::vhost::fragment { 'myfragment':
+#     vhost   => 'myvhost',
+#     content => '# Foo',
+#   }
+#
+# @example With a vhost with priority
+#   include apache
+#   apache::vhost { 'myvhost':
+#     priority => '42',
+#   }
+#   apache::vhost::fragment { 'myfragment':
+#     vhost    => 'myvhost',
+#     priority => '42',
+#     content  => '# Foo',
+#   }
+#
+# @example With a vhost with default vhost
+#   include apache
+#   apache::vhost { 'myvhost':
+#     default_vhost => true,
+#   }
+#   apache::vhost::fragment { 'myfragment':
+#     vhost    => 'myvhost',
+#     priority => '10', # default_vhost implies priority 10
+#     content  => '# Foo',
+#   }
+#
+# @example Adding a fragment to the built in default vhost
+#   include apache
+#   apache::vhost::fragment { 'myfragment':
+#     vhost    => 'default',
+#     priority => '15',
+#     content  => '# Foo',
+#   }
+#
+define apache::vhost::fragment(
+  String[1] $vhost,
+  $priority = undef,
+  Optional[String] $content = undef,
+  Integer[0] $order = 900,
+) {
+  # This copies the logic from apache::vhost
+  if $priority {
+    $priority_real = "${priority}-"
+  } elsif $priority == false {
+    $priority_real = ''
+  } else {
+    $priority_real = '25-'
+  }
+
+  $filename = regsubst($vhost, ' ', '_', 'G')
+
+  if $content =~ String[1] {
+    concat::fragment { "${vhost}-${title}":
+      target  => "${priority_real}${filename}.conf",
+      order   => $order,
+      content => $content,
+    }
+  }
+}

--- a/spec/defines/vhost_fragment_spec.rb
+++ b/spec/defines/vhost_fragment_spec.rb
@@ -1,0 +1,117 @@
+require 'spec_helper'
+
+describe 'apache::vhost::fragment' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:title) { 'myfragment' }
+
+      context 'adding to the default vhost' do
+        let(:pre_condition) { 'include apache' }
+
+        let(:params) do
+          {
+            vhost: 'default',
+            priority: '15',
+          }
+        end
+
+        context 'with content' do
+          let(:params) { super().merge(content: '# Foo') }
+
+          it 'creates a vhost concat fragment' do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_concat('15-default.conf')
+            is_expected.to create_concat__fragment('default-myfragment')
+              .with_target('15-default.conf')
+              .with_order(900)
+              .with_content('# Foo')
+          end
+        end
+
+        context 'without content' do
+          let(:params) { super().merge(content: '') }
+
+          it 'does not create a vhost concat fragment' do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_concat('15-default.conf')
+            is_expected.not_to contain_concat__fragment('default-myfragment')
+          end
+        end
+      end
+
+      context 'adding to a custom vhost' do
+        let(:params) do
+          {
+            vhost: 'custom',
+            content: '# Foo',
+          }
+        end
+
+        context 'with priority => false' do
+          let(:params) { super().merge(priority: false) }
+          let(:pre_condition) do
+            <<-PUPPET
+            include apache
+            apache::vhost { 'custom':
+              docroot  => '/path/to/docroot',
+              priority => false,
+            }
+            PUPPET
+          end
+
+          it 'creates a vhost concat fragment' do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_concat('custom.conf')
+            is_expected.to create_concat__fragment('custom-myfragment')
+              .with_target('custom.conf')
+              .with_order(900)
+              .with_content('# Foo')
+          end
+        end
+
+        context 'with priority => 42' do
+          let(:params) { super().merge(priority: '42') }
+          let(:pre_condition) do
+            <<-PUPPET
+            include apache
+            apache::vhost { 'custom':
+              docroot  => '/path/to/docroot',
+              priority => '42',
+            }
+            PUPPET
+          end
+
+          it 'creates a vhost concat fragment' do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_concat('42-custom.conf')
+            is_expected.to create_concat__fragment('custom-myfragment')
+              .with_target('42-custom.conf')
+              .with_order(900)
+              .with_content('# Foo')
+          end
+        end
+
+        context 'with default priority' do
+          let(:pre_condition) do
+            <<-PUPPET
+            include apache
+            apache::vhost { 'custom':
+              docroot  => '/path/to/docroot',
+            }
+            PUPPET
+          end
+
+          it 'creates a vhost concat fragment' do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_concat('25-custom.conf')
+            is_expected.to create_concat__fragment('custom-myfragment')
+              .with_target('25-custom.conf')
+              .with_order(900)
+              .with_content('# Foo')
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The apache::vhost::fragment define allows adding fragments to an existing vhost. This is easier than using the custom_fragment property, especially when one class defines the vhost and another class wants to add add some content to that.

This work was inspired by https://github.com/puppetlabs/puppetlabs-apache/pull/1659.