### PR TITLE
Fix newline being added before proxy params

### DIFF
--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -189,6 +189,20 @@ describe 'apache::vhost', type: :define do
                   'auth_ldap_referrals' => 'off',
                 },
                 {
+                  'path'       => '/proxy',
+                  'provider'   => 'location',
+                  'proxy_pass' => [
+                    {
+                      'url'             => 'http://backend-b/',
+                      'keywords'        => ['noquery', 'interpolate'],
+                      'params' => {
+                        'retry'   => '0',
+                        'timeout' => '5',
+                      },
+                    },
+                  ],
+                },
+                {
                   'path'                                                => '/var/www/node-app/public',
                   'passenger_enabled'                                   => true,
                   'passenger_base_uri'                                  => '/app',
@@ -609,6 +623,11 @@ describe 'apache::vhost', type: :define do
           it {
             is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
               content: %r{^\s+LDAPReferrals off$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
+              content: %r{^\s+ProxyPass http://backend-b/ retry=0 timeout=5 noquery interpolate$},
             )
           }
           it {

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -460,7 +460,7 @@
     <%- end -%>
     <%- if directory['proxy_pass'] and directory['provider'] and directory['provider'].match('location') -%>
       <%- directory['proxy_pass'].flatten.compact.each do |proxy| -%>
-    ProxyPass <%= proxy['url'] %>
+    ProxyPass <%= proxy['url'] -%>
         <%- if proxy['params'] -%>
           <%- proxy['params'].keys.sort.each do |key| -%> <%= key %>=<%= proxy['params'][key] -%>
           <%- end -%>


### PR DESCRIPTION
When a proxy_pass with additional params is defined within a directories location entry, the params get appended in a new line (which breaks config).
The change in this pull request removes the superfluous newline.