### PR TITLE
Add template variables and parameters for ModSecurity Audit Logs

### DIFF
--- a/manifests/mod/security.pp
+++ b/manifests/mod/security.pp
@@ -27,6 +27,12 @@
 #   Defines which parts of each transaction are going to be recorded in the audit log. Each part is assigned a single letter; when a
 #   letter appears in the list then the equivalent part will be recorded.
 # 
+# @param audit_log_type
+#   Defines the type of audit logging mechanism to be used.
+# 
+# @param audit_log_storage_dir
+#   Defines the directory where concurrent audit log entries are to be stored. This directive is only needed when concurrent audit logging is used.
+# 
 # @param secpcrematchlimit
 #   Sets the match limit in the PCRE library.
 # 
@@ -96,6 +102,8 @@ class apache::mod::security (
   $modsec_secruleengine        = $::apache::params::modsec_secruleengine,
   $audit_log_relevant_status   = '^(?:5|4(?!04))',
   $audit_log_parts             = $::apache::params::modsec_audit_log_parts,
+  $audit_log_type              = $::apache::params::modsec_audit_log_type,
+  $audit_log_storage_dir       = undef,
   $secpcrematchlimit           = $::apache::params::secpcrematchlimit,
   $secpcrematchlimitrecursion  = $::apache::params::secpcrematchlimitrecursion,
   $allowed_methods             = 'GET HEAD POST OPTIONS',
@@ -169,6 +177,8 @@ class apache::mod::security (
   # - logroot
   # - $modsec_dir
   # - $audit_log_parts
+  # - $audit_log_type
+  # - $audit_log_storage_dir
   # - secpcrematchlimit
   # - secpcrematchlimitrecursion
   # - secrequestbodylimit

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,6 +35,7 @@ class apache::params inherits ::apache::version {
   $vhost_include_pattern = '*'
 
   $modsec_audit_log_parts = 'ABIJDEFHZ'
+  $modsec_audit_log_type = 'Serial'
 
   # no client certs should be trusted for auth by default.
   $ssl_certs_dir          = undef

--- a/spec/classes/mod/security_spec.rb
+++ b/spec/classes/mod/security_spec.rb
@@ -42,6 +42,7 @@ describe 'apache::mod::security', type: :class do
             is_expected.to contain_file('security.conf')
               .with_content(%r{^\s+SecAuditLogRelevantStatus "\^\(\?:5\|4\(\?!04\)\)"$})
               .with_content(%r{^\s+SecAuditLogParts ABIJDEFHZ$})
+              .with_content(%r{^\s+SecAuditLogType Serial$})
               .with_content(%r{^\s+SecDebugLog /var/log/httpd/modsec_debug.log$})
               .with_content(%r{^\s+SecAuditLog /var/log/httpd/modsec_audit.log$})
           }
@@ -78,12 +79,16 @@ describe 'apache::mod::security', type: :class do
                 ],
                 audit_log_relevant_status: '^(?:5|4(?!01|04))',
                 audit_log_parts: 'ABCDZ',
+                audit_log_type: 'Concurrent',
+                audit_log_storage_dir: '/var/log/httpd/audit',
                 secdefaultaction: 'deny,status:406,nolog,auditlog',
               }
             end
 
             it { is_expected.to contain_file('security.conf').with_content %r{^\s+SecAuditLogRelevantStatus "\^\(\?:5\|4\(\?!01\|04\)\)"$} }
             it { is_expected.to contain_file('security.conf').with_content %r{^\s+SecAuditLogParts ABCDZ$} }
+            it { is_expected.to contain_file('security.conf').with_content %r{^\s+SecAuditLogType Concurrent$} }
+            it { is_expected.to contain_file('security.conf').with_content %r{^\s+SecAuditLogStorageDir /var/log/httpd/audit$} }
             it { is_expected.to contain_file('/etc/httpd/modsecurity.d/security_crs.conf').with_content %r{^\s*SecDefaultAction "phase:2,deny,status:406,nolog,auditlog"$} }
             it {
               is_expected.to contain_file('bar.conf').with(
@@ -126,6 +131,7 @@ describe 'apache::mod::security', type: :class do
             is_expected.to contain_file('security.conf')
               .with_content(%r{^\s+SecAuditLogRelevantStatus "\^\(\?:5\|4\(\?!04\)\)"$})
               .with_content(%r{^\s+SecAuditLogParts ABIJDEFHZ$})
+              .with_content(%r{^\s+SecAuditLogType Serial$})
               .with_content(%r{^\s+SecDebugLog /var/log/apache2/modsec_debug.log$})
               .with_content(%r{^\s+SecAuditLog /var/log/apache2/modsec_audit.log$})
           }
@@ -165,6 +171,8 @@ describe 'apache::mod::security', type: :class do
                 ],
                 audit_log_relevant_status: '^(?:5|4(?!01|04))',
                 audit_log_parts: 'ABCDZ',
+                audit_log_type: 'Concurrent',
+                audit_log_storage_dir: '/var/log/httpd/audit',
                 secdefaultaction: 'deny,status:406,nolog,auditlog',
               }
             end
@@ -173,6 +181,7 @@ describe 'apache::mod::security', type: :class do
                (facts[:os]['release']['major'].to_i < 9 && facts[:os]['name'] == 'Debian')
               it { is_expected.to contain_file('security.conf').with_content %r{^\s+SecAuditLogRelevantStatus "\^\(\?:5\|4\(\?!01\|04\)\)"$} }
               it { is_expected.to contain_file('security.conf').with_content %r{^\s+SecAuditLogParts ABCDZ$} }
+              it { is_expected.to contain_file('security.conf').with_content %r{^\s+SecAuditLogStorageDir /var/log/httpd/audit$} }
               it { is_expected.to contain_file('/etc/modsecurity/security_crs.conf').with_content %r{^\s*SecDefaultAction "phase:2,deny,status:406,nolog,auditlog"$} }
               it {
                 is_expected.to contain_file('bar.conf').with(

--- a/templates/mod/security.conf.erb
+++ b/templates/mod/security.conf.erb
@@ -45,7 +45,10 @@
     SecAuditEngine RelevantOnly
     SecAuditLogRelevantStatus "<%= @audit_log_relevant_status %>"
     SecAuditLogParts <%= @audit_log_parts %>
-    SecAuditLogType Serial
+    SecAuditLogType <%= @audit_log_type %>
+    <%- if @audit_log_storage_dir -%>
+    SecAuditLogStorageDir <%= @audit_log_storage_dir %>
+    <%- end -%>
     SecArgumentSeparator &
     SecCookieFormat 0
 <%- if scope.lookupvar('::osfamily') == 'Debian' -%>


### PR DESCRIPTION
- Add new parameter and update security.conf template to enable configuration of ModSecurity [SecAuditLogType](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-%28v2.x%29#secauditlogtype)
- Add new parameter and update security.conf template to enable configuration of ModSecurity [SecAuditLogStorageDir](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual-%28v2.x%29#secauditlogstoragedir)
- Add tests for new parameters and defaults