### PR TITLE
(MODULES-10391) ssl_protocol includes SSLv2 and SSLv3 on all platforms

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -5453,7 +5453,7 @@ Data type: `Any`
 
 Configure usable SSL/TLS protocol versions.
 
-Default value: ['all']
+Default value: ['all', '-SSLv2', '-SSLv3']
 
 ##### `ssl_proxy_protocol`
 

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -85,7 +85,7 @@ class apache::mod::ssl (
   $ssl_ca                                                   = undef,
   $ssl_cipher                                               = 'HIGH:MEDIUM:!aNULL:!MD5:!RC4:!3DES',
   Variant[Boolean, Enum['on', 'off']] $ssl_honorcipherorder = true,
-  $ssl_protocol                                             = ['all'],   # Implementations of the SSLv2 and SSLv3 protocol versions have been removed from OpenSSL (and hence mod_ssl) because these are no longer considered secure. For additional documentation https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/deploying_different_types_of_servers/setting-apache-web-server_deploying-different-types-of-servers
+  $ssl_protocol                                             = $::apache::params::ssl_protocol,
   Array $ssl_proxy_protocol                                 = [],
   $ssl_pass_phrase_dialog                                   = 'builtin',
   $ssl_random_seed_bytes                                    = '512',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -791,4 +791,10 @@ class apache::params inherits ::apache::version {
   } else {
     $verify_command = '/usr/sbin/apachectl -t'
   }
+
+  if ($::operatingsystem == 'RedHat' and ($facts['operatingsystemmajrelease'] == '8') ) {
+    $ssl_protocol = ['all'] # Implementations of the SSLv2 and SSLv3 protocol versions have been removed from OpenSSL (and hence mod_ssl) because these are no longer considered secure. For additional documentation https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/deploying_different_types_of_servers/setting-apache-web-server_deploying-different-types-of-servers
+  } else {
+    $ssl_protocol = [ 'all', '-SSLv2', '-SSLv3' ]
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -792,7 +792,7 @@ class apache::params inherits ::apache::version {
     $verify_command = '/usr/sbin/apachectl -t'
   }
 
-  if ($::operatingsystem == 'RedHat' and ($facts['operatingsystemmajrelease'] == '8') ) {
+  if ($::osfamily == 'RedHat' and ($facts['operatingsystemmajrelease'] >= '8') ) {
     $ssl_protocol = ['all'] # Implementations of the SSLv2 and SSLv3 protocol versions have been removed from OpenSSL (and hence mod_ssl) because these are no longer considered secure. For additional documentation https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/deploying_different_types_of_servers/setting-apache-web-server_deploying-different-types-of-servers
   } else {
     $ssl_protocol = [ 'all', '-SSLv2', '-SSLv3' ]

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -792,7 +792,7 @@ class apache::params inherits ::apache::version {
     $verify_command = '/usr/sbin/apachectl -t'
   }
 
-  if ($facts['os']['family'] == 'RedHat' and ($facts['os']['release']['major'] >= '8') ) {
+  if $::osfamily == 'RedHat' and versioncmp($::operatingsystemrelease, '8.0') >= 0 {
     $ssl_protocol = ['all'] # Implementations of the SSLv2 and SSLv3 protocol versions have been removed from OpenSSL (and hence mod_ssl) because these are no longer considered secure. For additional documentation https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/deploying_different_types_of_servers/setting-apache-web-server_deploying-different-types-of-servers
   } else {
     $ssl_protocol = [ 'all', '-SSLv2', '-SSLv3' ]

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -792,7 +792,7 @@ class apache::params inherits ::apache::version {
     $verify_command = '/usr/sbin/apachectl -t'
   }
 
-  if ($::osfamily == 'RedHat' and ($facts['operatingsystemmajrelease'] >= '8') ) {
+  if ($facts['os']['family'] == 'RedHat' and ($facts['os']['release']['major'] >= '8') ) {
     $ssl_protocol = ['all'] # Implementations of the SSLv2 and SSLv3 protocol versions have been removed from OpenSSL (and hence mod_ssl) because these are no longer considered secure. For additional documentation https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/deploying_different_types_of_servers/setting-apache-web-server_deploying-different-types-of-servers
   } else {
     $ssl_protocol = [ 'all', '-SSLv2', '-SSLv3' ]

--- a/spec/acceptance/apache_ssl_spec.rb
+++ b/spec/acceptance/apache_ssl_spec.rb
@@ -19,6 +19,15 @@ describe 'apache ssl' do
       idempotent_apply(pp)
     end
 
+    describe file("#{apache_hash['mod_ssl_dir']}/ssl.conf") do
+      it { is_expected.to be_file }
+      if os[:family] =~ %r{redhat} && os[:release].to_i == 8
+        it { is_expected.to contain 'SSLProtocol all' }
+      else
+        it { is_expected.to contain 'SSLProtocol all -SSLv2 -SSLv3' }
+      end
+    end
+
     describe file("#{apache_hash['vhost_dir']}/15-default-ssl.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain 'SSLCertificateFile      "/tmp/ssl_cert"' }

--- a/spec/classes/mod/ssl_spec.rb
+++ b/spec/classes/mod/ssl_spec.rb
@@ -36,6 +36,26 @@ describe 'apache::mod::ssl', type: :class do
       it { is_expected.to contain_apache__mod('ssl') }
       it { is_expected.to contain_package('mod_ssl') }
       it { is_expected.to contain_file('ssl.conf').with_path('/etc/httpd/conf.d/ssl.conf') }
+      it { is_expected.to contain_file('ssl.conf').with_content(%r{SSLProtocol all -SSLv2 -SSLv3}) }
+    end
+    context '8 OS' do
+      let :facts do
+        {
+          osfamily: 'RedHat',
+          operatingsystemrelease: '8',
+          operatingsystem: 'RedHat',
+          id: 'root',
+          kernel: 'Linux',
+          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+          is_pe: false,
+        }
+      end
+
+      it { is_expected.to contain_class('apache::params') }
+      it { is_expected.to contain_apache__mod('ssl') }
+      it { is_expected.to contain_package('mod_ssl') }
+      it { is_expected.to contain_file('ssl.conf').with_path('/etc/httpd/conf.d/ssl.conf') }
+      it { is_expected.to contain_file('ssl.conf').with_content(%r{SSLProtocol all}) }
     end
     context '6 OS with a custom package_name parameter' do
       let :facts do
@@ -104,8 +124,8 @@ describe 'apache::mod::ssl', type: :class do
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('ssl') }
     it { is_expected.not_to contain_package('libapache2-mod-ssl') }
+    it { is_expected.to contain_file('ssl.conf').with_content(%r{SSLProtocol all -SSLv2 -SSLv3}) }
   end
-
   context 'on a FreeBSD OS' do
     let :facts do
       {

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -67,17 +67,21 @@ def apache_settings_hash
     apache['suphp_handler']    = 'php5-script'
     apache['suphp_configpath'] = 'undef'
     if (operatingsystemrelease >= 7 && operatingsystemrelease < 8) && (osfamily == 'redhat')
-      apache['version'] = '2.4'
-      apache['mod_dir'] = '/etc/httpd/conf.modules.d'
+      apache['version']     = '2.4'
+      apache['mod_dir']     = '/etc/httpd/conf.modules.d'
+      apache['mod_ssl_dir'] = apache['confd_dir']
     elsif operatingsystemrelease >= 8 && osfamily == 'redhat'
-      apache['version'] = '2.4'
-      apache['mod_dir'] = '/etc/httpd/conf.d'
+      apache['version']     = '2.4'
+      apache['mod_dir']     = '/etc/httpd/conf.d'
+      apache['mod_ssl_dir'] = apache['mod_dir']
     elsif operatingsystemrelease >= 7 && osfamily == 'oracle'
-      apache['version'] = '2.4'
-      apache['mod_dir'] = '/etc/httpd/conf.modules.d'
+      apache['version']     = '2.4'
+      apache['mod_dir']     = '/etc/httpd/conf.modules.d'
+      apache['mod_ssl_dir'] = apache['confd_dir']
     else
-      apache['version'] = '2.2'
-      apache['mod_dir'] = '/etc/httpd/conf.d'
+      apache['version']     = '2.2'
+      apache['mod_dir']     = '/etc/httpd/conf.d'
+      apache['mod_ssl_dir'] = apache['mod_dir']
     end
   when 'debian', 'ubuntu'
     apache['confd_dir']        = '/etc/apache2/conf.d'
@@ -100,6 +104,7 @@ def apache_settings_hash
                         else
                           '2.2'
                         end
+    apache['mod_ssl_dir']      = apache['mod_dir']
   when 'freebsd'
     apache['confd_dir']        = '/usr/local/etc/apache24/Includes'
     apache['mod_dir']          = '/usr/local/etc/apache24/Modules'
@@ -112,7 +117,8 @@ def apache_settings_hash
     apache['service_name']     = 'apache24'
     apache['package_name']     = 'apache24'
     apache['error_log']        = 'http-error.log'
-    apache['version'] = '2.2'
+    apache['version']          = '2.2'
+    apache['mod_ssl_dir']      = apache['mod_dir']
   when 'gentoo'
     apache['confd_dir']        = '/etc/apache2/conf.d'
     apache['mod_dir']          = '/etc/apache2/modules.d'
@@ -125,7 +131,8 @@ def apache_settings_hash
     apache['service_name']     = 'apache2'
     apache['package_name']     = 'www-servers/apache'
     apache['error_log']        = 'http-error.log'
-    apache['version'] = '2.4'
+    apache['version']          = '2.4'
+    apache['mod_ssl_dir']      = apache['mod_dir']
   when 'suse', 'sles'
     apache['confd_dir']        = '/etc/apache2/conf.d'
     apache['mod_dir']          = '/etc/apache2/mods-available'
@@ -143,6 +150,7 @@ def apache_settings_hash
                         else
                           '2.4'
                         end
+    apache['mod_ssl_dir'] = apache['mod_dir']
   else
     raise 'unable to figure out what apache version'
   end


### PR DESCRIPTION
(Reported as MODULES-10391)

The default for the `apache::mod::ssl_protocol` parameter was changed to allow SSLv2 and SSLv3 on all platforms, which isn't desirable on anything with an older version of OpenSSL.  Noticed on CentOS 7 hosts after upgrading this module, without changing any parameters.

Hence this PR is to move the default setting to the params class and only set it for RHEL 8, which appears to be in the intention of the prior change in FM-8721 (PR #1691 

This then fixes this regression on other platforms.