### PR TITLE
(MODULES-10360) Fix icon paths for RedHat systems

### DIFF
--- a/manifests/mod/autoindex.pp
+++ b/manifests/mod/autoindex.pp
@@ -10,10 +10,10 @@ class apache::mod::autoindex {
   # Determine icon filename suffix for autoindex.conf.erb
   case $operatingsystem {
     'Debian', 'Ubuntu': {
-      $icon_suffix = '-20x22'
+      $::icon_suffix = '-20x22'
     }
     default: {
-      $icon_suffix = ''
+      $::icon_suffix = ''
     }
   }
 

--- a/manifests/mod/autoindex.pp
+++ b/manifests/mod/autoindex.pp
@@ -6,7 +6,17 @@
 class apache::mod::autoindex {
   include ::apache
   ::apache::mod { 'autoindex': }
-  # Template changes content based on @osfamily
+
+  # Determine icon filename suffix for autoindex.conf.erb
+  case $operatingsystem {
+    'Debian', 'Ubuntu': {
+      icon_suffix = '-20x22'
+    }
+    default: {
+      icon_suffix = ''
+    }
+  }
+
   file { 'autoindex.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/autoindex.conf",

--- a/manifests/mod/autoindex.pp
+++ b/manifests/mod/autoindex.pp
@@ -6,7 +6,7 @@
 class apache::mod::autoindex {
   include ::apache
   ::apache::mod { 'autoindex': }
-  # Template uses no variables
+  # Template changes content based on @osfamily
   file { 'autoindex.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/autoindex.conf",

--- a/manifests/mod/autoindex.pp
+++ b/manifests/mod/autoindex.pp
@@ -8,12 +8,12 @@ class apache::mod::autoindex {
   ::apache::mod { 'autoindex': }
 
   # Determine icon filename suffix for autoindex.conf.erb
-  case $operatingsystem {
+  case $::operatingsystem {
     'Debian', 'Ubuntu': {
-      $::icon_suffix = '-20x22'
+      $icon_suffix = '-20x22'
     }
     default: {
-      $::icon_suffix = ''
+      $icon_suffix = ''
     }
   }
 

--- a/manifests/mod/autoindex.pp
+++ b/manifests/mod/autoindex.pp
@@ -10,10 +10,10 @@ class apache::mod::autoindex {
   # Determine icon filename suffix for autoindex.conf.erb
   case $operatingsystem {
     'Debian', 'Ubuntu': {
-      icon_suffix = '-20x22'
+      $icon_suffix = '-20x22'
     }
     default: {
-      icon_suffix = ''
+      $icon_suffix = ''
     }
   }
 

--- a/templates/mod/autoindex.conf.erb
+++ b/templates/mod/autoindex.conf.erb
@@ -30,24 +30,24 @@ AddIcon /icons/hand.right.gif README
 AddIcon /icons/folder.gif ^^DIRECTORY^^
 AddIcon /icons/blank.gif ^^BLANKICON^^
 
-AddIcon /icons/odf6odt<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .odt
-AddIcon /icons/odf6ods<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .ods
-AddIcon /icons/odf6odp<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .odp
-AddIcon /icons/odf6odg<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .odg
-AddIcon /icons/odf6odc<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .odc
-AddIcon /icons/odf6odf<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .odf
-AddIcon /icons/odf6odb<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .odb
-AddIcon /icons/odf6odi<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .odi
-AddIcon /icons/odf6odm<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .odm
+AddIcon /icons/odf6odt<%= @icon_suffix %>.png .odt
+AddIcon /icons/odf6ods<%= @icon_suffix %>.png .ods
+AddIcon /icons/odf6odp<%= @icon_suffix %>.png .odp
+AddIcon /icons/odf6odg<%= @icon_suffix %>.png .odg
+AddIcon /icons/odf6odc<%= @icon_suffix %>.png .odc
+AddIcon /icons/odf6odf<%= @icon_suffix %>.png .odf
+AddIcon /icons/odf6odb<%= @icon_suffix %>.png .odb
+AddIcon /icons/odf6odi<%= @icon_suffix %>.png .odi
+AddIcon /icons/odf6odm<%= @icon_suffix %>.png .odm
 
-AddIcon /icons/odf6ott<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .ott
-AddIcon /icons/odf6ots<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .ots
-AddIcon /icons/odf6otp<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .otp
-AddIcon /icons/odf6otg<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .otg
-AddIcon /icons/odf6otc<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .otc
-AddIcon /icons/odf6otf<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .otf
-AddIcon /icons/odf6oti<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .oti
-AddIcon /icons/odf6oth<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .oth
+AddIcon /icons/odf6ott<%= @icon_suffix %>.png .ott
+AddIcon /icons/odf6ots<%= @icon_suffix %>.png .ots
+AddIcon /icons/odf6otp<%= @icon_suffix %>.png .otp
+AddIcon /icons/odf6otg<%= @icon_suffix %>.png .otg
+AddIcon /icons/odf6otc<%= @icon_suffix %>.png .otc
+AddIcon /icons/odf6otf<%= @icon_suffix %>.png .otf
+AddIcon /icons/odf6oti<%= @icon_suffix %>.png .oti
+AddIcon /icons/odf6oth<%= @icon_suffix %>.png .oth
 
 DefaultIcon /icons/unknown.gif
 ReadmeName README.html

--- a/templates/mod/autoindex.conf.erb
+++ b/templates/mod/autoindex.conf.erb
@@ -30,24 +30,24 @@ AddIcon /icons/hand.right.gif README
 AddIcon /icons/folder.gif ^^DIRECTORY^^
 AddIcon /icons/blank.gif ^^BLANKICON^^
 
-AddIcon /icons/odf6odt-20x22.png .odt
-AddIcon /icons/odf6ods-20x22.png .ods
-AddIcon /icons/odf6odp-20x22.png .odp
-AddIcon /icons/odf6odg-20x22.png .odg
-AddIcon /icons/odf6odc-20x22.png .odc
-AddIcon /icons/odf6odf-20x22.png .odf
-AddIcon /icons/odf6odb-20x22.png .odb
-AddIcon /icons/odf6odi-20x22.png .odi
-AddIcon /icons/odf6odm-20x22.png .odm
+AddIcon /icons/odf6odt<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .odt
+AddIcon /icons/odf6ods<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .ods
+AddIcon /icons/odf6odp<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .odp
+AddIcon /icons/odf6odg<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .odg
+AddIcon /icons/odf6odc<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .odc
+AddIcon /icons/odf6odf<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .odf
+AddIcon /icons/odf6odb<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .odb
+AddIcon /icons/odf6odi<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .odi
+AddIcon /icons/odf6odm<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .odm
 
-AddIcon /icons/odf6ott-20x22.png .ott
-AddIcon /icons/odf6ots-20x22.png .ots
-AddIcon /icons/odf6otp-20x22.png .otp
-AddIcon /icons/odf6otg-20x22.png .otg
-AddIcon /icons/odf6otc-20x22.png .otc
-AddIcon /icons/odf6otf-20x22.png .otf
-AddIcon /icons/odf6oti-20x22.png .oti
-AddIcon /icons/odf6oth-20x22.png .oth
+AddIcon /icons/odf6ott<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .ott
+AddIcon /icons/odf6ots<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .ots
+AddIcon /icons/odf6otp<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .otp
+AddIcon /icons/odf6otg<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .otg
+AddIcon /icons/odf6otc<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .otc
+AddIcon /icons/odf6otf<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .otf
+AddIcon /icons/odf6oti<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .oti
+AddIcon /icons/odf6oth<% if @osfamily != 'RedHat' -%>-20x22<% end -%>.png .oth
 
 DefaultIcon /icons/unknown.gif
 ReadmeName README.html


### PR DESCRIPTION
Icon paths in autoindex.conf.erb are not correct on systems with @osfamily == 'RedHat' or @osfamily == 'Suse'.

The proposed patch removes the filename suffix '-20x22' on those systems.
This way compatibility with systems noted in metadata.json is ensured.

The proposed patch would solve: https://tickets.puppetlabs.com/projects/MODULES/issues/MODULES-10360?filter=allissues

Thank you for your time and effort.