### PR TITLE
Fix proxy_html Module to work on Debian 10

### DIFF
--- a/manifests/mod/proxy_html.pp
+++ b/manifests/mod/proxy_html.pp
@@ -19,10 +19,22 @@ class apache::mod::proxy_html {
         'i686'  => 'i386',
         default => $::hardwaremodel,
       }
-      $loadfiles = $::apache::params::distrelease ? {
-        '6'     => ['/usr/lib/libxml2.so.2'],
-        '10'    => ['/usr/lib/libxml2.so.2'],
-        default => ["/usr/lib/${gnu_path}-linux-gnu/libxml2.so.2"],
+      case $::operatingsystem {
+        'Ubuntu': {
+          $loadfiles = $::apache::params::distrelease ? {
+            '10'    => ['/usr/lib/libxml2.so.2'],
+            default => ["/usr/lib/${gnu_path}-linux-gnu/libxml2.so.2"],
+          }
+        }
+        'Debian': {
+          $loadfiles = $::apache::params::distrelease ? {
+            '6'     => ['/usr/lib/libxml2.so.2'],
+            default => ["/usr/lib/${gnu_path}-linux-gnu/libxml2.so.2"],
+          }
+        }
+        default: {
+          $loadfiles = ["/usr/lib/${gnu_path}-linux-gnu/libxml2.so.2"]
+        }
       }
       if versioncmp($::apache::apache_version, '2.4') >= 0 {
         ::apache::mod { 'xml2enc': }


### PR DESCRIPTION
In https://github.com/puppetlabs/puppetlabs-apache/commit/8e7ef1550cc8a4f816a0f4d7235df36b48664998 a fix was made to support Ubuntu 10.04, where libxml2 is at another location.
But since the "case"-clause is using $::osfamily as parameter it now matches on Debian 10 too.

This fix implements the distinction between Debian and Ubuntu systems.