### PR TITLE
Re-add package for fcgid on debian/ubuntu machines

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -385,6 +385,7 @@ class apache::params inherits ::apache::version {
         'authnz_pam'            => 'libapache2-mod-authnz-pam',
         'dav_svn'               => 'libapache2-mod-svn',
         'fastcgi'               => 'libapache2-mod-fastcgi',
+        'fcgid'                 => 'libapache2-mod-fcgid',
         'geoip'                 => 'libapache2-mod-geoip',
         'intercept_form_submit' => 'libapache2-mod-intercept-form-submit',
         'jk'                    => 'libapache2-mod-jk',


### PR DESCRIPTION
I'm not sure why this was ever removed. See #1932 

* https://packages.debian.org/buster/libapache2-mod-fcgid
* https://packages.ubuntu.com/eoan/libapache2-mod-fcgid