### PR TITLE
Add ProxyIOBufferSize option

### DIFF
--- a/manifests/mod/proxy.pp
+++ b/manifests/mod/proxy.pp
@@ -19,6 +19,9 @@
 # @param proxy_timeout
 #   Network timeout for proxied requests.
 #
+# @param proxy_iobuffersize
+#   Set the size of internal data throughput buffer
+#
 # @see https://httpd.apache.org/docs/current/mod/mod_proxy.html for additional documentation.
 #
 class apache::mod::proxy (
@@ -28,7 +31,7 @@ class apache::mod::proxy (
   $package_name       = undef,
   $proxy_via          = 'On',
   $proxy_timeout      = undef,
-  $proxyiobuffersize  = undef,
+  $proxy_iobuffersize = undef,
 ) {
   include ::apache
   $_proxy_timeout = $apache::timeout

--- a/manifests/mod/proxy.pp
+++ b/manifests/mod/proxy.pp
@@ -1,33 +1,34 @@
 # @summary
 #   Installs and configures `mod_proxy`.
-# 
+#
 # @param proxy_requests
 #   Enables forward (standard) proxy requests.
-# 
+#
 # @param allow_from
 #   List of IPs allowed to access proxy.
-# 
+#
 # @param apache_version
 #   Used to verify that the Apache version you have requested is compatible with the module.
-# 
+#
 # @param package_name
 #   Name of the proxy package to install.
-# 
+#
 # @param proxy_via
 #   Set local IP address for outgoing proxy connections.
-# 
+#
 # @param proxy_timeout
 #   Network timeout for proxied requests.
-# 
+#
 # @see https://httpd.apache.org/docs/current/mod/mod_proxy.html for additional documentation.
 #
 class apache::mod::proxy (
-  $proxy_requests = 'Off',
-  $allow_from     = undef,
-  $apache_version = undef,
-  $package_name   = undef,
-  $proxy_via      = 'On',
-  $proxy_timeout  = undef,
+  $proxy_requests     = 'Off',
+  $allow_from         = undef,
+  $apache_version     = undef,
+  $package_name       = undef,
+  $proxy_via          = 'On',
+  $proxy_timeout      = undef,
+  $proxyiobuffersize  = undef,
 ) {
   include ::apache
   $_proxy_timeout = $apache::timeout

--- a/templates/mod/proxy.conf.erb
+++ b/templates/mod/proxy.conf.erb
@@ -29,6 +29,6 @@
   ProxyTimeout <%= @proxy_timeout %>
   <%- end -%>
   <%- if @proxyiobuffersize -%>
-  ProxyIOBufferSize <%= @proxyiobuffersize %>
+  ProxyIOBufferSize <%= @proxy_iobuffersize %>
   <%- end -%>
 </IfModule>

--- a/templates/mod/proxy.conf.erb
+++ b/templates/mod/proxy.conf.erb
@@ -28,4 +28,7 @@
   <%- if @proxy_timeout -%>
   ProxyTimeout <%= @proxy_timeout %>
   <%- end -%>
+  <%- if @proxyiobuffersize -%>
+  ProxyIOBufferSize <%= @proxyiobuffersize %>
+  <%- end -%>
 </IfModule>


### PR DESCRIPTION
Add [ProxyIOBufferSize](https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#proxyiobuffersize) for `mod_proxy`

Found we need to adjust this in combination w/ AJP to account for larger headers (cookies)