### PR TITLE
Changed the apache-mod-ldap.conf title to ldap.conf

### DIFF
--- a/manifests/mod/ldap.pp
+++ b/manifests/mod/ldap.pp
@@ -68,7 +68,7 @@ class apache::mod::ldap (
     package => $package_name,
   }
   # Template uses $_apache_version
-  file { 'apache-mod-ldap.conf':
+  file { 'ldap.conf':
     ensure  => file,
     path    => "${::apache::mod_dir}/ldap.conf",
     mode    => $::apache::file_mode,

--- a/spec/classes/mod/ldap_spec.rb
+++ b/spec/classes/mod/ldap_spec.rb
@@ -22,13 +22,13 @@ describe 'apache::mod::ldap', type: :class do
     it { is_expected.to contain_apache__mod('ldap') }
 
     context 'default ldap_trusted_global_cert_file' do
-      it { is_expected.to contain_file('apache-mod-ldap.conf').without_content(%r{^LDAPTrustedGlobalCert}) }
+      it { is_expected.to contain_file('ldap.conf').without_content(%r{^LDAPTrustedGlobalCert}) }
     end
 
     context 'ldap_trusted_global_cert_file param' do
       let(:params) { { ldap_trusted_global_cert_file: 'ca.pem' } }
 
-      it { is_expected.to contain_file('apache-mod-ldap.conf').with_content(%r{^LDAPTrustedGlobalCert CA_BASE64 ca\.pem$}) }
+      it { is_expected.to contain_file('ldap.conf').with_content(%r{^LDAPTrustedGlobalCert CA_BASE64 ca\.pem$}) }
     end
 
     context 'set multiple ldap params' do
@@ -46,20 +46,20 @@ describe 'apache::mod::ldap', type: :class do
         }
       end
 
-      it { is_expected.to contain_file('apache-mod-ldap.conf').with_content(%r{^LDAPTrustedGlobalCert CA_DER ca\.pem$}) }
-      it { is_expected.to contain_file('apache-mod-ldap.conf').with_content(%r{^LDAPTrustedMode TLS$}) }
-      it { is_expected.to contain_file('apache-mod-ldap.conf').with_content(%r{^LDAPSharedCacheSize 500000$}) }
-      it { is_expected.to contain_file('apache-mod-ldap.conf').with_content(%r{^LDAPCacheEntries 1024$}) }
-      it { is_expected.to contain_file('apache-mod-ldap.conf').with_content(%r{^LDAPCacheTTL 600$}) }
-      it { is_expected.to contain_file('apache-mod-ldap.conf').with_content(%r{^LDAPOpCacheEntries 1024$}) }
-      it { is_expected.to contain_file('apache-mod-ldap.conf').with_content(%r{^LDAPOpCacheTTL 600$}) }
+      it { is_expected.to contain_file('ldap.conf').with_content(%r{^LDAPTrustedGlobalCert CA_DER ca\.pem$}) }
+      it { is_expected.to contain_file('ldap.conf').with_content(%r{^LDAPTrustedMode TLS$}) }
+      it { is_expected.to contain_file('ldap.conf').with_content(%r{^LDAPSharedCacheSize 500000$}) }
+      it { is_expected.to contain_file('ldap.conf').with_content(%r{^LDAPCacheEntries 1024$}) }
+      it { is_expected.to contain_file('ldap.conf').with_content(%r{^LDAPCacheTTL 600$}) }
+      it { is_expected.to contain_file('ldap.conf').with_content(%r{^LDAPOpCacheEntries 1024$}) }
+      it { is_expected.to contain_file('ldap.conf').with_content(%r{^LDAPOpCacheTTL 600$}) }
 
       expected_ldap_path_re =
         "<Location /custom-ldap-status>\n"\
         "\s*SetHandler ldap-status\n"\
         ".*\n"\
         "</Location>\n"
-      it { is_expected.to contain_file('apache-mod-ldap.conf').with_content(%r{#{expected_ldap_path_re}}m) }
+      it { is_expected.to contain_file('ldap.conf').with_content(%r{#{expected_ldap_path_re}}m) }
     end
   end # Debian
 
@@ -81,13 +81,13 @@ describe 'apache::mod::ldap', type: :class do
     it { is_expected.to contain_apache__mod('ldap') }
 
     context 'default ldap_trusted_global_cert_file' do
-      it { is_expected.to contain_file('apache-mod-ldap.conf').without_content(%r{^LDAPTrustedGlobalCert}) }
+      it { is_expected.to contain_file('ldap.conf').without_content(%r{^LDAPTrustedGlobalCert}) }
     end
 
     context 'ldap_trusted_global_cert_file param' do
       let(:params) { { ldap_trusted_global_cert_file: 'ca.pem' } }
 
-      it { is_expected.to contain_file('apache-mod-ldap.conf').with_content(%r{^LDAPTrustedGlobalCert CA_BASE64 ca\.pem$}) }
+      it { is_expected.to contain_file('ldap.conf').with_content(%r{^LDAPTrustedGlobalCert CA_BASE64 ca\.pem$}) }
     end
 
     context 'ldap_trusted_global_cert_file and ldap_trusted_global_cert_type params' do
@@ -98,7 +98,7 @@ describe 'apache::mod::ldap', type: :class do
         }
       end
 
-      it { is_expected.to contain_file('apache-mod-ldap.conf').with_content(%r{^LDAPTrustedGlobalCert CA_DER ca\.pem$}) }
+      it { is_expected.to contain_file('ldap.conf').with_content(%r{^LDAPTrustedGlobalCert CA_DER ca\.pem$}) }
     end
 
     context 'SCL' do


### PR DESCRIPTION
Otherwise no symlink for the ldap.conf is created in /etc/apache2/mods-enabled as required by mod.pp. Thus the custom ldap options in the /etc/apache2/mods-available are not applied in the /etc/apache2/mods-enabled and are not loaded.