### PR TITLE
MODULES-10586 Centos 8: wrong package used to install mod_authnz_ldap

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -210,6 +210,7 @@ class apache::params inherits ::apache::version {
       'auth_openidc'          => 'mod_auth_openidc',
       'authnz_ldap'           => $::apache::version::distrelease ? {
         '7'     => 'mod_ldap',
+        '8'     => 'mod_ldap',
         default => 'mod_authz_ldap',
       },
       'authnz_pam'            => 'mod_authnz_pam',

--- a/spec/acceptance/mod_authnz_ldap_spec.rb
+++ b/spec/acceptance/mod_authnz_ldap_spec.rb
@@ -5,10 +5,24 @@ apache_hash = apache_settings_hash
 # dependency issues to solve on all supported platforms.
 describe 'apache::mod_authnz_ldap', if: os[:family] == 'redhat' && os[:release].to_i > 6 do
   context 'Default mod_authnz_ldap module installation' do
-    pp = <<-MANIFEST
+    pp = if run_shell("grep 'Oracle Linux Server' /etc/os-release", expect_failures: true).exit_status == 0
+           <<-MANIFEST
+      yumrepo { 'ol7_optional_latest':
+        name 	  => 'ol7_optional_latest',
+        baseurl 	  => 'https://yum.oracle.com/repo/OracleLinux/OL7/optional/latest/x86_64/',
+        gpgkey 	  => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-oracle',
+        gpgcheck => 1,
+        enabled	   => 1,
+      }
       class { 'apache': }
       class { 'apache::mod::authnz_ldap': }
       MANIFEST
+         else
+           <<-MANIFEST
+        class { 'apache': }
+        class { 'apache::mod::authnz_ldap': }
+        MANIFEST
+         end
 
     it 'succeeds in installing the mod_authnz_ldap module' do
       apply_manifest(pp, catch_failures: true)

--- a/spec/acceptance/mod_authnz_ldap_spec.rb
+++ b/spec/acceptance/mod_authnz_ldap_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper_acceptance'
+apache_hash = apache_settings_hash
+
+# We need to restrict this test to RHEL 7.x, 8.x derived OSs as there are too many unique
+# dependency issues to solve on all supported platforms.
+describe 'apache::mod_authnz_ldap', if: os[:family] == 'redhat' && os[:release].to_i > 6 do
+  context 'Default mod_authnz_ldap module installation' do
+    pp = <<-MANIFEST
+      class { 'apache': }
+      class { 'apache::mod::authnz_ldap': }
+      MANIFEST
+
+    it 'succeeds in installing the mod_authnz_ldap module' do
+      apply_manifest(pp, catch_failures: true)
+    end
+
+    describe file("#{apache_hash['mod_dir']}/authnz_ldap.load") do
+      it { is_expected.to contain 'mod_authnz_ldap.so' }
+    end
+  end
+end

--- a/spec/acceptance/mod_authnz_ldap_spec.rb
+++ b/spec/acceptance/mod_authnz_ldap_spec.rb
@@ -19,6 +19,9 @@ describe 'apache::mod_authnz_ldap', if: os[:family] == 'redhat' && os[:release].
       MANIFEST
          else
            <<-MANIFEST
+        package { 'epel-release':
+          ensure => present,
+        }
         class { 'apache': }
         class { 'apache::mod::authnz_ldap': }
         MANIFEST


### PR DESCRIPTION
see https://tickets.puppetlabs.com/browse/MODULES-10586

the change was tested on a fresh centos 8 install

note on unit tests: 

- I edited the tests 'default configuration with parameters on a RedHat OS' in authnz_ldap_spec.rb and ldap_spec.rb (updated the facts operatingsystemrelease line to '8') in the puppetlabs module (not containing my change) 
- so those tests should have failed but didn't 

so I was unable to provide a sensible unit test