### PR TITLE
update passenger yum repo gpgkey url

### DIFF
--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -818,7 +818,7 @@ class apache::mod::passenger (
       descr         => 'passenger',
       enabled       => '1',
       gpgcheck      => '0',
-      gpgkey        => 'https://packagecloud.io/phusion/passenger/gpgkey',
+      gpgkey        => 'https://oss-binaries.phusionpassenger.com/auto-software-signing-gpg-key.txt',
       repo_gpgcheck => '1',
       sslcacert     => '/etc/pki/tls/certs/ca-bundle.crt',
       sslverify     => '1',


### PR DESCRIPTION
Installation of passenger module fails on el systems because yum repo gpgkey  has been changed from `https://packagecloud.io/phusion/passenger/gpgkey`
to` https://oss-binaries.phusionpassenger.com/auto-software-signing-gpg-key.txt`

Reference:  
https://github.com/phusion/passenger/issues/2276
https://tickets.puppetlabs.com/browse/MODULES-10656
