### PR TITLE
(maint) Restrict test exec platforms for accept tests affected by IAC-587, IAC-785 & IAC-787

### DIFF
--- a/spec/acceptance/apache_parameters_spec.rb
+++ b/spec/acceptance/apache_parameters_spec.rb
@@ -92,28 +92,28 @@ describe 'apache parameters' do
     end
   end
 
-  if os[:family] == 'debian'
-    describe 'conf_enabled => /etc/apache2/conf-enabled' do
-      pp = <<-MANIFEST
-          class { 'apache':
-            purge_configs   => false,
-            conf_enabled    => "/etc/apache2/conf-enabled"
-          }
-      MANIFEST
-      it 'applies cleanly' do
-        run_shell('touch /etc/apache2/conf-enabled/test.conf')
-        apply_manifest(pp, catch_failures: true)
-      end
+  # IAC-785: The Shibboleth mod does not seem to be configured correctly on Debian 10 systems. We should reenable
+  # this test on Debian 10 systems once the issue has been RCA'd and resolved.
+  describe 'conf_enabled => /etc/apache2/conf-enabled', if: os[:family] == 'debian' && os[:release].to_i < 10 do
+    pp = <<-MANIFEST
+        class { 'apache':
+          purge_configs   => false,
+          conf_enabled    => "/etc/apache2/conf-enabled"
+        }
+    MANIFEST
+    it 'applies cleanly' do
+      run_shell('touch /etc/apache2/conf-enabled/test.conf')
+      apply_manifest(pp, catch_failures: true)
+    end
 
-      # Ensure the created file didn't disappear.
-      describe file('/etc/apache2/conf-enabled/test.conf') do
-        it { is_expected.to be_file }
-      end
+    # Ensure the created file didn't disappear.
+    describe file('/etc/apache2/conf-enabled/test.conf') do
+      it { is_expected.to be_file }
+    end
 
-      # Ensure the default file didn't disappear.
-      describe file('/etc/apache2/conf-enabled/security.conf') do
-        it { is_expected.to be_file }
-      end
+    # Ensure the default file didn't disappear.
+    describe file('/etc/apache2/conf-enabled/security.conf') do
+      it { is_expected.to be_file }
     end
   end
 

--- a/spec/acceptance/itk_spec.rb
+++ b/spec/acceptance/itk_spec.rb
@@ -14,7 +14,9 @@ when 'freebsd'
   variant = :prefork
 end
 
-describe 'apache::mod::itk class', if: service_name do
+# IAC-787: The http-itk mod package is not available in any of the standard RHEL/CentOS 8.x repos. Disable this test
+# on those platforms until we can find a suitable source for this package.
+describe 'apache::mod::itk class', if: service_name, unless: os[:family] == 'redhat' && os[:release].to_i >= 8 do
   describe 'running puppet code' do
     let(:pp) do
       case variant

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -1198,6 +1198,8 @@ describe 'apache::vhost define' do
     end
   end
 
+  # IAC-587: These tests do not currently run successfully on certain RHEL OSs due to dependency issues with the
+  # mod_auth_openidc module.
   describe 'auth_oidc', if: (os[:family] == 'ubuntu' && os[:release].to_i > 14 || os[:family] == 'debian') do
     pp = <<-MANIFEST
         class { 'apache': }

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -1198,7 +1198,7 @@ describe 'apache::vhost define' do
     end
   end
 
-  describe 'auth_oidc', unless: (os[:family] == 'ubuntu' && os[:release].to_f == 14.04) do
+  describe 'auth_oidc', if: (os[:family] == 'ubuntu' && os[:release].to_i > 14 || os[:family] == 'debian') do
     pp = <<-MANIFEST
         class { 'apache': }
         apache::vhost { 'test.server':


### PR DESCRIPTION
There are a number of issues against the `puppetlabs-apache` module that are either been actively worked upon or have tickets raised to be worked on:

**[IAC-587](https://tickets.puppetlabs.com/browse/IAC-587)**: mod_auth_openidc module is not installing correctly on RHEL 8.x systems
**[IAC-785](https://tickets.puppetlabs.com/browse/IAC-785)**: Shibboleth module not configuring correctly on Debian 10 systems
**[IAC-787](https://tickets.puppetlabs.com/browse/IAC-787)**: httpd-itk module not available from main repos on RHEL 8 and CentOS 8

There have been a number of new features merged to the branch and other PRs waiting to be merged. A new release of the module is overdue too, so this PR is simply to back out these tests and unblock the release.

The functionality affected should be addressed and not kicked in to the long grass, however, weighing against what could ship, it does not make sense to hold back those features, especially given these issues affect the module as-is right now in deployments.