### PR TITLE
Allow IPv6 CIDRs for proxy_protocol_exceptions in mod remoteip

### DIFF
--- a/manifests/mod/remoteip.pp
+++ b/manifests/mod/remoteip.pp
@@ -60,7 +60,7 @@ class apache::mod::remoteip (
   Optional[Stdlib::Absolutepath]                             $internal_proxy_list       = undef,
   Optional[String]                                           $proxies_header            = undef,
   Boolean                                                    $proxy_protocol            = false,
-  Optional[Array[Stdlib::Host]]                              $proxy_protocol_exceptions = undef,
+  Optional[Array[Variant[Stdlib::Host,Stdlib::IP::Address]]] $proxy_protocol_exceptions = undef,
   Optional[Array[Stdlib::Host]]                              $trusted_proxy             = undef,
   Optional[Array[Stdlib::Host]]                              $trusted_proxy_ips         = undef,
   Optional[Stdlib::Absolutepath]                             $trusted_proxy_list        = undef,

--- a/spec/classes/mod/remoteip_spec.rb
+++ b/spec/classes/mod/remoteip_spec.rb
@@ -90,6 +90,28 @@ describe 'apache::mod::remoteip', type: :class do
       it { is_expected.to contain_file('remoteip.conf').with_content(%r{^RemoteIPTrustedProxy 10.42.17.8$}) }
       it { is_expected.to contain_file('remoteip.conf').with_content(%r{^RemoteIPTrustedProxy 10.42.18.99$}) }
     end
+    describe 'with proxy_protocol_exceptions => [ 10.42.17.8, 10.42.18.99 ]' do
+      let :params do
+        { proxy_protocol_exceptions: ['10.42.17.8', '10.42.18.99'] }
+      end
+
+      it { is_expected.to contain_file('remoteip.conf').with_content(%r{^RemoteIPProxyProtocolExceptions 10.42.17.8$}) }
+      it { is_expected.to contain_file('remoteip.conf').with_content(%r{^RemoteIPProxyProtocolExceptions 10.42.18.99$}) }
+    end
+    describe 'with IPv4 CIDR in proxy_protocol_exceptions => [ 192.168.1.0/24 ]' do
+      let :params do
+        { proxy_protocol_exceptions: ['192.168.1.0/24'] }
+      end
+
+      it { is_expected.to contain_file('remoteip.conf').with_content(%r{^RemoteIPProxyProtocolExceptions 192.168.1.0/24$}) }
+    end
+    describe 'with IPv6 CIDR in proxy_protocol_exceptions => [ fd00:fd00:fd00:2000::/64 ]' do
+      let :params do
+        { proxy_protocol_exceptions: ['fd00:fd00:fd00:2000::/64'] }
+      end
+
+      it { is_expected.to contain_file('remoteip.conf').with_content(%r{^RemoteIPProxyProtocolExceptions fd00:fd00:fd00:2000::/64$}) }
+    end
     describe 'with Apache version < 2.4' do
       let :params do
         { apache_version: '2.2' }

--- a/templates/mod/remoteip.conf.epp
+++ b/templates/mod/remoteip.conf.epp
@@ -4,7 +4,7 @@
   Optional[Stdlib::Absolutepath]                             $internal_proxy_list       = undef,
   Optional[String]                                           $proxies_header            = undef,
   Boolean                                                    $proxy_protocol            = undef,
-  Optional[Array[Stdlib::IP::Address]]                       $proxy_protocol_exceptions = undef,
+  Optional[Array[Variant[Stdlib::Host,Stdlib::IP::Address]]] $proxy_protocol_exceptions = undef,
   Optional[Array[Stdlib::IP::Address]]                       $trusted_proxy             = undef,
   Optional[Stdlib::Absolutepath]                             $trusted_proxy_list        = undef,
 | -%>


### PR DESCRIPTION
This is the same fix as in https://github.com/puppetlabs/puppetlabs-apache/pull/1891