### PR TITLE
(IAC-824) Ability to exclude Apache MOD tests from unsupported platforms

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -4,3 +4,4 @@ require 'puppet_litmus'
 require 'spec_helper_acceptance_local' if File.file?(File.join(File.dirname(__FILE__), 'spec_helper_acceptance_local.rb'))
 
 PuppetLitmus.configure!
+ApacheModTestFilterHelper.instance.initialize_ampc(os)

--- a/spec/util/_resources/test_metadata_json.rb
+++ b/spec/util/_resources/test_metadata_json.rb
@@ -1,0 +1,86 @@
+METADATA_JSON = '{
+  "name": "puppetlabs-apache",
+  "version": "5.4.0",
+  "author": "puppetlabs",
+  "summary": "Installs, configures, and manages Apache virtual hosts, web services, and modules.",
+  "license": "Apache-2.0",
+  "source": "https://github.com/puppetlabs/puppetlabs-apache",
+  "project_page": "https://github.com/puppetlabs/puppetlabs-apache",
+  "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
+  "dependencies": [
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 4.13.1 < 7.0.0"
+    },
+    {
+      "name": "puppetlabs/concat",
+      "version_requirement": ">= 2.2.1 < 7.0.0"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Scientific",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "8",
+        "9",
+        "10"
+      ]
+    },
+    {
+      "operatingsystem": "SLES",
+      "operatingsystemrelease": [
+        "11 SP1",
+        "12",
+        "15"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "14.04",
+        "16.04",
+        "18.04"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 5.5.10 < 7.0.0"
+    }
+  ],
+  "description": "Module for Apache configuration",
+  "pdk-version": "1.17.0",
+  "template-url": "https://github.com/puppetlabs/pdk-templates#master",
+  "template-ref": "heads/master-0-g095317c"
+}'.freeze

--- a/spec/util/apache_mod_platform_support_spec.rb
+++ b/spec/util/apache_mod_platform_support_spec.rb
@@ -1,0 +1,179 @@
+require 'rspec'
+require 'rspec-puppet-facts'
+require_relative '../../util/apache_mod_platform_support'
+require_relative '_resources/test_metadata_json'
+
+describe ApacheModPlatformCompatibility do
+  foobar_pp = 'foobar.pp'
+  foobar_mod = 'apache::mod::foobar'
+  foobar_class = "class #{foobar_mod}"
+  foobar_linux = 'foobar_linux'
+
+  expected_compatible_platform_versions = {
+    'redhat' => [6, 7, 8],
+    'centos' => [6, 7, 8],
+    'oraclelinux' => [6, 7],
+    'scientific' => [6, 7],
+    'debian' => [8, 9, 10],
+    'sles' => [11, 12, 15],
+    'ubuntu' => [14, 16, 18],
+  }
+
+  context 'when initialized' do
+    describe '#process_line' do
+      ampc = described_class.new
+      it 'returns an empty hash when given garbage line' do
+        expect(ampc.process_line('foobar')).to eq({})
+      end
+      it 'returns a hash with type: :unsupported_platform_declaration and extracted value' do
+        expect(ampc.process_line('# @note Unsupported platforms: foobar')).to eq(type: :unsupported_platform_declaration, value: 'foobar')
+      end
+      it 'returns a hash with type: :class_declaration and extracted value' do
+        expect(ampc.process_line(foobar_class)).to eq(type: :class_declaration, value: foobar_mod)
+      end
+    end
+
+    describe '#extract_os_ver_pairs' do
+      ampc = described_class.new
+      it 'handles single OS with single Version' do
+        expect(ampc.extract_os_ver_pairs('Debian: 5')).to eq('debian' => [5])
+      end
+      it 'handles single OS with multiple Versions' do
+        expect(ampc.extract_os_ver_pairs('Debian: 5, 6, 7')).to eq('debian' => [5, 6, 7])
+      end
+      it 'handles multiple OSs with multiple Versions' do
+        expect(ampc.extract_os_ver_pairs('Debian: 5, 6, 7; CentOS: 5,6,7')).to eq('debian' => [5, 6, 7], 'centos' => [5, 6, 7])
+      end
+      it 'handles Versions in \d+\.\d+ format' do
+        expect(ampc.extract_os_ver_pairs('Ubuntu: 14.04, 16.04')).to eq('ubuntu' => [14, 16])
+      end
+      it 'handles Versions with "SP"' do
+        expect(ampc.extract_os_ver_pairs('SLES: 11 SP1, 12')).to eq('sles' => [11, 12])
+      end
+      it 'returns an empty Hash when given data in an entirely invalid format' do
+        expect(ampc.extract_os_ver_pairs('foobar')).to eq({})
+      end
+      it 'returns an empty Hash when given data with incorrect OS/Version group separator' do
+        expect(ampc.extract_os_ver_pairs('Ubuntu#14.04, 16.04')).to eq({})
+      end
+      it 'returns an empty Hash when given data with incorrect OS + Version separator' do
+        expect(ampc.extract_os_ver_pairs('CentOS:5,6#Debian:5,6')).to eq({})
+      end
+      it 'returns an empty Hash when given data with incorrect Version separator' do
+        expect(ampc.extract_os_ver_pairs('CentOS:5@6')).to eq({})
+      end
+    end
+
+    describe '#register_unsupported_platforms' do
+      ampc = described_class.new
+      it 'registers a valid unsupported platform' do
+        ampc.register_running_platform(family: 'debian', release: '8.11', arch: 'x86_64')
+        expect(ampc).to receive(:valid_os?).with('debian').and_return(true)
+        ampc.register_unsupported_platforms(foobar_pp, 1, foobar_mod, 'debian' => [8])
+        expect(ampc.mod_supported_on_platform?(foobar_mod)).to be(false)
+      end
+      it 'registers multiple valid unsupported platforms' do
+        expect(ampc).to receive(:valid_os?).with('debian').and_return(true)
+        expect(ampc).to receive(:valid_os?).with('ubuntu').and_return(true)
+        ampc.register_unsupported_platforms(foobar_pp, 1, foobar_mod, 'debian' => [8])
+        ampc.register_unsupported_platforms(foobar_pp, 1, foobar_mod, 'ubuntu' => [14])
+        ampc.register_running_platform(family: 'debian', release: '8.11', arch: 'x86_64')
+        expect(ampc.mod_supported_on_platform?(foobar_mod)).to be(false)
+        ampc.register_running_platform(family: 'ubuntu', release: '14.04', arch: 'x86_64')
+        expect(ampc.mod_supported_on_platform?(foobar_mod)).to be(false)
+      end
+      it 'registers an :os_parse error when given an invalid platform' do
+        expect(ampc).to receive(:valid_os?).with(foobar_linux).and_return(false)
+        expect(ampc).to receive(:register_error).with(foobar_pp, 1, :os_parse, foobar_linux)
+        ampc.register_unsupported_platforms(foobar_pp, 1, foobar_mod, foobar_linux => [1])
+        ampc.register_running_platform(family: 'debian', release: '8.11', arch: 'x86_64')
+      end
+    end
+
+    describe '#generate_supported_platforms_versions' do
+      ampc = described_class.new
+
+      before(:each) do
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with('../../metadata.json').and_return(METADATA_JSON)
+        ampc.generate_supported_platforms_versions
+        ampc.register_unsupported_platforms(foobar_pp, 1, foobar_mod, foobar_linux => [1])
+      end
+
+      context 'after parsing the metadata.json' do
+        expected_compatible_platform_versions.each do |os, vers|
+          vers.each do |ver|
+            it "should state #{os} version #{ver} IS a compatible platform" do
+              ampc.register_running_platform(family: os, version: ver)
+              expect(ampc.mod_supported_on_platform?(foobar_mod)).to be(true)
+            end
+          end
+        end
+      end
+    end
+
+    describe '#mod_unsupported_on_platform' do
+      ampc = described_class.new
+      before(:each) do
+        allow(File).to receive(:read).and_call_original
+        allow(File).to receive(:read).with('../../metadata.json').and_return(METADATA_JSON)
+        ampc = described_class.new
+        ampc.generate_supported_platforms_versions
+      end
+
+      ubuntu_14_04_os = { family: 'ubuntu', release: '14.04' }
+
+      it 'returns false when running on an OS with all versions incompatible' do
+        ampc.register_running_platform(ubuntu_14_04_os)
+        ampc.register_unsupported_platforms(foobar_pp, 1, foobar_mod, 'ubuntu' => [0])
+        expect(ampc.mod_supported_on_platform?(foobar_mod)).to be(false)
+      end
+      it 'returns false when running on an OS with one specific version incompatible' do
+        ampc.register_running_platform(ubuntu_14_04_os)
+        ampc.register_unsupported_platforms(foobar_pp, 1, foobar_mod, 'ubuntu' => [14])
+        expect(ampc.mod_supported_on_platform?(foobar_mod)).to be(false)
+      end
+      it 'returns true when running on an OS with no versions marked as incompatible' do
+        ampc.register_running_platform(ubuntu_14_04_os)
+        ampc.register_unsupported_platforms(foobar_pp, 1, foobar_mod, 'debian' => [6, 7])
+        expect(ampc.mod_supported_on_platform?(foobar_mod)).to be(true)
+      end
+      it 'returns true when running on an OS version not marked as incompatible' do
+        ampc.register_running_platform(ubuntu_14_04_os)
+        ampc.register_unsupported_platforms(foobar_pp, 1, foobar_mod, 'ubuntu' => [16, 18])
+        expect(ampc.mod_supported_on_platform?(foobar_mod)).to be(true)
+      end
+    end
+
+    describe '#print_parsing_errors' do
+      ampc = described_class.new
+      abc_pp = 'abc.pp'
+      abc_pp_error_line = 1
+      abc_pp_error_type = :tag_parse
+      abc_pp_error_type_msg = 'OS and version information in incorrect format:'
+      abc_pp_error_detail = 'Bad line'
+      def_pp = 'def.pp'
+      def_pp_error_line = 2
+      def_pp_error_type = :os_parse
+      def_pp_error_type_msg = 'OS name is not present in metadata.json:'
+      def_pp_error_detail = foobar_linux
+
+      tag_format_help_msg_txt = ['succint', 'warning']
+
+      expected_stderr_msg = "The following errors were encountered when trying to parse the 'Unsupported platforms' tag(s) in 'manifests/mod':\n" \
+                            " * #{abc_pp} (line #{abc_pp_error_line}): #{abc_pp_error_type_msg} #{abc_pp_error_detail}\n" \
+                            " * #{def_pp} (line #{def_pp_error_line}): #{def_pp_error_type_msg} #{def_pp_error_detail}\n" \
+                            "#{tag_format_help_msg_txt[0]}\n" \
+                            "#{tag_format_help_msg_txt[1]}\n"
+
+      context 'given a number of errors were discovered when parsing the manifests' do
+        ampc.register_error(abc_pp, abc_pp_error_line, abc_pp_error_type, abc_pp_error_detail)
+        ampc.register_error(def_pp, def_pp_error_line, def_pp_error_type, def_pp_error_detail)
+        it 'prints the expected warnings to $stderr' do
+          allow(File).to receive(:readlines).with('util/_resources/tag_format_help_msg.txt').and_return(tag_format_help_msg_txt)
+          expect { ampc.print_parsing_errors }.to output(expected_stderr_msg).to_stderr
+        end
+      end
+    end
+  end
+end

--- a/util/_resources/tag_format_help_msg.txt
+++ b/util/_resources/tag_format_help_msg.txt
@@ -1,0 +1,22 @@
+Tags to mark an Apache MOD as unsupported on a specific OS version must be in the following format:
+
+# @note Unsupported platforms: OS: ver, ver; OS: ver, ver, ver; OS: all'
+class apache::mod::foobar {
+...
+
+For example:
+# @note Unsupported platforms: RedHat: 5, 6; Ubuntu: 14.04; SLES: all; Scientific: 11 SP1'
+class apache::mod::actions {
+...
+
+- All OS/Version declarations must be preceded with '@note Unsupported platforms:'
+- The tag must be declared ABOVE the class declaration (i.e. not as footer at the bottom of the file)
+- Each OS/Version declaration must be separated by semicolons (;)
+- Each version must be separated by a comma (,)
+- Versions CANNOT be declared in ranges (e.g. 'RedHat:5-7'), they should be explicitly declared (e.g. 'RedHat:5,6,7')
+- However, to declare all versions of an OS as unsupported, use the word 'all' (e.g. SLES:all)
+- OSs with word characters as part of their versions are acceptable (e.g. 'Scientific: 11 SP1, 11 SP2, 12, 13')
+- Spaces are permitted between OS/Version declarations and version numbers within a declaration
+- Refer to the 'operatingsystem_support' values in the metadata.json to find the acceptable OS name and version syntax:
+--- E.g. OracleLinux OR oraclelinux, not: [Oracle, OraLinux]
+--- E.g. RedHat OR redhat, not: [Red Hat Enterprise Linux, RHEL, Red Hat]

--- a/util/apache_mod_platform_support.rb
+++ b/util/apache_mod_platform_support.rb
@@ -1,0 +1,147 @@
+require 'json'
+# Helper class to facilitate exclusion of tests that use an Apache MOD on platforms it isn't supported on.
+# All Apache MOD classes are defined under 'manifests/mod'. The exclusion should be in the format:
+#
+# @note Unsupported platforms: OS: ver, ver; OS: ver, ver, ver; OS: all'
+# class apache::mod::foobar {
+# ...
+#
+# For example:
+# @note Unsupported platforms: RedHat: 5, 6; Ubuntu: 14.04; SLES: all; Scientific: 11 SP1'
+# class apache::mod::actions {
+#   apache::mod { 'actions': }
+# }
+#
+# Filtering is then performed during the test using RSpec's filtering, like so:
+#
+# describe 'auth_oidc', unless: mod_unsupported_on_platform('apache::mod::auth_openidc') do
+# ...
+# it 'applies cleanly', unless: mod_unsupported_on_platform('apache::mod::auth_openidc') do
+# ...
+class ApacheModPlatformCompatibility
+  ERROR_MSG = {
+    tag_parse:  'OS and version information in incorrect format:',
+    os_parse:   'OS name is not present in metadata.json:',
+  }.freeze
+
+  def initialize
+    @os = {}
+    @mapping = {}
+    @manifest_errors = []
+    @compatible_platform_versions = {}
+    @mod_platform_compatibility_mapping = {}
+  end
+
+  def register_running_platform(os)
+    @os = { family: os[:family], release: os[:release].to_i }
+  end
+
+  def generate_supported_platforms_versions
+    metadata = JSON.parse(File.read('metadata.json'))
+    metadata['operatingsystem_support'].each do |os|
+      @compatible_platform_versions[os['operatingsystem'].downcase] = os['operatingsystemrelease'].map(&:to_i)
+    end
+  end
+
+  # Class to hold the details of an error whilst parsing an unsupported tag
+  class ManifestError
+    attr_reader :manifest, :line_num, :error_type, :error_detail
+
+    def initialize(manifest, line_num, error_type, error_detail)
+      @manifest = manifest
+      @line_num = line_num
+      @error_type = error_type
+      @error_detail = error_detail
+    end
+  end
+
+  def print_parsing_errors
+    return if @manifest_errors.empty?
+    $stderr.puts "The following errors were encountered when trying to parse the 'Unsupported platforms' tag(s) in 'manifests/mod':\n"
+    @manifest_errors.each do |manifest_error|
+      $stderr.puts " * #{manifest_error.manifest} (line #{manifest_error.line_num}): #{ERROR_MSG[manifest_error.error_type]} #{manifest_error.error_detail}"
+    end
+    File.readlines('util/_resources/tag_format_help_msg.txt').each do |line|
+      $stderr.puts line
+    end
+  end
+
+  def valid_os?(os)
+    @compatible_platform_versions.keys.include? os
+  end
+
+  def register_error(manifest, line_num, error_type, error_detail)
+    @manifest_errors << ManifestError.new(manifest, line_num, error_type, error_detail)
+  end
+
+  def register_unsupported_platforms(manifest, line_num, mod, platforms_versions)
+    platforms_versions.keys.each do |os|
+      unless valid_os?(os)
+        register_error(manifest, line_num, :os_parse, os)
+        next
+      end
+      if @mod_platform_compatibility_mapping.key? mod
+        @mod_platform_compatibility_mapping[mod].merge!(platforms_versions)
+      else
+        @mod_platform_compatibility_mapping[mod] = platforms_versions
+      end
+    end
+  end
+
+  def extract_os_ver_pairs(line)
+    platforms_versions = {}
+    os_ver_groups = line.delete(' ').downcase
+    # E.g. "debian:5,6;centos:5;sles:11sp1,12;scientific:all;ubuntu:14.04,16.04"
+    if %r{^((?:\w+:(?:(?:\d+(?:\.\d+|sp\d+)?|all),?)+;?)+)$}i =~ os_ver_groups
+      os_ver_groups.split(';').each do |os_vers|
+        os, vers = os_vers.split(':')
+        vers.gsub!(%r{sp\d+}, '') # Remove SP ver as we cannot determine this level of granularity from values from Litmus
+        platforms_versions[os] = vers.split(',').map(&:to_i) # 'all' will be converted to 0
+      end
+    end
+    platforms_versions
+  end
+
+  def process_line(line)
+    data = {}
+    return data unless line =~ %r{@note\sUnsupported\splatforms?:\s?|class\sapache::mod}i
+    if (match = %r{@note\sUnsupported\splatforms?:\s?(?<os_vers>.*)$}i.match(line))
+      data[:type] = :unsupported_platform_declaration
+      data[:value] = match[:os_vers]
+    elsif (match = %r{class\s(?<mod>apache::mod::\w+)}i.match(line))
+      data[:type] = :class_declaration
+      data[:value] = match[:mod]
+    end
+    data
+  end
+
+  def generate_mod_platform_exclusions
+    Dir.glob('manifests/mod/*.pp').each do |manifest|
+      platforms_versions = []
+      line_num = 0
+      File.readlines(manifest).each do |line|
+        line_num += 1
+        data = process_line(line)
+        next if data.empty?
+        if data[:type] == :unsupported_platform_declaration
+          platforms_versions = extract_os_ver_pairs(data[:value])
+          register_error(manifest, line_num, :tag_parse, line) if platforms_versions.empty?
+          next
+        elsif data[:type] == :class_declaration
+          register_unsupported_platforms(manifest, line_num, data[:value], platforms_versions) unless platforms_versions.empty?
+          break # Once we detect the class declaration, we can move on
+        end
+      end
+    end
+  end
+
+  # Called from within the context of a test run, making use of RSpec's filtering, e.g.:
+  # it 'should do some test', if: mod_supported_on_platform('apache::mod::foobar')
+  def mod_supported_on_platform?(mod)
+    return true if @mod_platform_compatibility_mapping.empty?
+    return true unless @mod_platform_compatibility_mapping.key? mod
+    return true unless @mod_platform_compatibility_mapping[mod].key? @os[:family]
+    return false if @mod_platform_compatibility_mapping[mod][@os[:family]] == [0]
+    !@mod_platform_compatibility_mapping[mod][@os[:family]].include? @os[:release]
+  end
+end


### PR DESCRIPTION
# Description / Context

We have been battling a long running issue with tests that use Apache MODs failing on certain Linux platforms whenever the package or package dependencies become available on a specific platform. This has been defined in [IAC-801](https://tickets.puppetlabs.com/browse/IAC-801). A number of recently raised JIRA tickets share the this root cause:
- **[IAC-790](https://tickets.puppetlabs.com/browse/IAC-790):** Missing dependencies for ldap_mod package on RHEL 7.x Docker containers
- **[IAC-787](https://tickets.puppetlabs.com/browse/IAC-787):** http-itk module not installing on RHEL 8.x systems
- **[IAC-587](https://tickets.puppetlabs.com/browse/IAC-587):** apache module failing with 'Cannot load /usr/lib64/apache2/mod_auth_openidc.so' on RHEL distros

# Proposed Solution
Provide:
- The ability to tag Apache MODs under [manifests/mod](https://github.com/puppetlabs/puppetlabs-apache/tree/983b1fd3ff178d46145f4b8c0a88bae36dfad12b/manifests/mod) with unsupported OSs and version(s).
- A helper method to be used in conjunction with [RSpec's conditional filtering](https://relishapp.com/rspec/rspec-core/v/3-8/docs/filtering/conditional-filters) during runtime to determine whether a test should be filtered out based on whether a given Apache MOD is supported on that platform.

# Implementation Details
The [ApacheModPlatformCompatibility class](https://github.com/puppetlabs/puppetlabs-apache/pull/2036/files#diff-0e508a7a33344d830c8232be8e77239d) is [initialised from `spec_helper_acceptance_local`](https://github.com/puppetlabs/puppetlabs-apache/pull/2036/files#diff-08070fc30be3f9dd014e20b26f80934bR11).

The [`register_running_platform`](https://github.com/puppetlabs/puppetlabs-apache/pull/2036/files#diff-0e508a7a33344d830c8232be8e77239dR35-R37) is called from [within the `RSpec.configure` block](https://github.com/puppetlabs/puppetlabs-apache/pull/2036/files#diff-08070fc30be3f9dd014e20b26f80934bR58), after `PuppetLitmus.configure!` has been called and the `os` variable has been correctly set with the parameters of the platform we're running the test on.

The [`generate_mod_platform_exclusions`](https://github.com/puppetlabs/puppetlabs-apache/pull/2036/files#diff-0e508a7a33344d830c8232be8e77239dR118-R137) method is called after, in [the `RSpec.configure` block](https://github.com/puppetlabs/puppetlabs-apache/pull/2036/files#diff-08070fc30be3f9dd014e20b26f80934bR59), which will parse the files under [`manifests/mod`](https://github.com/puppetlabs/puppetlabs-apache/tree/983b1fd3ff178d46145f4b8c0a88bae36dfad12b/manifests/mod), extracting all tags that follow the syntax:
```ruby
# @note Unsupported platforms: OS: ver, ver; OS: ver, ver, ver; OS: all
```
The class definition for the Apache MOD will be extracted too. A concrete example would look something like this:
```ruby
# @note Unsupported platforms: RedHat: 5, 6; Ubuntu: 14.04; SLES: all; Scientific: 11 SP1
class apache::mod::actions {
    apache::mod { 'actions': }
}
```
The rules for defining OS/Version pairs as as follows:
- All OS/Version declarations must be preceded with `@note Unsupported platforms:`
- The tag must be declared ABOVE the class declaration (i.e. not as footer at the bottom of the file)
- Each OS/Version declaration must be separated by semicolons (`;`)
- Each version must be separated by a comma (`,`)
- Versions CANNOT be declared in ranges (e.g. `RedHat:5-7`), they should be explicitly declared (e.g. `RedHat:5,6,7`)
- However, to declare all versions of an OS as unsupported, use the word `all` (e.g. `SLES:all`)
- OSs with word characters as part of their versions are acceptable (e.g. `Scientific: 11 SP1, 11 SP2, 12, 13`). **PLEASE NOTE:** The "SP" value will be stripped and normalised to the major version (e.g. `11 SP1` -> `11`). This is because Litmus (using `serverspec` underneath) will not report the SP level of Scientific Linux with the 'SP' tag. We could potentially map the SP level to the `minor` version equivalent reported by `serverspec`, but that seems more like a stretch goal.
- Spaces are permitted between OS/Version declarations and version numbers within a declaration
- Refer to the [`operatingsystem_support`](https://github.com/puppetlabs/puppetlabs-apache/blob/a7e04c25ba29ec5b0985c5959825b43cd5f2da40/metadata.json#L20-L76) values in the [`metadata.json`](https://github.com/puppetlabs/puppetlabs-apache/blob/a7e04c25ba29ec5b0985c5959825b43cd5f2da40/metadata.json) to find the acceptable OS name and version syntax:
-- E.g. `OracleLinux` OR `oraclelinux`, not: `[Oracle, OraLinux]`
-- E.g. `RedHat` OR `redhat`, not: `[Red Hat Enterprise Linux, RHEL, Red Hat]`
- OS names defined in the `metadata.json` map to the names reported back by Litmus / serverspec in the `os` value.

There is now a mapping of class names to unsupported OSs, and using [RSpec's conditional filtering](https://relishapp.com/rspec/rspec-core/v/3-8/docs/filtering/conditional-filters), we can now use the [`mod_unsupported_on_platform`](https://github.com/puppetlabs/puppetlabs-apache/pull/2036/files#diff-0e508a7a33344d830c8232be8e77239dR141-R146) method from within the tests to exclude it, if we're running against an unsupported platform:
```ruby
describe 'auth_oidc', unless: mod_unsupported_on_platform('apache::mod::auth_openidc') do
```
**Please note:** The onus is still on the IAC Team / Contributor to determine what tests use what Apache MOD. As described in [this document](https://confluence.puppetlabs.com/display/ECO/IAC-801%3A+Apache+MOD+Test+Exclusion+Functionality), there are a few tests you'll encounter in the module:

- A 1:1 MOD class <-> acceptance test mapping, such as [`spec/acceptance/mod_php_spec.rb`](https://github.com/puppetlabs/puppetlabs-apache/blob/983b1fd3ff178d46145f4b8c0a88bae36dfad12b/spec/acceptance/mod_php_spec.rb), where the class under test is [defined in the describe block](https://github.com/puppetlabs/puppetlabs-apache/blob/983b1fd3ff178d46145f4b8c0a88bae36dfad12b/spec/acceptance/mod_php_spec.rb#L4) of the test
- A test that does not explicitly define the class under test, but does [import a MOD class](https://github.com/puppetlabs/puppetlabs-apache/blob/983b1fd3ff178d46145f4b8c0a88bae36dfad12b/spec/acceptance/vhost_spec.rb#L1068) as part of a manifest defined for the test ([`spec/acceptance/vhost_spec.rb`](https://github.com/puppetlabs/puppetlabs-apache/blob/983b1fd3ff178d46145f4b8c0a88bae36dfad12b/spec/defines/vhost_spec.rb))
- A test that does not explicitly define the class under test OR import a MOD class as part of a manifest. Instead, the test eventually triggers a code path where a module is loaded as part of the functionality, either with [a specific parameter](https://github.com/puppetlabs/puppetlabs-apache/blob/983b1fd3ff178d46145f4b8c0a88bae36dfad12b/spec/acceptance/vhost_spec.rb#L1209) or just determined within the module code at some other point ([`spec/acceptance/vhost_spec.rb`](https://github.com/puppetlabs/puppetlabs-apache/blob/983b1fd3ff178d46145f4b8c0a88bae36dfad12b/spec/defines/vhost_spec.rb))

# Still TODO
- [x] Unit tests for `print_parsing_errors` method
- [x] Unit tests for `mod_unsupported_on_platform` method
- [x] Manual integration testing in acceptance test run

# Manual Test Scenarios
- [x] Acceptance tests execute without any `Unsupported platform` tags
- [x] Warning is printed for incorrectly formatted tag, but tests continue to execute
- [x] Test(s) can be excluded on a specific platform using an `Unsupported platform` tag
- [x] Test(s) continue to execute on platform versions that are not excluded