### PR TITLE
pdksync - (IAC-886) Back out SLES 11 from release checks

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -22,7 +22,7 @@ travis_el7:
   images: ['litmusimage/centos:7', 'litmusimage/oraclelinux:7', 'litmusimage/scientificlinux:7']
 release_checks_5:
   provisioner: abs
-  images: ['redhat-6-x86_64', 'redhat-7-x86_64', 'redhat-8-x86_64', 'centos-6-x86_64', 'centos-7-x86_64',  'centos-8-x86_64', 'oracle-6-x86_64', 'oracle-7-x86_64', 'scientific-6-x86_64', 'scientific-7-x86_64', 'debian-8-x86_64', 'debian-9-x86_64',  'debian-10-x86_64', 'ubuntu-1404-x86_64', 'ubuntu-1604-x86_64', 'ubuntu-1804-x86_64', 'sles-11-x86_64', 'sles-12-x86_64', 'sles-15-x86_64']
+  images: ['redhat-6-x86_64', 'redhat-7-x86_64', 'redhat-8-x86_64', 'centos-6-x86_64', 'centos-7-x86_64',  'centos-8-x86_64', 'oracle-6-x86_64', 'oracle-7-x86_64', 'scientific-6-x86_64', 'scientific-7-x86_64', 'debian-8-x86_64', 'debian-9-x86_64',  'debian-10-x86_64', 'ubuntu-1404-x86_64', 'ubuntu-1604-x86_64', 'ubuntu-1804-x86_64', 'sles-12-x86_64', 'sles-15-x86_64']
 release_checks_6:
   provisioner: abs
-  images: ['redhat-6-x86_64', 'redhat-7-x86_64', 'redhat-8-x86_64', 'centos-6-x86_64', 'centos-7-x86_64',  'centos-8-x86_64', 'oracle-6-x86_64', 'oracle-7-x86_64', 'scientific-6-x86_64', 'scientific-7-x86_64', 'debian-8-x86_64', 'debian-9-x86_64',  'debian-10-x86_64', 'ubuntu-1404-x86_64', 'ubuntu-1604-x86_64', 'ubuntu-1804-x86_64', 'ubuntu-2004-x86_64', 'sles-11-x86_64', 'sles-12-x86_64', 'sles-15-x86_64']
+  images: ['redhat-6-x86_64', 'redhat-7-x86_64', 'redhat-8-x86_64', 'centos-6-x86_64', 'centos-7-x86_64',  'centos-8-x86_64', 'oracle-6-x86_64', 'oracle-7-x86_64', 'scientific-6-x86_64', 'scientific-7-x86_64', 'debian-8-x86_64', 'debian-9-x86_64',  'debian-10-x86_64', 'ubuntu-1404-x86_64', 'ubuntu-1604-x86_64', 'ubuntu-1804-x86_64', 'ubuntu-2004-x86_64', 'sles-12-x86_64', 'sles-15-x86_64']


### PR DESCRIPTION
(IAC-886) Back out SLES 11 from release checks
pdk version: `1.17.0` 
