### PR TITLE
Update mod_dir, alias_icons_path, error_documents_path for CentOS 8

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -171,6 +171,7 @@ class apache::params inherits ::apache::version {
     } else {
       $mod_dir              = $::apache::version::distrelease ? {
         '7'     => "${httpd_dir}/conf.modules.d",
+        '8'     => "${httpd_dir}/conf.modules.d",
         default => "${httpd_dir}/conf.d",
       }
     }
@@ -263,10 +264,12 @@ class apache::params inherits ::apache::version {
     $docroot              = '/var/www/html'
     $alias_icons_path     = $::apache::version::distrelease ? {
       '7'     => '/usr/share/httpd/icons',
+      '8'     => '/usr/share/httpd/icons',
       default => '/var/www/icons',
     }
     $error_documents_path = $::apache::version::distrelease ? {
       '7'     => '/usr/share/httpd/error',
+      '8'     => '/usr/share/httpd/error',
       default => '/var/www/error'
     }
     if $::osfamily == 'RedHat' {

--- a/spec/classes/mod/passenger_spec.rb
+++ b/spec/classes/mod/passenger_spec.rb
@@ -431,7 +431,7 @@ describe 'apache::mod::passenger', type: :class do
                 is_expected.to contain_file('passenger_package.conf').with('path' => '/etc/httpd/conf.d/passenger.conf')
               }
               it {
-                is_expected.to contain_file('zpassenger.load').with('path' => '/etc/httpd/conf.d/zpassenger.load')
+                is_expected.to contain_file('zpassenger.load').with('path' => '/etc/httpd/conf.modules.d/zpassenger.load')
               }
             end
           end

--- a/spec/classes/mod/security_spec.rb
+++ b/spec/classes/mod/security_spec.rb
@@ -34,7 +34,7 @@ describe 'apache::mod::security', type: :class do
           if facts[:os]['release']['major'].to_i >= 8
             it {
               is_expected.to contain_file('security.conf').with(
-                path: '/etc/httpd/conf.d/security.conf',
+                path: '/etc/httpd/conf.modules.d/security.conf',
               )
             }
           end

--- a/spec/classes/mod/ssl_spec.rb
+++ b/spec/classes/mod/ssl_spec.rb
@@ -54,7 +54,7 @@ describe 'apache::mod::ssl', type: :class do
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('ssl') }
       it { is_expected.to contain_package('mod_ssl') }
-      it { is_expected.to contain_file('ssl.conf').with_path('/etc/httpd/conf.d/ssl.conf') }
+      it { is_expected.to contain_file('ssl.conf').with_path('/etc/httpd/conf.modules.d/ssl.conf') }
       it { is_expected.to contain_file('ssl.conf').with_content(%r{SSLProtocol all}) }
     end
     context '6 OS with a custom package_name parameter' do


### PR DESCRIPTION
Updating modules path, icons path, error documents path for CentOS 8. Without this patch, all the module .load and .conf files ended up in $confd_dir.