### PR TITLE
MODULES-10712 fix mod_ldap on RH/CentOS 5 and 6

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -199,7 +199,7 @@ class apache::params inherits ::apache::version {
     $suphp_configpath     = undef
     $php_version = $facts['operatingsystemmajrelease'] ? {
         '8'     => '7', # RedHat8
-        default => '5', # RedHat5, RedHat6, RedHat7 
+        default => '5', # RedHat5, RedHat6, RedHat7
       }
     $mod_packages         = {
       # NOTE: The auth_cas module isn't available on RH/CentOS without providing dependency packages provided by EPEL.
@@ -221,7 +221,11 @@ class apache::params inherits ::apache::version {
       'fcgid'                 => 'mod_fcgid',
       'geoip'                 => 'mod_geoip',
       'intercept_form_submit' => 'mod_intercept_form_submit',
-      'ldap'                  => 'mod_ldap',
+      'ldap'                  => $::apache::version::distrelease ? {
+        '5'     => undef,
+        '6'     => undef,
+        default => 'mod_ldap',
+      },
       'lookup_identity'       => 'mod_lookup_identity',
       'pagespeed'             => 'mod-pagespeed-stable',
       # NOTE: The passenger module isn't available on RH/CentOS without

--- a/spec/acceptance/mod_ldap_spec.rb
+++ b/spec/acceptance/mod_ldap_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper_acceptance'
+apache_hash = apache_settings_hash
+
+describe 'apache::mod::ldap', unless: os[:family] == 'redhat' && os[:release].to_i >= 8 do
+  context 'Default ldap module installation' do
+    pp = <<-MANIFEST
+        class { 'apache': }
+        class { 'apache::mod::ldap': }
+    MANIFEST
+
+    it 'succeeds in installing the ldap module' do
+      apply_manifest(pp, catch_failures: true)
+    end
+
+    describe file("#{apache_hash['mod_dir']}/ldap.load") do
+      it { is_expected.to contain 'mod_ldap.so' }
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/puppetlabs/puppetlabs-apache/pull/1913 changed ldap package to always be mod_ldap, but on rhel/centos 5 and 6 mod_ldap is in the httpd package and there is no mod_ldap package.

