### PR TITLE
(maint) Update test settings hash for CentOS 8 expectations

### DIFF
--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -73,10 +73,11 @@ def apache_settings_hash
     apache['error_log']        = 'error_log'
     apache['suphp_handler']    = 'php5-script'
     apache['suphp_configpath'] = 'undef'
-    if (operatingsystemrelease >= 7 && operatingsystemrelease < 8) && (osfamily == 'redhat')
+    if (operatingsystemrelease >= 7 && operatingsystemrelease < 9) && (osfamily == 'redhat')
       apache['version']     = '2.4'
       apache['mod_dir']     = '/etc/httpd/conf.modules.d'
       apache['mod_ssl_dir'] = apache['confd_dir']
+      apache['mod_ssl_dir'] = apache['mod_dir'] if operatingsystemrelease >= 8
     elsif operatingsystemrelease >= 8 && osfamily == 'redhat'
       apache['version']     = '2.4'
       apache['mod_dir']     = '/etc/httpd/conf.d'


### PR DESCRIPTION
After the recent introduction of the CentOS 8 platform to TravisCI's tests in https://github.com/puppetlabs/puppetlabs-apache/pull/2040, it caused a number of test failures as the test expectations were not updated with the common conf dirs for CentOS 8. This PR should not have been merged without the TravisCI tests executing.

See failing tests [here](https://travis-ci.org/github/puppetlabs/puppetlabs-apache/builds/701224969)