### PR TITLE
(maint) Straighten up test settings for EL8

### DIFF
--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -73,15 +73,14 @@ def apache_settings_hash
     apache['error_log']        = 'error_log'
     apache['suphp_handler']    = 'php5-script'
     apache['suphp_configpath'] = 'undef'
-    if (operatingsystemrelease >= 7 && operatingsystemrelease < 9) && (osfamily == 'redhat')
-      apache['version']     = '2.4'
-      apache['mod_dir']     = '/etc/httpd/conf.modules.d'
-      apache['mod_ssl_dir'] = apache['confd_dir']
-      apache['mod_ssl_dir'] = apache['mod_dir'] if operatingsystemrelease >= 8
-    elsif operatingsystemrelease >= 8 && osfamily == 'redhat'
+    if operatingsystemrelease >= 8 && osfamily == 'redhat'
       apache['version']     = '2.4'
       apache['mod_dir']     = '/etc/httpd/conf.d'
       apache['mod_ssl_dir'] = apache['mod_dir']
+    elsif operatingsystemrelease >= 7 && osfamily == 'redhat'
+      apache['version']     = '2.4'
+      apache['mod_dir']     = '/etc/httpd/conf.modules.d'
+      apache['mod_ssl_dir'] = apache['confd_dir']
     elsif operatingsystemrelease >= 7 && osfamily == 'oracle'
       apache['version']     = '2.4'
       apache['mod_dir']     = '/etc/httpd/conf.modules.d'


### PR DESCRIPTION
beff9916e26807d3d75462bda868d093225fac1a changed the logic, but in a very complicated way. This prefers to put the newest version first and fall back to older versions. That avoids multiple if conditions.