### PR TITLE
(maint) Fix test expectations from bad PR merge

### DIFF
--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -75,7 +75,7 @@ def apache_settings_hash
     apache['suphp_configpath'] = 'undef'
     if operatingsystemrelease >= 8 && osfamily == 'redhat'
       apache['version']     = '2.4'
-      apache['mod_dir']     = '/etc/httpd/conf.d'
+      apache['mod_dir']     = '/etc/httpd/conf.modules.d'
       apache['mod_ssl_dir'] = apache['mod_dir']
     elsif operatingsystemrelease >= 7 && osfamily == 'redhat'
       apache['version']     = '2.4'


### PR DESCRIPTION
https://github.com/puppetlabs/puppetlabs-apache/pull/2042 fixed an issue with the apache_settings hash being set with incorrect expectations for RHEL 8.x systems. https://github.com/puppetlabs/puppetlabs-apache/pull/2043 attempted to improve upon that, but reverted the change made to set the 'mod_dir' for RHEL 8.x in https://github.com/puppetlabs/puppetlabs-apache/pull/2042 . Some CI test runner issues obsficated the break in both cases.