### PR TITLE
(IAC-587) Tag apache::mod:authnz_ldap with unsupported platforms

### DIFF
--- a/manifests/mod/authnz_ldap.pp
+++ b/manifests/mod/authnz_ldap.pp
@@ -8,7 +8,7 @@
 #   The name of the ldap package.
 # 
 # @see https://httpd.apache.org/docs/current/mod/mod_authnz_ldap.html for additional documentation.
-#
+# @note Unsupported platforms: RedHat: 6, 8; CentOS: 6, 8; OracleLinux: 6, 8; Ubuntu: 14.04; SLES: all
 class apache::mod::authnz_ldap (
   Boolean $verify_server_cert = true,
   $package_name               = undef,

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -1200,7 +1200,7 @@ describe 'apache::vhost define' do
 
   # IAC-587: These tests do not currently run successfully on certain RHEL OSs due to dependency issues with the
   # mod_auth_openidc module.
-  describe 'auth_oidc', if: (os[:family] == 'ubuntu' && os[:release].to_i > 14 || os[:family] == 'debian') do
+  describe 'auth_oidc', if: mod_supported_on_platform?('apache::mod::authnz_ldap') do
     pp = <<-MANIFEST
         class { 'apache': }
         apache::vhost { 'test.server':


### PR DESCRIPTION
Requires https://github.com/puppetlabs/puppetlabs-apache/pull/2036 to be merged first.