### PR TITLE
(IAC-934) Use tagging to filter Apache MOD tests from execution

### DIFF
--- a/manifests/mod/authnz_ldap.pp
+++ b/manifests/mod/authnz_ldap.pp
@@ -8,7 +8,7 @@
 #   The name of the ldap package.
 # 
 # @see https://httpd.apache.org/docs/current/mod/mod_authnz_ldap.html for additional documentation.
-# @note Unsupported platforms: RedHat: 6, 8; CentOS: 6, 8; OracleLinux: 6, 8; Ubuntu: 14.04; SLES: all
+# @note Unsupported platforms: RedHat: 6, 8; CentOS: 6, 8; OracleLinux: 6, 8; Ubuntu: all; Debian: all; SLES: all
 class apache::mod::authnz_ldap (
   Boolean $verify_server_cert = true,
   $package_name               = undef,

--- a/manifests/mod/event.pp
+++ b/manifests/mod/event.pp
@@ -45,7 +45,7 @@
 #   apache::mod::worker on the same server.
 #
 # @see https://httpd.apache.org/docs/current/mod/event.html for additional documentation.
-#
+# @note Unsupported platforms: SLES: all
 class apache::mod::event (
   $startservers           = '2',
   $maxclients             = '150',

--- a/manifests/mod/itk.pp
+++ b/manifests/mod/itk.pp
@@ -28,7 +28,7 @@
 #   Used to verify that the Apache version you have requested is compatible with the module.
 # 
 # @see http://mpm-itk.sesse.net for additional documentation.
-#
+# @note Unsupported platforms: CentOS: 8; RedHat: 8; SLES: all
 class apache::mod::itk (
   $startservers        = '8',
   $minspareservers     = '5',

--- a/manifests/mod/ldap.pp
+++ b/manifests/mod/ldap.pp
@@ -47,7 +47,7 @@
 #   }
 #
 # @see https://httpd.apache.org/docs/current/mod/mod_ldap.html for additional documentation.
-#
+# @note Unsupported platforms: CentOS: 8; RedHat: 8
 class apache::mod::ldap (
   $apache_version                                  = undef,
   $package_name                                    = undef,

--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -3,6 +3,7 @@
 # 
 # @todo
 #   Add docs
+# @note Unsupported platforms: SLES: all
 class apache::mod::php (
   $package_name     = undef,
   $package_ensure   = 'present',

--- a/manifests/mod/shib.pp
+++ b/manifests/mod/shib.pp
@@ -22,7 +22,7 @@
 #   See the [Shibboleth Service Provider Installation Guide](http://wiki.aaf.edu.au/tech-info/sp-install-guide).
 #
 # @see https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPApacheConfig for additional documentation.
-#
+# @note Unsupported platforms: RedHat: all; CentOS: all; Scientific: all; SLES: all; Debian: 7, 8; Ubuntu: all; OracleLinux: all
 class apache::mod::shib (
   $suppress_warning = false,
   $mod_full_path    = undef,

--- a/manifests/mod/wsgi.pp
+++ b/manifests/mod/wsgi.pp
@@ -26,7 +26,7 @@
 #   Defines the path to the mod_wsgi shared object (.so) file.
 # 
 # @see https://github.com/GrahamDumpleton/mod_wsgi for additional documentation.
-#
+# @note Unsupported platforms: SLES: all; RedHat: all; CentOS: all; OracleLinux: all; Scientific: all
 class apache::mod::wsgi (
   $wsgi_restrict_embedded = undef,
   $wsgi_socket_prefix     = $::apache::params::wsgi_socket_prefix,

--- a/spec/acceptance/apache_parameters_spec.rb
+++ b/spec/acceptance/apache_parameters_spec.rb
@@ -94,7 +94,7 @@ describe 'apache parameters' do
 
   # IAC-785: The Shibboleth mod does not seem to be configured correctly on Debian 10 systems. We should reenable
   # this test on Debian 10 systems once the issue has been RCA'd and resolved.
-  describe 'conf_enabled => /etc/apache2/conf-enabled', if: os[:family] == 'debian' && os[:release].to_i < 10 do
+  describe 'conf_enabled => /etc/apache2/conf-enabled', skip: 'IAC-785' do
     pp = <<-MANIFEST
         class { 'apache':
           purge_configs   => false,

--- a/spec/acceptance/itk_spec.rb
+++ b/spec/acceptance/itk_spec.rb
@@ -16,7 +16,7 @@ end
 
 # IAC-787: The http-itk mod package is not available in any of the standard RHEL/CentOS 8.x repos. Disable this test
 # on those platforms until we can find a suitable source for this package.
-describe 'apache::mod::itk class', if: service_name, unless: os[:family] == 'redhat' && os[:release].to_i >= 8 do
+describe 'apache::mod::itk class', if: service_name && mod_supported_on_platform?('apache::mod::itk') do
   describe 'running puppet code' do
     let(:pp) do
       case variant

--- a/spec/acceptance/mod_authnz_ldap_spec.rb
+++ b/spec/acceptance/mod_authnz_ldap_spec.rb
@@ -3,10 +3,12 @@ apache_hash = apache_settings_hash
 
 # We need to restrict this test to RHEL 7.x, 8.x derived OSs as there are too many unique
 # dependency issues to solve on all supported platforms.
-describe 'apache::mod_authnz_ldap', if: os[:family] == 'redhat' && os[:release].to_i > 6 do
+describe 'apache::mod::authnz_ldap', if: mod_supported_on_platform?('apache::mod::authnz_ldap') do
   before(:each) do
-    run_shell('yum clean all') # To clear some issues when configuring EPEL / Optional repos
-    run_shell('dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm -y') if os[:release].to_i == 8
+    if os[:family] == 'redhat'
+      run_shell('yum clean all') # To clear some issues when configuring EPEL / Optional repos
+      run_shell('dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm -y') if os[:release].to_i == 8
+    end
   end
   context 'Default mod_authnz_ldap module installation' do
     pp = if run_shell("grep 'Oracle Linux Server' /etc/os-release", expect_failures: true).exit_status == 0

--- a/spec/acceptance/mod_ldap_spec.rb
+++ b/spec/acceptance/mod_ldap_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper_acceptance'
 apache_hash = apache_settings_hash
 
-describe 'apache::mod::ldap', unless: os[:family] == 'redhat' && os[:release].to_i >= 8 do
+describe 'apache::mod::ldap', if: mod_supported_on_platform?('apache::mod::ldap') do
   context 'Default ldap module installation' do
     pp = <<-MANIFEST
         class { 'apache': }

--- a/spec/acceptance/mod_php_spec.rb
+++ b/spec/acceptance/mod_php_spec.rb
@@ -1,88 +1,87 @@
 require 'spec_helper_acceptance'
 apache_hash = apache_settings_hash
-unless os[:family] == 'sles' && os[:release].to_i >= 12
-  describe 'apache::mod::php class' do
-    context 'default php config' do
-      pp = <<-MANIFEST
-          class { 'apache':
-            mpm_module => 'prefork',
-          }
-          class { 'apache::mod::php': }
-          apache::vhost { 'php.example.com':
-            port    => '80',
-            docroot => '#{apache_hash['doc_root']}/php',
-          }
-          host { 'php.example.com': ip => '127.0.0.1', }
-          file { '#{apache_hash['doc_root']}/php/index.php':
-            ensure  => file,
-            content => "<?php phpinfo(); ?>\\n",
-          }
-      MANIFEST
-      it 'succeeds in puppeting php' do
-        apply_manifest(pp, catch_failures: true)
-      end
 
-      if (os[:family] == 'ubuntu' && os[:release] == '16.04') ||
-         (os[:family] == 'debian' && os[:release] =~ %r{9})
-        describe file("#{apache_hash['mod_dir']}/php7.0.conf") do
-          it { is_expected.to contain 'DirectoryIndex index.php' }
-        end
-      elsif os[:family] == 'debian' && os[:release] =~ %r{10}
-        describe file("#{apache_hash['mod_dir']}/php7.3.conf") do
-          it { is_expected.to contain 'DirectoryIndex index.php' }
-        end
-      elsif os[:family] == 'ubuntu' && os[:release] == '18.04'
-        describe file("#{apache_hash['mod_dir']}/php7.2.conf") do
-          it { is_expected.to contain 'DirectoryIndex index.php' }
-        end
-      elsif os[:family] == 'ubuntu' && os[:release] == '20.04'
-        describe file("#{apache_hash['mod_dir']}/php7.4.conf") do
-          it { is_expected.to contain 'DirectoryIndex index.php' }
-        end
-      elsif os[:family] == 'redhat' && os[:release] =~ %r{^8}
-        describe file("#{apache_hash['mod_dir']}/php7.conf") do
-          it { is_expected.to contain 'DirectoryIndex index.php' }
-        end
-      else
-        describe file("#{apache_hash['mod_dir']}/php5.conf") do
-          it { is_expected.to contain 'DirectoryIndex index.php' }
-        end
-      end
+describe 'apache::mod::php class', if: mod_supported_on_platform?('apache::mod::php') do
+  context 'default php config' do
+    pp = <<-MANIFEST
+        class { 'apache':
+          mpm_module => 'prefork',
+        }
+        class { 'apache::mod::php': }
+        apache::vhost { 'php.example.com':
+          port    => '80',
+          docroot => '#{apache_hash['doc_root']}/php',
+        }
+        host { 'php.example.com': ip => '127.0.0.1', }
+        file { '#{apache_hash['doc_root']}/php/index.php':
+          ensure  => file,
+          content => "<?php phpinfo(); ?>\\n",
+        }
+    MANIFEST
+    it 'succeeds in puppeting php' do
+      apply_manifest(pp, catch_failures: true)
     end
 
-    context 'custom extensions, php_flag, php_value, php_admin_flag, and php_admin_value' do
-      pp = <<-MANIFEST
-          class { 'apache':
-            mpm_module => 'prefork',
-          }
-           class { 'apache::mod::php':
-           extensions => ['.php','.php5'],
-         }
-
-          apache::vhost { 'php.example.com':
-            port             => '80',
-            docroot          => '#{apache_hash['doc_root']}/php',
-            php_values       => { 'include_path' => '.:/usr/share/pear:/usr/bin/php', },
-            php_flags        => { 'display_errors' => 'on', },
-            php_admin_values => { 'open_basedir' => '/var/www/php/:/usr/share/pear/', },
-            php_admin_flags  => { 'engine' => 'on', },
-          }
-          host { 'php.example.com': ip => '127.0.0.1', }
-          file { '#{apache_hash['doc_root']}/php/index.php5':
-            ensure  => file,
-            content => "<?php phpinfo(); ?>\\n",
-          }
-      MANIFEST
-      it 'succeeds in puppeting php' do
-        apply_manifest(pp, catch_failures: true)
+    if (os[:family] == 'ubuntu' && os[:release] == '16.04') ||
+       (os[:family] == 'debian' && os[:release] =~ %r{9})
+      describe file("#{apache_hash['mod_dir']}/php7.0.conf") do
+        it { is_expected.to contain 'DirectoryIndex index.php' }
       end
-
-      describe file("#{apache_hash['vhost_dir']}/25-php.example.com.conf") do
-        it { is_expected.to contain '  php_flag display_errors on' }
-        it { is_expected.to contain '  php_value include_path ".:/usr/share/pear:/usr/bin/php"' }
-        it { is_expected.to contain '  php_admin_flag engine on' }
-        it { is_expected.to contain '  php_admin_value open_basedir /var/www/php/:/usr/share/pear/' }
+    elsif os[:family] == 'debian' && os[:release] =~ %r{10}
+      describe file("#{apache_hash['mod_dir']}/php7.3.conf") do
+        it { is_expected.to contain 'DirectoryIndex index.php' }
       end
+    elsif os[:family] == 'ubuntu' && os[:release] == '18.04'
+      describe file("#{apache_hash['mod_dir']}/php7.2.conf") do
+        it { is_expected.to contain 'DirectoryIndex index.php' }
+      end
+    elsif os[:family] == 'ubuntu' && os[:release] == '20.04'
+      describe file("#{apache_hash['mod_dir']}/php7.4.conf") do
+        it { is_expected.to contain 'DirectoryIndex index.php' }
+      end
+    elsif os[:family] == 'redhat' && os[:release] =~ %r{^8}
+      describe file("#{apache_hash['mod_dir']}/php7.conf") do
+        it { is_expected.to contain 'DirectoryIndex index.php' }
+      end
+    else
+      describe file("#{apache_hash['mod_dir']}/php5.conf") do
+        it { is_expected.to contain 'DirectoryIndex index.php' }
+      end
+    end
+  end
+
+  context 'custom extensions, php_flag, php_value, php_admin_flag, and php_admin_value' do
+    pp = <<-MANIFEST
+        class { 'apache':
+          mpm_module => 'prefork',
+        }
+         class { 'apache::mod::php':
+         extensions => ['.php','.php5'],
+       }
+
+        apache::vhost { 'php.example.com':
+          port             => '80',
+          docroot          => '#{apache_hash['doc_root']}/php',
+          php_values       => { 'include_path' => '.:/usr/share/pear:/usr/bin/php', },
+          php_flags        => { 'display_errors' => 'on', },
+          php_admin_values => { 'open_basedir' => '/var/www/php/:/usr/share/pear/', },
+          php_admin_flags  => { 'engine' => 'on', },
+        }
+        host { 'php.example.com': ip => '127.0.0.1', }
+        file { '#{apache_hash['doc_root']}/php/index.php5':
+          ensure  => file,
+          content => "<?php phpinfo(); ?>\\n",
+        }
+    MANIFEST
+    it 'succeeds in puppeting php' do
+      apply_manifest(pp, catch_failures: true)
+    end
+
+    describe file("#{apache_hash['vhost_dir']}/25-php.example.com.conf") do
+      it { is_expected.to contain '  php_flag display_errors on' }
+      it { is_expected.to contain '  php_value include_path ".:/usr/share/pear:/usr/bin/php"' }
+      it { is_expected.to contain '  php_admin_flag engine on' }
+      it { is_expected.to contain '  php_admin_value open_basedir /var/www/php/:/usr/share/pear/' }
     end
   end
 end

--- a/spec/acceptance/prefork_worker_spec.rb
+++ b/spec/acceptance/prefork_worker_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 apache_hash = apache_settings_hash
-describe 'prefork_worker_spec.rb', unless: (os[:family] =~ %r{sles}) do
+describe 'prefork_worker_spec.rb', if: mod_supported_on_platform?('apache::mod::event') do
   describe 'apache::mod::event class' do
     describe 'running puppet code' do
       let(:pp) do

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -752,7 +752,7 @@ describe 'apache::vhost define' do
     end
   end
 
-  describe 'parameter tests', unless: (os[:family] =~ %r{redhat} && os[:release].to_i == 8) do
+  describe 'parameter tests', if: mod_supported_on_platform?('apache::mod::itk') do
     pp = <<-MANIFEST
       class { 'apache': }
       host { 'test.itk': ip => '127.0.0.1' }
@@ -1103,7 +1103,7 @@ describe 'apache::vhost define' do
   end
 
   describe 'wsgi' do
-    context 'filter on OS', unless: (os[:family] =~ %r{sles|redhat}) do
+    context 'filter on OS', if: mod_supported_on_platform?('apache::mod::wsgi') do
       pp = <<-MANIFEST
       class { 'apache': }
       class { 'apache::mod::wsgi': }


### PR DESCRIPTION
Using the functionality available after #2036 was merged to make the Apache MOD test exclusion a bit tidier.