### PR TITLE
Use python3-mod_wsgi instead of mod_wsgi on CentOS8

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -240,7 +240,10 @@ class apache::params inherits ::apache::version {
       # See http://wiki.aaf.edu.au/tech-info/sp-install-guide
       'shibboleth'            => 'shibboleth',
       'ssl'                   => 'mod_ssl',
-      'wsgi'                  => 'mod_wsgi',
+      'wsgi'                  => $facts['operatingsystemmajrelease'] ? {
+        '8'     => 'python3-mod_wsgi', # RedHat8
+        default => 'mod_wsgi',         # RedHat5, RedHat6, RedHat7
+      },
       'dav_svn'               => 'mod_dav_svn',
       'suphp'                 => 'mod_suphp',
       'xsendfile'             => 'mod_xsendfile',


### PR DESCRIPTION
The mod_wsgi package was renamed to python3-mod_wsgi on CentOS8, and
now the old name doesn't work since the provides and obsoletes for it
was removed[1].

[1] https://centos.pkgs.org/8/centos-appstream-x86_64/python3-mod_wsgi-4.6.4-4.el8.x86_64.rpm.html