### PR TITLE
Configure default shared lib path for mod_wsgi on RHEL8

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -260,6 +260,10 @@ class apache::params inherits ::apache::version {
     }
     $mod_libs             = {
       'nss' => 'libmodnss.so',
+      'wsgi'                  => $::apache::version::distrelease ? {
+        '8'     => 'mod_wsgi_python3.so',
+        default => 'mod_wsgi.so',
+      },
     }
     $conf_template        = 'apache/httpd.conf.erb'
     $http_protocol_options  = undef

--- a/spec/classes/mod/wsgi_spec.rb
+++ b/spec/classes/mod/wsgi_spec.rb
@@ -45,6 +45,16 @@ describe 'apache::mod::wsgi', type: :class do
     }
     it { is_expected.to contain_package('mod_wsgi') }
 
+    context 'on RHEL8' do
+      let(:facts) do
+        super().merge(operatingsystemrelease: '8')
+      end
+
+      it { is_expected.to contain_class('apache::params') }
+      it { is_expected.to contain_file('wsgi.load').with_content(%r{LoadModule wsgi_module modules/mod_wsgi_python3.so}) }
+      it { is_expected.to contain_package('python3-mod_wsgi') }
+    end
+
     describe 'with WSGIRestrictEmbedded enabled' do
       let :params do
         { wsgi_restrict_embedded: 'On' }


### PR DESCRIPTION
RHEL8:
```
  # rpm -ql python3-mod_wsgi | grep \.so$
  /usr/lib64/httpd/modules/mod_wsgi_python3.so
```

RHEL7:
```
  # rpm -ql mod_wsgi | grep \.so$
  /usr/lib64/httpd/modules/mod_wsgi.so
```

Tests might need to be changed. The package name selection has already been patched in commit [d346b76d1aab954b642c55942d3ff8cf6cb578ac](https://github.com/puppetlabs/puppetlabs-apache/commit/d346b76d1aab954b642c55942d3ff8cf6cb578ac).