### PR TITLE
(maint) Use 'policycoreutils-python-utils' on RHEL 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -902,6 +902,9 @@ apache::vhost { 'test.server':
 }
 ```
 
+**NOTE:** On RHEL 8, the SELinux packages contained in `policycoreutils-python` have been replaced by the `policycoreutils-python-utils` package.
+See [here](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/considerations_in_adopting_rhel_8/index#selinux-python3_security) for more details.
+
 You must set the contexts using `semanage fcontext` instead of `chcon` because Puppet's `file` resources reset the values' context in the database if the resource doesn't specify it.
 
 ### Ubuntu 10.04

--- a/spec/acceptance/apache_parameters_spec.rb
+++ b/spec/acceptance/apache_parameters_spec.rb
@@ -429,6 +429,7 @@ describe 'apache parameters' do
           if $::osfamily == 'RedHat' and "$::selinux" == "true" {
             $semanage_package = $::operatingsystemmajrelease ? {
               '5'     => 'policycoreutils',
+              '8'     => 'policycoreutils-python-utils',
               default => 'policycoreutils-python',
             }
 

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -42,6 +42,7 @@ describe 'apache class' do
         if $::osfamily == 'RedHat' and "$::selinux" == "true" {
           $semanage_package = $::operatingsystemmajrelease ? {
             '5'     => 'policycoreutils',
+            '8'     => 'policycoreutils-python-utils',
             default => 'policycoreutils-python',
           }
 


### PR DESCRIPTION
The `policycoreutils-python` has now been replaced by the `policycoreutils-python-utils`
on RHEL 8 according to [this documentation](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/considerations_in_adopting_rhel_8/index#selinux-python3_security)