### PR TITLE
(maint) Use 'policycoreutils-python-utils' on RHEL 8

### DIFF
--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -1144,6 +1144,7 @@ describe 'apache::vhost define' do
       if $::osfamily == 'RedHat' and "$::selinux" == "true" {
         $semanage_package = $::operatingsystemmajrelease ? {
           '5'     => 'policycoreutils',
+          '8'     => 'policycoreutils-python-utils',
           default => 'policycoreutils-python',
         }
         exec { 'set_apache_defaults':


### PR DESCRIPTION
Add an additional reference that was missed in [this PR](https://github.com/puppetlabs/puppetlabs-apache/pull/2065)