### PR TITLE
Make the logfiles use servername instead of name in their name.

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -2070,9 +2070,9 @@ define apache::vhost(
     $error_log_destination = $error_log_syslog
   } else {
     if $ssl {
-      $error_log_destination = "${logroot}/${name}_error_ssl.log"
+      $error_log_destination = "${logroot}/${servername}_error_ssl.log"
     } else {
-      $error_log_destination = "${logroot}/${name}_error.log"
+      $error_log_destination = "${logroot}/${servername}_error.log"
     }
   }
 
@@ -2091,9 +2091,9 @@ define apache::vhost(
     $modsec_audit_log_destination = $modsec_audit_log_pipe
   } elsif $modsec_audit_log {
     if $ssl {
-      $modsec_audit_log_destination = "${logroot}/${name}_security_ssl.log"
+      $modsec_audit_log_destination = "${logroot}/${servername}_security_ssl.log"
     } else {
-      $modsec_audit_log_destination = "${logroot}/${name}_security.log"
+      $modsec_audit_log_destination = "${logroot}/${servername}_security.log"
     }
   } else {
     $modsec_audit_log_destination = undef

--- a/templates/vhost/_access_log.erb
+++ b/templates/vhost/_access_log.erb
@@ -14,8 +14,8 @@
 <%   elsif log['pipe'] -%>
 <%     destination = log['pipe'] -%>
 <%   else -%>
-<%     destination ||= "#{@logroot}/#{@name}_access_ssl.log" if @ssl -%>
-<%     destination ||= "#{@logroot}/#{@name}_access.log" -%>
+<%     destination ||= "#{@logroot}/#{@servername}_access_ssl.log" if @ssl -%>
+<%     destination ||= "#{@logroot}/#{@servername}_access.log" -%>
 <%   end -%>
   CustomLog "<%= destination %>" <%= format %> <%= env %>
 <% end -%>


### PR DESCRIPTION
Since we already use $ssl to add "_ssl" to the log filenames, and the
examples for a mix of SSL and not typically would result in logfiles
with names like "mix.example.com non-ssl_access.log" and
"mix.example.com ssl_access_ssl.log", this patch fixes that by using
$servername instead and thus getting what it probably more expected:
"mix.example.com_access.log" and "mix.example.com_access_ssl.log"