### PR TITLE
make apache::mod::fcgid redhat 8 compatible

### DIFF
--- a/manifests/mod/fcgid.pp
+++ b/manifests/mod/fcgid.pp
@@ -39,7 +39,7 @@ class apache::mod::fcgid(
   $options = {},
 ) {
   include ::apache
-  if ($::osfamily == 'RedHat' and $::operatingsystemmajrelease == '7') or $::osfamily == 'FreeBSD' {
+  if ($::osfamily == 'RedHat' and $::operatingsystemmajrelease >= '7') or $::osfamily == 'FreeBSD' {
     $loadfile_name = 'unixd_fcgid.load'
     $conf_name = 'unixd_fcgid.conf'
   } else {


### PR DESCRIPTION
before -> rhel 8, fcgid.load is loaded before unixd.load  which causes httpd to fail
So the name unixd_fcgid.load should also be implemented for rhel 8