### PR TITLE
Add ssl_proxy_machine_cert_chain param to vhost class

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -9070,6 +9070,20 @@ apache::vhost { 'sample.example.net':
 
 Default value: `undef`
 
+##### `ssl_proxy_machine_cert_chain`
+
+Data type: `Any`
+
+Sets the [SSLProxyMachineCertificateChainFile](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxymachinecertificatechainfile)
+directive, which specifies an all-in-one file where you keep the certificate chain for
+all of the client certs in use. This directive will be needed if the remote server
+presents a list of CA certificates that are not direct signers of one of the configured
+client certificates. This referenced file is simply the concatenation of the various
+PEM-encoded certificate files. Upon startup, each client certificate configured will be
+examined and a chain of trust will be constructed.
+
+Default value: `undef`
+
 ##### `ssl_proxy_check_peer_cn`
 
 Data type: `Optional[Enum['on', 'off']]`

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1592,6 +1592,14 @@
 #     ssl_proxy_machine_cert => '/etc/httpd/ssl/client_certificate.pem',
 #   }
 #   ```
+# @param ssl_proxy_machine_cert_chain
+#   Sets the [SSLProxyMachineCertificateChainFile](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxymachinecertificatechainfile)
+#   directive, which specifies an all-in-one file where you keep the certificate chain for
+#   all of the client certs in use. This directive will be needed if the remote server
+#   presents a list of CA certificates that are not direct signers of one of the configured
+#   client certificates. This referenced file is simply the concatenation of the various
+#   PEM-encoded certificate files. Upon startup, each client certificate configured will be
+#   examined and a chain of trust will be constructed.
 #
 # @param ssl_proxy_check_peer_cn
 #   Sets the [SSLProxyCheckPeerCN](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxycheckpeercn) 
@@ -1726,6 +1734,7 @@ define apache::vhost(
   Optional[Enum['on', 'off']] $ssl_proxy_check_peer_name                            = undef,
   Optional[Enum['on', 'off']] $ssl_proxy_check_peer_expire                          = undef,
   $ssl_proxy_machine_cert                                                           = undef,
+  $ssl_proxy_machine_cert_chain                                                     = undef,
   $ssl_proxy_cipher_suite                                                           = undef,
   $ssl_proxy_protocol                                                               = undef,
   $ssl_options                                                                      = undef,
@@ -2475,6 +2484,7 @@ define apache::vhost(
   # - $ssl_proxy_check_peer_name
   # - $ssl_proxy_check_peer_expire
   # - $ssl_proxy_machine_cert
+  # - $ssl_proxy_machine_cert_chain
   # - $ssl_proxy_protocol
   if $ssl_proxyengine {
     concat::fragment { "${name}-sslproxy":

--- a/templates/vhost/_sslproxy.erb
+++ b/templates/vhost/_sslproxy.erb
@@ -23,6 +23,9 @@
   <%- if @ssl_proxy_machine_cert -%>
   SSLProxyMachineCertificateFile "<%= @ssl_proxy_machine_cert %>"
   <%- end -%>
+  <%- if @ssl_proxy_machine_cert_chain -%>
+  SSLProxyMachineCertificateChainFile "<%= @ssl_proxy_machine_cert_chain %>"
+  <%- end -%>
   <%- if @ssl_proxy_cipher_suite -%>
   SSLProxyCipherSuite <%= @ssl_proxy_cipher_suite %>
   <%- end -%>


### PR DESCRIPTION
Added the Apache vhost proxy config option SSLProxyMachineCertificateChainFile.

Reference: https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxymachinecertificatechainfile