### PR TITLE
Use Ruby 2.7 compatible string matching

### DIFF
--- a/lib/puppet/functions/apache/bool2httpd.rb
+++ b/lib/puppet/functions/apache/bool2httpd.rb
@@ -17,8 +17,14 @@ Puppet::Functions.create_function(:'apache::bool2httpd') do
   #   apache::bool2httpd(undef) # returns 'Off'
   #
   def bool2httpd(arg)
-    return 'Off' if arg.nil? || arg == false || arg =~ %r{false}i || arg == :undef
-    return 'On' if arg == true || arg =~ %r{true}i
+    return 'Off' if arg.nil? || arg == false || matches_string?(arg, %r{false}i) || arg == :undef
+    return 'On' if arg == true || matches_string?(arg, %r{true}i)
     arg.to_s
+  end
+
+  private
+
+  def matches_string?(value, matcher)
+    value.is_a?(String) && value.match?(matcher)
   end
 end

--- a/spec/functions/bool2httpd_spec.rb
+++ b/spec/functions/bool2httpd_spec.rb
@@ -5,10 +5,12 @@ shared_examples 'apache::bool2httpd function' do
   it { is_expected.to run.with_params.and_raise_error(ArgumentError) }
   it { is_expected.to run.with_params('1', '2').and_raise_error(ArgumentError) }
   it { is_expected.to run.with_params(true).and_return('On') }
+  it { is_expected.to run.with_params('true').and_return('On') }
   it 'expected to return a string "On"' do
     expect(subject.execute(true)).to be_an_instance_of(String)
   end
   it { is_expected.to run.with_params(false).and_return('Off') }
+  it { is_expected.to run.with_params('false').and_return('Off') }
   it 'expected to return a string "Off"' do
     expect(subject.execute(false)).to be_an_instance_of(String)
   end


### PR DESCRIPTION
#2060 was incorrectly merged to `master` instead of `main`:
> In Ruby 2.7, performing `true =~ %r{false}i` raises a deprecation warning.