### PR TITLE
Allow relative paths in oidc_redirect_uri

### DIFF
--- a/types/oidcsettings.pp
+++ b/types/oidcsettings.pp
@@ -1,7 +1,7 @@
 # https://github.com/zmartzone/mod_auth_openidc/blob/master/auth_openidc.conf
 type Apache::OIDCSettings = Struct[
   {
-    Optional['RedirectURI']                             => Variant[Stdlib::HTTPSUrl,Stdlib::HttpUrl],
+    Optional['RedirectURI']                             => Variant[Stdlib::HTTPSUrl,Stdlib::HttpUrl,Pattern[/^\/[A-Za-z0-9\-\._%\/]*$/]],
     Optional['CryptoPassphrase']                        => String,
     Optional['MetadataDir']                             => String,
     Optional['ProviderMetadataURL']                     => Stdlib::HTTPSUrl,


### PR DESCRIPTION
From the settings of auth_openidc [1]

```
 # You can use a relative URL like /protected/redirect_uri if you want to
# support multiple vhosts that belong to the same security domain in a dynamic way
#OIDCRedirectURI https://www.example.com/protected/redirect_uri
```

This patch allows full urls and relative paths in the OIDCRedirectURI setting



[1] https://github.com/zmartzone/mod_auth_openidc/blob/master/auth_openidc.conf