### PR TITLE
WIP: Support mod_auth_gssapi parameters

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1475,6 +1475,24 @@
 #   }
 #   ```
 # 
+# @param gssapi
+#  Specfies mod_auth_gssapi parameters for particular directories in a virtual host directory
+#  ```puppet
+#   include apache::mod::auth_gssapi
+#   apache::vhost { 'sample.example.net':
+#     docroot     => '/path/to/directory',
+#     directories => [
+#       { path   => '/path/to/different/dir',
+#         gssapi => {
+#           credstore => 'keytab:/foo/bar.keytab',
+#           localname => 'Off',
+#           sslonly   => 'On',
+#         }
+#       },
+#     ],
+#   }
+#   ```
+#
 # @param ssl
 #   Enables SSL for the virtual host. SSL virtual hosts only respond to HTTPS queries.
 #

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -246,6 +246,11 @@ describe 'apache::vhost', type: :define do
                   'passenger_allow_encoded_slashes'                     => false,
                   'passenger_app_log_file'                              => '/tmp/app.log',
                   'passenger_debugger'                                  => false,
+                  'gssapi'                                              => {
+                    'credstore' => 'keytab:/foo/bar.keytab',
+                    'localname' => 'On',
+                    'sslonly'   => 'Off',
+                  },
                 },
               ],
               'error_log'                   => false,
@@ -919,6 +924,21 @@ describe 'apache::vhost', type: :define do
           it {
             is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
               content: %r{^\s+PassengerDebugger\sOff$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
+              content: %r{^\s+GssapiCredStore\skeytab:/foo/bar.keytab$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
+              content: %r{^\s+GssapiSSLonly\sOff$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
+              content: %r{^\s+GssapiLocalName\sOn$},
             )
           }
           it { is_expected.to contain_concat__fragment('rspec.example.com-additional_includes') }

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -497,6 +497,9 @@
     <%- if directory['custom_fragment'] -%>
     <%= directory['custom_fragment'] %>
     <%- end -%>
+    <%- if directory['gssapi'] -%>
+      <%= scope.call_function('epp',["apache/vhost/_gssapi.epp", directory['gssapi']]) -%>
+    <%- end -%>
   </<%= provider %>>
     <%- end -%>
   <%- end -%>

--- a/templates/vhost/_gssapi.epp
+++ b/templates/vhost/_gssapi.epp
@@ -1,0 +1,16 @@
+<%|
+  # https://github.com/gssapi/mod_auth_gssapi
+  Optional[String[1]]        $credstore = undef,
+  Optional[Enum['On','Off']] $sslonly   = undef,
+  Optional[Enum['On','Off']] $localname = undef,
+|%>
+# mod_auth_gssapi configuration
+<% if $sslonly { -%>
+    GssapiSSLonly <%= $sslonly %>
+<% } -%>
+<% if $localname { -%>
+    GssapiLocalName <%= $localname %>
+<% } -%>
+<% if $credstore { -%>
+    GssapiCredStore <%= $credstore %>
+<% } -%>


### PR DESCRIPTION
mod_auth_gssapi parameters can only used inside a directory section of a vhost.

Parameters are specified as a hash `gssapi` to the directories parameter.

Currently only the three obvious parameters are supported, adding extra ones is a
trivial addition to the `_gssapi.epp` template.

Example

```puppet
include apache::mod::auth_gssapi
apache::vhost { 'sample.example.net':
  docroot     => '/path/to/directory',
  directories => [
    { path   => '/path/to/different/dir',
      gssapi => {
        credstore => 'keytab:/foo/bar.keytab',
        localname => 'Off',
        sslonly   => 'On',
      }
    },
  ],
```

These 3 values match to an apache configuration of

```config
<Directory /path/to/different/directory>
  GssapiSSLonly Off
  GssapiLocalName On
  GssapiCredStore keytab:/foo/bar.keytab
</Directory>
```

https://github.com/gssapi/mod_auth_gssapi#gssapisslonly