### PR TITLE
Fix apreq2 LoadModule

### DIFF
--- a/manifests/mod/apreq2.pp
+++ b/manifests/mod/apreq2.pp
@@ -1,0 +1,11 @@
+# @summary
+#   Installs `mod_apreq2`.
+#
+# @see http://httpd.apache.org/apreq/docs/libapreq2/group__mod__apreq2.html for additional documentation.
+#
+
+class apache::mod::apreq2 {
+  ::apache::mod { 'apreq2':
+    id => 'apreq_module',
+  }
+}


### PR DESCRIPTION
The LoadModule ID is currently wrong created.

The module creates the .load-File with
>LoadModule **apreq2_module**    modules/mod_apreq2.so

instead of

> LoadModule **apreq_module**    modules/mod_apreq2.so

http://httpd.apache.org/apreq/docs/libapreq2/group__mod__apreq2.html