### PR TITLE
(IAC-1186) Add new $use_servername_for_filenames parameter

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1717,6 +1717,12 @@
 #   client request exceeds that limit, the server will return an error response
 #   instead of servicing the request.
 #
+# @param $use_servername_for_filenames
+#   When set to true, default log / config file names will be derived from the sanitized
+#   value of the $servername parameter.
+#   When set to false (default), the existing behaviour of using the $name parameter
+#   will remain.
+
 define apache::vhost (
   Variant[Boolean,String] $docroot,
   $manage_docroot                                                                   = true,
@@ -1782,6 +1788,7 @@ define apache::vhost (
   $access_log_format                                                                = false,
   $access_log_env_var                                                               = false,
   Optional[Array] $access_logs                                                      = undef,
+  Optional[Boolean] $use_servername_for_filenames                                   = false,
   $aliases                                                                          = undef,
   Optional[Variant[Hash, Array[Variant[Array,Hash]]]] $directories                  = undef,
   Boolean $error_log                                                                = true,
@@ -2036,8 +2043,39 @@ define apache::vhost (
     $priority_real = '25-'
   }
 
-  ## Apache include does not always work with spaces in the filename
-  $filename = regsubst($name, ' ', '_', 'G')
+  # IAC-1186: A number of configuration and log file names are generated using the $name parameter. It is possible for
+  # the $name parameter to contain spaces, which could then be transferred to the log / config filenames. Although
+  # POSIX compliant, this can be cumbersome.
+  #
+  # It seems more appropriate to use the $servername parameter to derive default log / config filenames from. We should
+  # also perform some sanitiation on the $servername parameter to strip spaces from it, as it defaults to the value of
+  # $name, should $servername NOT be defined.
+  #
+  # We will retain the default behaviour for filenames but allow the use of a sanitized version of $servername to be
+  # used, using the new $use_servername_for_filenames parameter.
+  #
+  # This will default to false until the next major release (v6.0.0), at which point, we will default this to true and
+  # warn about it's imminent deprecation in the subsequent major release (v7.0.0)
+  #
+  # In v7.0.0, we will deprecate the $use_servername_for_filenames parameter altogether and use the sanitized value of
+  # $servername for default log / config filenames.
+  $filename = $use_servername_for_filenames ? {
+    true => regsubst($servername, ' ', '_', 'G'),
+    false => $name,
+  }
+
+  if ! $use_servername_for_filenames {
+    $use_servername_for_filenames_warn_msg = '
+    It is possible for the $name parameter to be defined with spaces in it. Although supported on POSIX systems, this
+    can lead to cumbersome file names. The $servername attribute has stricter conditions from Apache (i.e. no spaces)
+    When $use_servername_for_filenames = true, the $servername parameter, sanitized, is used to construct log and config
+    file names.
+
+    From version v6.0.0 of the puppetlabs-apache module, this parameter will default to true. From version v7.0.0 of the
+    module, the $use_servername_for_filenames will be removed and log/config file names will be dervied from the
+    sanitized $servername parameter when not explicitly defined.'
+    warning($use_servername_for_filenames_warn_msg)
+  }
 
   # This ensures that the docroot exists
   # But enables it to be specified across multiple vhost resources
@@ -2096,9 +2134,9 @@ define apache::vhost (
     $error_log_destination = $error_log_syslog
   } else {
     if $ssl {
-      $error_log_destination = "${logroot}/${name}_error_ssl.log"
+      $error_log_destination = "${logroot}/${filename}_error_ssl.log"
     } else {
-      $error_log_destination = "${logroot}/${name}_error.log"
+      $error_log_destination = "${logroot}/${filename}_error.log"
     }
   }
 
@@ -2117,9 +2155,9 @@ define apache::vhost (
     $modsec_audit_log_destination = $modsec_audit_log_pipe
   } elsif $modsec_audit_log {
     if $ssl {
-      $modsec_audit_log_destination = "${logroot}/${name}_security_ssl.log"
+      $modsec_audit_log_destination = "${logroot}/${filename}_security_ssl.log"
     } else {
-      $modsec_audit_log_destination = "${logroot}/${name}_security.log"
+      $modsec_audit_log_destination = "${logroot}/${filename}_security.log"
     }
   } else {
     $modsec_audit_log_destination = undef

--- a/templates/vhost/_access_log.erb
+++ b/templates/vhost/_access_log.erb
@@ -14,8 +14,8 @@
 <%   elsif log['pipe'] -%>
 <%     destination = log['pipe'] -%>
 <%   else -%>
-<%     destination ||= "#{@logroot}/#{@name}_access_ssl.log" if @ssl -%>
-<%     destination ||= "#{@logroot}/#{@name}_access.log" -%>
+<%     destination ||= "#{@logroot}/#{@filename}_access_ssl.log" if @ssl -%>
+<%     destination ||= "#{@logroot}/#{@filename}_access.log" -%>
 <%   end -%>
   CustomLog "<%= destination %>" <%= format %> <%= env %>
 <% end -%>


### PR DESCRIPTION
Prior to this commit, the `$filename` variable, which is used to
construct the filename of Apache's various config and log files,
obtained it's default value from the `$name` parameter.

As #2064 highlights, it is possible for `$name` to contain spaces
in it and this can cause cumbersome log file names, albeit POSIX
compliant.

Also related is #2068, which changes the `$filename` variable source
from `$name` to `$servername`. This arguably seems more appropriate,
especially given that `$servername` defaults to `$name` if undefined.

This commit attempts to create a satisfactory solution to both #2064
and #2068 by introducing the `$use_servername_for_filenames` param.
When set to `true`, a sanitized `$servername` parameter value will be
used to construct `$filename`.

When undefined or set to `$false`, it will retain the existing
behaviour and use the `$name` parameter value.

This will default to `false` until the next major release (v6.0.0),
after which it will default to `true`. Then, in the subsequent major
release (v7.0.0) it will be deprecated altogether and the default
behaviour will be to use the sanitized value of `$servername` for the
`$filename` var.

Warning messages are output to the console to alert users of this
change in behaviour.

Closes: #2064 , #2068 