### PR TITLE
Fix bool2httpd function call for older ruby versions

### DIFF
--- a/lib/puppet/functions/apache/bool2httpd.rb
+++ b/lib/puppet/functions/apache/bool2httpd.rb
@@ -25,6 +25,10 @@ Puppet::Functions.create_function(:'apache::bool2httpd') do
   private
 
   def matches_string?(value, matcher)
-    value.is_a?(String) && value.match?(matcher)
+    if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4.0')
+      value =~ matcher
+    else
+      value.is_a?(String) && value.match?(matcher)
+    end
   end
 end


### PR DESCRIPTION
Based on the changes in PR https://github.com/puppetlabs/puppetlabs-apache/pull/2060 added separate clause for older ruby versions as `match?` was introduced [here](https://www.ruby-lang.org/en/news/2016/12/25/ruby-2-4-0-released/)