### PR TITLE
Support GssapiBasicAuth

### DIFF
--- a/templates/vhost/_gssapi.epp
+++ b/templates/vhost/_gssapi.epp
@@ -1,10 +1,14 @@
 <%|
   # https://github.com/gssapi/mod_auth_gssapi
+  Optional[Enum['On','Off']] $basicauth = undef,
   Optional[String[1]]        $credstore = undef,
   Optional[Enum['On','Off']] $sslonly   = undef,
   Optional[Enum['On','Off']] $localname = undef,
 |%>
 # mod_auth_gssapi configuration
+<% if $basicauth { -%>
+    GssapiBasicAuth <%= $basicauth %>
+<% } -%>
 <% if $sslonly { -%>
     GssapiSSLonly <%= $sslonly %>
 <% } -%>


### PR DESCRIPTION
Adds support for the GssapiBasiAuth setting in mod_gssapi (which allows falling back to password authentication when spnego negotiate fails)