### PR TITLE
Compare with major release version

### DIFF
--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -17,7 +17,7 @@ class apache::default_mods (
       if versioncmp($apache_version, '2.4') >= 0 {
         # Lets fork it
         # Do not try to load mod_systemd on RHEL/CentOS 6 SCL.
-        if ( !($::osfamily == 'redhat' and versioncmp($::operatingsystemrelease, '7.0') == -1) and !($::operatingsystem == 'Amazon') ) {
+        if ( !($::osfamily == 'redhat' and versioncmp($::operatingsystemmajrelease, '7') == -1) and !($::operatingsystem == 'Amazon') ) {
           if ($use_systemd) {
             ::apache::mod { 'systemd': }
           }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -551,7 +551,7 @@ class apache (
     default => '(event|itk|prefork|worker)'
   }
 
-  if $::osfamily == 'RedHat' and $apache::version::distrelease == '7' {
+  if $::osfamily == 'RedHat' and $facts['operatingsystemmajrelease'] == '7' {
     # On redhat 7 the ssl.conf lives in /etc/httpd/conf.d (the confd_dir)
     # when all other module configs live in /etc/httpd/conf.modules.d (the
     # mod_dir). On all other platforms and versions, ssl.conf lives in the

--- a/manifests/mod/fastcgi.pp
+++ b/manifests/mod/fastcgi.pp
@@ -5,7 +5,7 @@
 #
 class apache::mod::fastcgi {
   include apache
-  if ($::osfamily == 'Redhat' and versioncmp($::operatingsystemrelease, '7.0') >= 0) {
+  if ($::osfamily == 'Redhat' and versioncmp($::operatingsystemmajrelease, '7') >= 0) {
     fail('mod_fastcgi is no longer supported on el7 and above.')
   }
   if ($facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['major'], '18.04') >= 0) {

--- a/manifests/mod/proxy_html.pp
+++ b/manifests/mod/proxy_html.pp
@@ -21,13 +21,13 @@ class apache::mod::proxy_html {
       }
       case $::operatingsystem {
         'Ubuntu': {
-          $loadfiles = $apache::params::distrelease ? {
+          $loadfiles = $facts['operatingsystemmajrelease'] ? {
             '10'    => ['/usr/lib/libxml2.so.2'],
             default => ["/usr/lib/${gnu_path}-linux-gnu/libxml2.so.2"],
           }
         }
         'Debian': {
-          $loadfiles = $apache::params::distrelease ? {
+          $loadfiles = $facts['operatingsystemmajrelease'] ? {
             '6'     => ['/usr/lib/libxml2.so.2'],
             default => ["/usr/lib/${gnu_path}-linux-gnu/libxml2.so.2"],
           }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -61,7 +61,7 @@ class apache::params inherits ::apache::version {
     $server_root          = "${httpd_root}/etc/httpd"
     $conf_dir             = "${httpd_dir}/conf"
     $confd_dir            = "${httpd_dir}/conf.d"
-    $mod_dir              = $apache::version::distrelease ? {
+    $mod_dir              = $facts['operatingsystemmajrelease'] ? {
       '7'     => "${httpd_dir}/conf.modules.d",
       default => "${httpd_dir}/conf.d",
     }
@@ -107,11 +107,11 @@ class apache::params inherits ::apache::version {
     $mime_support_package = 'mailcap'
     $mime_types_config    = '/etc/mime.types'
     $docroot              = "${httpd_root}/var/www/html"
-    $alias_icons_path     = $apache::version::distrelease ? {
+    $alias_icons_path     = $facts['operatingsystemmajrelease'] ? {
       '7'     => "${httpd_root}/usr/share/httpd/icons",
       default => '/var/www/icons',
     }
-    $error_documents_path = $apache::version::distrelease ? {
+    $error_documents_path = $facts['operatingsystemmajrelease'] ? {
       '7'     => "${httpd_root}/usr/share/httpd/error",
       default => '/var/www/error'
     }
@@ -172,7 +172,7 @@ class apache::params inherits ::apache::version {
       # Amazon Linux 2 uses the /conf.modules.d/ dir
       $mod_dir            = "${httpd_dir}/conf.modules.d"
     } else {
-      $mod_dir              = $apache::version::distrelease ? {
+      $mod_dir              = $facts['operatingsystemmajrelease'] ? {
         '7'     => "${httpd_dir}/conf.modules.d",
         '8'     => "${httpd_dir}/conf.modules.d",
         default => "${httpd_dir}/conf.d",
@@ -200,7 +200,7 @@ class apache::params inherits ::apache::version {
     $suphp_addhandler     = 'php5-script'
     $suphp_engine         = 'off'
     $suphp_configpath     = undef
-    $php_version = $apache::version::distrelease ? {
+    $php_version = $facts['operatingsystemmajrelease'] ? {
       '8'     => '7', # RedHat8
       default => '5', # RedHat5, RedHat6, RedHat7
     }
@@ -211,13 +211,13 @@ class apache::params inherits ::apache::version {
       'auth_gssapi'           => 'mod_auth_gssapi',
       'auth_mellon'           => 'mod_auth_mellon',
       'auth_openidc'          => 'mod_auth_openidc',
-      'authnz_ldap'           => $apache::version::distrelease ? {
+      'authnz_ldap'           => $facts['operatingsystemmajrelease'] ? {
         '7'     => 'mod_ldap',
         '8'     => 'mod_ldap',
         default => 'mod_authz_ldap',
       },
       'authnz_pam'            => 'mod_authnz_pam',
-      'fastcgi'               => $apache::version::distrelease ? {
+      'fastcgi'               => $facts['operatingsystemmajrelease'] ? {
         '5'     => 'mod_fastcgi',
         '6'     => 'mod_fastcgi',
         default => undef,
@@ -225,7 +225,7 @@ class apache::params inherits ::apache::version {
       'fcgid'                 => 'mod_fcgid',
       'geoip'                 => 'mod_geoip',
       'intercept_form_submit' => 'mod_intercept_form_submit',
-      'ldap'                  => $apache::version::distrelease ? {
+      'ldap'                  => $facts['operatingsystemmajrelease'] ? {
         '5'     => undef,
         '6'     => undef,
         default => 'mod_ldap',
@@ -239,7 +239,7 @@ class apache::params inherits ::apache::version {
       # https://www.phusionpassenger.com/library/install/apache/install/oss/el7/
       'passenger'             => 'mod_passenger',
       'perl'                  => 'mod_perl',
-      'php5'                  => $apache::version::distrelease ? {
+      'php5'                  => $facts['operatingsystemmajrelease'] ? {
         '5'     => 'php53',
         default => 'php',
       },
@@ -252,7 +252,7 @@ class apache::params inherits ::apache::version {
       # See http://wiki.aaf.edu.au/tech-info/sp-install-guide
       'shibboleth'            => 'shibboleth',
       'ssl'                   => 'mod_ssl',
-      'wsgi'                  => $apache::version::distrelease ? {
+      'wsgi'                  => $facts['operatingsystemmajrelease'] ? {
         '8'     => 'python3-mod_wsgi', # RedHat8
         default => 'mod_wsgi',         # RedHat5, RedHat6, RedHat7
       },
@@ -264,7 +264,7 @@ class apache::params inherits ::apache::version {
     }
     $mod_libs             = {
       'nss' => 'libmodnss.so',
-      'wsgi'                  => $apache::version::distrelease ? {
+      'wsgi'                  => $facts['operatingsystemmajrelease'] ? {
         '8'     => 'mod_wsgi_python3.so',
         default => 'mod_wsgi.so',
       },
@@ -278,12 +278,12 @@ class apache::params inherits ::apache::version {
     $mime_support_package = 'mailcap'
     $mime_types_config    = '/etc/mime.types'
     $docroot              = '/var/www/html'
-    $alias_icons_path     = $apache::version::distrelease ? {
+    $alias_icons_path     = $facts['operatingsystemmajrelease'] ? {
       '7'     => '/usr/share/httpd/icons',
       '8'     => '/usr/share/httpd/icons',
       default => '/var/www/icons',
     }
-    $error_documents_path = $apache::version::distrelease ? {
+    $error_documents_path = $facts['operatingsystemmajrelease'] ? {
       '7'     => '/usr/share/httpd/error',
       '8'     => '/usr/share/httpd/error',
       default => '/var/www/error'
@@ -790,7 +790,7 @@ class apache::params inherits ::apache::version {
     $verify_command = '/usr/sbin/apachectl -t'
   }
 
-  if $::osfamily == 'RedHat' and versioncmp($::operatingsystemrelease, '8.0') >= 0 {
+  if $::osfamily == 'RedHat' and versioncmp($facts['operatingsystemmajrelease'], '8') >= 0 {
     $ssl_protocol = ['all'] # Implementations of the SSLv2 and SSLv3 protocol versions have been removed from OpenSSL (and hence mod_ssl) because these are no longer considered secure. For additional documentation https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/deploying_different_types_of_servers/setting-apache-web-server_deploying-different-types-of-servers
   } else {
     $ssl_protocol = ['all', '-SSLv2', '-SSLv3']

--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -6,13 +6,6 @@ class apache::version (
   Optional[String] $scl_httpd_version = undef,
   Optional[String] $scl_php_version   = undef,
 ) {
-  # This will be 5 or 6 on RedHat, 6 or wheezy on Debian, 12 or quantal on Ubuntu, etc.
-  $osr_array = split($::operatingsystemrelease,'[\/\.]')
-  $distrelease = $osr_array[0]
-  if ! $distrelease {
-    fail("Class['apache::version']: Unparsable \$::operatingsystemrelease: ${::operatingsystemrelease}")
-  }
-
   case $::osfamily {
     'RedHat': {
       if $scl_httpd_version {
@@ -20,16 +13,16 @@ class apache::version (
       }
       elsif ($::operatingsystem == 'Amazon') {
         $default = '2.2'
-      } elsif ($::operatingsystem == 'Fedora' and versioncmp($distrelease, '18') >= 0) or ($::operatingsystem != 'Fedora' and versioncmp($distrelease, '7') >= 0) {
+      } elsif ($::operatingsystem == 'Fedora' and versioncmp($facts['operatingsystemmajrelease'], '18') >= 0) or ($::operatingsystem != 'Fedora' and versioncmp($facts['operatingsystemmajrelease'], '7') >= 0) {
         $default = '2.4'
       } else {
         $default = '2.2'
       }
     }
     'Debian': {
-      if $::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '13.10') >= 0 {
+      if $::operatingsystem == 'Ubuntu' and versioncmp($facts['operatingsystemmajrelease'], '13.10') >= 0 {
         $default = '2.4'
-      } elsif $::operatingsystem == 'Debian' and versioncmp($distrelease, '8') >= 0 {
+      } elsif $::operatingsystem == 'Debian' and versioncmp($facts['operatingsystemmajrelease'], '8') >= 0 {
         $default = '2.4'
       } else {
         $default = '2.2'
@@ -42,7 +35,7 @@ class apache::version (
       $default = '2.4'
     }
     'Suse': {
-      if ($::operatingsystem == 'SLES' and versioncmp($::operatingsystemrelease, '12') >= 0) or ($::operatingsystem == 'OpenSuSE' and versioncmp($::operatingsystemrelease, '42') >= 0) {
+      if ($::operatingsystem == 'SLES' and versioncmp($facts['operatingsystemmajrelease'], '12') >= 0) or ($::operatingsystem == 'OpenSuSE' and versioncmp($facts['operatingsystemmajrelease'], '42') >= 0) {
         $default = '2.4'
       } else {
         $default = '2.2'

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -65,6 +65,7 @@ shared_context 'Fedora 17' do
       osfamily: 'RedHat',
       operatingsystem: 'Fedora',
       operatingsystemrelease: '17',
+      operatingsystemmajrelease: '17',
       path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
     }
   end
@@ -78,6 +79,7 @@ shared_context 'Fedora 21' do
       osfamily: 'RedHat',
       operatingsystem: 'Fedora',
       operatingsystemrelease: '21',
+      operatingsystemmajrelease: '21',
       path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
     }
   end
@@ -91,6 +93,7 @@ shared_context 'Fedora 28' do
       osfamily: 'RedHat',
       operatingsystem: 'Fedora',
       operatingsystemrelease: '28',
+      operatingsystemmajrelease: '28',
       path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
     }
   end
@@ -104,6 +107,7 @@ shared_context 'Fedora Rawhide' do
       osfamily: 'RedHat',
       operatingsystem: 'Fedora',
       operatingsystemrelease: 'Rawhide',
+      operatingsystemmajrelease: 'Rawhide',
       path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
     }
   end
@@ -142,7 +146,8 @@ shared_context 'Gentoo' do
       kernel: 'Linux',
       osfamily: 'Gentoo',
       operatingsystem: 'Gentoo',
-      operatingsystemrelease: '3.16.1-gentoo',
+      operatingsystemrelease: '2.7',
+      operatingsystemmajrelease: '2.7',
       path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
     }
   end


### PR DESCRIPTION
CentOS 8 stream doesn't have a minor version so this check likely fails. However, it's irrelevant here and we can use the major release version fact instead.

There are a lot more odd cases with facts, but I don't want to touch too much code.