### PR TITLE
(MAINT) Perform pdk update

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -50,3 +50,6 @@ spec/spec_helper.rb:
   unmanaged: false
 .github/workflows/pr_test.yml:
   unmanaged: false
+Rakefile:
+  extras:
+    "FastGettext.default_text_domain = 'default-text-domain'"

--- a/Rakefile
+++ b/Rakefile
@@ -85,3 +85,4 @@ EOM
   end
 end
 
+FastGettext.default_text_domain = 'default-text-domain'


### PR DESCRIPTION
This was primarily done to add the following line to the Rakefile:
`FastGettext.default_text_domain = 'default-text-domain'` and
prevent syntax checks failing because of the text domain is not
set (which generates a return code of 1).