### PR TITLE
(MAINT) Use shared examples for facts + other spec cleanups

### DIFF
--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -4,18 +4,7 @@ require 'spec_helper'
 
 describe 'apache', type: :class do
   context 'on a Debian OS' do
-    let :facts do
-      {
-        id: 'root',
-        kernel: 'Linux',
-        lsbdistcodename: 'squeeze',
-        osfamily: 'Debian',
-        operatingsystem: 'Debian',
-        operatingsystemrelease: '6',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 6'
 
     it { is_expected.to contain_class('apache::params') }
     it {
@@ -244,10 +233,7 @@ describe 'apache', type: :class do
     end
 
     context '8' do
-      let :facts do
-        super().merge(lsbdistcodename: 'jessie',
-                      operatingsystemrelease: '8.0.0')
-      end
+      include_examples 'Debian 8'
 
       it {
         is_expected.to contain_file('/var/www/html').with(
@@ -265,11 +251,7 @@ describe 'apache', type: :class do
     end
 
     context 'on Ubuntu 14.04' do
-      let :facts do
-        super().merge(operatingsystem: 'Ubuntu',
-                      lsbdistrelease: '14.04',
-                      operatingsystemrelease: '14.04')
-      end
+      include_examples 'Ubuntu 14.04'
 
       it {
         is_expected.to contain_file('/var/www/html').with(
@@ -280,17 +262,7 @@ describe 'apache', type: :class do
   end
 
   context 'on a RedHat 5 OS' do
-    let :facts do
-      {
-        id: 'root',
-        kernel: 'Linux',
-        osfamily: 'RedHat',
-        operatingsystem: 'RedHat',
-        operatingsystemrelease: '5',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 5'
 
     it { is_expected.to contain_class('apache::params') }
     it {
@@ -667,46 +639,24 @@ describe 'apache', type: :class do
     end
 
     context 'on Fedora 21' do
-      let :facts do
-        super().merge(operatingsystem: 'Fedora',
-                      lsbdistrelease: '21',
-                      operatingsystemrelease: '21')
-      end
+      include_examples 'Fedora 21'
 
       it { is_expected.to contain_class('apache').with_apache_version('2.4') }
     end
     context 'on Fedora Rawhide' do
-      let :facts do
-        super().merge(operatingsystem: 'Fedora',
-                      lsbdistrelease: 'Rawhide',
-                      operatingsystemrelease: 'Rawhide')
-      end
+      include_examples 'Fedora Rawhide'
 
       it { is_expected.to contain_class('apache').with_apache_version('2.4') }
     end
     # kinda obsolete
     context 'on Fedora 17' do
-      let :facts do
-        super().merge(operatingsystem: 'Fedora',
-                      lsbdistrelease: '17',
-                      operatingsystemrelease: '17')
-      end
+      include_examples 'Fedora 17'
 
       it { is_expected.to contain_class('apache').with_apache_version('2.2') }
     end
   end
   context 'on a FreeBSD OS' do
-    let :facts do
-      {
-        id: 'root',
-        kernel: 'FreeBSD',
-        osfamily: 'FreeBSD',
-        operatingsystem: 'FreeBSD',
-        operatingsystemrelease: '10',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'FreeBSD 10'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_class('apache::package').with('ensure' => 'present') }
@@ -764,17 +714,7 @@ describe 'apache', type: :class do
     end
   end
   context 'on a Gentoo OS' do
-    let :facts do
-      {
-        id: 'root',
-        kernel: 'Linux',
-        osfamily: 'Gentoo',
-        operatingsystem: 'Gentoo',
-        operatingsystemrelease: '3.16.1-gentoo',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Gentoo'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_user('apache') }
@@ -805,17 +745,7 @@ describe 'apache', type: :class do
     }
   end
   context 'on all OSes' do
-    let :facts do
-      {
-        id: 'root',
-        kernel: 'Linux',
-        osfamily: 'RedHat',
-        operatingsystem: 'RedHat',
-        operatingsystemrelease: '6',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     context 'with a custom apache_name parameter' do
       let :params do
@@ -900,11 +830,7 @@ describe 'apache', type: :class do
     end
   end
   context 'with unsupported osfamily' do
-    let :facts do
-      { osfamily: 'Darwin',
-        operatingsystemrelease: '13.1.0',
-        is_pe: false }
-    end
+    include_examples 'Darwin'
 
     it { is_expected.to compile.and_raise_error(%r{Unsupported osfamily}) }
   end

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -252,8 +252,8 @@ describe 'apache', type: :class do
     end
   end
 
-  context 'on a RedHat 5 OS' do
-    include_examples 'RedHat 5'
+  context 'on a RedHat 8 OS' do
+    include_examples 'RedHat 8'
 
     it { is_expected.to contain_class('apache::params') }
     it {
@@ -301,7 +301,7 @@ describe 'apache', type: :class do
       end
 
       # Assert that load files are placed for these mods, but no conf file.
-      ['auth_basic', 'authn_file', 'authz_default', 'authz_groupfile', 'authz_host', 'authz_user', 'dav', 'env'].each do |modname|
+      ['auth_basic', 'authn_file', 'authz_groupfile', 'authz_host', 'authz_user', 'dav', 'env'].each do |modname|
         it {
           is_expected.to contain_file("#{modname}.load").with_path(
             "/etc/httpd/mod.d/#{modname}.load",
@@ -328,7 +328,7 @@ describe 'apache', type: :class do
         }
       end
 
-      it { is_expected.to contain_file('/etc/httpd/conf/httpd.conf').with_content %r{^Include "/etc/httpd/site\.d/\*"$} }
+      it { is_expected.to contain_file('/etc/httpd/conf/httpd.conf').with_content %r{^IncludeOptional "/etc/httpd/site\.d/\*"$} }
       it { is_expected.to contain_file('/etc/httpd/conf/httpd.conf').with_content %r{^Include "/etc/httpd/mod\.d/\*\.conf"$} }
       it { is_expected.to contain_file('/etc/httpd/conf/httpd.conf').with_content %r{^Include "/etc/httpd/mod\.d/\*\.load"$} }
     end

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'apache', type: :class do
   context 'on a Debian OS' do
-    include_examples 'Debian 6'
+    include_examples 'Debian 8'
 
     it { is_expected.to contain_class('apache::params') }
     it {
@@ -17,7 +17,7 @@ describe 'apache', type: :class do
     it { is_expected.to contain_group('www-data') }
     it { is_expected.to contain_class('apache::service') }
     it {
-      is_expected.to contain_file('/var/www').with(
+      is_expected.to contain_file('/var/www/html').with(
         'ensure' => 'directory',
       )
     }
@@ -46,7 +46,7 @@ describe 'apache', type: :class do
       ).that_notifies('Class[Apache::Service]')
     }
     # Assert that load files are placed and symlinked for these mods, but no conf file.
-    ['auth_basic', 'authn_file', 'authz_default', 'authz_groupfile', 'authz_host', 'authz_user', 'dav', 'env'].each do |modname|
+    ['auth_basic', 'authn_file', 'authz_groupfile', 'authz_host', 'authz_user', 'dav', 'env'].each do |modname|
       it {
         is_expected.to contain_file("#{modname}.load").with(
           'path'   => "/etc/apache2/mods-available/#{modname}.load",
@@ -232,22 +232,13 @@ describe 'apache', type: :class do
       end
     end
 
-    context '8' do
-      include_examples 'Debian 8'
-
-      it {
-        is_expected.to contain_file('/var/www/html').with(
-          'ensure' => 'directory',
-        )
-      }
-      describe 'Alternate mpm_modules when declaring mpm_module => prefork' do
-        let :params do
-          { mpm_module: 'worker' }
-        end
-
-        it { is_expected.to contain_exec('/usr/sbin/a2dismod event') }
-        it { is_expected.to contain_exec('/usr/sbin/a2dismod prefork') }
+    describe 'Alternate mpm_modules when declaring mpm_module => prefork' do
+      let :params do
+        { mpm_module: 'worker' }
       end
+
+      it { is_expected.to contain_exec('/usr/sbin/a2dismod event') }
+      it { is_expected.to contain_exec('/usr/sbin/a2dismod prefork') }
     end
 
     context 'on Ubuntu 14.04' do

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -241,8 +241,8 @@ describe 'apache', type: :class do
       it { is_expected.to contain_exec('/usr/sbin/a2dismod prefork') }
     end
 
-    context 'on Ubuntu 14.04' do
-      include_examples 'Ubuntu 14.04'
+    context 'on Ubuntu 18.04' do
+      include_examples 'Ubuntu 18.04'
 
       it {
         is_expected.to contain_file('/var/www/html').with(

--- a/spec/classes/mod/alias_spec.rb
+++ b/spec/classes/mod/alias_spec.rb
@@ -7,66 +7,25 @@ describe 'apache::mod::alias', type: :class do
 
   context 'default configuration with parameters' do
     context 'on a Debian OS', :compile do
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'Linux',
-          lsbdistcodename: 'jessie',
-          osfamily: 'Debian',
-          operatingsystem: 'Debian',
-          operatingsystemrelease: '8',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'Debian 8'
 
       it { is_expected.to contain_apache__mod('alias') }
       it { is_expected.to contain_file('alias.conf').with(content: %r{Alias \/icons\/ "\/usr\/share\/apache2\/icons\/"}) }
     end
     context 'on a RedHat 6-based OS', :compile do
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'Linux',
-          osfamily: 'RedHat',
-          operatingsystem: 'RedHat',
-          operatingsystemrelease: '6',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'RedHat 6'
 
       it { is_expected.to contain_apache__mod('alias') }
       it { is_expected.to contain_file('alias.conf').with(content: %r{Alias \/icons\/ "\/var\/www\/icons\/"}) }
     end
     context 'on a RedHat 7-based OS', :compile do
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'Linux',
-          osfamily: 'RedHat',
-          operatingsystem: 'RedHat',
-          operatingsystemrelease: '7',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'RedHat 7'
 
       it { is_expected.to contain_apache__mod('alias') }
       it { is_expected.to contain_file('alias.conf').with(content: %r{Alias \/icons\/ "\/usr\/share\/httpd\/icons\/"}) }
     end
     context 'on a RedHat 8-based OS', :compile do
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'Linux',
-          osfamily: 'RedHat',
-          operatingsystem: 'RedHat',
-          operatingsystemrelease: '8',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'RedHat 8'
 
       it { is_expected.to contain_apache__mod('alias') }
       it { is_expected.to contain_file('alias.conf').with(content: %r{Alias \/icons\/ "\/usr\/share\/httpd\/icons\/"}) }
@@ -75,22 +34,13 @@ describe 'apache::mod::alias', type: :class do
       let :pre_condition do
         'class { apache: default_mods => false }'
       end
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'Linux',
-          osfamily: 'RedHat',
-          operatingsystem: 'RedHat',
-          operatingsystemrelease: '7',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
       let :params do
         {
           'icons_options' => 'foo',
         }
       end
+
+      include_examples 'RedHat 7'
 
       it { is_expected.to contain_apache__mod('alias') }
       it { is_expected.to contain_file('alias.conf').with(content: %r{Options foo}) }
@@ -99,38 +49,19 @@ describe 'apache::mod::alias', type: :class do
       let :pre_condition do
         'class { apache: default_mods => false }'
       end
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'Linux',
-          osfamily: 'RedHat',
-          operatingsystem: 'RedHat',
-          operatingsystemrelease: '7',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
       let :params do
         {
           'icons_prefix' => 'apache-icons',
         }
       end
 
+      include_examples 'RedHat 7'
+
       it { is_expected.to contain_apache__mod('alias') }
       it { is_expected.to contain_file('alias.conf').with(content: %r{Alias \/apache-icons\/ "\/usr\/share\/httpd\/icons\/"}) }
     end
     context 'on a FreeBSD OS', :compile do
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'FreeBSD',
-          osfamily: 'FreeBSD',
-          operatingsystem: 'FreeBSD',
-          operatingsystemrelease: '10',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'FreeBSD 10'
 
       it { is_expected.to contain_apache__mod('alias') }
       it { is_expected.to contain_file('alias.conf').with(content: %r{Alias \/icons\/ "\/usr\/local\/www\/apache24\/icons\/"}) }

--- a/spec/classes/mod/auth_cas_spec.rb
+++ b/spec/classes/mod/auth_cas_spec.rb
@@ -24,18 +24,7 @@ describe 'apache::mod::auth_cas', type: :class do
     end
 
     context 'on a Debian OS', :compile do
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'Linux',
-          lsbdistcodename: 'jessie',
-          osfamily: 'Debian',
-          operatingsystem: 'Debian',
-          operatingsystemrelease: '8',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'Debian 8'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('auth_cas') }
@@ -44,17 +33,7 @@ describe 'apache::mod::auth_cas', type: :class do
       it { is_expected.to contain_file('/var/cache/apache2/mod_auth_cas/').with_owner('www-data') }
     end
     context 'on a RedHat OS', :compile do
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'Linux',
-          osfamily: 'RedHat',
-          operatingsystem: 'RedHat',
-          operatingsystemrelease: '6',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'RedHat 6'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('auth_cas') }
@@ -68,17 +47,7 @@ describe 'apache::mod::auth_cas', type: :class do
         "class { 'apache': } apache::vhost { 'test.server': docroot => '/var/www/html', cas_root_proxied_as => 'http://test.server', cas_cookie_path => '/my/cas/path'} "
       end
 
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'Linux',
-          osfamily: 'RedHat',
-          operatingsystem: 'RedHat',
-          operatingsystemrelease: '6',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'RedHat 6'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('auth_cas') }

--- a/spec/classes/mod/auth_gssapi_spec.rb
+++ b/spec/classes/mod/auth_gssapi_spec.rb
@@ -7,7 +7,7 @@ describe 'apache::mod::auth_gssapi', type: :class do
 
   context 'default configuration with parameters' do
     context 'on a Debian OS', :compile do
-      include_examples 'Debian 6'
+      include_examples 'Debian 8'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('auth_gssapi') }

--- a/spec/classes/mod/auth_gssapi_spec.rb
+++ b/spec/classes/mod/auth_gssapi_spec.rb
@@ -7,69 +7,28 @@ describe 'apache::mod::auth_gssapi', type: :class do
 
   context 'default configuration with parameters' do
     context 'on a Debian OS', :compile do
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'Linux',
-          lsbdistcodename: 'squeeze',
-          osfamily: 'Debian',
-          operatingsystem: 'Debian',
-          operatingsystemrelease: '6',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'Debian 6'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('auth_gssapi') }
       it { is_expected.to contain_package('libapache2-mod-auth-gssapi') }
     end
     context 'on a RedHat OS', :compile do
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'Linux',
-          osfamily: 'RedHat',
-          operatingsystem: 'RedHat',
-          operatingsystemrelease: '6',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'RedHat 6'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('auth_gssapi') }
       it { is_expected.to contain_package('mod_auth_gssapi') }
     end
     context 'on a FreeBSD OS', :compile do
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'FreeBSD',
-          osfamily: 'FreeBSD',
-          operatingsystem: 'FreeBSD',
-          operatingsystemrelease: '9',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'FreeBSD 9'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('auth_gssapi') }
       it { is_expected.to contain_package('www/mod_auth_gssapi') }
     end
     context 'on a Gentoo OS', :compile do
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'Linux',
-          osfamily: 'Gentoo',
-          operatingsystem: 'Gentoo',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
-          operatingsystemrelease: '3.16.1-gentoo',
-          is_pe: false,
-        }
-      end
+      include_examples 'Gentoo'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('auth_gssapi') }

--- a/spec/classes/mod/auth_kerb_spec.rb
+++ b/spec/classes/mod/auth_kerb_spec.rb
@@ -7,7 +7,7 @@ describe 'apache::mod::auth_kerb', type: :class do
 
   context 'default configuration with parameters' do
     context 'on a Debian OS', :compile do
-      include_examples 'Debian 6'
+      include_examples 'Debian 8'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('auth_kerb') }

--- a/spec/classes/mod/auth_kerb_spec.rb
+++ b/spec/classes/mod/auth_kerb_spec.rb
@@ -7,69 +7,28 @@ describe 'apache::mod::auth_kerb', type: :class do
 
   context 'default configuration with parameters' do
     context 'on a Debian OS', :compile do
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'Linux',
-          lsbdistcodename: 'jessie',
-          osfamily: 'Debian',
-          operatingsystem: 'Debian',
-          operatingsystemrelease: '8',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'Debian 6'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('auth_kerb') }
       it { is_expected.to contain_package('libapache2-mod-auth-kerb') }
     end
     context 'on a RedHat OS', :compile do
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'Linux',
-          osfamily: 'RedHat',
-          operatingsystem: 'RedHat',
-          operatingsystemrelease: '6',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'RedHat 6'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('auth_kerb') }
       it { is_expected.to contain_package('mod_auth_kerb') }
     end
     context 'on a FreeBSD OS', :compile do
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'FreeBSD',
-          osfamily: 'FreeBSD',
-          operatingsystem: 'FreeBSD',
-          operatingsystemrelease: '9',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'FreeBSD 9'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('auth_kerb') }
       it { is_expected.to contain_package('www/mod_auth_kerb2') }
     end
     context 'on a Gentoo OS', :compile do
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'Linux',
-          osfamily: 'Gentoo',
-          operatingsystem: 'Gentoo',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
-          operatingsystemrelease: '3.16.1-gentoo',
-          is_pe: false,
-        }
-      end
+      include_examples 'Gentoo'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('auth_kerb') }
@@ -78,17 +37,7 @@ describe 'apache::mod::auth_kerb', type: :class do
   end
   context 'overriding mod_packages' do
     context 'on a RedHat OS', :compile do
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'Linux',
-          osfamily: 'RedHat',
-          operatingsystem: 'RedHat',
-          operatingsystemrelease: '6',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'RedHat 6'
       let :pre_condition do
         <<-MANIFEST
         include apache::params

--- a/spec/classes/mod/auth_mellon_spec.rb
+++ b/spec/classes/mod/auth_mellon_spec.rb
@@ -6,19 +6,7 @@ describe 'apache::mod::auth_mellon', type: :class do
   it_behaves_like 'a mod class, without including apache'
 
   context 'default configuration with parameters on a Debian OS' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        lsbdistcodename: 'jessie',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        fqdn: 'test.example.com',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     describe 'with no parameters' do
       it { is_expected.to contain_apache__mod('auth_mellon') }
@@ -47,18 +35,7 @@ describe 'apache::mod::auth_mellon', type: :class do
     end
   end
   context 'default configuration with parameters on a RedHat OS' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystemrelease: '6',
-        operatingsystem: 'RedHat',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        fqdn: 'test.example.com',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     describe 'with no parameters' do
       it { is_expected.to contain_apache__mod('auth_mellon') }

--- a/spec/classes/mod/auth_openidc_spec.rb
+++ b/spec/classes/mod/auth_openidc_spec.rb
@@ -7,52 +7,21 @@ describe 'apache::mod::auth_openidc', type: :class do
 
   context 'default configuration with parameters' do
     context 'on a Debian OS', :compile do
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'Linux',
-          lsbdistcodename: 'jessie',
-          osfamily: 'Debian',
-          operatingsystem: 'Debian',
-          operatingsystemrelease: '8',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'Debian 8'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('auth_openidc') }
       it { is_expected.to contain_package('libapache2-mod-auth-openidc') }
     end
     context 'on a RedHat OS', :compile do
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'Linux',
-          osfamily: 'RedHat',
-          operatingsystem: 'RedHat',
-          operatingsystemrelease: '6',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'RedHat 6'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('auth_openidc') }
       it { is_expected.to contain_package('mod_auth_openidc') }
     end
     context 'on a FreeBSD OS', :compile do
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'FreeBSD',
-          osfamily: 'FreeBSD',
-          operatingsystem: 'FreeBSD',
-          operatingsystemrelease: '9',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'FreeBSD 9'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('auth_openidc') }
@@ -61,17 +30,7 @@ describe 'apache::mod::auth_openidc', type: :class do
   end
   context 'overriding mod_packages' do
     context 'on a RedHat OS', :compile do
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'Linux',
-          osfamily: 'RedHat',
-          operatingsystem: 'RedHat',
-          operatingsystemrelease: '6',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'RedHat 6'
       let :pre_condition do
         <<-MANIFEST
         include apache::params

--- a/spec/classes/mod/authn_dbd_spec.rb
+++ b/spec/classes/mod/authn_dbd_spec.rb
@@ -23,18 +23,7 @@ describe 'apache::mod::authn_dbd', type: :class do
     end
 
     context 'on a Debian OS', :compile do
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'Linux',
-          lsbdistcodename: 'jessie',
-          osfamily: 'Debian',
-          operatingsystem: 'Debian',
-          operatingsystemrelease: '8',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'Debian 8'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('authn_dbd') }
@@ -43,17 +32,7 @@ describe 'apache::mod::authn_dbd', type: :class do
     end
 
     context 'on a RedHat OS', :compile do
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'Linux',
-          osfamily: 'RedHat',
-          operatingsystem: 'RedHat',
-          operatingsystemrelease: '6',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'RedHat 6'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('authn_dbd') }

--- a/spec/classes/mod/authnz_ldap_spec.rb
+++ b/spec/classes/mod/authnz_ldap_spec.rb
@@ -6,18 +6,7 @@ describe 'apache::mod::authnz_ldap', type: :class do
   it_behaves_like 'a mod class, without including apache'
 
   context 'default configuration with parameters on a Debian OS' do
-    let :facts do
-      {
-        lsbdistcodename: 'jessie',
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        id: 'root',
-        kernel: 'Linux',
-        operatingsystem: 'Debian',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_class('apache::mod::ldap') }

--- a/spec/classes/mod/authnz_pam_spec.rb
+++ b/spec/classes/mod/authnz_pam_spec.rb
@@ -7,18 +7,7 @@ describe 'apache::mod::authnz_pam', type: :class do
 
   context 'default configuration with parameters' do
     context 'on a Debian OS' do
-      let :facts do
-        {
-          lsbdistcodename: 'jessie',
-          osfamily: 'Debian',
-          operatingsystemrelease: '8',
-          id: 'root',
-          kernel: 'Linux',
-          operatingsystem: 'Debian',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'Debian 8'
 
       it { is_expected.to contain_class('apache') }
       it { is_expected.to contain_package('libapache2-mod-authnz-pam') }
@@ -26,17 +15,7 @@ describe 'apache::mod::authnz_pam', type: :class do
     end # Debian
 
     context 'on a RedHat OS' do
-      let :facts do
-        {
-          osfamily: 'RedHat',
-          operatingsystemrelease: '8',
-          id: 'root',
-          kernel: 'Linux',
-          operatingsystem: 'RedHat',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'RedHat 8'
 
       it { is_expected.to contain_class('apache') }
       it { is_expected.to contain_package('mod_authnz_pam') }

--- a/spec/classes/mod/cluster_spec.rb
+++ b/spec/classes/mod/cluster_spec.rb
@@ -4,17 +4,7 @@ require 'spec_helper'
 
 describe 'apache::mod::cluster', type: :class do
   context 'on a RedHat OS Release 7 with mod version = 1.3.0' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystemrelease: '7',
-        operatingsystem: 'RedHat',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 7'
 
     let(:params) do
       {
@@ -37,17 +27,7 @@ describe 'apache::mod::cluster', type: :class do
   end
 
   context 'on a RedHat OS Release 7 with mod version > 1.3.0' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystemrelease: '7',
-        operatingsystem: 'RedHat',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 7'
 
     let(:params) do
       {
@@ -70,17 +50,7 @@ describe 'apache::mod::cluster', type: :class do
   end
 
   context 'on a RedHat OS Release 6 with mod version < 1.3.0' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystemrelease: '6',
-        operatingsystem: 'RedHat',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     let(:params) do
       {

--- a/spec/classes/mod/data_spec.rb
+++ b/spec/classes/mod/data_spec.rb
@@ -4,17 +4,7 @@ require 'spec_helper'
 
 describe 'apache::mod::data', type: :class do
   context 'on a Debian OS' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        lsbdistcodename: 'jessie',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-      }
-    end
+    include_examples 'Debian 8'
     let :params do
       { apache_version: '2.4' }
     end

--- a/spec/classes/mod/dav_svn_spec.rb
+++ b/spec/classes/mod/dav_svn_spec.rb
@@ -7,19 +7,7 @@ describe 'apache::mod::dav_svn', type: :class do
 
   context 'default configuration with parameters' do
     context 'on a Debian OS' do
-      let :facts do
-        {
-          lsbdistcodename: 'jessie',
-          osfamily: 'Debian',
-          operatingsystemrelease: '8',
-          operatingsystemmajrelease: '8',
-          operatingsystem: 'Debian',
-          id: 'root',
-          kernel: 'Linux',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'Debian 8'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('dav_svn') }
@@ -40,18 +28,7 @@ describe 'apache::mod::dav_svn', type: :class do
       end
     end
     context 'on a RedHat OS' do
-      let :facts do
-        {
-          osfamily: 'RedHat',
-          operatingsystemrelease: '6',
-          operatingsystemmajrelease: '6',
-          operatingsystem: 'RedHat',
-          id: 'root',
-          kernel: 'Linux',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'RedHat 6'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('dav_svn') }
@@ -72,18 +49,7 @@ describe 'apache::mod::dav_svn', type: :class do
       end
     end
     context 'on a FreeBSD OS' do
-      let :facts do
-        {
-          osfamily: 'FreeBSD',
-          operatingsystemrelease: '9',
-          operatingsystemmajrelease: '9',
-          operatingsystem: 'FreeBSD',
-          id: 'root',
-          kernel: 'Linux',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'FreeBSD 9'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('dav_svn') }
@@ -105,17 +71,7 @@ describe 'apache::mod::dav_svn', type: :class do
       end
     end
     context 'on a Gentoo OS', :compile do
-      let :facts do
-        {
-          id: 'root',
-          operatingsystemrelease: '3.16.1-gentoo',
-          kernel: 'Linux',
-          osfamily: 'Gentoo',
-          operatingsystem: 'Gentoo',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'Gentoo'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('dav_svn') }

--- a/spec/classes/mod/deflate_spec.rb
+++ b/spec/classes/mod/deflate_spec.rb
@@ -37,18 +37,7 @@ describe 'apache::mod::deflate', type: :class do
     end
 
     context 'On a Debian OS with default params' do
-      let :facts do
-        {
-          id: 'root',
-          lsbdistcodename: 'jessie',
-          kernel: 'Linux',
-          osfamily: 'Debian',
-          operatingsystem: 'Debian',
-          operatingsystemrelease: '8',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'Debian 8'
 
       # Load the more generic tests for this context
       general_deflate_specs
@@ -64,17 +53,7 @@ describe 'apache::mod::deflate', type: :class do
     end
 
     context 'on a RedHat OS with default params' do
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'Linux',
-          osfamily: 'RedHat',
-          operatingsystem: 'RedHat',
-          operatingsystemrelease: '6',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'RedHat 6'
 
       # Load the more generic tests for this context
       general_deflate_specs
@@ -83,17 +62,7 @@ describe 'apache::mod::deflate', type: :class do
     end
 
     context 'On a FreeBSD OS with default params' do
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'FreeBSD',
-          osfamily: 'FreeBSD',
-          operatingsystem: 'FreeBSD',
-          operatingsystemrelease: '9',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'FreeBSD 9'
 
       # Load the more generic tests for this context
       general_deflate_specs
@@ -105,17 +74,7 @@ describe 'apache::mod::deflate', type: :class do
     end
 
     context 'On a Gentoo OS with default params' do
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'Linux',
-          osfamily: 'Gentoo',
-          operatingsystem: 'Gentoo',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
-          operatingsystemrelease: '3.16.1-gentoo',
-          is_pe: false,
-        }
-      end
+      include_examples 'Gentoo'
 
       # Load the more generic tests for this context
       general_deflate_specs

--- a/spec/classes/mod/dev_spec.rb
+++ b/spec/classes/mod/dev_spec.rb
@@ -11,24 +11,9 @@ describe 'apache::mod::dev', type: :class do
 
   it_behaves_like 'a mod class, without including apache'
 
-  [
-    ['RedHat', '6', 'Santiago', 'Linux'],
-    ['Debian', '8', 'jessie', 'Linux'],
-    ['FreeBSD', '9', 'FreeBSD', 'FreeBSD'],
-  ].each do |osfamily, operatingsystemrelease, lsbdistcodename, kernel|
-    context "on a #{osfamily} OS" do
-      let :facts do
-        {
-          lsbdistcodename: lsbdistcodename,
-          osfamily: osfamily,
-          operatingsystem: osfamily,
-          operatingsystemrelease: operatingsystemrelease,
-          is_pe: false,
-          id: 'root',
-          path: '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
-          kernel: kernel,
-        }
-      end
+  ['RedHat 6', 'Debian 8', 'FreeBSD 9'].each do |os|
+    context "on a #{os} OS" do
+      include_examples os
 
       it { is_expected.to contain_class('apache::dev') }
     end

--- a/spec/classes/mod/dir_spec.rb
+++ b/spec/classes/mod/dir_spec.rb
@@ -3,106 +3,31 @@
 require 'spec_helper'
 
 describe 'apache::mod::dir', type: :class do
-  it_behaves_like 'a mod class, without including apache'
+  ['Debian 8', 'RedHat 6', 'FreeBSD 9', 'Gentoo'].each do |os|
+    context "default configuration with parameters on #{os}" do
+      include_examples os
 
-  context 'default configuration with parameters on a Debian OS' do
-    include_examples 'Debian 8'
-
-    context 'passing no parameters' do
-      it { is_expected.to contain_class('apache::params') }
-      it { is_expected.to contain_apache__mod('dir') }
-      it do
-        is_expected.to contain_file('dir.conf')
-          .with_content(%r{^DirectoryIndex })
-          .with_content(%r{ index\.html })
-          .with_content(%r{ index\.html\.var })
-          .with_content(%r{ index\.cgi })
-          .with_content(%r{ index\.pl })
-          .with_content(%r{ index\.php })
-          .with_content(%r{ index\.xhtml$})
+      context 'passing no parameters' do
+        it { is_expected.to contain_class('apache::params') }
+        it { is_expected.to contain_apache__mod('dir') }
+        it do
+          is_expected.to contain_file('dir.conf')
+            .with_content(%r{^DirectoryIndex })
+            .with_content(%r{ index\.html })
+            .with_content(%r{ index\.html\.var })
+            .with_content(%r{ index\.cgi })
+            .with_content(%r{ index\.pl })
+            .with_content(%r{ index\.php })
+            .with_content(%r{ index\.xhtml$})
+        end
       end
-    end
-    context "passing indexes => ['example.txt','fearsome.aspx']" do
-      let :params do
-        { indexes: ['example.txt', 'fearsome.aspx'] }
-      end
+      context "passing indexes => ['example.txt','fearsome.aspx']" do
+        let :params do
+          { indexes: ['example.txt', 'fearsome.aspx'] }
+        end
 
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ example\.txt }).with_content(%r{ fearsome\.aspx$}) }
-    end
-  end
-  context 'default configuration with parameters on a RedHat OS' do
-    include_examples 'RedHat 6'
-
-    context 'passing no parameters' do
-      it { is_expected.to contain_class('apache::params') }
-      it { is_expected.to contain_apache__mod('dir') }
-      it do
-        is_expected.to contain_file('dir.conf')
-          .with_content(%r{^DirectoryIndex })
-          .with_content(%r{ index\.html })
-          .with_content(%r{ index\.html\.var })
-          .with_content(%r{ index\.cgi })
-          .with_content(%r{ index\.pl })
-          .with_content(%r{ index\.php })
-          .with_content(%r{ index\.xhtml$})
+        it { is_expected.to contain_file('dir.conf').with_content(%r{ example\.txt }).with_content(%r{ fearsome\.aspx$}) }
       end
-    end
-    context "passing indexes => ['example.txt','fearsome.aspx']" do
-      let :params do
-        { indexes: ['example.txt', 'fearsome.aspx'] }
-      end
-
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ example\.txt }).with_content(%r{ fearsome\.aspx$}) }
-    end
-  end
-  context 'default configuration with parameters on a FreeBSD OS' do
-    include_examples 'FreeBSD 9'
-
-    context 'passing no parameters' do
-      it { is_expected.to contain_class('apache::params') }
-      it { is_expected.to contain_apache__mod('dir') }
-      it do
-        is_expected.to contain_file('dir.conf')
-          .with_content(%r{^DirectoryIndex })
-          .with_content(%r{ index\.html })
-          .with_content(%r{ index\.html\.var })
-          .with_content(%r{ index\.cgi })
-          .with_content(%r{ index\.pl })
-          .with_content(%r{ index\.php })
-          .with_content(%r{ index\.xhtml$})
-      end
-    end
-    context "passing indexes => ['example.txt','fearsome.aspx']" do
-      let :params do
-        { indexes: ['example.txt', 'fearsome.aspx'] }
-      end
-
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ example\.txt }).with_content(%r{ fearsome\.aspx$}) }
-    end
-  end
-  context 'default configuration with parameters on a Gentoo OS' do
-    include_examples 'Gentoo'
-
-    context 'passing no parameters' do
-      it { is_expected.to contain_class('apache::params') }
-      it { is_expected.to contain_apache__mod('dir') }
-      it do
-        is_expected.to contain_file('dir.conf')
-          .with_content(%r{^DirectoryIndex })
-          .with_content(%r{ index\.html })
-          .with_content(%r{ index\.html\.var })
-          .with_content(%r{ index\.cgi })
-          .with_content(%r{ index\.pl })
-          .with_content(%r{ index\.php })
-          .with_content(%r{ index\.xhtml$})
-      end
-    end
-    context "passing indexes => ['example.txt','fearsome.aspx']" do
-      let :params do
-        { indexes: ['example.txt', 'fearsome.aspx'] }
-      end
-
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ example\.txt }).with_content(%r{ fearsome\.aspx$}) }
     end
   end
 end

--- a/spec/classes/mod/dir_spec.rb
+++ b/spec/classes/mod/dir_spec.rb
@@ -11,21 +11,23 @@ describe 'apache::mod::dir', type: :class do
     context 'passing no parameters' do
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('dir') }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{^DirectoryIndex }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ index\.html }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ index\.html\.var }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ index\.cgi }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ index\.pl }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ index\.php }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ index\.xhtml$}) }
+      it do
+        is_expected.to contain_file('dir.conf')
+          .with_content(%r{^DirectoryIndex })
+          .with_content(%r{ index\.html })
+          .with_content(%r{ index\.html\.var })
+          .with_content(%r{ index\.cgi })
+          .with_content(%r{ index\.pl })
+          .with_content(%r{ index\.php })
+          .with_content(%r{ index\.xhtml$})
+      end
     end
     context "passing indexes => ['example.txt','fearsome.aspx']" do
       let :params do
         { indexes: ['example.txt', 'fearsome.aspx'] }
       end
 
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ example\.txt }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ fearsome\.aspx$}) }
+      it { is_expected.to contain_file('dir.conf').with_content(%r{ example\.txt }).with_content(%r{ fearsome\.aspx$}) }
     end
   end
   context 'default configuration with parameters on a RedHat OS' do
@@ -34,21 +36,23 @@ describe 'apache::mod::dir', type: :class do
     context 'passing no parameters' do
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('dir') }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{^DirectoryIndex }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ index\.html }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ index\.html\.var }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ index\.cgi }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ index\.pl }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ index\.php }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ index\.xhtml$}) }
+      it do
+        is_expected.to contain_file('dir.conf')
+          .with_content(%r{^DirectoryIndex })
+          .with_content(%r{ index\.html })
+          .with_content(%r{ index\.html\.var })
+          .with_content(%r{ index\.cgi })
+          .with_content(%r{ index\.pl })
+          .with_content(%r{ index\.php })
+          .with_content(%r{ index\.xhtml$})
+      end
     end
     context "passing indexes => ['example.txt','fearsome.aspx']" do
       let :params do
         { indexes: ['example.txt', 'fearsome.aspx'] }
       end
 
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ example\.txt }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ fearsome\.aspx$}) }
+      it { is_expected.to contain_file('dir.conf').with_content(%r{ example\.txt }).with_content(%r{ fearsome\.aspx$}) }
     end
   end
   context 'default configuration with parameters on a FreeBSD OS' do
@@ -57,21 +61,23 @@ describe 'apache::mod::dir', type: :class do
     context 'passing no parameters' do
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('dir') }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{^DirectoryIndex }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ index\.html }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ index\.html\.var }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ index\.cgi }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ index\.pl }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ index\.php }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ index\.xhtml$}) }
+      it do
+        is_expected.to contain_file('dir.conf')
+          .with_content(%r{^DirectoryIndex })
+          .with_content(%r{ index\.html })
+          .with_content(%r{ index\.html\.var })
+          .with_content(%r{ index\.cgi })
+          .with_content(%r{ index\.pl })
+          .with_content(%r{ index\.php })
+          .with_content(%r{ index\.xhtml$})
+      end
     end
     context "passing indexes => ['example.txt','fearsome.aspx']" do
       let :params do
         { indexes: ['example.txt', 'fearsome.aspx'] }
       end
 
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ example\.txt }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ fearsome\.aspx$}) }
+      it { is_expected.to contain_file('dir.conf').with_content(%r{ example\.txt }).with_content(%r{ fearsome\.aspx$}) }
     end
   end
   context 'default configuration with parameters on a Gentoo OS' do
@@ -80,21 +86,23 @@ describe 'apache::mod::dir', type: :class do
     context 'passing no parameters' do
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('dir') }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{^DirectoryIndex }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ index\.html }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ index\.html\.var }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ index\.cgi }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ index\.pl }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ index\.php }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ index\.xhtml$}) }
+      it do
+        is_expected.to contain_file('dir.conf')
+          .with_content(%r{^DirectoryIndex })
+          .with_content(%r{ index\.html })
+          .with_content(%r{ index\.html\.var })
+          .with_content(%r{ index\.cgi })
+          .with_content(%r{ index\.pl })
+          .with_content(%r{ index\.php })
+          .with_content(%r{ index\.xhtml$})
+      end
     end
     context "passing indexes => ['example.txt','fearsome.aspx']" do
       let :params do
         { indexes: ['example.txt', 'fearsome.aspx'] }
       end
 
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ example\.txt }) }
-      it { is_expected.to contain_file('dir.conf').with_content(%r{ fearsome\.aspx$}) }
+      it { is_expected.to contain_file('dir.conf').with_content(%r{ example\.txt }).with_content(%r{ fearsome\.aspx$}) }
     end
   end
 end

--- a/spec/classes/mod/dir_spec.rb
+++ b/spec/classes/mod/dir_spec.rb
@@ -6,18 +6,7 @@ describe 'apache::mod::dir', type: :class do
   it_behaves_like 'a mod class, without including apache'
 
   context 'default configuration with parameters on a Debian OS' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        lsbdistcodename: 'jessie',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     context 'passing no parameters' do
       it { is_expected.to contain_class('apache::params') }
@@ -40,17 +29,7 @@ describe 'apache::mod::dir', type: :class do
     end
   end
   context 'default configuration with parameters on a RedHat OS' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystemrelease: '6',
-        operatingsystem: 'Redhat',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     context 'passing no parameters' do
       it { is_expected.to contain_class('apache::params') }
@@ -73,17 +52,7 @@ describe 'apache::mod::dir', type: :class do
     end
   end
   context 'default configuration with parameters on a FreeBSD OS' do
-    let :facts do
-      {
-        osfamily: 'FreeBSD',
-        operatingsystemrelease: '9',
-        operatingsystem: 'FreeBSD',
-        id: 'root',
-        kernel: 'FreeBSD',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'FreeBSD 9'
 
     context 'passing no parameters' do
       it { is_expected.to contain_class('apache::params') }
@@ -106,17 +75,7 @@ describe 'apache::mod::dir', type: :class do
     end
   end
   context 'default configuration with parameters on a Gentoo OS' do
-    let :facts do
-      {
-        osfamily: 'Gentoo',
-        operatingsystem: 'Gentoo',
-        operatingsystemrelease: '3.16.1-gentoo',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Gentoo'
 
     context 'passing no parameters' do
       it { is_expected.to contain_class('apache::params') }

--- a/spec/classes/mod/disk_cache_spec.rb
+++ b/spec/classes/mod/disk_cache_spec.rb
@@ -4,18 +4,7 @@ require 'spec_helper'
 
 describe 'apache::mod::disk_cache', type: :class do
   context 'on a Debian OS' do
-    let :facts do
-      {
-        id: 'root',
-        kernel: 'Linux',
-        lsbdistcodename: 'jessie',
-        osfamily: 'Debian',
-        operatingsystem: 'Debian',
-        operatingsystemrelease: '8',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     let(:params) do
       {
@@ -61,17 +50,7 @@ describe 'apache::mod::disk_cache', type: :class do
   end
 
   context 'on a RedHat 6-based OS' do
-    let :facts do
-      {
-        id: 'root',
-        kernel: 'Linux',
-        osfamily: 'RedHat',
-        operatingsystem: 'RedHat',
-        operatingsystemrelease: '6',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     let(:params) do
       {
@@ -111,17 +90,7 @@ describe 'apache::mod::disk_cache', type: :class do
     end
   end
   context 'on a FreeBSD OS' do
-    let :facts do
-      {
-        id: 'root',
-        kernel: 'FreeBSD',
-        osfamily: 'FreeBSD',
-        operatingsystem: 'FreeBSD',
-        operatingsystemrelease: '10',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'FreeBSD 10'
 
     let(:params) do
       {

--- a/spec/classes/mod/dumpio_spec.rb
+++ b/spec/classes/mod/dumpio_spec.rb
@@ -10,19 +10,8 @@ describe 'apache::mod::dumpio', type: :class do
          mod_dir    => "/tmp/junk",
        }'
     end
-    let :facts do
-      {
-        lsbdistcodename: 'jessie',
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        operatingsystemmajrelease: '8',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+
+    include_examples 'Debian 8'
 
     context 'default configuration fore parameters' do
       it { is_expected.to compile }

--- a/spec/classes/mod/event_spec.rb
+++ b/spec/classes/mod/event_spec.rb
@@ -8,52 +8,21 @@ describe 'apache::mod::event', type: :class do
   end
 
   context 'on a FreeBSD OS' do
-    let :facts do
-      {
-        osfamily: 'FreeBSD',
-        operatingsystemrelease: '9',
-        operatingsystem: 'FreeBSD',
-        id: 'root',
-        kernel: 'FreeBSD',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'FreeBSD 9'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('event') }
     it { is_expected.to contain_file('/usr/local/etc/apache24/Modules/event.conf').with_ensure('file') }
   end
   context 'on a Gentoo OS' do
-    let :facts do
-      {
-        osfamily: 'Gentoo',
-        operatingsystem: 'Gentoo',
-        operatingsystemrelease: '3.16.1-gentoo',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Gentoo'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('event') }
     it { is_expected.to contain_file('/etc/apache2/modules.d/event.conf').with_ensure('file') }
   end
   context 'on a Debian OS' do
-    let :facts do
-      {
-        lsbdistcodename: 'jessie',
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('event') }
@@ -178,17 +147,7 @@ describe 'apache::mod::event', type: :class do
     end
   end
   context 'on a RedHat OS' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystemrelease: '6',
-        operatingsystem: 'RedHat',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     context 'with Apache version >= 2.4' do
       let :params do

--- a/spec/classes/mod/expires_spec.rb
+++ b/spec/classes/mod/expires_spec.rb
@@ -6,18 +6,7 @@ describe 'apache::mod::expires', type: :class do
   it_behaves_like 'a mod class, without including apache'
 
   context 'with expires active', :compile do
-    let :facts do
-      {
-        id: 'root',
-        kernel: 'Linux',
-        lsbdistcodename: 'jessie',
-        osfamily: 'Debian',
-        operatingsystem: 'Debian',
-        operatingsystemrelease: '8',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     it { is_expected.to contain_apache__mod('expires') }
     it { is_expected.to contain_file('expires.conf').with(content: %r{ExpiresActive On\n}) }
@@ -26,22 +15,13 @@ describe 'apache::mod::expires', type: :class do
     let :pre_condition do
       'class { apache: default_mods => false }'
     end
-    let :facts do
-      {
-        id: 'root',
-        kernel: 'Linux',
-        osfamily: 'RedHat',
-        operatingsystem: 'RedHat',
-        operatingsystemrelease: '7',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
     let :params do
       {
         'expires_default' => 'access plus 1 month',
       }
     end
+
+    include_examples 'RedHat 7'
 
     it { is_expected.to contain_apache__mod('expires') }
     it {
@@ -55,17 +35,6 @@ describe 'apache::mod::expires', type: :class do
     let :pre_condition do
       'class { apache: default_mods => false }'
     end
-    let :facts do
-      {
-        id: 'root',
-        kernel: 'Linux',
-        osfamily: 'RedHat',
-        operatingsystem: 'RedHat',
-        operatingsystemrelease: '7',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
     let :params do
       {
         'expires_by_type' => [
@@ -74,6 +43,8 @@ describe 'apache::mod::expires', type: :class do
         ],
       }
     end
+
+    include_examples 'RedHat 7'
 
     it { is_expected.to contain_apache__mod('expires') }
     it {

--- a/spec/classes/mod/ext_filter_spec.rb
+++ b/spec/classes/mod/ext_filter_spec.rb
@@ -5,19 +5,7 @@ require 'spec_helper'
 describe 'apache::mod::ext_filter', type: :class do
   it_behaves_like 'a mod class, without including apache'
   context 'on a Debian OS' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        lsbdistcodename: 'jessie',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        fqdn: 'test.example.com',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     describe 'with no parameters' do
       it { is_expected.to contain_apache__mod('ext_filter') }
@@ -34,18 +22,7 @@ describe 'apache::mod::ext_filter', type: :class do
     end
   end
   context 'on a RedHat OS' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystemrelease: '6',
-        operatingsystem: 'RedHat',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        fqdn: 'test.example.com',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     describe 'with no parameters' do
       it { is_expected.to contain_apache__mod('ext_filter') }

--- a/spec/classes/mod/fcgid_spec.rb
+++ b/spec/classes/mod/fcgid_spec.rb
@@ -6,19 +6,7 @@ describe 'apache::mod::fcgid', type: :class do
   it_behaves_like 'a mod class, without including apache'
 
   context 'on a Debian OS' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        operatingsystemmajrelease: '8',
-        lsbdistcodename: 'jessie',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     it { is_expected.to contain_class('apache::params') }
     it {
@@ -28,18 +16,7 @@ describe 'apache::mod::fcgid', type: :class do
   end
 
   context 'on a RHEL6' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystemrelease: '6',
-        operatingsystemmajrelease: '6',
-        operatingsystem: 'RedHat',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     describe 'without parameters' do
       it { is_expected.to contain_class('apache::params') }
@@ -77,18 +54,7 @@ describe 'apache::mod::fcgid', type: :class do
   end
 
   context 'on RHEL7' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystemrelease: '7',
-        operatingsystemmajrelease: '7',
-        operatingsystem: 'RedHat',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 7'
 
     describe 'without parameters' do
       it { is_expected.to contain_class('apache::params') }
@@ -100,18 +66,7 @@ describe 'apache::mod::fcgid', type: :class do
   end
 
   context 'on a FreeBSD OS' do
-    let :facts do
-      {
-        osfamily: 'FreeBSD',
-        operatingsystemrelease: '10',
-        operatingsystemmajrelease: '10',
-        operatingsystem: 'FreeBSD',
-        id: 'root',
-        kernel: 'FreeBSD',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'FreeBSD 10'
 
     it { is_expected.to contain_class('apache::params') }
     it {
@@ -121,17 +76,7 @@ describe 'apache::mod::fcgid', type: :class do
   end
 
   context 'on a Gentoo OS' do
-    let :facts do
-      {
-        osfamily: 'Gentoo',
-        operatingsystem: 'Gentoo',
-        operatingsystemrelease: '3.16.1-gentoo',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Gentoo'
 
     it { is_expected.to contain_class('apache::params') }
     it {

--- a/spec/classes/mod/http2_spec.rb
+++ b/spec/classes/mod/http2_spec.rb
@@ -6,18 +6,7 @@ describe 'apache::mod::http2', type: :class do
   it_behaves_like 'a mod class, without including apache'
 
   context 'default configuration with parameters on a Debian OS' do
-    let :facts do
-      {
-        lsbdistcodename: 'jessie',
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        id: 'root',
-        kernel: 'Linux',
-        operatingsystem: 'Debian',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     it { is_expected.to contain_class('apache::mod::http2') }
     context 'with default values' do

--- a/spec/classes/mod/info_spec.rb
+++ b/spec/classes/mod/info_spec.rb
@@ -124,10 +124,10 @@ describe 'apache::mod::info', type: :class do
   it_behaves_like 'a mod class, without including apache'
 
   context 'On a Debian OS' do
-    include_examples 'Debian 6'
+    include_examples 'Debian 8'
 
     # Load the more generic tests for this context
-    general_info_specs_apache22
+    general_info_specs_apache24
 
     it {
       is_expected.to contain_file('info.conf').with(ensure: 'file',

--- a/spec/classes/mod/info_spec.rb
+++ b/spec/classes/mod/info_spec.rb
@@ -124,18 +124,7 @@ describe 'apache::mod::info', type: :class do
   it_behaves_like 'a mod class, without including apache'
 
   context 'On a Debian OS' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystemrelease: '6',
-        lsbdistcodename: 'squeeze',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 6'
 
     # Load the more generic tests for this context
     general_info_specs_apache22
@@ -151,17 +140,7 @@ describe 'apache::mod::info', type: :class do
   end
 
   context 'on a RedHat OS' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystemrelease: '6',
-        operatingsystem: 'RedHat',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     # Load the more generic tests for this context
     general_info_specs_apache22
@@ -173,17 +152,7 @@ describe 'apache::mod::info', type: :class do
   end
 
   context 'on a FreeBSD OS' do
-    let :facts do
-      {
-        osfamily: 'FreeBSD',
-        operatingsystemrelease: '10',
-        operatingsystem: 'FreeBSD',
-        id: 'root',
-        kernel: 'FreeBSD',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'FreeBSD 10'
 
     # Load the more generic tests for this context
     general_info_specs_apache24
@@ -195,17 +164,7 @@ describe 'apache::mod::info', type: :class do
   end
 
   context 'on a Gentoo OS' do
-    let :facts do
-      {
-        osfamily: 'Gentoo',
-        operatingsystem: 'Gentoo',
-        operatingsystemrelease: '3.16.1-gentoo',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Gentoo'
 
     # Load the more generic tests for this context
     general_info_specs_apache24

--- a/spec/classes/mod/intercept_form_submit_spec.rb
+++ b/spec/classes/mod/intercept_form_submit_spec.rb
@@ -7,18 +7,7 @@ describe 'apache::mod::intercept_form_submit', type: :class do
 
   context 'default configuration with parameters' do
     context 'on a Debian OS' do
-      let :facts do
-        {
-          lsbdistcodename: 'jessie',
-          osfamily: 'Debian',
-          operatingsystemrelease: '8',
-          id: 'root',
-          kernel: 'Linux',
-          operatingsystem: 'Debian',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'Debian 8'
 
       it { is_expected.to contain_class('apache') }
       it { is_expected.to contain_package('libapache2-mod-intercept-form-submit') }
@@ -26,17 +15,7 @@ describe 'apache::mod::intercept_form_submit', type: :class do
     end # Debian
 
     context 'on a RedHat OS' do
-      let :facts do
-        {
-          osfamily: 'RedHat',
-          operatingsystemrelease: '6',
-          id: 'root',
-          kernel: 'Linux',
-          operatingsystem: 'RedHat',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'RedHat 6'
 
       it { is_expected.to contain_class('apache') }
       it { is_expected.to contain_package('mod_intercept_form_submit') }

--- a/spec/classes/mod/itk_spec.rb
+++ b/spec/classes/mod/itk_spec.rb
@@ -8,18 +8,7 @@ describe 'apache::mod::itk', type: :class do
   end
 
   context 'on a Debian OS' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        lsbdistcodename: 'jessie',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('itk') }
@@ -81,17 +70,7 @@ describe 'apache::mod::itk', type: :class do
   end
 
   context 'on a RedHat OS' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystemrelease: '6',
-        operatingsystem: 'RedHat',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('itk') }
@@ -156,18 +135,8 @@ describe 'apache::mod::itk', type: :class do
       'class { "apache": mpm_module => false, }'
     end
 
-    let :facts do
-      {
-        osfamily: 'FreeBSD',
-        operatingsystemrelease: '10',
-        operatingsystem: 'FreeBSD',
-        id: 'root',
-        kernel: 'FreeBSD',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-        mpm_module: 'itk',
-      }
-    end
+    include_examples 'FreeBSD 10'
+    # TODO: fact mpm_module itk?
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('itk') }

--- a/spec/classes/mod/jk_spec.rb
+++ b/spec/classes/mod/jk_spec.rb
@@ -64,14 +64,7 @@ describe 'apache::mod::jk', type: :class do
   altern8_port = 8008
 
   context 'Debian 8' do
-    let(:facts) do
-      {
-        osfamily: 'Debian',
-        operatingsystem: 'Debian',
-        operatingsystemrelease: '8',
-        ipaddress: default_ip,
-      }
-    end
+    include_examples 'Debian 8'
 
     context 'with only required facts and default parameters' do
       let(:facts) { super().merge('ipaddress' => default_ip) }
@@ -98,14 +91,7 @@ describe 'apache::mod::jk', type: :class do
   end
 
   context 'RHEL 6' do
-    let(:facts) do
-      {
-        osfamily: 'RedHat',
-        operatingsystem: 'RedHat',
-        operatingsystemrelease: '6',
-        ipaddress: default_ip,
-      }
-    end
+    include_examples 'RedHat 6'
     let(:pre_condition) do
       'include apache'
     end

--- a/spec/classes/mod/jk_spec.rb
+++ b/spec/classes/mod/jk_spec.rb
@@ -63,36 +63,7 @@ describe 'apache::mod::jk', type: :class do
   default_port = 80
   altern8_port = 8008
 
-  context 'RHEL 6 with only required facts and default parameters' do
-    let(:facts) do
-      {
-        osfamily: 'RedHat',
-        operatingsystem: 'RedHat',
-        operatingsystemrelease: '6',
-        ipaddress: default_ip,
-      }
-    end
-    let(:pre_condition) do
-      'include apache'
-    end
-    let(:params) do
-      {
-        logroot: '/var/log/httpd',
-      }
-    end
-    let(:mod_dir) { mod_dir }
-
-    mod_dir = '/etc/httpd/conf.d'
-
-    it_behaves_like 'minimal resources', mod_dir
-    it_behaves_like 'specific workers_file', mod_dir
-    it { is_expected.to contain_apache__listen("#{default_ip}:#{default_port}") }
-    it {
-      verify_contents(catalogue, 'jk.conf', ['<IfModule jk_module>', '</IfModule>'])
-    }
-  end
-
-  context 'Debian 8 with only required facts and default parameters' do
+  context 'Debian 8' do
     let(:facts) do
       {
         osfamily: 'Debian',
@@ -101,146 +72,127 @@ describe 'apache::mod::jk', type: :class do
         ipaddress: default_ip,
       }
     end
-    let(:pre_condition) do
-      'include apache'
-    end
-    let(:params) do
-      {
-        logroot: '/var/log/apache2',
-      }
-    end
-    let(:mod_dir) { mod_dir }
 
-    mod_dir = '/etc/apache2/mods-available'
-
-    it_behaves_like 'minimal resources', mod_dir
-    it_behaves_like 'specific workers_file', mod_dir
-    it { is_expected.to contain_apache__listen("#{default_ip}:#{default_port}") }
-    it { is_expected.to contain_package('libapache2-mod-jk') }
-    it {
-      verify_contents(catalogue, 'jk.conf', ['<IfModule jk_module>', '</IfModule>'])
-    }
-  end
-
-  context 'RHEL 6 with required facts and alternative IP' do
-    let(:facts) do
-      {
-        osfamily: 'RedHat',
-        operatingsystem: 'RedHat',
-        operatingsystemrelease: '6',
-        ipaddress: default_ip,
-      }
-    end
-    let(:pre_condition) do
-      'include apache'
-    end
-    let(:params) do
-      {
-        ip: altern8_ip,
-        logroot: '/var/log/httpd',
-      }
-    end
-
-    it { is_expected.to contain_apache__listen("#{altern8_ip}:#{default_port}") }
-  end
-
-  context 'RHEL 6 with required facts and alternative port' do
-    let(:facts) do
-      {
-        osfamily: 'RedHat',
-        operatingsystem: 'RedHat',
-        operatingsystemrelease: '6',
-        ipaddress: default_ip,
-      }
-    end
-    let(:pre_condition) do
-      'include apache'
-    end
-    let(:params) do
-      {
-        port: altern8_port,
-        logroot: '/var/log/httpd',
-      }
-    end
-
-    it { is_expected.to contain_apache__listen("#{default_ip}:#{altern8_port}") }
-  end
-
-  context 'RHEL 6 with required facts and no binding' do
-    let(:facts) do
-      {
-        osfamily: 'RedHat',
-        operatingsystem: 'RedHat',
-        operatingsystemrelease: '6',
-        ipaddress: default_ip,
-      }
-    end
-    let(:pre_condition) do
-      'include apache'
-    end
-    let(:params) do
-      {
-        add_listen: false,
-        logroot: '/var/log/httpd',
-      }
-    end
-
-    it { is_expected.not_to contain_apache__listen("#{default_ip}:#{default_port}") }
-  end
-
-  {
-    default: {
-      shm_file: :undef,
-      log_file: :undef,
-      shm_path: '/var/log/httpd/jk-runtime-status',
-      log_path: '/var/log/httpd/mod_jk.log',
-    },
-    relative: {
-      shm_file: 'shm_file',
-      log_file: 'log_file',
-      shm_path: '/var/log/httpd/shm_file',
-      log_path: '/var/log/httpd/log_file',
-    },
-    absolute: {
-      shm_file: '/run/shm_file',
-      log_file: '/tmp/log_file',
-      shm_path: '/run/shm_file',
-      log_path: '/tmp/log_file',
-    },
-    pipe: {
-      shm_file: :undef,
-      log_file: '"|rotatelogs /var/log/httpd/mod_jk.log.%Y%m%d 86400 -180"',
-      shm_path: '/var/log/httpd/jk-runtime-status',
-      log_path: '"|rotatelogs /var/log/httpd/mod_jk.log.%Y%m%d 86400 -180"',
-    },
-  }.each do |option, paths|
-    context "RHEL 6 with #{option} shm_file and log_file paths" do
-      let(:facts) do
-        {
-          osfamily: 'RedHat',
-          operatingsystem: 'RedHat',
-          operatingsystemrelease: '6',
-        }
-      end
+    context 'with only required facts and default parameters' do
+      let(:facts) { super().merge('ipaddress' => default_ip) }
       let(:pre_condition) do
         'include apache'
       end
       let(:params) do
         {
-          logroot: '/var/log/httpd',
-          shm_file: paths[:shm_file],
-          log_file: paths[:log_file],
+          logroot: '/var/log/apache2',
+        }
+      end
+      let(:mod_dir) { mod_dir }
+
+      mod_dir = '/etc/apache2/mods-available'
+
+      it_behaves_like 'minimal resources', mod_dir
+      it_behaves_like 'specific workers_file', mod_dir
+      it { is_expected.to contain_apache__listen("#{default_ip}:#{default_port}") }
+      it { is_expected.to contain_package('libapache2-mod-jk') }
+      it {
+        verify_contents(catalogue, 'jk.conf', ['<IfModule jk_module>', '</IfModule>'])
+      }
+    end
+  end
+
+  context 'RHEL 6' do
+    let(:facts) do
+      {
+        osfamily: 'RedHat',
+        operatingsystem: 'RedHat',
+        operatingsystemrelease: '6',
+        ipaddress: default_ip,
+      }
+    end
+    let(:pre_condition) do
+      'include apache'
+    end
+    let(:params) do
+      {
+        logroot: '/var/log/httpd',
+      }
+    end
+
+    context 'with required facts' do
+      let(:facts) { super().merge('ipaddress' => default_ip) }
+
+      context 'and default parameters' do
+        let(:mod_dir) { mod_dir }
+
+        mod_dir = '/etc/httpd/conf.d'
+
+        it_behaves_like 'minimal resources', mod_dir
+        it_behaves_like 'specific workers_file', mod_dir
+        it { is_expected.to contain_apache__listen("#{default_ip}:#{default_port}") }
+        it {
+          verify_contents(catalogue, 'jk.conf', ['<IfModule jk_module>', '</IfModule>'])
         }
       end
 
-      expected = "# This file is generated automatically by Puppet - DO NOT EDIT\n"\
-                 "# Any manual changes will be overwritten\n"\
-                 "\n"\
-                 "<IfModule jk_module>\n"\
-                 "  JkShmFile #{paths[:shm_path]}\n"\
-                 "  JkLogFile #{paths[:log_path]}\n"\
-                 "</IfModule>\n"
-      it { is_expected.to contain_file('jk.conf').with_content(expected) }
+      context 'and alternative IP' do
+        let(:params) { super().merge(ip: altern8_ip) }
+
+        it { is_expected.to contain_apache__listen("#{altern8_ip}:#{default_port}") }
+      end
+
+      context 'and alternative port' do
+        let(:params) { super().merge(port: altern8_port) }
+
+        it { is_expected.to contain_apache__listen("#{default_ip}:#{altern8_port}") }
+      end
+
+      context 'no binding' do
+        let(:params) { super().merge(add_listen: false) }
+
+        it { is_expected.not_to contain_apache__listen("#{default_ip}:#{default_port}") }
+      end
+
+      {
+        default: {
+          shm_file: :undef,
+          log_file: :undef,
+          shm_path: '/var/log/httpd/jk-runtime-status',
+          log_path: '/var/log/httpd/mod_jk.log',
+        },
+        relative: {
+          shm_file: 'shm_file',
+          log_file: 'log_file',
+          shm_path: '/var/log/httpd/shm_file',
+          log_path: '/var/log/httpd/log_file',
+        },
+        absolute: {
+          shm_file: '/run/shm_file',
+          log_file: '/tmp/log_file',
+          shm_path: '/run/shm_file',
+          log_path: '/tmp/log_file',
+        },
+        pipe: {
+          shm_file: :undef,
+          log_file: '"|rotatelogs /var/log/httpd/mod_jk.log.%Y%m%d 86400 -180"',
+          shm_path: '/var/log/httpd/jk-runtime-status',
+          log_path: '"|rotatelogs /var/log/httpd/mod_jk.log.%Y%m%d 86400 -180"',
+        },
+      }.each do |option, paths|
+        context "#{option} shm_file and log_file paths" do
+          let(:params) do
+            super().merge(
+              shm_file: paths[:shm_file],
+              log_file: paths[:log_file],
+            )
+          end
+
+          expected = "# This file is generated automatically by Puppet - DO NOT EDIT\n"\
+                     "# Any manual changes will be overwritten\n"\
+                     "\n"\
+                     "<IfModule jk_module>\n"\
+                     "  JkShmFile #{paths[:shm_path]}\n"\
+                     "  JkLogFile #{paths[:log_path]}\n"\
+                     "</IfModule>\n"
+          it { is_expected.to contain_file('jk.conf').with_content(expected) }
+        end
+      end
     end
   end
 end

--- a/spec/classes/mod/ldap_spec.rb
+++ b/spec/classes/mod/ldap_spec.rb
@@ -6,18 +6,7 @@ describe 'apache::mod::ldap', type: :class do
   it_behaves_like 'a mod class, without including apache'
 
   context 'on a Debian OS' do
-    let :facts do
-      {
-        lsbdistcodename: 'jessie',
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        id: 'root',
-        kernel: 'Linux',
-        operatingsystem: 'Debian',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_class('apache::mod::ldap') }
@@ -66,17 +55,7 @@ describe 'apache::mod::ldap', type: :class do
   end # Debian
 
   context 'on a RedHat OS' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystemrelease: '6',
-        id: 'root',
-        kernel: 'Linux',
-        operatingsystem: 'RedHat',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_class('apache::mod::ldap') }

--- a/spec/classes/mod/lookup_identity.rb
+++ b/spec/classes/mod/lookup_identity.rb
@@ -7,18 +7,7 @@ describe 'apache::mod::lookup_identity', type: :class do
 
   context 'default configuration with parameters' do
     context 'on a Debian OS' do
-      let :facts do
-        {
-          lsbdistcodename: 'jessie',
-          osfamily: 'Debian',
-          operatingsystemrelease: '8',
-          id: 'root',
-          kernel: 'Linux',
-          operatingsystem: 'Debian',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'Debian 8'
 
       it { is_expected.to contain_class('apache') }
       it { is_expected.to contain_package('libapache2-mod-lookup-identity') }
@@ -26,17 +15,7 @@ describe 'apache::mod::lookup_identity', type: :class do
     end # Debian
 
     context 'on a RedHat OS' do
-      let :facts do
-        {
-          osfamily: 'RedHat',
-          operatingsystemrelease: '6',
-          id: 'root',
-          kernel: 'Linux',
-          operatingsystem: 'RedHat',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'RedHat 6'
 
       it { is_expected.to contain_class('apache') }
       it { is_expected.to contain_package('mod_lookup_identity') }

--- a/spec/classes/mod/mime_magic_spec.rb
+++ b/spec/classes/mod/mime_magic_spec.rb
@@ -11,18 +11,7 @@ describe 'apache::mod::mime_magic', type: :class do
   it_behaves_like 'a mod class, without including apache'
 
   context 'On a Debian OS with default params' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystemrelease: '6',
-        lsbdistcodename: 'jessie',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 6'
 
     general_mime_magic_specs
 
@@ -55,17 +44,7 @@ describe 'apache::mod::mime_magic', type: :class do
   end
 
   context 'on a RedHat OS with default params' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystemrelease: '6',
-        operatingsystem: 'RedHat',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     general_mime_magic_specs
 
@@ -79,18 +58,7 @@ describe 'apache::mod::mime_magic', type: :class do
   end
 
   context 'with magic_file => /tmp/magic' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystemrelease: '6',
-        lsbdistcodename: 'jessie',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 6'
 
     let :params do
       { magic_file: '/tmp/magic' }

--- a/spec/classes/mod/mime_magic_spec.rb
+++ b/spec/classes/mod/mime_magic_spec.rb
@@ -11,7 +11,7 @@ describe 'apache::mod::mime_magic', type: :class do
   it_behaves_like 'a mod class, without including apache'
 
   context 'On a Debian OS with default params' do
-    include_examples 'Debian 6'
+    include_examples 'Debian 8'
 
     general_mime_magic_specs
 
@@ -58,7 +58,7 @@ describe 'apache::mod::mime_magic', type: :class do
   end
 
   context 'with magic_file => /tmp/magic' do
-    include_examples 'Debian 6'
+    include_examples 'Debian 8'
 
     let :params do
       { magic_file: '/tmp/magic' }

--- a/spec/classes/mod/mime_spec.rb
+++ b/spec/classes/mod/mime_spec.rb
@@ -18,18 +18,7 @@ describe 'apache::mod::mime', type: :class do
   it_behaves_like 'a mod class, without including apache'
 
   context 'On a Debian OS with default params', :compile do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        lsbdistcodename: 'jessie',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     general_mime_specs
 
@@ -37,17 +26,7 @@ describe 'apache::mod::mime', type: :class do
   end
 
   context 'on a RedHat OS with default params', :compile do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystemrelease: '6',
-        operatingsystem: 'RedHat',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     general_mime_specs
 

--- a/spec/classes/mod/negotiation_spec.rb
+++ b/spec/classes/mod/negotiation_spec.rb
@@ -5,18 +5,7 @@ require 'spec_helper'
 describe 'apache::mod::negotiation', type: :class do
   it_behaves_like 'a mod class, without including apache'
   describe 'OS independent tests' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystem: 'Debian',
-        kernel: 'Linux',
-        lsbdistcodename: 'jessie',
-        operatingsystemrelease: '8',
-        id: 'root',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     context 'default params' do
       it { is_expected.to contain_class('apache') }

--- a/spec/classes/mod/pagespeed_spec.rb
+++ b/spec/classes/mod/pagespeed_spec.rb
@@ -4,18 +4,7 @@ require 'spec_helper'
 
 describe 'apache::mod::pagespeed', type: :class do
   context 'on a Debian OS' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        lsbdistcodename: 'jessie',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('pagespeed') }
@@ -39,17 +28,7 @@ describe 'apache::mod::pagespeed', type: :class do
   end
 
   context 'on a RedHat OS' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystemrelease: '6',
-        operatingsystem: 'RedHat',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('pagespeed') }

--- a/spec/classes/mod/passenger_spec.rb
+++ b/spec/classes/mod/passenger_spec.rb
@@ -223,9 +223,6 @@ describe 'apache::mod::passenger', type: :class do
           end
 
           describe 'warns when an option is deprecated' do
-            puts facts[:os]['family']
-            puts facts[:os]['release']
-
             let :params do
               {
                 passenger_installed_version: '5.0.0',

--- a/spec/classes/mod/perl_spec.rb
+++ b/spec/classes/mod/perl_spec.rb
@@ -5,69 +5,28 @@ require 'spec_helper'
 describe 'apache::mod::perl', type: :class do
   it_behaves_like 'a mod class, without including apache'
   context 'on a Debian OS' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        lsbdistcodename: 'jessie',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('perl') }
     it { is_expected.to contain_package('libapache2-mod-perl2') }
   end
   context 'on a RedHat OS' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystemrelease: '6',
-        operatingsystem: 'RedHat',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('perl') }
     it { is_expected.to contain_package('mod_perl') }
   end
   context 'on a FreeBSD OS' do
-    let :facts do
-      {
-        osfamily: 'FreeBSD',
-        operatingsystemrelease: '9',
-        operatingsystem: 'FreeBSD',
-        id: 'root',
-        kernel: 'FreeBSD',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'FreeBSD 9'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('perl') }
     it { is_expected.to contain_package('www/mod_perl2') }
   end
   context 'on a Gentoo OS' do
-    let :facts do
-      {
-        osfamily: 'Gentoo',
-        operatingsystemrelease: '3.16.1-gentoo',
-        operatingsystem: 'Gentoo',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Gentoo'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('perl') }

--- a/spec/classes/mod/peruser_spec.rb
+++ b/spec/classes/mod/peruser_spec.rb
@@ -8,32 +8,12 @@ describe 'apache::mod::peruser', type: :class do
   end
 
   context 'on a FreeBSD OS' do
-    let :facts do
-      {
-        osfamily: 'FreeBSD',
-        operatingsystemrelease: '10',
-        operatingsystem: 'FreeBSD',
-        id: 'root',
-        kernel: 'FreeBSD',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'FreeBSD 10'
 
     it { is_expected.to compile.and_raise_error(%r{Unsupported osfamily FreeBSD}) }
   end
   context 'on a Gentoo OS' do
-    let :facts do
-      {
-        osfamily: 'Gentoo',
-        operatingsystem: 'Gentoo',
-        operatingsystemrelease: '3.16.1-gentoo',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Gentoo'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('peruser') }

--- a/spec/classes/mod/prefork_spec.rb
+++ b/spec/classes/mod/prefork_spec.rb
@@ -8,18 +8,7 @@ describe 'apache::mod::prefork', type: :class do
   end
 
   context 'on a Debian OS' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        lsbdistcodename: 'jessie',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('prefork') }
@@ -54,17 +43,7 @@ describe 'apache::mod::prefork', type: :class do
     end
   end
   context 'on a RedHat OS' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystemrelease: '6',
-        operatingsystem: 'RedHat',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('prefork') }
@@ -104,34 +83,14 @@ describe 'apache::mod::prefork', type: :class do
     end
   end
   context 'on a FreeBSD OS' do
-    let :facts do
-      {
-        osfamily: 'FreeBSD',
-        operatingsystemrelease: '9',
-        operatingsystem: 'FreeBSD',
-        id: 'root',
-        kernel: 'FreeBSD',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'FreeBSD 9'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('prefork') }
     it { is_expected.to contain_file('/usr/local/etc/apache24/Modules/prefork.conf').with_ensure('file') }
   end
   context 'on a Gentoo OS' do
-    let :facts do
-      {
-        osfamily: 'Gentoo',
-        operatingsystem: 'Gentoo',
-        operatingsystemrelease: '3.16.1-gentoo',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Gentoo'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('prefork') }

--- a/spec/classes/mod/proxy_balancer_spec.rb
+++ b/spec/classes/mod/proxy_balancer_spec.rb
@@ -24,18 +24,7 @@ describe 'apache::mod::proxy_balancer', type: :class do
 
   context 'default configuration with default parameters' do
     context 'on a Debian OS' do
-      let :facts do
-        {
-          osfamily: 'Debian',
-          operatingsystemrelease: '8',
-          lsbdistcodename: 'jessie',
-          operatingsystem: 'Debian',
-          id: 'root',
-          kernel: 'Linux',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'Debian 8'
 
       it { is_expected.to contain_apache__mod('proxy_balancer') }
 
@@ -44,17 +33,7 @@ describe 'apache::mod::proxy_balancer', type: :class do
     end
 
     context 'on a RedHat OS' do
-      let :facts do
-        {
-          osfamily: 'RedHat',
-          operatingsystemrelease: '6',
-          operatingsystem: 'RedHat',
-          id: 'root',
-          kernel: 'Linux',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'RedHat 6'
 
       it { is_expected.to contain_apache__mod('proxy_balancer') }
 
@@ -63,18 +42,7 @@ describe 'apache::mod::proxy_balancer', type: :class do
     end
   end
   context "default configuration with custom parameters $manager => true, $allow_from => ['10.10.10.10','11.11.11.11'], $status_path => '/custom-manager' on a Debian OS" do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        lsbdistcodename: 'jessie',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
     let :params do
       {
         manager: true,

--- a/spec/classes/mod/proxy_connect_spec.rb
+++ b/spec/classes/mod/proxy_connect_spec.rb
@@ -11,22 +11,8 @@ describe 'apache::mod::proxy_connect', type: :class do
 
   it_behaves_like 'a mod class, without including apache'
   context 'on a Debian OS' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
-
     context 'with Apache version < 2.2' do
-      let :facts do
-        super().merge(operatingsystemrelease: '7.0',
-                      lsbdistcodename: 'wheezy')
-      end
+      include_examples 'Debian 7'
       let :params do
         {
           apache_version: '2.1',
@@ -36,10 +22,7 @@ describe 'apache::mod::proxy_connect', type: :class do
       it { is_expected.not_to contain_apache__mod('proxy_connect') }
     end
     context 'with Apache version = 2.2' do
-      let :facts do
-        super().merge(operatingsystemrelease: '7.0',
-                      lsbdistcodename: 'wheezy')
-      end
+      include_examples 'Debian 7'
       let :params do
         {
           apache_version: '2.2',
@@ -49,10 +32,7 @@ describe 'apache::mod::proxy_connect', type: :class do
       it { is_expected.to contain_apache__mod('proxy_connect') }
     end
     context 'with Apache version >= 2.4' do
-      let :facts do
-        super().merge(operatingsystemrelease: '8.0',
-                      lsbdistcodename: 'jessie')
-      end
+      include_examples 'Debian 8'
       let :params do
         {
           apache_version: '2.4',

--- a/spec/classes/mod/proxy_connect_spec.rb
+++ b/spec/classes/mod/proxy_connect_spec.rb
@@ -9,37 +9,33 @@ describe 'apache::mod::proxy_connect', type: :class do
     ]
   end
 
-  it_behaves_like 'a mod class, without including apache'
-  context 'on a Debian OS' do
-    context 'with Apache version < 2.2' do
-      include_examples 'Debian 7'
-      let :params do
-        {
-          apache_version: '2.1',
-        }
-      end
+  include_examples 'a mod class, without including apache'
 
-      it { is_expected.not_to contain_apache__mod('proxy_connect') }
+  context 'with Apache version < 2.2' do
+    let :params do
+      {
+        apache_version: '2.1',
+      }
     end
-    context 'with Apache version = 2.2' do
-      include_examples 'Debian 7'
-      let :params do
-        {
-          apache_version: '2.2',
-        }
-      end
 
-      it { is_expected.to contain_apache__mod('proxy_connect') }
+    it { is_expected.not_to contain_apache__mod('proxy_connect') }
+  end
+  context 'with Apache version = 2.2' do
+    let :params do
+      {
+        apache_version: '2.2',
+      }
     end
-    context 'with Apache version >= 2.4' do
-      include_examples 'Debian 8'
-      let :params do
-        {
-          apache_version: '2.4',
-        }
-      end
 
-      it { is_expected.to contain_apache__mod('proxy_connect') }
+    it { is_expected.to contain_apache__mod('proxy_connect') }
+  end
+  context 'with Apache version >= 2.4' do
+    let :params do
+      {
+        apache_version: '2.4',
+      }
     end
+
+    it { is_expected.to contain_apache__mod('proxy_connect') }
   end
 end

--- a/spec/classes/mod/proxy_html_spec.rb
+++ b/spec/classes/mod/proxy_html_spec.rb
@@ -17,24 +17,11 @@ describe 'apache::mod::proxy_html', type: :class do
       it { is_expected.to contain_apache__mod('proxy_html').with(loadfiles: loadfiles) }
       it { is_expected.to contain_package('libapache2-mod-proxy-html') }
     end
-    let :facts do
-      {
-        osfamily: 'Debian',
-        architecture: 'i386',
-        lsbdistcodename: 'jessie',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        hardwaremodel: 'i386',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     context 'on jessie i386' do
       let(:facts) do
-        super().merge(operatingsystemrelease: '8',
-                      hardwaremodel: 'i686',
+        super().merge(hardwaremodel: 'i686',
                       architecture: 'i386')
       end
 
@@ -43,8 +30,7 @@ describe 'apache::mod::proxy_html', type: :class do
     end
     context 'on jessie x64' do
       let(:facts) do
-        super().merge(operatingsystemrelease: '8',
-                      hardwaremodel: 'x86_64',
+        super().merge(hardwaremodel: 'x86_64',
                       architecture: 'amd64')
       end
 
@@ -54,17 +40,7 @@ describe 'apache::mod::proxy_html', type: :class do
   end
 
   context 'on a RedHat OS', :compile do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystemrelease: '6',
-        operatingsystem: 'RedHat',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('proxy_html').with(loadfiles: nil) }
@@ -72,17 +48,7 @@ describe 'apache::mod::proxy_html', type: :class do
     it { is_expected.to contain_apache__mod('xml2enc').with(loadfiles: nil) }
   end
   context 'on a FreeBSD OS', :compile do
-    let :facts do
-      {
-        osfamily: 'FreeBSD',
-        operatingsystemrelease: '9',
-        operatingsystem: 'FreeBSD',
-        id: 'root',
-        kernel: 'FreeBSD',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'FreeBSD 9'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('proxy_html').with(loadfiles: nil) }
@@ -90,17 +56,7 @@ describe 'apache::mod::proxy_html', type: :class do
     it { is_expected.to contain_package('www/mod_proxy_html') }
   end
   context 'on a Gentoo OS', :compile do
-    let :facts do
-      {
-        osfamily: 'Gentoo',
-        operatingsystem: 'Gentoo',
-        operatingsystemrelease: '3.16.1-gentoo',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Gentoo'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('proxy_html').with(loadfiles: nil) }

--- a/spec/classes/mod/python_spec.rb
+++ b/spec/classes/mod/python_spec.rb
@@ -6,35 +6,14 @@ describe 'apache::mod::python', type: :class do
   it_behaves_like 'a mod class, without including apache'
 
   context 'on a Debian OS' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        lsbdistcodename: 'jessie',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('python') }
     it { is_expected.to contain_package('libapache2-mod-python') }
   end
   context 'on a RedHat OS' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystemrelease: '6',
-        operatingsystem: 'RedHat',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('python') }
@@ -50,34 +29,14 @@ describe 'apache::mod::python', type: :class do
     end
   end
   context 'on a FreeBSD OS' do
-    let :facts do
-      {
-        osfamily: 'FreeBSD',
-        operatingsystemrelease: '9',
-        operatingsystem: 'FreeBSD',
-        id: 'root',
-        kernel: 'FreeBSD',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'FreeBSD 9'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('python') }
     it { is_expected.to contain_package('www/mod_python3') }
   end
   context 'on a Gentoo OS' do
-    let :facts do
-      {
-        osfamily: 'Gentoo',
-        operatingsystem: 'Gentoo',
-        operatingsystemrelease: '3.16.1-gentoo',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Gentoo'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('python') }

--- a/spec/classes/mod/remoteip_spec.rb
+++ b/spec/classes/mod/remoteip_spec.rb
@@ -4,17 +4,7 @@ require 'spec_helper'
 
 describe 'apache::mod::remoteip', type: :class do
   context 'on a Debian OS' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        lsbdistcodename: 'jessie',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-      }
-    end
+    include_examples 'Debian 8'
     let :params do
       { apache_version: '2.4' }
     end

--- a/spec/classes/mod/reqtimeout_spec.rb
+++ b/spec/classes/mod/reqtimeout_spec.rb
@@ -5,18 +5,7 @@ require 'spec_helper'
 describe 'apache::mod::reqtimeout', type: :class do
   it_behaves_like 'a mod class, without including apache'
   context 'on a Debian OS' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        lsbdistcodename: 'jessie',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     context 'passing no parameters' do
       it { is_expected.to contain_class('apache::params') }
@@ -43,17 +32,7 @@ describe 'apache::mod::reqtimeout', type: :class do
     end
   end
   context 'on a RedHat OS' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystemrelease: '6',
-        operatingsystem: 'Redhat',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     context 'passing no parameters' do
       it { is_expected.to contain_class('apache::params') }
@@ -80,17 +59,7 @@ describe 'apache::mod::reqtimeout', type: :class do
     end
   end
   context 'on a FreeBSD OS' do
-    let :facts do
-      {
-        osfamily: 'FreeBSD',
-        operatingsystemrelease: '9',
-        operatingsystem: 'FreeBSD',
-        id: 'root',
-        kernel: 'FreeBSD',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'FreeBSD 9'
 
     context 'passing no parameters' do
       it { is_expected.to contain_class('apache::params') }
@@ -117,17 +86,7 @@ describe 'apache::mod::reqtimeout', type: :class do
     end
   end
   context 'on a Gentoo OS' do
-    let :facts do
-      {
-        osfamily: 'Gentoo',
-        operatingsystem: 'Gentoo',
-        operatingsystemrelease: '3.16.1-gentoo',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Gentoo'
 
     context 'passing no parameters' do
       it { is_expected.to contain_class('apache::params') }

--- a/spec/classes/mod/rpaf_spec.rb
+++ b/spec/classes/mod/rpaf_spec.rb
@@ -5,18 +5,7 @@ require 'spec_helper'
 describe 'apache::mod::rpaf', type: :class do
   it_behaves_like 'a mod class, without including apache'
   context 'on a Debian OS' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        lsbdistcodename: 'jessie',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('rpaf') }
@@ -49,17 +38,7 @@ describe 'apache::mod::rpaf', type: :class do
     end
   end
   context 'on a FreeBSD OS' do
-    let :facts do
-      {
-        osfamily: 'FreeBSD',
-        operatingsystemrelease: '9',
-        operatingsystem: 'FreeBSD',
-        id: 'root',
-        kernel: 'FreeBSD',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'FreeBSD 9'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('rpaf') }
@@ -92,17 +71,7 @@ describe 'apache::mod::rpaf', type: :class do
     end
   end
   context 'on a Gentoo OS' do
-    let :facts do
-      {
-        osfamily: 'Gentoo',
-        operatingsystem: 'Gentoo',
-        operatingsystemrelease: '3.16.1-gentoo',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Gentoo'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('rpaf') }

--- a/spec/classes/mod/shib_spec.rb
+++ b/spec/classes/mod/shib_spec.rb
@@ -5,37 +5,14 @@ require 'spec_helper'
 describe 'apache::mod::shib', type: :class do
   it_behaves_like 'a mod class, without including apache'
   context 'on a Debian OS' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        lsbdistcodename: 'jessie',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        fqdn: 'test.example.com',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     describe 'with no parameters' do
       it { is_expected.to contain_apache__mod('shib2').with_id('mod_shib') }
     end
   end
   context 'on a RedHat OS' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystemrelease: '6',
-        operatingsystem: 'RedHat',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        fqdn: 'test.example.com',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     describe 'with no parameters' do
       it { is_expected.to contain_apache__mod('shib2').with_id('mod_shib') }

--- a/spec/classes/mod/speling_spec.rb
+++ b/spec/classes/mod/speling_spec.rb
@@ -5,34 +5,13 @@ require 'spec_helper'
 describe 'apache::mod::speling', type: :class do
   it_behaves_like 'a mod class, without including apache'
   context 'on a Debian OS' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        lsbdistcodename: 'jessie',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     it { is_expected.to contain_apache__mod('speling') }
   end
 
   context 'on a RedHat OS' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystemrelease: '6',
-        operatingsystem: 'RedHat',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     it { is_expected.to contain_apache__mod('speling') }
   end

--- a/spec/classes/mod/ssl_spec.rb
+++ b/spec/classes/mod/ssl_spec.rb
@@ -5,34 +5,14 @@ require 'spec_helper'
 describe 'apache::mod::ssl', type: :class do
   it_behaves_like 'a mod class, without including apache'
   context 'on an unsupported OS' do
-    let :facts do
-      {
-        osfamily: 'Magic',
-        operatingsystemrelease: '0',
-        operatingsystem: 'Magic',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Unsupported OS'
 
     it { is_expected.to compile.and_raise_error(%r{Unsupported osfamily:}) }
   end
 
   context 'on a RedHat' do
     context '6 OS' do
-      let :facts do
-        {
-          osfamily: 'RedHat',
-          operatingsystemrelease: '6',
-          operatingsystem: 'RedHat',
-          id: 'root',
-          kernel: 'Linux',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'RedHat 6'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('ssl') }
@@ -41,17 +21,7 @@ describe 'apache::mod::ssl', type: :class do
       it { is_expected.to contain_file('ssl.conf').with_content(%r{SSLProtocol all -SSLv2 -SSLv3}) }
     end
     context '8 OS' do
-      let :facts do
-        {
-          osfamily: 'RedHat',
-          operatingsystemrelease: '8',
-          operatingsystem: 'RedHat',
-          id: 'root',
-          kernel: 'Linux',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'RedHat 8'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('ssl') }
@@ -60,17 +30,7 @@ describe 'apache::mod::ssl', type: :class do
       it { is_expected.to contain_file('ssl.conf').with_content(%r{SSLProtocol all}) }
     end
     context '6 OS with a custom package_name parameter' do
-      let :facts do
-        {
-          osfamily: 'RedHat',
-          operatingsystemrelease: '6',
-          operatingsystem: 'RedHat',
-          id: 'root',
-          kernel: 'Linux',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'RedHat 6'
       let :params do
         { package_name: 'httpd24-mod_ssl' }
       end
@@ -83,17 +43,7 @@ describe 'apache::mod::ssl', type: :class do
     end
 
     context '7 OS with custom directories for PR#1635' do
-      let :facts do
-        {
-          osfamily: 'RedHat',
-          operatingsystemrelease: '7',
-          operatingsystem: 'RedHat',
-          id: 'root',
-          kernel: 'Linux',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'RedHat 7'
       let :pre_condition do
         "class { 'apache':
           confd_dir           => '/etc/httpd/conf.puppet.d',
@@ -110,18 +60,7 @@ describe 'apache::mod::ssl', type: :class do
   end
 
   context 'on a Debian OS' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        lsbdistcodename: 'jessie',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('ssl') }
@@ -129,34 +68,14 @@ describe 'apache::mod::ssl', type: :class do
     it { is_expected.to contain_file('ssl.conf').with_content(%r{SSLProtocol all -SSLv2 -SSLv3}) }
   end
   context 'on a FreeBSD OS' do
-    let :facts do
-      {
-        osfamily: 'FreeBSD',
-        operatingsystemrelease: '9',
-        operatingsystem: 'FreeBSD',
-        id: 'root',
-        kernel: 'FreeBSD',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'FreeBSD 9'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('ssl') }
   end
 
   context 'on a Gentoo OS' do
-    let :facts do
-      {
-        osfamily: 'Gentoo',
-        operatingsystem: 'Gentoo',
-        operatingsystemrelease: '3.16.1-gentoo',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Gentoo'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('ssl') }
@@ -164,17 +83,7 @@ describe 'apache::mod::ssl', type: :class do
   end
 
   context 'on a Suse OS' do
-    let :facts do
-      {
-        osfamily: 'Suse',
-        operatingsystem: 'SLES',
-        operatingsystemrelease: '12',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'SLES 12'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('ssl') }
@@ -182,17 +91,7 @@ describe 'apache::mod::ssl', type: :class do
   end
   # Template config doesn't vary by distro
   context 'on all distros' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystem: 'CentOS',
-        operatingsystemrelease: '6',
-        kernel: 'Linux',
-        id: 'root',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     context 'not setting ssl_pass_phrase_dialog' do
       it { is_expected.to contain_file('ssl.conf').with_content(%r{^  SSLPassPhraseDialog builtin$}) }

--- a/spec/classes/mod/status_spec.rb
+++ b/spec/classes/mod/status_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 # Helper function for testing the contents of `status.conf`
 # Apache < 2.4
-def status_conf_spec(allow_from, extended_status, status_path)
+shared_examples 'status_conf_spec' do |allow_from, extended_status, status_path|
   expected =
     "<Location #{status_path}>\n"\
     "    SetHandler server-status\n"\
@@ -47,7 +47,7 @@ def require_directives(requires)
   end
 end
 
-def status_conf_spec_require(requires, extended_status, status_path)
+shared_examples 'status_conf_spec_require' do |requires, extended_status, status_path|
   expected =
     "<Location #{status_path}>\n"\
     "    SetHandler server-status\n"\
@@ -84,7 +84,7 @@ describe 'apache::mod::status', type: :class do
 
       it { is_expected.to contain_apache__mod('status') }
 
-      status_conf_spec(['127.0.0.1', '::1'], 'On', '/server-status')
+      include_examples 'status_conf_spec', ['127.0.0.1', '::1'], 'On', '/server-status'
 
       it {
         is_expected.to contain_file('status.conf').with(ensure: 'file',
@@ -112,7 +112,7 @@ describe 'apache::mod::status', type: :class do
 
       it { is_expected.to contain_apache__mod('status') }
 
-      status_conf_spec(['127.0.0.1', '::1'], 'On', '/server-status')
+      include_examples 'status_conf_spec', ['127.0.0.1', '::1'], 'On', '/server-status'
 
       it { is_expected.to contain_file('status.conf').with_path('/etc/httpd/conf.d/status.conf') }
     end
@@ -164,7 +164,7 @@ describe 'apache::mod::status', type: :class do
 
         it { is_expected.to contain_apache__mod('status') }
 
-        status_conf_spec_require(req_value, 'On', '/server-status')
+        include_examples 'status_conf_spec_require', req_value, 'On', '/server-status'
 
         it {
           is_expected.to contain_file('status.conf').with(ensure: 'file',
@@ -198,7 +198,7 @@ describe 'apache::mod::status', type: :class do
 
         it { is_expected.to contain_apache__mod('status') }
 
-        status_conf_spec_require(req_value, 'On', '/server-status')
+        include_examples 'status_conf_spec_require', req_value, 'On', '/server-status'
 
         it { is_expected.to contain_file('status.conf').with_path('/etc/httpd/conf.modules.d/status.conf') }
       end
@@ -224,7 +224,7 @@ describe 'apache::mod::status', type: :class do
 
         it { is_expected.to contain_apache__mod('status') }
 
-        status_conf_spec_require(req_value, 'On', '/server-status')
+        include_examples 'status_conf_spec_require', req_value, 'On', '/server-status'
 
         it { is_expected.to contain_file('status.conf').with_path('/etc/httpd/conf.modules.d/status.conf') }
       end
@@ -253,7 +253,7 @@ describe 'apache::mod::status', type: :class do
 
       it { is_expected.to compile }
 
-      status_conf_spec(['10.10.10.10', '11.11.11.11'], 'Off', '/custom-status')
+      include_examples 'status_conf_spec', ['10.10.10.10', '11.11.11.11'], 'Off', '/custom-status'
     end
 
     context "with valid parameter type $allow_from => ['10.10.10.10']" do

--- a/spec/classes/mod/status_spec.rb
+++ b/spec/classes/mod/status_spec.rb
@@ -68,13 +68,13 @@ describe 'apache::mod::status', type: :class do
   it_behaves_like 'a mod class, without including apache'
 
   context 'default configuration with parameters' do
-    context 'on a Debian 6 OS' do
-      include_examples 'Debian 6'
+    context 'on a Debian 8 OS' do
+      include_examples 'Debian 8'
 
       context 'with default params' do
         it { is_expected.to contain_apache__mod('status') }
 
-        include_examples 'status_conf_spec', ['127.0.0.1', '::1'], 'On', '/server-status'
+        include_examples 'status_conf_spec_require', 'ip 127.0.0.1 ::1', 'On', '/server-status'
 
         it {
           is_expected.to contain_file('status.conf').with(ensure: 'file',
@@ -98,7 +98,7 @@ describe 'apache::mod::status', type: :class do
 
         it { is_expected.to compile }
 
-        include_examples 'status_conf_spec', ['10.10.10.10', '11.11.11.11'], 'Off', '/custom-status'
+        include_examples 'status_conf_spec_require', 'ip 10.10.10.10 11.11.11.11', 'Off', '/custom-status'
       end
 
       context "with valid parameter type $allow_from => ['10.10.10.10']" do

--- a/spec/classes/mod/status_spec.rb
+++ b/spec/classes/mod/status_spec.rb
@@ -69,18 +69,7 @@ describe 'apache::mod::status', type: :class do
 
   context 'default configuration with parameters' do
     context 'on a Debian 6 OS' do
-      let :facts do
-        {
-          osfamily: 'Debian',
-          operatingsystemrelease: '6',
-          lsbdistcodename: 'squeeze',
-          operatingsystem: 'Debian',
-          id: 'root',
-          kernel: 'Linux',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'Debian 6'
 
       context 'with default params' do
         it { is_expected.to contain_apache__mod('status') }
@@ -123,17 +112,6 @@ describe 'apache::mod::status', type: :class do
       end
 
       context "with invalid parameter type $allow_from => '10.10.10.10'" do
-        let :facts do
-          {
-            osfamily: 'Debian',
-            operatingsystemrelease: '6',
-            operatingsystem: 'Debian',
-            id: 'root',
-            kernel: 'Linux',
-            path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-            is_pe: false,
-          }
-        end
         let :params do
           { allow_from: '10.10.10.10' }
         end
@@ -170,17 +148,7 @@ describe 'apache::mod::status', type: :class do
     end
 
     context 'on a RedHat 6 OS' do
-      let :facts do
-        {
-          osfamily: 'RedHat',
-          operatingsystemrelease: '6',
-          operatingsystem: 'RedHat',
-          id: 'root',
-          kernel: 'Linux',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'RedHat 6'
 
       context 'with default params' do
         it { is_expected.to contain_apache__mod('status') }
@@ -224,18 +192,7 @@ describe 'apache::mod::status', type: :class do
         end
 
         context 'on a Debian 8 OS' do
-          let :facts do
-            {
-              osfamily: 'Debian',
-              operatingsystemrelease: '8',
-              lsbdistcodename: 'squeeze',
-              operatingsystem: 'Debian',
-              id: 'root',
-              kernel: 'Linux',
-              path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-              is_pe: false,
-            }
-          end
+          include_examples 'Debian 8'
 
           it { is_expected.to contain_apache__mod('status') }
 
@@ -253,17 +210,7 @@ describe 'apache::mod::status', type: :class do
         end
 
         context 'on a RedHat 7 OS' do
-          let :facts do
-            {
-              osfamily: 'RedHat',
-              operatingsystemrelease: '7',
-              operatingsystem: 'RedHat',
-              id: 'root',
-              kernel: 'Linux',
-              path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-              is_pe: false,
-            }
-          end
+          include_examples 'RedHat 7'
 
           it { is_expected.to contain_apache__mod('status') }
 
@@ -273,17 +220,7 @@ describe 'apache::mod::status', type: :class do
         end
 
         context 'on a RedHat 8 OS' do
-          let :facts do
-            {
-              osfamily: 'RedHat',
-              operatingsystemrelease: '8',
-              operatingsystem: 'RedHat',
-              id: 'root',
-              kernel: 'Linux',
-              path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-              is_pe: false,
-            }
-          end
+          include_examples 'RedHat 8'
 
           it { is_expected.to contain_apache__mod('status') }
 

--- a/spec/classes/mod/userdir_spec.rb
+++ b/spec/classes/mod/userdir_spec.rb
@@ -10,19 +10,8 @@ describe 'apache::mod::userdir', type: :class do
          mod_dir      => "/tmp/junk",
        }'
     end
-    let :facts do
-      {
-        lsbdistcodename: 'jessie',
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        operatingsystemmajrelease: '8',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+
+    include_examples 'Debian 8'
 
     context 'default parameters' do
       it { is_expected.to compile }

--- a/spec/classes/mod/worker_spec.rb
+++ b/spec/classes/mod/worker_spec.rb
@@ -8,18 +8,7 @@ describe 'apache::mod::worker', type: :class do
   end
 
   context 'on a Debian OS' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        lsbdistcodename: 'jessie',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('worker') }
@@ -54,17 +43,7 @@ describe 'apache::mod::worker', type: :class do
     end
   end
   context 'on a RedHat OS' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystemrelease: '6',
-        operatingsystem: 'RedHat',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('worker') }
@@ -98,34 +77,14 @@ describe 'apache::mod::worker', type: :class do
     end
   end
   context 'on a FreeBSD OS' do
-    let :facts do
-      {
-        osfamily: 'FreeBSD',
-        operatingsystemrelease: '9',
-        operatingsystem: 'FreeBSD',
-        id: 'root',
-        kernel: 'FreeBSD',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'FreeBSD 9'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('worker') }
     it { is_expected.to contain_file('/usr/local/etc/apache24/Modules/worker.conf').with_ensure('file') }
   end
   context 'on a Gentoo OS' do
-    let :facts do
-      {
-        osfamily: 'Gentoo',
-        operatingsystem: 'Gentoo',
-        operatingsystemrelease: '3.16.1-gentoo',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Gentoo'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('worker') }
@@ -134,17 +93,7 @@ describe 'apache::mod::worker', type: :class do
 
   # Template config doesn't vary by distro
   context 'on all distros' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystem: 'CentOS',
-        operatingsystemrelease: '6',
-        kernel: 'Linux',
-        id: 'root',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     context 'defaults' do
       it { is_expected.to contain_file('/etc/httpd/conf.d/worker.conf').with(content: %r{^<IfModule mpm_worker_module>$}) }

--- a/spec/classes/mod/wsgi_spec.rb
+++ b/spec/classes/mod/wsgi_spec.rb
@@ -5,18 +5,7 @@ require 'spec_helper'
 describe 'apache::mod::wsgi', type: :class do
   it_behaves_like 'a mod class, without including apache'
   context 'on a Debian OS' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        lsbdistcodename: 'jessie',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     it { is_expected.to contain_class('apache::params') }
     it {
@@ -27,17 +16,7 @@ describe 'apache::mod::wsgi', type: :class do
     it { is_expected.to contain_package('libapache2-mod-wsgi') }
   end
   context 'on a RedHat OS' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystemrelease: '6',
-        operatingsystem: 'RedHat',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     it { is_expected.to contain_class('apache::params') }
     it {
@@ -48,9 +27,7 @@ describe 'apache::mod::wsgi', type: :class do
     it { is_expected.to contain_package('mod_wsgi') }
 
     context 'on RHEL8' do
-      let(:facts) do
-        super().merge(operatingsystemrelease: '8')
-      end
+      include_examples 'RedHat 8'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_file('wsgi.load').with_content(%r{LoadModule wsgi_module modules/mod_wsgi_python3.so}) }
@@ -141,17 +118,7 @@ describe 'apache::mod::wsgi', type: :class do
     end
   end
   context 'on a FreeBSD OS' do
-    let :facts do
-      {
-        osfamily: 'FreeBSD',
-        operatingsystemrelease: '9',
-        operatingsystem: 'FreeBSD',
-        id: 'root',
-        kernel: 'FreeBSD',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'FreeBSD 9'
 
     it { is_expected.to contain_class('apache::params') }
     it {
@@ -162,17 +129,7 @@ describe 'apache::mod::wsgi', type: :class do
     it { is_expected.to contain_package('www/mod_wsgi') }
   end
   context 'on a Gentoo OS' do
-    let :facts do
-      {
-        osfamily: 'Gentoo',
-        operatingsystem: 'Gentoo',
-        operatingsystemrelease: '3.16.1-gentoo',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Gentoo'
 
     it { is_expected.to contain_class('apache::params') }
     it {
@@ -184,17 +141,7 @@ describe 'apache::mod::wsgi', type: :class do
   end
   context 'overriding mod_libs' do
     context 'on a RedHat OS', :compile do
-      let :facts do
-        {
-          id: 'root',
-          kernel: 'Linux',
-          osfamily: 'RedHat',
-          operatingsystem: 'Fedora',
-          operatingsystemrelease: '28',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'Fedora 28'
       let :pre_condition do
         <<-MANIFEST
         include apache::params

--- a/spec/classes/params_spec.rb
+++ b/spec/classes/params_spec.rb
@@ -4,18 +4,7 @@ require 'spec_helper'
 
 describe 'apache::params', type: :class do
   context 'On a Debian OS' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        lsbdistcodename: 'jessie',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     it { is_expected.to compile.with_all_deps }
     it { is_expected.to have_resource_count(0) }

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -8,18 +8,7 @@ describe 'apache::service', type: :class do
   end
 
   context 'on a Debian OS' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        lsbdistcodename: 'jessie',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     it {
       is_expected.to contain_service('httpd').with(
@@ -107,17 +96,7 @@ describe 'apache::service', type: :class do
   end
 
   context 'on a RedHat 5 OS, do not manage service' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystemrelease: '5',
-        operatingsystem: 'RedHat',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 5'
     let(:params) do
       {
         'service_ensure' => 'running',
@@ -129,18 +108,8 @@ describe 'apache::service', type: :class do
     it { is_expected.not_to contain_service('httpd') }
   end
 
-  context 'on a FreeBSD 5 OS' do
-    let :facts do
-      {
-        osfamily: 'FreeBSD',
-        operatingsystemrelease: '9',
-        operatingsystem: 'FreeBSD',
-        id: 'root',
-        kernel: 'FreeBSD',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+  context 'on a FreeBSD 9 OS' do
+    include_examples 'FreeBSD 9'
 
     it {
       is_expected.to contain_service('httpd').with(
@@ -152,17 +121,7 @@ describe 'apache::service', type: :class do
   end
 
   context 'on a Gentoo OS' do
-    let :facts do
-      {
-        osfamily: 'Gentoo',
-        operatingsystem: 'Gentoo',
-        operatingsystemrelease: '3.16.1-gentoo',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Gentoo'
 
     it {
       is_expected.to contain_service('httpd').with(

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -95,8 +95,8 @@ describe 'apache::service', type: :class do
     end
   end
 
-  context 'on a RedHat 5 OS, do not manage service' do
-    include_examples 'RedHat 5'
+  context 'on a RedHat 8 OS, do not manage service' do
+    include_examples 'RedHat 8'
     let(:params) do
       {
         'service_ensure' => 'running',

--- a/spec/classes/vhosts_spec.rb
+++ b/spec/classes/vhosts_spec.rb
@@ -4,17 +4,7 @@ require 'spec_helper'
 
 describe 'apache::vhosts', type: :class do
   context 'on all OSes' do
-    let :facts do
-      {
-        id: 'root',
-        kernel: 'Linux',
-        osfamily: 'RedHat',
-        operatingsystem: 'RedHat',
-        operatingsystemrelease: '6',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     context 'with custom vhosts parameter' do
       let :params do

--- a/spec/defines/balancer_spec.rb
+++ b/spec/defines/balancer_spec.rb
@@ -6,18 +6,8 @@ describe 'apache::balancer', type: :define do
   let :title do
     'myapp'
   end
-  let :facts do
-    {
-      osfamily: 'Debian',
-      operatingsystem: 'Debian',
-      operatingsystemrelease: '8',
-      lsbdistcodename: 'jessie',
-      id: 'root',
-      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-      kernel: 'Linux',
-      is_pe: false,
-    }
-  end
+
+  include_examples 'Debian 8'
 
   describe 'apache pre_condition with defaults' do
     let :pre_condition do

--- a/spec/defines/balancermember_spec.rb
+++ b/spec/defines/balancermember_spec.rb
@@ -6,18 +6,8 @@ describe 'apache::balancermember', type: :define do
   let :pre_condition do
     'include apache'
   end
-  let :facts do
-    {
-      osfamily: 'Debian',
-      operatingsystem: 'Debian',
-      operatingsystemrelease: '8',
-      lsbdistcodename: 'jessie',
-      id: 'root',
-      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-      kernel: 'Linux',
-      is_pe: false,
-    }
-  end
+
+  include_examples 'Debian 8'
 
   describe 'allows multiple balancermembers with the same url' do
     let :pre_condition do

--- a/spec/defines/custom_config_spec.rb
+++ b/spec/defines/custom_config_spec.rb
@@ -9,18 +9,8 @@ describe 'apache::custom_config', type: :define do
   let :title do
     'rspec'
   end
-  let :facts do
-    {
-      osfamily: 'Debian',
-      operatingsystemrelease: '8',
-      lsbdistcodename: 'jessie',
-      operatingsystem: 'Debian',
-      id: 'root',
-      kernel: 'Linux',
-      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-      is_pe: false,
-    }
-  end
+
+  include_examples 'Debian 8'
 
   context 'defaults with content' do
     let :params do

--- a/spec/defines/custom_config_spec.rb
+++ b/spec/defines/custom_config_spec.rb
@@ -20,21 +20,21 @@ describe 'apache::custom_config', type: :define do
     end
 
     it {
-      is_expected.to contain_exec('syntax verification for rspec').with('refreshonly' => 'true',
-                                                                        'subscribe'   => 'File[apache_rspec]',
-                                                                        'command'     => '/usr/sbin/apachectl -t',
-                                                                        'notify'      => 'Class[Apache::Service]',
-                                                                        'before'      => 'Exec[remove rspec if invalid]')
+      is_expected.to contain_exec('syntax verification for rspec')
+        .with('refreshonly' => 'true', 'command' => '/usr/sbin/apachectl -t')
+        .that_subscribes_to('File[apache_rspec]')
+        .that_notifies('Class[Apache::Service]')
+        .that_comes_before('Exec[remove rspec if invalid]')
     }
     it {
-      is_expected.to contain_exec('remove rspec if invalid').with('unless' => '/usr/sbin/apachectl -t',
-                                                                  'subscribe'   => 'File[apache_rspec]',
-                                                                  'refreshonly' => 'true')
+      is_expected.to contain_exec('remove rspec if invalid')
+        .with('unless' => '/usr/sbin/apachectl -t', 'refreshonly' => 'true')
+        .that_subscribes_to('File[apache_rspec]')
     }
     it {
-      is_expected.to contain_file('apache_rspec').with('ensure' => 'present',
-                                                       'content' => '# Test',
-                                                       'require' => 'Package[httpd]')
+      is_expected.to contain_file('apache_rspec')
+        .with('ensure' => 'present', 'content' => '# Test')
+        .that_requires('Package[httpd]')
     }
   end
   context 'set everything with source' do
@@ -55,10 +55,11 @@ describe 'apache::custom_config', type: :define do
                                                                   'unless' => '/bin/true')
     }
     it {
-      is_expected.to contain_file('apache_rspec').with('path' => '/dne/30-rspec.conf',
-                                                       'ensure' => 'present',
-                                                       'source' => 'puppet:///modules/apache/test',
-                                                       'require' => 'Package[httpd]')
+      is_expected.to contain_file('apache_rspec')
+        .that_requires('Package[httpd]')
+        .with('path' => '/dne/30-rspec.conf',
+              'ensure' => 'present',
+              'source' => 'puppet:///modules/apache/test')
     }
   end
   context 'verify_config => false' do
@@ -71,9 +72,7 @@ describe 'apache::custom_config', type: :define do
 
     it { is_expected.not_to contain_exec('syntax verification for rspec') }
     it { is_expected.not_to contain_exec('remove rspec if invalid') }
-    it {
-      is_expected.to contain_file('apache_rspec').with('notify' => 'Class[Apache::Service]')
-    }
+    it { is_expected.to contain_file('apache_rspec').that_notifies('Class[Apache::Service]') }
   end
   context 'ensure => absent' do
     let :params do
@@ -84,9 +83,7 @@ describe 'apache::custom_config', type: :define do
 
     it { is_expected.not_to contain_exec('syntax verification for rspec') }
     it { is_expected.not_to contain_exec('remove rspec if invalid') }
-    it {
-      is_expected.to contain_file('apache_rspec').with('ensure' => 'absent')
-    }
+    it { is_expected.to contain_file('apache_rspec').with('ensure' => 'absent') }
   end
   describe 'validation' do
     context 'both content and source' do
@@ -97,18 +94,11 @@ describe 'apache::custom_config', type: :define do
         }
       end
 
-      it do
-        expect {
-          catalogue
-        }.to raise_error(Puppet::Error, %r{Only one of \$content and \$source can be specified\.})
-      end
+      it { is_expected.to compile.and_raise_error(%r{Only one of \$content and \$source can be specified\.}) }
     end
+
     context 'neither content nor source' do
-      it do
-        expect {
-          catalogue
-        }.to raise_error(Puppet::Error, %r{One of \$content and \$source must be specified\.})
-      end
+      it { is_expected.to compile.and_raise_error(%r{One of \$content and \$source must be specified\.}) }
     end
   end
 end

--- a/spec/defines/mod_spec.rb
+++ b/spec/defines/mod_spec.rb
@@ -7,14 +7,14 @@ describe 'apache::mod', type: :define do
     'include apache'
   end
 
+  let :title do
+    'spec_m'
+  end
+
   context 'on a RedHat osfamily' do
     include_examples 'RedHat 6'
 
     describe 'for non-special modules' do
-      let :title do
-        'spec_m'
-      end
-
       it { is_expected.to contain_class('apache::params') }
       it 'manages the module load file' do
         is_expected.to contain_file('spec_m.load').with(path: '/etc/httpd/conf.d/spec_m.load',
@@ -28,9 +28,6 @@ describe 'apache::mod', type: :define do
     describe 'with file_mode set' do
       let :pre_condition do
         "class {'::apache': file_mode => '0640'}"
-      end
-      let :title do
-        'spec_m'
       end
 
       it 'manages the module load file' do
@@ -55,10 +52,6 @@ describe 'apache::mod', type: :define do
     include_examples 'Debian 8'
 
     describe 'for non-special modules' do
-      let :title do
-        'spec_m'
-      end
-
       it { is_expected.to contain_class('apache::params') }
       it 'manages the module load file' do
         is_expected.to contain_file('spec_m.load').with(path: '/etc/apache2/mods-available/spec_m.load',
@@ -81,10 +74,6 @@ describe 'apache::mod', type: :define do
     include_examples 'FreeBSD 9'
 
     describe 'for non-special modules' do
-      let :title do
-        'spec_m'
-      end
-
       it { is_expected.to contain_class('apache::params') }
       it 'manages the module load file' do
         is_expected.to contain_file('spec_m.load').with(path: '/usr/local/etc/apache24/Modules/spec_m.load',
@@ -100,10 +89,6 @@ describe 'apache::mod', type: :define do
     include_examples 'Gentoo'
 
     describe 'for non-special modules' do
-      let :title do
-        'spec_m'
-      end
-
       it { is_expected.to contain_class('apache::params') }
       it 'manages the module load file' do
         is_expected.to contain_file('spec_m.load').with(path: '/etc/apache2/modules.d/spec_m.load',

--- a/spec/defines/mod_spec.rb
+++ b/spec/defines/mod_spec.rb
@@ -8,17 +8,7 @@ describe 'apache::mod', type: :define do
   end
 
   context 'on a RedHat osfamily' do
-    let :facts do
-      {
-        osfamily: 'RedHat',
-        operatingsystemrelease: '6',
-        operatingsystem: 'RedHat',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'RedHat 6'
 
     describe 'for non-special modules' do
       let :title do
@@ -62,18 +52,7 @@ describe 'apache::mod', type: :define do
   end
 
   context 'on a Debian osfamily' do
-    let :facts do
-      {
-        osfamily: 'Debian',
-        operatingsystemrelease: '8',
-        lsbdistcodename: 'jessie',
-        operatingsystem: 'Debian',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Debian 8'
 
     describe 'for non-special modules' do
       let :title do
@@ -99,17 +78,7 @@ describe 'apache::mod', type: :define do
   end
 
   context 'on a FreeBSD osfamily' do
-    let :facts do
-      {
-        osfamily: 'FreeBSD',
-        operatingsystemrelease: '9',
-        operatingsystem: 'FreeBSD',
-        id: 'root',
-        kernel: 'FreeBSD',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'FreeBSD 9'
 
     describe 'for non-special modules' do
       let :title do
@@ -128,17 +97,7 @@ describe 'apache::mod', type: :define do
   end
 
   context 'on a Gentoo osfamily' do
-    let :facts do
-      {
-        osfamily: 'Gentoo',
-        operatingsystem: 'Gentoo',
-        operatingsystemrelease: '3.16.1-gentoo',
-        id: 'root',
-        kernel: 'Linux',
-        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
-        is_pe: false,
-      }
-    end
+    include_examples 'Gentoo'
 
     describe 'for non-special modules' do
       let :title do

--- a/spec/defines/vhost_custom_spec.rb
+++ b/spec/defines/vhost_custom_spec.rb
@@ -6,7 +6,7 @@ describe 'apache::vhost::custom', type: :define do
   let :title do
     'rspec.example.com'
   end
-  let :default_params do
+  let(:params) do
     {
       content: 'foobar',
     }
@@ -15,13 +15,11 @@ describe 'apache::vhost::custom', type: :define do
   describe 'os-dependent items' do
     context 'on RedHat based systems' do
       include_examples 'RedHat 6'
-      let(:params) { default_params }
 
       it { is_expected.to compile }
     end
     context 'on Debian based systems' do
       include_examples 'Debian 8'
-      let(:params) { default_params }
 
       it {
         is_expected.to contain_file('apache_rspec.example.com').with(
@@ -40,7 +38,6 @@ describe 'apache::vhost::custom', type: :define do
     end
     context 'on FreeBSD systems' do
       include_examples 'FreeBSD 9'
-      let(:params) { default_params }
 
       it {
         is_expected.to contain_file('apache_rspec.example.com').with(
@@ -52,7 +49,6 @@ describe 'apache::vhost::custom', type: :define do
     end
     context 'on Gentoo systems' do
       include_examples 'Gentoo'
-      let(:params) { default_params }
 
       it {
         is_expected.to contain_file('apache_rspec.example.com').with(

--- a/spec/defines/vhost_custom_spec.rb
+++ b/spec/defines/vhost_custom_spec.rb
@@ -14,37 +14,14 @@ describe 'apache::vhost::custom', type: :define do
 
   describe 'os-dependent items' do
     context 'on RedHat based systems' do
-      let :default_facts do
-        {
-          osfamily: 'RedHat',
-          operatingsystemrelease: '6',
-          operatingsystem: 'RedHat',
-          id: 'root',
-          kernel: 'Linux',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'RedHat 6'
       let(:params) { default_params }
-      let(:facts) { default_facts }
 
       it { is_expected.to compile }
     end
     context 'on Debian based systems' do
-      let :default_facts do
-        {
-          osfamily: 'Debian',
-          operatingsystemrelease: '8',
-          lsbdistcodename: 'jessie',
-          operatingsystem: 'Debian',
-          id: 'root',
-          kernel: 'Linux',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'Debian 8'
       let(:params) { default_params }
-      let(:facts) { default_facts }
 
       it {
         is_expected.to contain_file('apache_rspec.example.com').with(
@@ -62,19 +39,8 @@ describe 'apache::vhost::custom', type: :define do
       }
     end
     context 'on FreeBSD systems' do
-      let :default_facts do
-        {
-          osfamily: 'FreeBSD',
-          operatingsystemrelease: '9',
-          operatingsystem: 'FreeBSD',
-          id: 'root',
-          kernel: 'FreeBSD',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'FreeBSD 9'
       let(:params) { default_params }
-      let(:facts) { default_facts }
 
       it {
         is_expected.to contain_file('apache_rspec.example.com').with(
@@ -85,19 +51,8 @@ describe 'apache::vhost::custom', type: :define do
       }
     end
     context 'on Gentoo systems' do
-      let :default_facts do
-        {
-          osfamily: 'Gentoo',
-          operatingsystem: 'Gentoo',
-          operatingsystemrelease: '3.16.1-gentoo',
-          id: 'root',
-          kernel: 'Linux',
-          path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
-          is_pe: false,
-        }
-      end
+      include_examples 'Gentoo'
       let(:params) { default_params }
-      let(:facts) { default_facts }
 
       it {
         is_expected.to contain_file('apache_rspec.example.com').with(

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -2119,247 +2119,74 @@ describe 'apache::vhost', type: :define do
           end
         end # error logs format
         describe 'validation' do
-          context 'bad ensure' do
-            let :params do
-              {
-                'docroot' => '/rspec/docroot',
-                'ensure'  => 'bogus',
-              }
-            end
-
-            it { is_expected.to raise_error(Puppet::Error) }
+          let(:params) do
+            {
+              'docroot' => '/rspec/docroot',
+            }
           end
-          context 'bad suphp_engine' do
-            let :params do
-              {
-                'docroot'      => '/rspec/docroot',
-                'suphp_engine' => 'bogus',
-              }
-            end
 
-            it { is_expected.to raise_error(Puppet::Error) }
-          end
-          context 'bad ip_based' do
-            let :params do
-              {
-                'docroot'  => '/rspec/docroot',
-                'ip_based' => 'bogus',
-              }
-            end
+          [
+            'ensure', 'suphp_engine', 'ip_based', 'access_log', 'error_log',
+            'ssl', 'default_vhost', 'ssl_proxyengine', 'rewrites', 'suexec_user_group',
+            'wsgi_script_alias', 'wsgi_daemon_process_options',
+            'wsgi_import_script_alias', 'itk', 'logroot_ensure', 'log_level',
+            'fallbackresource'
+          ].each do |parameter|
+            context "bad #{parameter}" do
+              let(:params) { super().merge(parameter => 'bogus') }
 
-            it { is_expected.to raise_error(Puppet::Error) }
-          end
-          context 'bad access_log' do
-            let :params do
-              {
-                'docroot'    => '/rspec/docroot',
-                'access_log' => 'bogus',
-              }
+              it { is_expected.to raise_error(Puppet::Error) }
             end
-
-            it { is_expected.to raise_error(Puppet::Error) }
           end
-          context 'bad error_log' do
-            let :params do
-              {
-                'docroot'   => '/rspec/docroot',
-                'error_log' => 'bogus',
-              }
-            end
 
-            it { is_expected.to raise_error(Puppet::Error) }
-          end
-          context 'bad_ssl' do
-            let :params do
-              {
-                'docroot' => '/rspec/docroot',
-                'ssl'     => 'bogus',
-              }
-            end
-
-            it { is_expected.to raise_error(Puppet::Error) }
-          end
-          context 'bad default_vhost' do
-            let :params do
-              {
-                'docroot'       => '/rspec/docroot',
-                'default_vhost' => 'bogus',
-              }
-            end
-
-            it { is_expected.to raise_error(Puppet::Error) }
-          end
-          context 'bad ssl_proxyengine' do
-            let :params do
-              {
-                'docroot'         => '/rspec/docroot',
-                'ssl_proxyengine' => 'bogus',
-              }
-            end
-
-            it { is_expected.to raise_error(Puppet::Error) }
-          end
-          context 'bad rewrites' do
-            let :params do
-              {
-                'docroot'  => '/rspec/docroot',
-                'rewrites' => 'bogus',
-              }
-            end
-
-            it { is_expected.to raise_error(Puppet::Error) }
-          end
           context 'bad rewrites 2' do
-            let :params do
-              {
-                'docroot'  => '/rspec/docroot',
-                'rewrites' => ['bogus'],
-              }
-            end
+            let(:params) { super().merge('rewrites' => ['bogus']) }
 
             it { is_expected.to raise_error(Puppet::Error) }
           end
           context 'empty rewrites' do
-            let :params do
-              {
-                'docroot'  => '/rspec/docroot',
-                'rewrites' => [],
-              }
-            end
+            let(:params) { super().merge('rewrites' => []) }
 
             it { is_expected.to compile }
           end
-          context 'bad suexec_user_group' do
-            let :params do
-              {
-                'docroot'           => '/rspec/docroot',
-                'suexec_user_group' => 'bogus',
-              }
-            end
-
-            it { is_expected.to raise_error(Puppet::Error) }
-          end
-          context 'bad wsgi_script_alias' do
-            let :params do
-              {
-                'docroot'           => '/rspec/docroot',
-                'wsgi_script_alias' => 'bogus',
-              }
-            end
-
-            it { is_expected.to raise_error(Puppet::Error) }
-          end
-          context 'bad wsgi_daemon_process_options' do
-            let :params do
-              {
-                'docroot'                     => '/rspec/docroot',
-                'wsgi_daemon_process_options' => 'bogus',
-              }
-            end
-
-            it { is_expected.to raise_error(Puppet::Error) }
-          end
-          context 'bad wsgi_import_script_alias' do
-            let :params do
-              {
-                'docroot'                  => '/rspec/docroot',
-                'wsgi_import_script_alias' => 'bogus',
-              }
-            end
-
-            it { is_expected.to raise_error(Puppet::Error) }
-          end
-          context 'bad itk' do
-            let :params do
-              {
-                'docroot' => '/rspec/docroot',
-                'itk'     => 'bogus',
-              }
-            end
-
-            it { is_expected.to raise_error(Puppet::Error) }
-          end
-          context 'bad logroot_ensure' do
-            let :params do
-              {
-                'docroot'   => '/rspec/docroot',
-                'log_level' => 'bogus',
-              }
-            end
-
-            it { is_expected.to raise_error(Puppet::Error) }
-          end
-          context 'bad log_level' do
-            let :params do
-              {
-                'docroot'   => '/rspec/docroot',
-                'log_level' => 'bogus',
-              }
-            end
-
-            it { is_expected.to raise_error(Puppet::Error) }
-          end
           context 'bad error_log_format flag' do
             let :params do
-              {
-                'docroot'   => '/rspec/docroot',
+              super().merge(
                 'error_log_format' => [
                   { 'some format' => 'bogus' },
                 ],
-              }
+              )
             end
 
             it { is_expected.to raise_error(Puppet::Error) }
           end
           context 'access_log_file and access_log_pipe' do
             let :params do
-              {
-                'docroot'         => '/rspec/docroot',
+              super().merge(
                 'access_log_file' => 'bogus',
                 'access_log_pipe' => 'bogus',
-              }
+              )
             end
 
             it { is_expected.to raise_error(Puppet::Error) }
           end
           context 'error_log_file and error_log_pipe' do
             let :params do
-              {
-                'docroot'        => '/rspec/docroot',
+              super().merge(
                 'error_log_file' => 'bogus',
                 'error_log_pipe' => 'bogus',
-              }
-            end
-
-            it { is_expected.to raise_error(Puppet::Error) }
-          end
-          context 'bad fallbackresource' do
-            let :params do
-              {
-                'docroot'          => '/rspec/docroot',
-                'fallbackresource' => 'bogus',
-              }
+              )
             end
 
             it { is_expected.to raise_error(Puppet::Error) }
           end
           context 'bad custom_fragment' do
-            let :params do
-              {
-                'docroot'         => '/rspec/docroot',
-                'custom_fragment' => true,
-              }
-            end
+            let(:params) { super().merge('custom_fragment' => true) }
 
             it { is_expected.to raise_error(Puppet::Error) }
           end
           context 'bad access_logs' do
-            let :params do
-              {
-                'docroot'     => '/rspec/docroot',
-                'access_logs' => '/var/log/somewhere',
-              }
-            end
+            let(:params) { super().merge('access_logs' => '/var/log/somewhere') }
 
             it { is_expected.to raise_error(Puppet::Error) }
           end
@@ -2414,31 +2241,24 @@ describe 'apache::vhost', type: :define do
             }
           end
           describe 'redirectmatch_*' do
-            let :dparams do
-              {
-                docroot: '/rspec/docroot',
-                port: '84',
-              }
-            end
+            let(:params) { super().merge(port: '84') }
 
             context 'status' do
-              let(:params) { dparams.merge(redirectmatch_status: '404') }
+              let(:params) { super().merge(redirectmatch_status: '404') }
 
               it { is_expected.to contain_class('apache::mod::alias') }
             end
             context 'dest' do
-              let(:params) { dparams.merge(redirectmatch_dest: 'http://other.example.com$1.jpg') }
+              let(:params) { super().merge(redirectmatch_dest: 'http://other.example.com$1.jpg') }
 
               it { is_expected.to contain_class('apache::mod::alias') }
             end
             context 'regexp' do
-              let(:params) { dparams.merge(redirectmatch_regexp: "(.*)\.gif$") }
+              let(:params) { super().merge(redirectmatch_regexp: "(.*)\.gif$") }
 
               it { is_expected.to contain_class('apache::mod::alias') }
             end
             context 'none' do
-              let(:params) { dparams }
-
               it { is_expected.not_to contain_class('apache::mod::alias') }
             end
           end

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -55,19 +55,6 @@ shared_context 'Ubuntu 14.04' do
   end
 end
 
-shared_context 'RedHat 5' do
-  let :facts do
-    {
-      id: 'root',
-      kernel: 'Linux',
-      osfamily: 'RedHat',
-      operatingsystem: 'RedHat',
-      operatingsystemrelease: '5',
-      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    }
-  end
-end
-
 shared_context 'RedHat 6' do
   let(:facts) { on_supported_os['redhat-6-x86_64'] }
 end

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -50,19 +50,6 @@ shared_context 'Debian 6' do
   end
 end
 
-shared_context 'Debian 7' do
-  let :facts do
-    {
-      id: 'root',
-      kernel: 'Linux',
-      osfamily: 'Debian',
-      operatingsystem: 'Debian',
-      operatingsystemrelease: '7.0.0',
-      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    }
-  end
-end
-
 shared_context 'Debian 8' do
   let(:facts) { on_supported_os['debian-8-x86_64'] }
 end

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -64,16 +64,7 @@ shared_context 'Debian 7' do
 end
 
 shared_context 'Debian 8' do
-  let :facts do
-    {
-      id: 'root',
-      kernel: 'Linux',
-      osfamily: 'Debian',
-      operatingsystem: 'Debian',
-      operatingsystemrelease: '8.0.0',
-      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    }
-  end
+  let(:facts) { on_supported_os['debian-8-x86_64'] }
 end
 
 shared_context 'Ubuntu 14.04' do
@@ -104,42 +95,15 @@ shared_context 'RedHat 5' do
 end
 
 shared_context 'RedHat 6' do
-  let :facts do
-    {
-      id: 'root',
-      kernel: 'Linux',
-      osfamily: 'RedHat',
-      operatingsystem: 'RedHat',
-      operatingsystemrelease: '6',
-      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    }
-  end
+  let(:facts) { on_supported_os['redhat-6-x86_64'] }
 end
 
 shared_context 'RedHat 7' do
-  let :facts do
-    {
-      id: 'root',
-      kernel: 'Linux',
-      osfamily: 'RedHat',
-      operatingsystem: 'RedHat',
-      operatingsystemrelease: '7',
-      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    }
-  end
+  let(:facts) { on_supported_os['redhat-7-x86_64'] }
 end
 
 shared_context 'RedHat 8' do
-  let :facts do
-    {
-      id: 'root',
-      kernel: 'Linux',
-      osfamily: 'RedHat',
-      operatingsystem: 'RedHat',
-      operatingsystemrelease: '8',
-      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    }
-  end
+  let(:facts) { on_supported_os['redhat-8-x86_64'] }
 end
 
 shared_context 'Fedora 17' do
@@ -256,14 +220,5 @@ shared_context 'Unsupported OS' do
 end
 
 shared_context 'SLES 12' do
-  let :facts do
-    {
-      osfamily: 'Suse',
-      operatingsystem: 'SLES',
-      operatingsystemrelease: '12',
-      id: 'root',
-      kernel: 'Linux',
-      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
-    }
-  end
+  let(:facts) { on_supported_os['sles-12-x86_64'] }
 end

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -41,18 +41,8 @@ shared_context 'Debian 8' do
   let(:facts) { on_supported_os['debian-8-x86_64'] }
 end
 
-shared_context 'Ubuntu 14.04' do
-  let :facts do
-    {
-      id: 'root',
-      kernel: 'Linux',
-      osfamily: 'Debian',
-      operatingsystem: 'Ubuntu',
-      operatingsystemrelease: '14.04',
-      lsbdistrelease: '14.04',
-      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    }
-  end
+shared_context 'Ubuntu 18.04' do
+  let(:facts) { on_supported_os['ubuntu-18.04-x86_64'] }
 end
 
 shared_context 'RedHat 6' do

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -37,19 +37,6 @@ shared_context 'a mod class, without including apache' do
   let(:facts) { on_supported_os['debian-8-x86_64'] }
 end
 
-shared_context 'Debian 6' do
-  let :facts do
-    {
-      id: 'root',
-      kernel: 'Linux',
-      osfamily: 'Debian',
-      operatingsystem: 'Debian',
-      operatingsystemrelease: '6',
-      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    }
-  end
-end
-
 shared_context 'Debian 8' do
   let(:facts) { on_supported_os['debian-8-x86_64'] }
 end

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -36,3 +36,234 @@ end
 shared_context 'a mod class, without including apache' do
   let(:facts) { on_supported_os['debian-8-x86_64'] }
 end
+
+shared_context 'Debian 6' do
+  let :facts do
+    {
+      id: 'root',
+      kernel: 'Linux',
+      osfamily: 'Debian',
+      operatingsystem: 'Debian',
+      operatingsystemrelease: '6',
+      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    }
+  end
+end
+
+shared_context 'Debian 7' do
+  let :facts do
+    {
+      id: 'root',
+      kernel: 'Linux',
+      osfamily: 'Debian',
+      operatingsystem: 'Debian',
+      operatingsystemrelease: '7.0.0',
+      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    }
+  end
+end
+
+shared_context 'Debian 8' do
+  let :facts do
+    {
+      id: 'root',
+      kernel: 'Linux',
+      osfamily: 'Debian',
+      operatingsystem: 'Debian',
+      operatingsystemrelease: '8.0.0',
+      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    }
+  end
+end
+
+shared_context 'Ubuntu 14.04' do
+  let :facts do
+    {
+      id: 'root',
+      kernel: 'Linux',
+      osfamily: 'Debian',
+      operatingsystem: 'Ubuntu',
+      operatingsystemrelease: '14.04',
+      lsbdistrelease: '14.04',
+      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    }
+  end
+end
+
+shared_context 'RedHat 5' do
+  let :facts do
+    {
+      id: 'root',
+      kernel: 'Linux',
+      osfamily: 'RedHat',
+      operatingsystem: 'RedHat',
+      operatingsystemrelease: '5',
+      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    }
+  end
+end
+
+shared_context 'RedHat 6' do
+  let :facts do
+    {
+      id: 'root',
+      kernel: 'Linux',
+      osfamily: 'RedHat',
+      operatingsystem: 'RedHat',
+      operatingsystemrelease: '6',
+      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    }
+  end
+end
+
+shared_context 'RedHat 7' do
+  let :facts do
+    {
+      id: 'root',
+      kernel: 'Linux',
+      osfamily: 'RedHat',
+      operatingsystem: 'RedHat',
+      operatingsystemrelease: '7',
+      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    }
+  end
+end
+
+shared_context 'RedHat 8' do
+  let :facts do
+    {
+      id: 'root',
+      kernel: 'Linux',
+      osfamily: 'RedHat',
+      operatingsystem: 'RedHat',
+      operatingsystemrelease: '8',
+      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    }
+  end
+end
+
+shared_context 'Fedora 17' do
+  let :facts do
+    {
+      id: 'root',
+      kernel: 'Linux',
+      osfamily: 'RedHat',
+      operatingsystem: 'Fedora',
+      operatingsystemrelease: '17',
+      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    }
+  end
+end
+
+shared_context 'Fedora 21' do
+  let :facts do
+    {
+      id: 'root',
+      kernel: 'Linux',
+      osfamily: 'RedHat',
+      operatingsystem: 'Fedora',
+      operatingsystemrelease: '21',
+      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    }
+  end
+end
+
+shared_context 'Fedora 28' do
+  let :facts do
+    {
+      id: 'root',
+      kernel: 'Linux',
+      osfamily: 'RedHat',
+      operatingsystem: 'Fedora',
+      operatingsystemrelease: '28',
+      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    }
+  end
+end
+
+shared_context 'Fedora Rawhide' do
+  let :facts do
+    {
+      id: 'root',
+      kernel: 'Linux',
+      osfamily: 'RedHat',
+      operatingsystem: 'Fedora',
+      operatingsystemrelease: 'Rawhide',
+      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    }
+  end
+end
+
+shared_context 'FreeBSD 9' do
+  let :facts do
+    {
+      osfamily: 'FreeBSD',
+      operatingsystemrelease: '9',
+      operatingsystem: 'FreeBSD',
+      id: 'root',
+      kernel: 'FreeBSD',
+      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    }
+  end
+end
+
+shared_context 'FreeBSD 10' do
+  let :facts do
+    {
+      id: 'root',
+      kernel: 'FreeBSD',
+      osfamily: 'FreeBSD',
+      operatingsystem: 'FreeBSD',
+      operatingsystemrelease: '10',
+      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    }
+  end
+end
+
+shared_context 'Gentoo' do
+  let :facts do
+    {
+      id: 'root',
+      kernel: 'Linux',
+      osfamily: 'Gentoo',
+      operatingsystem: 'Gentoo',
+      operatingsystemrelease: '3.16.1-gentoo',
+      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
+    }
+  end
+end
+
+shared_context 'Darwin' do
+  let :facts do
+    {
+      osfamily: 'Darwin',
+      operatingsystemrelease: '13.1.0',
+    }
+  end
+end
+
+shared_context 'Unsupported OS' do
+  let :facts do
+    {
+      osfamily: 'Magic',
+      operatingsystemrelease: '0',
+      operatingsystem: 'Magic',
+      id: 'root',
+      kernel: 'Linux',
+      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    }
+  end
+end
+
+shared_context 'SLES 12' do
+  let :facts do
+    {
+      osfamily: 'Suse',
+      operatingsystem: 'SLES',
+      operatingsystemrelease: '12',
+      id: 'root',
+      kernel: 'Linux',
+      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin',
+    }
+  end
+end


### PR DESCRIPTION
This extracts common sets of facts to shared examples to reduce duplication. It also makes it easier to actually provide correct OS facts and use modern facts.

It also has 2 other commits that slightly improve the specs.

I realize this is a large PR and that's why I haven't even started with making actual changes. It should have a net effect that it's the same coverage but with less code duplication. It's a preparation for https://github.com/puppetlabs/puppetlabs-apache/pull/2110.