### PR TITLE
Drop support for Debian < 9

### DIFF
--- a/manifests/dev.pp
+++ b/manifests/dev.pp
@@ -3,7 +3,7 @@
 #
 # The libraries installed depends on the `dev_packages` parameter of the `apache::params` 
 # class, based on your operating system:
-# - **Debian** : `libaprutil1-dev`, `libapr1-dev`; `apache2-dev` on Ubuntu 13.10 and Debian 8; `apache2-prefork-dev` on other versions.
+# - **Debian** : `libaprutil1-dev`, `libapr1-dev`; `apache2-dev`
 # - **FreeBSD**: `undef`; on FreeBSD, you must declare the `apache::package` or `apache` classes before declaring `apache::dev`.
 # - **Gentoo**: `undef`.
 # - **Red Hat**: `httpd-devel`.

--- a/manifests/mod/suphp.pp
+++ b/manifests/mod/suphp.pp
@@ -5,8 +5,7 @@
 #
 class apache::mod::suphp (
 ) {
-  if  ($facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['major'], '15.10') >= 0) or
-  $facts['os']['name'] == 'Debian' {
+  if $facts['os']['family'] == 'Debian' {
     fail("suphp was declared EOL by it's creators as of 2013 and so is no longer supported on Ubuntu 15.10/Debian 8 and above. Please use php-fpm")
   }
   include apache

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -361,38 +361,7 @@ class apache::params inherits ::apache::version {
     $suphp_addhandler    = 'x-httpd-php'
     $suphp_engine        = 'off'
     $suphp_configpath    = '/etc/php5/apache2'
-    if ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '16.04') < 0) or ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '9') < 0) {
-      # Only the major version is used here
-      $php_version = '5'
-      $mod_packages = {
-        'auth_cas'              => 'libapache2-mod-auth-cas',
-        'auth_kerb'             => 'libapache2-mod-auth-kerb',
-        'auth_openidc'          => 'libapache2-mod-auth-openidc',
-        'auth_gssapi'           => 'libapache2-mod-auth-gssapi',
-        'auth_mellon'           => 'libapache2-mod-auth-mellon',
-        'authnz_pam'            => 'libapache2-mod-authnz-pam',
-        'dav_svn'               => 'libapache2-svn',
-        'fastcgi'               => 'libapache2-mod-fastcgi',
-        'fcgid'                 => 'libapache2-mod-fcgid',
-        'geoip'                 => 'libapache2-mod-geoip',
-        'intercept_form_submit' => 'libapache2-mod-intercept-form-submit',
-        'jk'                    => 'libapache2-mod-jk',
-        'lookup_identity'       => 'libapache2-mod-lookup-identity',
-        'nss'                   => 'libapache2-mod-nss',
-        'pagespeed'             => 'mod-pagespeed-stable',
-        'passenger'             => 'libapache2-mod-passenger',
-        'perl'                  => 'libapache2-mod-perl2',
-        'phpXXX'                => 'libapache2-mod-phpXXX',
-        'proxy_html'            => 'libapache2-mod-proxy-html',
-        'python'                => 'libapache2-mod-python',
-        'rpaf'                  => 'libapache2-mod-rpaf',
-        'security'              => 'libapache2-modsecurity',
-        'shib2'                 => 'libapache2-mod-shib2',
-        'suphp'                 => 'libapache2-mod-suphp',
-        'wsgi'                  => 'libapache2-mod-wsgi',
-        'xsendfile'             => 'libapache2-mod-xsendfile',
-      }
-    } elsif ($::operatingsystem == 'Ubuntu') or ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '11') < 0) {
+    if ($::operatingsystem == 'Ubuntu') or ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '11') < 0) {
       $php_version = $facts['operatingsystemmajrelease'] ? {
         '9'     => '7.0', # Debian Stretch
         '16.04' => '7.0', # Ubuntu Xenial

--- a/metadata.json
+++ b/metadata.json
@@ -51,7 +51,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8",
         "9",
         "10",
         "11"
@@ -67,7 +66,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "14.04",
         "16.04",
         "18.04",
         "20.04"

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'apache', type: :class do
   context 'on a Debian OS' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     it { is_expected.to contain_class('apache::params') }
     it {

--- a/spec/classes/mod/alias_spec.rb
+++ b/spec/classes/mod/alias_spec.rb
@@ -7,7 +7,7 @@ describe 'apache::mod::alias', type: :class do
 
   context 'default configuration with parameters' do
     context 'on a Debian OS', :compile do
-      include_examples 'Debian 8'
+      include_examples 'Debian 11'
 
       it { is_expected.to contain_apache__mod('alias') }
       it { is_expected.to contain_file('alias.conf').with(content: %r{Alias \/icons\/ "\/usr\/share\/apache2\/icons\/"}) }

--- a/spec/classes/mod/auth_cas_spec.rb
+++ b/spec/classes/mod/auth_cas_spec.rb
@@ -24,7 +24,7 @@ describe 'apache::mod::auth_cas', type: :class do
     end
 
     context 'on a Debian OS', :compile do
-      include_examples 'Debian 8'
+      include_examples 'Debian 11'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('auth_cas') }

--- a/spec/classes/mod/auth_gssapi_spec.rb
+++ b/spec/classes/mod/auth_gssapi_spec.rb
@@ -7,7 +7,7 @@ describe 'apache::mod::auth_gssapi', type: :class do
 
   context 'default configuration with parameters' do
     context 'on a Debian OS', :compile do
-      include_examples 'Debian 8'
+      include_examples 'Debian 11'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('auth_gssapi') }

--- a/spec/classes/mod/auth_kerb_spec.rb
+++ b/spec/classes/mod/auth_kerb_spec.rb
@@ -7,7 +7,7 @@ describe 'apache::mod::auth_kerb', type: :class do
 
   context 'default configuration with parameters' do
     context 'on a Debian OS', :compile do
-      include_examples 'Debian 8'
+      include_examples 'Debian 11'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('auth_kerb') }

--- a/spec/classes/mod/auth_mellon_spec.rb
+++ b/spec/classes/mod/auth_mellon_spec.rb
@@ -6,7 +6,7 @@ describe 'apache::mod::auth_mellon', type: :class do
   it_behaves_like 'a mod class, without including apache'
 
   context 'default configuration with parameters on a Debian OS' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     describe 'with no parameters' do
       it { is_expected.to contain_apache__mod('auth_mellon') }

--- a/spec/classes/mod/auth_openidc_spec.rb
+++ b/spec/classes/mod/auth_openidc_spec.rb
@@ -7,7 +7,7 @@ describe 'apache::mod::auth_openidc', type: :class do
 
   context 'default configuration with parameters' do
     context 'on a Debian OS', :compile do
-      include_examples 'Debian 8'
+      include_examples 'Debian 11'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('auth_openidc') }

--- a/spec/classes/mod/authn_dbd_spec.rb
+++ b/spec/classes/mod/authn_dbd_spec.rb
@@ -23,7 +23,7 @@ describe 'apache::mod::authn_dbd', type: :class do
     end
 
     context 'on a Debian OS', :compile do
-      include_examples 'Debian 8'
+      include_examples 'Debian 11'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('authn_dbd') }

--- a/spec/classes/mod/authnz_ldap_spec.rb
+++ b/spec/classes/mod/authnz_ldap_spec.rb
@@ -6,7 +6,7 @@ describe 'apache::mod::authnz_ldap', type: :class do
   it_behaves_like 'a mod class, without including apache'
 
   context 'default configuration with parameters on a Debian OS' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_class('apache::mod::ldap') }

--- a/spec/classes/mod/authnz_pam_spec.rb
+++ b/spec/classes/mod/authnz_pam_spec.rb
@@ -7,7 +7,7 @@ describe 'apache::mod::authnz_pam', type: :class do
 
   context 'default configuration with parameters' do
     context 'on a Debian OS' do
-      include_examples 'Debian 8'
+      include_examples 'Debian 11'
 
       it { is_expected.to contain_class('apache') }
       it { is_expected.to contain_package('libapache2-mod-authnz-pam') }

--- a/spec/classes/mod/data_spec.rb
+++ b/spec/classes/mod/data_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'apache::mod::data', type: :class do
   context 'on a Debian OS' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
     let :params do
       { apache_version: '2.4' }
     end

--- a/spec/classes/mod/dav_svn_spec.rb
+++ b/spec/classes/mod/dav_svn_spec.rb
@@ -7,11 +7,11 @@ describe 'apache::mod::dav_svn', type: :class do
 
   context 'default configuration with parameters' do
     context 'on a Debian OS' do
-      include_examples 'Debian 8'
+      include_examples 'Debian 11'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('dav_svn') }
-      it { is_expected.to contain_package('libapache2-svn') }
+      it { is_expected.to contain_package('libapache2-mod-svn') }
       it { is_expected.to contain_file('dav_svn.load').with_content(%r{LoadModule dav_svn_module}) }
       describe 'with parameters' do
         let :params do
@@ -22,7 +22,7 @@ describe 'apache::mod::dav_svn', type: :class do
 
         it { is_expected.to contain_class('apache::params') }
         it { is_expected.to contain_apache__mod('dav_svn') }
-        it { is_expected.to contain_package('libapache2-svn') }
+        it { is_expected.to contain_package('libapache2-mod-svn') }
         it { is_expected.to contain_apache__mod('authz_svn') }
         it { is_expected.to contain_file('dav_svn_authz_svn.load').with_content(%r{LoadModule authz_svn_module}) }
       end

--- a/spec/classes/mod/deflate_spec.rb
+++ b/spec/classes/mod/deflate_spec.rb
@@ -37,7 +37,7 @@ describe 'apache::mod::deflate', type: :class do
     end
 
     context 'On a Debian OS with default params' do
-      include_examples 'Debian 8'
+      include_examples 'Debian 11'
 
       # Load the more generic tests for this context
       general_deflate_specs

--- a/spec/classes/mod/dev_spec.rb
+++ b/spec/classes/mod/dev_spec.rb
@@ -11,7 +11,7 @@ describe 'apache::mod::dev', type: :class do
 
   it_behaves_like 'a mod class, without including apache'
 
-  ['RedHat 6', 'Debian 8', 'FreeBSD 9'].each do |os|
+  ['RedHat 6', 'Debian 11', 'FreeBSD 9'].each do |os|
     context "on a #{os} OS" do
       include_examples os
 

--- a/spec/classes/mod/dir_spec.rb
+++ b/spec/classes/mod/dir_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe 'apache::mod::dir', type: :class do
-  ['Debian 8', 'RedHat 6', 'FreeBSD 9', 'Gentoo'].each do |os|
+  ['Debian 11', 'RedHat 6', 'FreeBSD 9', 'Gentoo'].each do |os|
     context "default configuration with parameters on #{os}" do
       include_examples os
 

--- a/spec/classes/mod/disk_cache_spec.rb
+++ b/spec/classes/mod/disk_cache_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'apache::mod::disk_cache', type: :class do
   context 'on a Debian OS' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     let(:params) do
       {

--- a/spec/classes/mod/dumpio_spec.rb
+++ b/spec/classes/mod/dumpio_spec.rb
@@ -11,7 +11,7 @@ describe 'apache::mod::dumpio', type: :class do
        }'
     end
 
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     context 'default configuration fore parameters' do
       it { is_expected.to compile }

--- a/spec/classes/mod/event_spec.rb
+++ b/spec/classes/mod/event_spec.rb
@@ -22,7 +22,7 @@ describe 'apache::mod::event', type: :class do
     it { is_expected.to contain_file('/etc/apache2/modules.d/event.conf').with_ensure('file') }
   end
   context 'on a Debian OS' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('event') }

--- a/spec/classes/mod/expires_spec.rb
+++ b/spec/classes/mod/expires_spec.rb
@@ -6,7 +6,7 @@ describe 'apache::mod::expires', type: :class do
   it_behaves_like 'a mod class, without including apache'
 
   context 'with expires active', :compile do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     it { is_expected.to contain_apache__mod('expires') }
     it { is_expected.to contain_file('expires.conf').with(content: %r{ExpiresActive On\n}) }

--- a/spec/classes/mod/ext_filter_spec.rb
+++ b/spec/classes/mod/ext_filter_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe 'apache::mod::ext_filter', type: :class do
   it_behaves_like 'a mod class, without including apache'
   context 'on a Debian OS' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     describe 'with no parameters' do
       it { is_expected.to contain_apache__mod('ext_filter') }

--- a/spec/classes/mod/fcgid_spec.rb
+++ b/spec/classes/mod/fcgid_spec.rb
@@ -6,7 +6,7 @@ describe 'apache::mod::fcgid', type: :class do
   it_behaves_like 'a mod class, without including apache'
 
   context 'on a Debian OS' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     it { is_expected.to contain_class('apache::params') }
     it {

--- a/spec/classes/mod/http2_spec.rb
+++ b/spec/classes/mod/http2_spec.rb
@@ -6,7 +6,7 @@ describe 'apache::mod::http2', type: :class do
   it_behaves_like 'a mod class, without including apache'
 
   context 'default configuration with parameters on a Debian OS' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     it { is_expected.to contain_class('apache::mod::http2') }
     context 'with default values' do

--- a/spec/classes/mod/info_spec.rb
+++ b/spec/classes/mod/info_spec.rb
@@ -124,7 +124,7 @@ describe 'apache::mod::info', type: :class do
   it_behaves_like 'a mod class, without including apache'
 
   context 'On a Debian OS' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     # Load the more generic tests for this context
     general_info_specs_apache24

--- a/spec/classes/mod/intercept_form_submit_spec.rb
+++ b/spec/classes/mod/intercept_form_submit_spec.rb
@@ -7,7 +7,7 @@ describe 'apache::mod::intercept_form_submit', type: :class do
 
   context 'default configuration with parameters' do
     context 'on a Debian OS' do
-      include_examples 'Debian 8'
+      include_examples 'Debian 11'
 
       it { is_expected.to contain_class('apache') }
       it { is_expected.to contain_package('libapache2-mod-intercept-form-submit') }

--- a/spec/classes/mod/itk_spec.rb
+++ b/spec/classes/mod/itk_spec.rb
@@ -8,7 +8,7 @@ describe 'apache::mod::itk', type: :class do
   end
 
   context 'on a Debian OS' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('itk') }

--- a/spec/classes/mod/jk_spec.rb
+++ b/spec/classes/mod/jk_spec.rb
@@ -63,8 +63,8 @@ describe 'apache::mod::jk', type: :class do
   default_port = 80
   altern8_port = 8008
 
-  context 'Debian 8' do
-    include_examples 'Debian 8'
+  context 'Debian 11' do
+    include_examples 'Debian 11'
 
     context 'with only required facts and default parameters' do
       let(:facts) { super().merge('ipaddress' => default_ip) }

--- a/spec/classes/mod/ldap_spec.rb
+++ b/spec/classes/mod/ldap_spec.rb
@@ -6,7 +6,7 @@ describe 'apache::mod::ldap', type: :class do
   it_behaves_like 'a mod class, without including apache'
 
   context 'on a Debian OS' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_class('apache::mod::ldap') }

--- a/spec/classes/mod/lookup_identity.rb
+++ b/spec/classes/mod/lookup_identity.rb
@@ -7,7 +7,7 @@ describe 'apache::mod::lookup_identity', type: :class do
 
   context 'default configuration with parameters' do
     context 'on a Debian OS' do
-      include_examples 'Debian 8'
+      include_examples 'Debian 11'
 
       it { is_expected.to contain_class('apache') }
       it { is_expected.to contain_package('libapache2-mod-lookup-identity') }

--- a/spec/classes/mod/mime_magic_spec.rb
+++ b/spec/classes/mod/mime_magic_spec.rb
@@ -56,18 +56,4 @@ describe 'apache::mod::mime_magic', type: :class do
 
     it { is_expected.to contain_file('mime_magic.conf').with_path('/etc/httpd/conf.d/mime_magic.conf') }
   end
-
-  context 'with magic_file => /tmp/magic' do
-    include_examples 'Debian 8'
-
-    let :params do
-      { magic_file: '/tmp/magic' }
-    end
-
-    it do
-      is_expected.to contain_file('mime_magic.conf').with_content(
-        "MIMEMagicFile \"/tmp/magic\"\n",
-      )
-    end
-  end
 end

--- a/spec/classes/mod/mime_magic_spec.rb
+++ b/spec/classes/mod/mime_magic_spec.rb
@@ -11,7 +11,7 @@ describe 'apache::mod::mime_magic', type: :class do
   it_behaves_like 'a mod class, without including apache'
 
   context 'On a Debian OS with default params' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     general_mime_magic_specs
 

--- a/spec/classes/mod/mime_spec.rb
+++ b/spec/classes/mod/mime_spec.rb
@@ -18,7 +18,7 @@ describe 'apache::mod::mime', type: :class do
   it_behaves_like 'a mod class, without including apache'
 
   context 'On a Debian OS with default params', :compile do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     general_mime_specs
 

--- a/spec/classes/mod/negotiation_spec.rb
+++ b/spec/classes/mod/negotiation_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe 'apache::mod::negotiation', type: :class do
   it_behaves_like 'a mod class, without including apache'
   describe 'OS independent tests' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     context 'default params' do
       it { is_expected.to contain_class('apache') }

--- a/spec/classes/mod/pagespeed_spec.rb
+++ b/spec/classes/mod/pagespeed_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'apache::mod::pagespeed', type: :class do
   context 'on a Debian OS' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('pagespeed') }

--- a/spec/classes/mod/perl_spec.rb
+++ b/spec/classes/mod/perl_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe 'apache::mod::perl', type: :class do
   it_behaves_like 'a mod class, without including apache'
   context 'on a Debian OS' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('perl') }

--- a/spec/classes/mod/php_spec.rb
+++ b/spec/classes/mod/php_spec.rb
@@ -20,29 +20,6 @@ describe 'apache::mod::php', type: :class do
             it { is_expected.to contain_class('apache::mod::prefork') }
           end
           case facts[:os]['release']['major']
-          when '8'
-            context 'on jessie' do
-              it {
-                is_expected.to contain_file('php5.load').with(
-                  content: "LoadModule php5_module /usr/lib/apache2/modules/libphp5.so\n",
-                )
-              }
-              context 'with mpm_module => itk on jessie' do
-                let :pre_condition do
-                  'class { "apache": mpm_module => itk, }'
-                end
-
-                it { is_expected.to contain_class('apache::params') }
-                it { is_expected.to contain_class('apache::mod::itk') }
-                it { is_expected.to contain_apache__mod('php5') }
-                it { is_expected.to contain_package('libapache2-mod-php5') }
-                it {
-                  is_expected.to contain_file('php5.load').with(
-                    content: "LoadModule php5_module /usr/lib/apache2/modules/libphp5.so\n",
-                  )
-                }
-              end
-            end
           when '9'
             context 'on stretch' do
               it { is_expected.to contain_apache__mod('php7.0') }

--- a/spec/classes/mod/prefork_spec.rb
+++ b/spec/classes/mod/prefork_spec.rb
@@ -8,7 +8,7 @@ describe 'apache::mod::prefork', type: :class do
   end
 
   context 'on a Debian OS' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('prefork') }

--- a/spec/classes/mod/proxy_balancer_spec.rb
+++ b/spec/classes/mod/proxy_balancer_spec.rb
@@ -24,7 +24,7 @@ describe 'apache::mod::proxy_balancer', type: :class do
 
   context 'default configuration with default parameters' do
     context 'on a Debian OS' do
-      include_examples 'Debian 8'
+      include_examples 'Debian 11'
 
       it { is_expected.to contain_apache__mod('proxy_balancer') }
 
@@ -42,7 +42,7 @@ describe 'apache::mod::proxy_balancer', type: :class do
     end
   end
   context "default configuration with custom parameters $manager => true, $allow_from => ['10.10.10.10','11.11.11.11'], $status_path => '/custom-manager' on a Debian OS" do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
     let :params do
       {
         manager: true,

--- a/spec/classes/mod/proxy_html_spec.rb
+++ b/spec/classes/mod/proxy_html_spec.rb
@@ -19,7 +19,7 @@ describe 'apache::mod::proxy_html', type: :class do
     end
     include_examples 'Debian 8'
 
-    context 'on jessie i386' do
+    context 'on i386' do
       let(:facts) do
         super().merge(hardwaremodel: 'i686',
                       architecture: 'i386')
@@ -28,7 +28,7 @@ describe 'apache::mod::proxy_html', type: :class do
       it { is_expected.to contain_apache__mod('xml2enc').with(loadfiles: nil) }
       it_behaves_like 'debian', ['/usr/lib/i386-linux-gnu/libxml2.so.2']
     end
-    context 'on jessie x64' do
+    context 'on x64' do
       let(:facts) do
         super().merge(hardwaremodel: 'x86_64',
                       architecture: 'amd64')

--- a/spec/classes/mod/proxy_html_spec.rb
+++ b/spec/classes/mod/proxy_html_spec.rb
@@ -15,9 +15,8 @@ describe 'apache::mod::proxy_html', type: :class do
     shared_examples 'debian' do |loadfiles|
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('proxy_html').with(loadfiles: loadfiles) }
-      it { is_expected.to contain_package('libapache2-mod-proxy-html') }
     end
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     context 'on i386' do
       let(:facts) do

--- a/spec/classes/mod/python_spec.rb
+++ b/spec/classes/mod/python_spec.rb
@@ -6,7 +6,7 @@ describe 'apache::mod::python', type: :class do
   it_behaves_like 'a mod class, without including apache'
 
   context 'on a Debian OS' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('python') }

--- a/spec/classes/mod/remoteip_spec.rb
+++ b/spec/classes/mod/remoteip_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'apache::mod::remoteip', type: :class do
   context 'on a Debian OS' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
     let :params do
       { apache_version: '2.4' }
     end

--- a/spec/classes/mod/reqtimeout_spec.rb
+++ b/spec/classes/mod/reqtimeout_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe 'apache::mod::reqtimeout', type: :class do
   it_behaves_like 'a mod class, without including apache'
   context 'on a Debian OS' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     context 'passing no parameters' do
       it { is_expected.to contain_class('apache::params') }

--- a/spec/classes/mod/rpaf_spec.rb
+++ b/spec/classes/mod/rpaf_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe 'apache::mod::rpaf', type: :class do
   it_behaves_like 'a mod class, without including apache'
   context 'on a Debian OS' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('rpaf') }

--- a/spec/classes/mod/shib_spec.rb
+++ b/spec/classes/mod/shib_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe 'apache::mod::shib', type: :class do
   it_behaves_like 'a mod class, without including apache'
   context 'on a Debian OS' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     describe 'with no parameters' do
       it { is_expected.to contain_apache__mod('shib2').with_id('mod_shib') }

--- a/spec/classes/mod/speling_spec.rb
+++ b/spec/classes/mod/speling_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe 'apache::mod::speling', type: :class do
   it_behaves_like 'a mod class, without including apache'
   context 'on a Debian OS' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     it { is_expected.to contain_apache__mod('speling') }
   end

--- a/spec/classes/mod/ssl_spec.rb
+++ b/spec/classes/mod/ssl_spec.rb
@@ -60,7 +60,7 @@ describe 'apache::mod::ssl', type: :class do
   end
 
   context 'on a Debian OS' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('ssl') }

--- a/spec/classes/mod/status_spec.rb
+++ b/spec/classes/mod/status_spec.rb
@@ -68,8 +68,8 @@ describe 'apache::mod::status', type: :class do
   it_behaves_like 'a mod class, without including apache'
 
   context 'default configuration with parameters' do
-    context 'on a Debian 8 OS' do
-      include_examples 'Debian 8'
+    context 'on a Debian 11 OS' do
+      include_examples 'Debian 11'
 
       context 'with default params' do
         it { is_expected.to contain_apache__mod('status') }
@@ -191,8 +191,8 @@ describe 'apache::mod::status', type: :class do
           }
         end
 
-        context 'on a Debian 8 OS' do
-          include_examples 'Debian 8'
+        context 'on a Debian 11 OS' do
+          include_examples 'Debian 11'
 
           it { is_expected.to contain_apache__mod('status') }
 

--- a/spec/classes/mod/userdir_spec.rb
+++ b/spec/classes/mod/userdir_spec.rb
@@ -11,7 +11,7 @@ describe 'apache::mod::userdir', type: :class do
        }'
     end
 
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     context 'default parameters' do
       it { is_expected.to compile }

--- a/spec/classes/mod/worker_spec.rb
+++ b/spec/classes/mod/worker_spec.rb
@@ -8,7 +8,7 @@ describe 'apache::mod::worker', type: :class do
   end
 
   context 'on a Debian OS' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('worker') }

--- a/spec/classes/mod/wsgi_spec.rb
+++ b/spec/classes/mod/wsgi_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe 'apache::mod::wsgi', type: :class do
   it_behaves_like 'a mod class, without including apache'
   context 'on a Debian OS' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     it { is_expected.to contain_class('apache::params') }
     it {
@@ -13,7 +13,7 @@ describe 'apache::mod::wsgi', type: :class do
         'wsgi_socket_prefix' => nil,
       )
     }
-    it { is_expected.to contain_package('libapache2-mod-wsgi') }
+    it { is_expected.to contain_package('libapache2-mod-wsgi-py3') }
   end
   context 'on a RedHat OS' do
     include_examples 'RedHat 6'

--- a/spec/classes/params_spec.rb
+++ b/spec/classes/params_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'apache::params', type: :class do
   context 'On a Debian OS' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     it { is_expected.to compile.with_all_deps }
     it { is_expected.to have_resource_count(0) }

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -8,7 +8,7 @@ describe 'apache::service', type: :class do
   end
 
   context 'on a Debian OS' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     it {
       is_expected.to contain_service('httpd').with(

--- a/spec/defines/balancer_spec.rb
+++ b/spec/defines/balancer_spec.rb
@@ -7,7 +7,7 @@ describe 'apache::balancer', type: :define do
     'myapp'
   end
 
-  include_examples 'Debian 8'
+  include_examples 'Debian 11'
 
   describe 'apache pre_condition with defaults' do
     let :pre_condition do

--- a/spec/defines/balancermember_spec.rb
+++ b/spec/defines/balancermember_spec.rb
@@ -7,7 +7,7 @@ describe 'apache::balancermember', type: :define do
     'include apache'
   end
 
-  include_examples 'Debian 8'
+  include_examples 'Debian 11'
 
   describe 'allows multiple balancermembers with the same url' do
     let :pre_condition do

--- a/spec/defines/custom_config_spec.rb
+++ b/spec/defines/custom_config_spec.rb
@@ -10,7 +10,7 @@ describe 'apache::custom_config', type: :define do
     'rspec'
   end
 
-  include_examples 'Debian 8'
+  include_examples 'Debian 11'
 
   context 'defaults with content' do
     let :params do

--- a/spec/defines/mod_spec.rb
+++ b/spec/defines/mod_spec.rb
@@ -49,7 +49,7 @@ describe 'apache::mod', type: :define do
   end
 
   context 'on a Debian osfamily' do
-    include_examples 'Debian 8'
+    include_examples 'Debian 11'
 
     describe 'for non-special modules' do
       it { is_expected.to contain_class('apache::params') }

--- a/spec/defines/vhost_custom_spec.rb
+++ b/spec/defines/vhost_custom_spec.rb
@@ -19,7 +19,7 @@ describe 'apache::vhost::custom', type: :define do
       it { is_expected.to compile }
     end
     context 'on Debian based systems' do
-      include_examples 'Debian 8'
+      include_examples 'Debian 11'
 
       it {
         is_expected.to contain_file('apache_rspec.example.com').with(

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -34,11 +34,11 @@ shared_examples :compile, compile: true do
 end
 
 shared_context 'a mod class, without including apache' do
-  let(:facts) { on_supported_os['debian-8-x86_64'] }
+  let(:facts) { on_supported_os['debian-10-x86_64'] }
 end
 
-shared_context 'Debian 8' do
-  let(:facts) { on_supported_os['debian-8-x86_64'] }
+shared_context 'Debian 11' do
+  let(:facts) { on_supported_os['debian-11-x86_64'] }
 end
 
 shared_context 'Ubuntu 18.04' do


### PR DESCRIPTION
This is a draft PR to push my local code. It includes https://github.com/puppetlabs/puppetlabs-apache/pull/2110. The idea is to keep the codebase smaller. Maybe this is too soon, but I'd like some feedback.

Alternatives are to drop Debian < 8 and Ubuntu < 16.04.