### PR TITLE
(MODULES-10899) Clean up PHP mod id handling in apache::mod::php

### DIFF
--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -16,7 +16,7 @@ class apache::mod::php (
   $libphp_prefix    = 'libphp'
 ) inherits apache::params {
   include apache
-  if (versioncmp($php_version, '7') <= 0) {
+  if (versioncmp($php_version, '8') < 0) {
     $mod = "php${php_version}"
   } else {
     $mod = 'php'
@@ -78,7 +78,7 @@ class apache::mod::php (
       id             => "php${_php_major}_module",
       path           => "${apache::lib_path}/mod_${mod}.so",
     }
-  } elsif (versioncmp($php_version, '7') <= 0) {
+  } elsif (versioncmp($php_version, '8') < 0) {
     ::apache::mod { $mod:
       package        => $_package_name,
       package_ensure => $package_ensure,

--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -3,7 +3,6 @@
 # 
 # @todo
 #   Add docs
-# @note Unsupported platforms: SLES: all
 class apache::mod::php (
   $package_name     = undef,
   $package_ensure   = 'present',
@@ -17,7 +16,7 @@ class apache::mod::php (
   $libphp_prefix    = 'libphp'
 ) inherits apache::params {
   include apache
-  if $php_version <= '7' {
+  if (versioncmp($php_version, '7') <= 0) {
     $mod = "php${php_version}"
   } else {
     $mod = "php"
@@ -79,7 +78,7 @@ class apache::mod::php (
       id             => "php${_php_major}_module",
       path           => "${apache::lib_path}/mod_${mod}.so",
     }
-  } elsif $php_version <= '7' {
+  } elsif (versioncmp($php_version, '7') <= 0) {
     ::apache::mod { $mod:
       package        => $_package_name,
       package_ensure => $package_ensure,

--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -69,30 +69,27 @@ class apache::mod::php (
     # Controls php version and libphp prefix
     $_lib = "${libphp_prefix}${php_version}.so"
   }
+  $_module_id = $_php_major ? {
+    '5'     => 'php5_module',
+    '7'     => 'php7_module',
+    default => 'php_module',
+  }
 
   if $::operatingsystem == 'SLES' {
     ::apache::mod { $mod:
       package        => $_package_name,
       package_ensure => $package_ensure,
       lib            => "mod_${mod}.so",
-      id             => "php${_php_major}_module",
+      id             => $_module_id,
       path           => "${apache::lib_path}/mod_${mod}.so",
     }
-  } elsif (versioncmp($php_version, '8') < 0) {
+  } else {
     ::apache::mod { $mod:
       package        => $_package_name,
       package_ensure => $package_ensure,
       lib            => $_lib,
-      id             => "php${_php_major}_module",
+      id             => $_module_id,
       path           => $path,
-    }
-  } else {
-    ::apache::mod { $mod:
-        package        => $_package_name,
-        package_ensure => $package_ensure,
-        lib            => "${libphp_prefix}.so",
-        id             => 'php_module',
-        path           => $path,
     }
   }
 

--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -19,7 +19,7 @@ class apache::mod::php (
   if (versioncmp($php_version, '7') <= 0) {
     $mod = "php${php_version}"
   } else {
-    $mod = "php"
+    $mod = 'php'
   }
 
   if $apache::version::scl_httpd_version == undef and $apache::version::scl_php_version != undef {
@@ -91,7 +91,7 @@ class apache::mod::php (
         package        => $_package_name,
         package_ensure => $package_ensure,
         lib            => "${libphp_prefix}.so",
-        id             => "php_module",
+        id             => 'php_module',
         path           => $path,
     }
   }

--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -17,7 +17,11 @@ class apache::mod::php (
   $libphp_prefix    = 'libphp'
 ) inherits apache::params {
   include apache
-  $mod = "php${php_version}"
+  if $php_version <= '7' {
+    $mod = "php${php_version}"
+  } else {
+    $mod = "php"
+  }
 
   if $apache::version::scl_httpd_version == undef and $apache::version::scl_php_version != undef {
     fail('If you define apache::version::scl_php_version, you also need to specify apache::version::scl_httpd_version')
@@ -75,13 +79,21 @@ class apache::mod::php (
       id             => "php${_php_major}_module",
       path           => "${apache::lib_path}/mod_${mod}.so",
     }
-  } else {
+  } elsif $php_version <= '7' {
     ::apache::mod { $mod:
       package        => $_package_name,
       package_ensure => $package_ensure,
       lib            => $_lib,
       id             => "php${_php_major}_module",
       path           => $path,
+    }
+  } else {
+    ::apache::mod { $mod:
+        package        => $_package_name,
+        package_ensure => $package_ensure,
+        lib            => "${libphp_prefix}.so",
+        id             => "php_module",
+        path           => $path,
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -698,26 +698,27 @@ class apache::params inherits ::apache::version {
     $logroot_mode        = undef
     $lib_path            = '/usr/lib64/apache2' #changes for some modules based on mpm
     $mpm_module          = 'prefork'
-
     if versioncmp($::operatingsystemrelease, '15') < 0 {
       $default_ssl_cert    = '/etc/apache2/ssl.crt/server.crt'
       $default_ssl_key     = '/etc/apache2/ssl.key/server.key'
+      $php_version         = '5'
     } else {
       $default_ssl_cert    = '/etc/apache2/ssl.crt/default-server.crt'
       $default_ssl_key     = '/etc/apache2/ssl.key/default-server.key'
+      $php_version         = '7'
     }
+    $suphp_configpath    = "/etc/php${php_version}/apache2"
     $ssl_sessioncache    = '/var/lib/apache2/ssl_scache(512000)'
     $suphp_addhandler    = 'x-httpd-php'
     $suphp_engine        = 'off'
-    $suphp_configpath    = '/etc/php5/apache2'
-    $php_version         = '5'
     if versioncmp($::operatingsystemrelease, '11') < 0 or versioncmp($::operatingsystemrelease, '12') >= 0 {
-      $mod_packages      = {
+      $mod_packages = {
         'auth_kerb'   => 'apache2-mod_auth_kerb',
         'auth_gssapi' => 'apache2-mod_auth_gssapi',
         'dav_svn'     => 'subversion-server',
         'perl'        => 'apache2-mod_perl',
         'php5'        => 'apache2-mod_php5',
+        'php7'        => 'apache2-mod_php7',
         'python'      => 'apache2-mod_python',
         'security'    => 'apache2-mod_security2',
         'worker'      => 'apache2-worker',

--- a/spec/acceptance/mod_php_spec.rb
+++ b/spec/acceptance/mod_php_spec.rb
@@ -45,6 +45,10 @@ describe 'apache::mod::php class', if: mod_supported_on_platform?('apache::mod::
       describe file("#{apache_hash['mod_dir']}/php7.conf") do
         it { is_expected.to contain 'DirectoryIndex index.php' }
       end
+    elsif os[:family] == 'sles' && os[:release].to_i >= 15
+      describe file("#{apache_hash['mod_dir']}/php7.conf") do
+        it { is_expected.to contain 'DirectoryIndex index.php' }
+      end
     else
       describe file("#{apache_hash['mod_dir']}/php5.conf") do
         it { is_expected.to contain 'DirectoryIndex index.php' }

--- a/spec/classes/mod/php_spec.rb
+++ b/spec/classes/mod/php_spec.rb
@@ -207,6 +207,7 @@ describe 'apache::mod::php', type: :class do
 
       # all the following tests are for legacy php/apache versions. They don't work on modern ubuntu and redhat 8
       next if (facts[:os]['release']['major'].to_i > 15 && facts[:os]['name'] == 'Ubuntu') ||
+              (facts[:os]['release']['major'].to_i >= 15 && facts[:os]['name'] == 'SLES')  ||
               (facts[:os]['release']['major'].to_i >= 9 && facts[:os]['name'] == 'Debian') ||
               (facts[:os]['release']['major'].to_i >= 8 && (facts[:os]['name'] == 'RedHat' || facts[:os]['name'] == 'CentOS'))
 

--- a/spec/classes/mod/php_spec.rb
+++ b/spec/classes/mod/php_spec.rb
@@ -53,6 +53,29 @@ describe 'apache::mod::php', type: :class do
                 )
               }
             end
+          when '10'
+            context 'on buster' do
+              it { is_expected.to contain_apache__mod('php7.3') }
+              it { is_expected.to contain_package('libapache2-mod-php7.3') }
+              it {
+                is_expected.to contain_file('php7.3.load').with(
+                  content: "LoadModule php7_module /usr/lib/apache2/modules/libphp7.3.so\n",
+                )
+              }
+            end
+            context 'on buster with experimental php8.0' do
+              let :params do
+                { php_version: '8.0' }
+              end
+
+              it { is_expected.to contain_apache__mod('php') }
+              it { is_expected.to contain_package('libapache2-mod-php8.0') }
+              it {
+                is_expected.to contain_file('php.load').with(
+                  content: "LoadModule php_module /usr/lib/apache2/modules/libphp8.0.so\n",
+                )
+              }
+            end
           when '16.04'
             context 'on stretch' do
               let :params do


### PR DESCRIPTION
I've added two tests and my try on fixing it:
- Debian 10 out of the box with the php 7.3 variant
- Debian 10 / experimental php 8.0 packages, configured via `$php_version = '8.0'`

Note on `/etc/apache2/mods-enabled/php.load`:
the code currently doesn't name the file as `php8.0.load` like the standard package would call it.
Doing so would also require to override the variable `$loadfile_name`, which looks silly. 

Note on `$mod` and `$_module_id`: 
Didn't notice this was only added in the PR, there's potential for cleaning up?