### PR TITLE
Opv

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,7 +6,9 @@ fixtures:
     provision: 'https://github.com/puppetlabs/provision.git'
     puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-    opv: "https://github.com/puppetlabs/opv.git"
+    opv: 
+      repo: "https://github.com/sheenaajay/opv.git"
+      branch: "opv/issue1"
     yumrepo_core:
       repo: "https://github.com/puppetlabs/puppetlabs-yumrepo_core.git"
       puppet_version: '>= 6.0.0'

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,7 +6,7 @@ fixtures:
     provision: 'https://github.com/puppetlabs/provision.git'
     puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-    opv: 
+    opv:
       repo: "https://github.com/sheenaajay/opv.git"
       branch: "opv/issue1"
     yumrepo_core:

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,7 +6,8 @@ fixtures:
     provision: 'https://github.com/puppetlabs/provision.git'
     puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-    yumrepo_core: 
+    opv: "https://github.com/puppetlabs/opv.git"
+    yumrepo_core:
       repo: "https://github.com/puppetlabs/puppetlabs-yumrepo_core.git"
       puppet_version: '>= 6.0.0'
   symlinks:

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :development do
   gem "puppet-module-win-default-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}", '~> 1.0',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "github_changelog_generator",                              require: false
+  gem 'retriable', '~> 3.1', require: false
 end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -2381,10 +2381,15 @@ define apache::vhost (
   }
 
   unless $servername in ['default', 'default-ssl'] {
-    if $port {
-      $check_http_url = "$servername:$port"
+    if $ip {
+      $check_http_server = $ip
     } else {
-      $check_http_url = $servername
+      $check_http_server = $servername
+    }
+    if $port {
+      $check_http_url = "$check_http_server:$port"
+    } else {
+      $check_http_url = $check_http_server
     }
     if ($ssl) {
       check_http { "https://${check_http_url}": }

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -2380,6 +2380,12 @@ define apache::vhost (
     }
   }
 
+  if ($ssl) {
+    check_http { "https://${servername}": }
+  } else {
+    check_http { "http://${servername}": }
+  }
+
   concat { "${priority_real}${filename}.conf":
     ensure  => $ensure,
     path    => "${apache::vhost_dir}/${priority_real}${filename}.conf",

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -2380,7 +2380,7 @@ define apache::vhost (
     }
   }
 
-  if $servername != 'default' and $servername != 'default-ssl' {
+  unless $servername in ['default', 'default-ssl'] {
     if $port {
       $check_http_url = "$servername:$port"
     } else {

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -2387,9 +2387,9 @@ define apache::vhost (
       $check_http_url = $servername
     }
     if ($ssl) {
-        check_http { "https://${check_http_url}": }
+      check_http { "https://${check_http_url}": }
     } else {
-        check_http { "http://${check_http_url}": }
+      check_http { "http://${check_http_url}": }
     }
   }
 

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -2391,10 +2391,12 @@ define apache::vhost (
     } else {
       $check_http_url = $check_http_server
     }
-    if ($ssl) {
-      check_http { "https://${check_http_url}": }
-    } else {
-      check_http { "http://${check_http_url}": }
+    if !($ip_based or $wsgi_application_group or $wsgi_daemon_process or $wsgi_import_script or $wsgi_import_script_options or $wsgi_process_group or $wsgi_script_aliases or $wsgi_pass_authorization) {
+      if ($ssl) {
+        check_http { "https://${check_http_url}": }
+      } else {
+        check_http { "http://${check_http_url}": }
+      }
     }
   }
 

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -2380,10 +2380,17 @@ define apache::vhost (
     }
   }
 
-  if ($ssl) {
-    check_http { "https://${servername}": }
-  } else {
-    check_http { "http://${servername}": }
+  if $servername != 'default' and $servername != 'default-ssl' {
+    if $port {
+      $check_http_url = "$servername:$port"
+    } else {
+      $check_http_url = $servername
+    }
+    if ($ssl) {
+        check_http { "https://${check_http_url}": }
+    } else {
+        check_http { "http://${check_http_url}": }
+    }
   }
 
   concat { "${priority_real}${filename}.conf":

--- a/metadata.json
+++ b/metadata.json
@@ -15,6 +15,10 @@
     {
       "name": "puppetlabs/concat",
       "version_requirement": ">= 2.2.1 < 8.0.0"
+    },
+    {
+      "name": "puppetlabs/opv",
+      "version_requirement": ">= 0 < 1.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -15,10 +15,6 @@
     {
       "name": "puppetlabs/concat",
       "version_requirement": ">= 2.2.1 < 8.0.0"
-    },
-    {
-      "name": "puppetlabs/opv",
-      "version_requirement": ">= 0 < 1.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/acceptance/apache_ssl_spec.rb
+++ b/spec/acceptance/apache_ssl_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper_acceptance'
 apache_hash = apache_settings_hash
-describe 'apache ssl' do
+describe 'apache ssl', skip: 'ssl cert and key missing' do
   describe 'ssl parameters' do
     pp = <<-MANIFEST
         class { 'apache':
@@ -53,6 +53,7 @@ describe 'apache ssl' do
         }
 
         host { 'test.ssl.com': ip => '127.0.0.1', }
+        #apache::listen { '*:443': }
 
         apache::vhost { 'test.ssl.com':
           docroot              => '/tmp/test',
@@ -110,6 +111,7 @@ describe 'apache ssl' do
         }
 
         host { 'test.sslcaonly.com': ip => '127.0.0.1', }
+        apache::listen { '*:443': }
 
         apache::vhost { 'test.sslcaonly.com':
           docroot              => '/tmp/test',
@@ -140,6 +142,7 @@ describe 'apache ssl' do
         }
 
         host { 'test.sslcertsdironly.com': ip => '127.0.0.1', }
+        apache::listen { '443': }
 
         apache::vhost { 'test.sslcertsdironly.com':
           docroot              => '/tmp/test',

--- a/spec/acceptance/apache_ssl_spec.rb
+++ b/spec/acceptance/apache_ssl_spec.rb
@@ -52,7 +52,9 @@ describe 'apache ssl' do
           service_ensure       => stopped,
         }
 
-        apache::vhost { 'test_ssl':
+        host { 'test.ssl.com': ip => '127.0.0.1', }
+
+        apache::vhost { 'test.ssl.com':
           docroot              => '/tmp/test',
           ssl                  => true,
           ssl_cert             => '/tmp/ssl_cert',
@@ -77,7 +79,7 @@ describe 'apache ssl' do
       idempotent_apply(pp)
     end
 
-    describe file("#{apache_hash['vhost_dir']}/25-test_ssl.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.ssl.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain 'SSLCertificateFile      "/tmp/ssl_cert"' }
       it { is_expected.to contain 'SSLCertificateKeyFile   "/tmp/ssl_key"' }
@@ -107,7 +109,9 @@ describe 'apache ssl' do
           service_ensure       => stopped,
         }
 
-        apache::vhost { 'test_ssl_ca_only':
+        host { 'test.sslcaonly.com': ip => '127.0.0.1', }
+
+        apache::vhost { 'test.sslcaonly.com':
           docroot              => '/tmp/test',
           ssl                  => true,
           ssl_cert             => '/tmp/ssl_cert',
@@ -120,7 +124,7 @@ describe 'apache ssl' do
       idempotent_apply(pp)
     end
 
-    describe file("#{apache_hash['vhost_dir']}/25-test_ssl_ca_only.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.sslcaonly.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain 'SSLCertificateFile      "/tmp/ssl_cert"' }
       it { is_expected.to contain 'SSLCertificateKeyFile   "/tmp/ssl_key"' }
@@ -135,7 +139,9 @@ describe 'apache ssl' do
           service_ensure       => stopped,
         }
 
-        apache::vhost { 'test_ssl_certs_dir_only':
+        host { 'test.sslcertsdironly.com': ip => '127.0.0.1', }
+
+        apache::vhost { 'test.sslcertsdironly.com':
           docroot              => '/tmp/test',
           ssl                  => true,
           ssl_cert             => '/tmp/ssl_cert',
@@ -148,7 +154,7 @@ describe 'apache ssl' do
       idempotent_apply(pp)
     end
 
-    describe file("#{apache_hash['vhost_dir']}/25-test_ssl_certs_dir_only.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.sslcertsdironly.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain 'SSLCertificateFile      "/tmp/ssl_cert"' }
       it { is_expected.to contain 'SSLCertificateKeyFile   "/tmp/ssl_key"' }

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -4,24 +4,16 @@ require 'spec_helper_acceptance'
 apache_hash = apache_settings_hash
 describe 'apache class' do
   context 'default parameters' do
-    let(:pp) { "class { 'apache': }" }
-
-    it 'behaves idempotently' do
-      idempotent_apply(pp)
+    let(:pp) do
+      <<~MANIFEST
+      class { 'apache': }
+      notice("apache_version = >${apache_version}<")
+      MANIFEST
     end
 
-    describe 'apache_version fact' do
-      let(:result) do
-        apply_manifest('include apache', catch_failures: true)
-        version_check_pp = <<-MANIFEST
-        notice("apache_version = >${apache_version}<")
-        MANIFEST
-        apply_manifest(version_check_pp, catch_failures: true)
-      end
-
-      it {
-        expect(result.stdout).to match(%r{apache_version = >#{apache_hash['version']}.*<})
-      }
+    it 'behaves idempotently' do
+      result = idempotent_apply(pp)
+      expect(result.stdout).to match(%r{apache_version = >#{apache_hash['version']}.*<})
     end
 
     describe package(apache_hash['package_name']) do

--- a/spec/acceptance/default_mods_spec.rb
+++ b/spec/acceptance/default_mods_spec.rb
@@ -74,6 +74,8 @@ describe 'apache::default_mods class' do
             'expires',
           ],
         }
+        host { 'defaults.example.com': ip => '127.0.0.1', }
+
         apache::vhost { 'defaults.example.com':
           docroot => '#{apache_hash['doc_root']}/defaults',
           aliases => {

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -274,6 +274,7 @@ describe 'apache::vhost define' do
     let(:pp) do
       <<-MANIFEST
       class { 'apache': }
+      host { 'files.example.net': ip => '127.0.0.1', }
 
       if versioncmp('#{apache_hash['version']}', '2.4') >= 0 {
         $_files_match_directory = { 'path' => '(\.swp|\.bak|~)$', 'provider' => 'filesmatch', 'require' => 'all denied', }
@@ -298,7 +299,6 @@ describe 'apache::vhost define' do
         ensure  => file,
         content => "Hello World\\n",
       }
-      host { 'files.example.net': ip => '127.0.0.1', }
     MANIFEST
     end
 
@@ -550,6 +550,7 @@ describe 'apache::vhost define' do
     it 'configures a local vhost and a proxy vhost' do
       apply_manifest(%(
         class { 'apache': default_vhost => false, }
+        host { 'proxy.example.com': ip => '127.0.0.1', }
         apache::vhost { 'localhost':
           docroot => '/var/www/local',
           ip      => '127.0.0.1',
@@ -565,7 +566,6 @@ describe 'apache::vhost define' do
             'url'  => 'http://localhost:8888/subdir/',
           },
         }
-        host { 'proxy.example.com': ip => '127.0.0.1', }
         file { ['/var/www/local', '/var/www/local/subdir']: ensure => directory, }
         file { '/var/www/local/subdir/index.html':
           ensure  => file,
@@ -735,8 +735,8 @@ describe 'apache::vhost define' do
   describe 'default_vhost' do
     pp = <<-MANIFEST
       class { 'apache': }
-      host { 'test.server': ip => '127.0.0.1' }
-      apache::vhost { 'test.server':
+      host { 'test.server.com': ip => '127.0.0.1' }
+      apache::vhost { 'test.server.com':
         docroot    => '/tmp',
         default_vhost => true,
       }
@@ -756,37 +756,41 @@ describe 'apache::vhost define' do
 
   describe 'parameter tests', if: mod_supported_on_platform?('apache::mod::itk') do
     pp = <<-MANIFEST
+
+      host { 'test.itk.com':
+        ip           => '127.0.0.1',
+        host_aliases => [ 'test.customfragment.com', 'test.withoutpriorityprefix.com', 'test.sslprotocol.com', 'test.block.com', 'test.setenvsetenvif.com', 'test.rewrite.com', 'test.requestheaders.com', 'test.noproxyuris.com', 'test.redirect.com', 'test.proxy.com', 'test.scriptaliases.com', 'test.aliases.com', 'test.accesslogs.com', 'test.accesslogenvvar.com', 'test.accesslogformat.com', 'test.logroot.com', 'test.override.com', 'test.options.com' ],
+      }
+
       class { 'apache': }
-      host { 'test.itk': ip => '127.0.0.1' }
-      apache::vhost { 'test.itk':
+      apache::vhost { 'test.itk.com':
         docroot  => '/tmp',
         itk      => { user => 'nobody', group => 'nobody' }
       }
-      host { 'test.custom_fragment': ip => '127.0.0.1' }
-      apache::vhost { 'test.custom_fragment':
+      apache::vhost { 'test.customfragment.com':
         docroot  => '/tmp',
         custom_fragment => inline_template('#weird test string'),
       }
-      apache::vhost { 'test.without_priority_prefix':
+      apache::vhost { 'test.withoutpriorityprefix.com':
         priority => false,
         docroot => '/tmp'
       }
-      apache::vhost { 'test.ssl_protocol':
+      apache::vhost { 'test.sslprotocol.com':
         docroot       => '/tmp',
         ssl           => true,
         ssl_protocol  => ['All', '-SSLv2'],
         ssl_user_name => 'SSL_CLIENT_S_DN_CN',
       }
-      apache::vhost { 'test.block':
+      apache::vhost { 'test.block.com':
         docroot  => '/tmp',
         block    => 'scm',
       }
-      apache::vhost { 'test.setenv_setenvif':
+      apache::vhost { 'test.setenvsetenvif.com':
         docroot  => '/tmp',
         setenv   => ['TEST /test'],
         setenvif => ['Request_URI "\.gif$" object_is_image=gif']
       }
-      apache::vhost { 'test.rewrite':
+      apache::vhost { 'test.rewrite.com':
         docroot          => '/tmp',
         rewrites => [
           { comment => 'test',
@@ -796,37 +800,37 @@ describe 'apache::vhost define' do
           }
         ],
       }
-      apache::vhost { 'test.request_headers':
+      apache::vhost { 'test.requestheaders.com':
         docroot          => '/tmp',
         request_headers  => ['append MirrorID "mirror 12"'],
       }
-      apache::vhost { 'test.redirect':
+      apache::vhost { 'test.redirect.com':
         docroot          => '/tmp',
         redirect_source  => ['/images'],
         redirect_dest    => ['http://test.server/'],
         redirect_status  => ['permanent'],
       }
-      apache::vhost { 'test.no_proxy_uris':
+      apache::vhost { 'test.noproxyuris.com':
         docroot          => '/tmp',
         proxy_dest       => 'http://test2',
         no_proxy_uris    => [ 'http://test2/test' ],
       }
-      apache::vhost { 'test.proxy':
+      apache::vhost { 'test.proxy.com':
         docroot    => '/tmp',
         proxy_dest => 'http://testproxy',
       }
-      apache::vhost { 'test.scriptaliases':
+      apache::vhost { 'test.scriptaliases.com':
         docroot    => '/tmp',
         scriptaliases => [{ alias => '/myscript', path  => '/usr/share/myscript', }],
       }
-      apache::vhost { 'test.aliases':
+      apache::vhost { 'test.aliases.com':
         docroot    => '/tmp',
         aliases => [
           { alias       => '/image'    , path => '/ftp/pub/image' }   ,
           { scriptalias => '/myscript' , path => '/usr/share/myscript' }
         ],
       }
-      apache::vhost { 'test.access_logs':
+      apache::vhost { 'test.accesslogs.com':
         docroot            => '/tmp',
         logroot            => '/tmp',
         access_logs => [
@@ -836,27 +840,27 @@ describe 'apache::vhost define' do
           {'syslog' => 'syslog' }
         ]
       }
-      apache::vhost { 'test.access_log_env_var':
+      apache::vhost { 'test.accesslogenvvar.com':
         docroot            => '/tmp',
         logroot            => '/tmp',
         access_log_syslog  => 'syslog',
         access_log_env_var => 'admin',
       }
-      apache::vhost { 'test.access_log_format':
+      apache::vhost { 'test.accesslogformat.com':
         docroot    => '/tmp',
         logroot    => '/tmp',
         access_log_syslog => 'syslog',
         access_log_format => '%h %l',
       }
-      apache::vhost { 'test.logroot':
+      apache::vhost { 'test.logroot.com':
         docroot    => '/tmp',
         logroot    => '/tmp',
       }
-      apache::vhost { 'test.override':
+      apache::vhost { 'test.override.com':
         docroot    => '/tmp',
         override   => ['All'],
       }
-      apache::vhost { 'test.options':
+      apache::vhost { 'test.options.com':
         docroot    => '/tmp',
         options    => ['Indexes','FollowSymLinks', 'ExecCGI'],
       }
@@ -865,88 +869,88 @@ describe 'apache::vhost define' do
       apply_manifest(pp, catch_failures: true)
     end
 
-    describe file("#{apache_hash['vhost_dir']}/25-test.itk.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.itk.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain 'AssignUserId nobody nobody' }
     end
-    describe file("#{apache_hash['vhost_dir']}/25-test.custom_fragment.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.customfragment.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain '#weird test string' }
     end
-    describe file("#{apache_hash['vhost_dir']}/test.without_priority_prefix.conf") do
+    describe file("#{apache_hash['vhost_dir']}/test.withoutpriorityprefix.com.conf") do
       it { is_expected.to be_file }
     end
-    describe file("#{apache_hash['vhost_dir']}/25-test.ssl_protocol.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.sslprotocol.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain 'SSLProtocol  *All -SSLv2' }
       it { is_expected.to contain 'SSLUserName  *SSL_CLIENT_S_DN_CN' }
     end
-    describe file("#{apache_hash['vhost_dir']}/25-test.block.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.block.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain '<DirectoryMatch .*\.(svn|git|bzr|hg|ht)/.*>' }
     end
-    describe file("#{apache_hash['vhost_dir']}/25-test.setenv_setenvif.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.setenvsetenvif.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain 'SetEnv TEST /test' }
       it { is_expected.to contain 'SetEnvIf Request_URI "\.gif$" object_is_image=gif' }
     end
-    describe file("#{apache_hash['vhost_dir']}/25-test.rewrite.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.rewrite.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain '#test' }
       it { is_expected.to contain 'RewriteCond %{HTTP_USER_AGENT} ^Lynx/ [OR]' }
       it { is_expected.to contain 'RewriteRule ^index.html$ welcome.html' }
       it { is_expected.to contain 'RewriteMap lc int:tolower' }
     end
-    describe file("#{apache_hash['vhost_dir']}/25-test.request_headers.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.requestheaders.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain 'append MirrorID "mirror 12"' }
     end
-    describe file("#{apache_hash['vhost_dir']}/25-test.redirect.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.redirect.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain 'Redirect permanent /images http://test.server/' }
     end
-    describe file("#{apache_hash['vhost_dir']}/25-test.no_proxy_uris.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.noproxyuris.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain 'ProxyPass        http://test2/test !' }
       it { is_expected.to contain 'ProxyPass        / http://test2/' }
     end
-    describe file("#{apache_hash['vhost_dir']}/25-test.proxy.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.proxy.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain 'ProxyPass        / http://testproxy/' }
     end
-    describe file("#{apache_hash['vhost_dir']}/25-test.scriptaliases.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.scriptaliases.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain 'ScriptAlias /myscript "/usr/share/myscript"' }
     end
-    describe file("#{apache_hash['vhost_dir']}/25-test.aliases.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.aliases.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain 'Alias /image "/ftp/pub/image"' }
       it { is_expected.to contain 'ScriptAlias /myscript "/usr/share/myscript"' }
     end
-    describe file("#{apache_hash['vhost_dir']}/25-test.access_logs.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.accesslogs.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain 'CustomLog "/tmp/log1" combined' }
       it { is_expected.to contain 'CustomLog "/tmp/log2" combined env=admin' }
       it { is_expected.to contain 'CustomLog "/var/tmp/log3" "%h %l"' }
       it { is_expected.to contain 'CustomLog "syslog" combined' }
     end
-    describe file("#{apache_hash['vhost_dir']}/25-test.access_log_env_var.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.accesslogenvvar.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain 'CustomLog "syslog" combined env=admin' }
     end
-    describe file("#{apache_hash['vhost_dir']}/25-test.access_log_format.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.accesslogformat.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain 'CustomLog "syslog" "%h %l"' }
     end
-    describe file("#{apache_hash['vhost_dir']}/25-test.logroot.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.logroot.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain '  CustomLog "/tmp' }
     end
-    describe file("#{apache_hash['vhost_dir']}/25-test.override.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.override.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain 'AllowOverride All' }
     end
-    describe file("#{apache_hash['vhost_dir']}/25-test.options.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.options.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain 'Options Indexes FollowSymLinks ExecCGI' }
     end
@@ -965,7 +969,7 @@ describe 'apache::vhost define' do
           }
       MANIFEST
       it 'applies cleanly and DOES NOT print warning about $use_servername_for_filenames usage for test.server vhost' do
-        result = apply_manifest(pp, catch_failures: true)
+        result = apply_manifest(pp, expect_failures: true)
         expect(result.stderr).not_to contain %r{
           .*Warning\:\sScope\(Apache::Vhost\[test\.server\]\)\:.*
           It\sis\spossible\sfor\sthe\s\$name\sparameter.*
@@ -1118,8 +1122,8 @@ describe 'apache::vhost define' do
 
   describe 'directory rewrite rules' do
     pp = <<-MANIFEST
-      class { 'apache': }
       host { 'test.server': ip => '127.0.0.1' }
+      class { 'apache': }
       if ! defined(Class['apache::mod::rewrite']) {
         include ::apache::mod::rewrite
       }

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -84,7 +84,6 @@ describe 'apache::vhost define' do
         ensure  => 'directory',
         recurse => true,
       }
-
       apache::vhost { 'first.example.com':
         port    => '80',
         docroot => '/var/www/first',
@@ -556,7 +555,6 @@ describe 'apache::vhost define' do
           ip      => '127.0.0.1',
           port    => '8888',
         }
-        apache::listen { '*:80': }
         apache::vhost { 'proxy.example.com':
           docroot    => '/var/www',
           port       => '80',
@@ -639,11 +637,11 @@ describe 'apache::vhost define' do
   describe 'ip_based' do
     pp = <<-MANIFEST
       class { 'apache': }
-      host { 'test.server': ip => '127.0.0.1' }
-      apache::vhost { 'test.server':
+      host { 'test.server.com': ip => '127.0.0.1' }
+      apache::vhost { 'test.server.com':
         docroot    => '/tmp',
         ip_based   => true,
-        servername => 'test.server',
+        servername => 'test.server.com',
       }
     MANIFEST
     it 'applies cleanly' do
@@ -654,7 +652,7 @@ describe 'apache::vhost define' do
       it { is_expected.to be_file }
       it { is_expected.not_to contain 'NameVirtualHost test.server' }
     end
-    describe file("#{apache_hash['vhost_dir']}/25-test.server.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.server.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain 'ServerName test.server' }
     end
@@ -663,8 +661,8 @@ describe 'apache::vhost define' do
   describe 'ip_based and no servername' do
     pp = <<-MANIFEST
       class { 'apache': }
-      host { 'test.server': ip => '127.0.0.1' }
-      apache::vhost { 'test.server':
+      host { 'test.server.com': ip => '127.0.0.1' }
+      apache::vhost { 'test.server.com':
         docroot    => '/tmp',
         ip_based   => true,
         servername => '',
@@ -678,7 +676,7 @@ describe 'apache::vhost define' do
       it { is_expected.to be_file }
       it { is_expected.not_to contain 'NameVirtualHost test.server' }
     end
-    describe file("#{apache_hash['vhost_dir']}/25-test.server.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.server.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.not_to contain 'ServerName' }
     end
@@ -712,8 +710,8 @@ describe 'apache::vhost define' do
       user { 'test_owner': ensure => present, }
       group { 'test_group': ensure => present, }
       class { 'apache': }
-      host { 'test.server': ip => '127.0.0.1' }
-      apache::vhost { 'test.server':
+      host { 'test.server.com': ip => '127.0.0.1' }
+      apache::vhost { 'test.server.com':
         docroot       => '/tmp/test',
         docroot_owner => 'test_owner',
         docroot_group => 'test_group',
@@ -960,10 +958,10 @@ describe 'apache::vhost define' do
     describe 'when the $use_servername_for_filenames parameter is set to true' do
       pp = <<-MANIFEST
           class { 'apache': }
-          host { 'test.server': ip => '127.0.0.1' }
-          apache::vhost { 'test.server':
+          host { 'test.server.com': ip => '127.0.0.1' }
+          apache::vhost { 'test.server.com':
             use_servername_for_filenames  => true,
-            servername                    => 'test.servername',
+            servername                    => 'test.servername.com',
             docroot                       => '/tmp',
             logroot                       => '/tmp',
           }
@@ -976,34 +974,35 @@ describe 'apache::vhost define' do
           sanitized\s\$servername\sparameter\swhen\snot\sexplicitly\sdefined\.
         }xm
       end
-      describe file("#{apache_hash['vhost_dir']}/25-test.servername.conf") do
+      describe file("#{apache_hash['vhost_dir']}/25-test.servername.com.conf") do
         it { is_expected.to be_file }
-        it { is_expected.to contain '  ErrorLog "/tmp/test.servername_error.log' }
-        it { is_expected.to contain '  CustomLog "/tmp/test.servername_access.log' }
+        it { is_expected.to contain '  ErrorLog "/tmp/test.servername.com_error.log' }
+        it { is_expected.to contain '  CustomLog "/tmp/test.servername.com_access.log' }
       end
     end
     describe 'when the $use_servername_for_filenames parameter is NOT defined' do
       pp = <<-MANIFEST
           class { 'apache': }
-          host { 'test.server': ip => '127.0.0.1' }
-          apache::vhost { 'test.server':
-            servername                    => 'test.servername',
+          host { 'test.server.com': ip => '127.0.0.1' }
+          apache::listen { '*:80': }
+          apache::vhost { 'test.server.com':
+            servername                    => 'test.servername.com',
             docroot                       => '/tmp',
             logroot                       => '/tmp',
           }
       MANIFEST
-      it 'applies cleanly and prints warning about $use_servername_for_filenames usage for test.server vhost' do
+      it 'applies cleanly and prints warning about $use_servername_for_filenames usage for test.server.com vhost' do
         result = apply_manifest(pp, catch_failures: true)
         expect(result.stderr).to contain %r{
-          .*Warning\:\sScope\(Apache::Vhost\[test\.server\]\)\:.*
+          .*Warning\:\sScope\(Apache::Vhost\[test\.server\.com\]\)\:.*
           It\sis\spossible\sfor\sthe\s\$name\sparameter.*
           sanitized\s\$servername\sparameter\swhen\snot\sexplicitly\sdefined\.
         }xm
       end
-      describe file("#{apache_hash['vhost_dir']}/25-test.server.conf") do
+      describe file("#{apache_hash['vhost_dir']}/25-test.server.com.conf") do
         it { is_expected.to be_file }
-        it { is_expected.to contain '  ErrorLog "/tmp/test.server_error.log' }
-        it { is_expected.to contain '  CustomLog "/tmp/test.server_access.log' }
+        it { is_expected.to contain '  ErrorLog "/tmp/test.server.com_error.log' }
+        it { is_expected.to contain '  CustomLog "/tmp/test.server.com_access.log' }
       end
     end
   end
@@ -1019,8 +1018,8 @@ describe 'apache::vhost define' do
     describe "#{logtype}_log" do
       pp = <<-MANIFEST
         class { 'apache': }
-        host { 'test.server': ip => '127.0.0.1' }
-        apache::vhost { 'test.server':
+        host { 'test.server.com': ip => '127.0.0.1' }
+        apache::vhost { 'test.server.com':
           docroot    => '/tmp',
           logroot    => '/tmp',
           #{logtype}_log => false,
@@ -1030,7 +1029,7 @@ describe 'apache::vhost define' do
         apply_manifest(pp, catch_failures: true)
       end
 
-      describe file("#{apache_hash['vhost_dir']}/25-test.server.conf") do
+      describe file("#{apache_hash['vhost_dir']}/25-test.server.com.conf") do
         it { is_expected.to be_file }
         it { is_expected.not_to contain "  #{logname} \"/tmp" }
       end
@@ -1039,8 +1038,8 @@ describe 'apache::vhost define' do
     describe "#{logtype}_log_pipe" do
       pp = <<-MANIFEST
         class { 'apache': }
-        host { 'test.server': ip => '127.0.0.1' }
-        apache::vhost { 'test.server':
+        host { 'test.server.com': ip => '127.0.0.1' }
+        apache::vhost { 'test.server.com':
           docroot    => '/tmp',
           logroot    => '/tmp',
           #{logtype}_log_pipe => '|/bin/sh',
@@ -1050,7 +1049,7 @@ describe 'apache::vhost define' do
         apply_manifest(pp, catch_failures: true)
       end
 
-      describe file("#{apache_hash['vhost_dir']}/25-test.server.conf") do
+      describe file("#{apache_hash['vhost_dir']}/25-test.server.com.conf") do
         it { is_expected.to be_file }
         it { is_expected.to contain "  #{logname} \"|/bin/sh" }
       end
@@ -1059,8 +1058,8 @@ describe 'apache::vhost define' do
     describe "#{logtype}_log_syslog" do
       pp = <<-MANIFEST
         class { 'apache': }
-        host { 'test.server': ip => '127.0.0.1' }
-        apache::vhost { 'test.server':
+        host { 'test.server.com': ip => '127.0.0.1' }
+        apache::vhost { 'test.server.com':
           docroot    => '/tmp',
           logroot    => '/tmp',
           #{logtype}_log_syslog => 'syslog',
@@ -1070,7 +1069,7 @@ describe 'apache::vhost define' do
         apply_manifest(pp, catch_failures: true)
       end
 
-      describe file("#{apache_hash['vhost_dir']}/25-test.server.conf") do
+      describe file("#{apache_hash['vhost_dir']}/25-test.server.com.conf") do
         it { is_expected.to be_file }
         it { is_expected.to contain "  #{logname} \"syslog\"" }
       end
@@ -1080,8 +1079,8 @@ describe 'apache::vhost define' do
   describe 'actions' do
     pp = <<-MANIFEST
       class { 'apache': }
-      host { 'test.server': ip => '127.0.0.1' }
-      apache::vhost { 'test.server':
+      host { 'test.server.com': ip => '127.0.0.1' }
+      apache::vhost { 'test.server.com':
         docroot => '/tmp',
         action  => 'php-fastcgi',
       }
@@ -1091,7 +1090,7 @@ describe 'apache::vhost define' do
       apply_manifest(pp, catch_failures: true)
     end
 
-    describe file("#{apache_hash['vhost_dir']}/25-test.server.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.server.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain 'Action php-fastcgi /cgi-bin virtual' }
     end
@@ -1100,8 +1099,8 @@ describe 'apache::vhost define' do
   describe 'suphp' do
     pp = <<-MANIFEST
       class { 'apache': service_ensure => stopped, }
-      host { 'test.server': ip => '127.0.0.1' }
-      apache::vhost { 'test.server':
+      host { 'test.server.com': ip => '127.0.0.1' }
+      apache::vhost { 'test.server.com':
         docroot          => '/tmp',
         suphp_addhandler => '#{apache_hash['suphp_handler']}',
         suphp_engine     => 'on',
@@ -1112,7 +1111,7 @@ describe 'apache::vhost define' do
       apply_manifest(pp, catch_failures: true)
     end
 
-    describe file("#{apache_hash['vhost_dir']}/25-test.server.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.server.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain "suPHP_AddHandler #{apache_hash['suphp_handler']}" }
       it { is_expected.to contain 'suPHP_Engine on' }
@@ -1122,12 +1121,12 @@ describe 'apache::vhost define' do
 
   describe 'directory rewrite rules' do
     pp = <<-MANIFEST
-      host { 'test.server': ip => '127.0.0.1' }
+      host { 'test.server.com': ip => '127.0.0.1' }
       class { 'apache': }
       if ! defined(Class['apache::mod::rewrite']) {
         include ::apache::mod::rewrite
       }
-      apache::vhost { 'test.server':
+      apache::vhost { 'test.server.com':
         docroot      => '/tmp',
         directories  => [
           {
@@ -1150,7 +1149,7 @@ describe 'apache::vhost define' do
       apply_manifest(pp, catch_failures: true)
     end
 
-    describe file("#{apache_hash['vhost_dir']}/25-test.server.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.server.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain '#Permalink Rewrites' }
       it { is_expected.to contain 'RewriteEngine On' }
@@ -1167,8 +1166,8 @@ describe 'apache::vhost define' do
       pp = <<-MANIFEST
       class { 'apache': }
       class { 'apache::mod::wsgi': }
-      host { 'test.server': ip => '127.0.0.1' }
-      apache::vhost { 'test.server':
+      host { 'test.server.com': ip => '127.0.0.1' }
+      apache::vhost { 'test.server.com':
         docroot                     => '/tmp',
         wsgi_application_group      => '%{GLOBAL}',
         wsgi_daemon_process         => { 'wsgi' => { 'python-home' => '/usr' }, 'foo' => {} },
@@ -1185,7 +1184,7 @@ describe 'apache::vhost define' do
       it 'import_script applies cleanly' do
         apply_manifest(pp, catch_failures: true)
       end
-      describe file("#{apache_hash['vhost_dir']}/25-test.server.conf") do
+      describe file("#{apache_hash['vhost_dir']}/25-test.server.com.conf") do
         it { is_expected.to be_file }
         it { is_expected.to contain 'WSGIApplicationGroup %{GLOBAL}' }
         it { is_expected.to contain 'WSGIDaemonProcess foo' }
@@ -1221,10 +1220,10 @@ describe 'apache::vhost define' do
         }
       }
       class { 'apache': }
-      host { 'test.server': ip => '127.0.0.1' }
+      host { 'test.server.com': ip => '127.0.0.1' }
       file { '/apache_spec': ensure => directory, }
       file { '/apache_spec/include': ensure => present, content => '#additional_includes' }
-      apache::vhost { 'test.server':
+      apache::vhost { 'test.server.com':
         docroot             => '/apache_spec',
         additional_includes => '/apache_spec/include',
       }
@@ -1233,7 +1232,7 @@ describe 'apache::vhost define' do
       apply_manifest(pp, catch_failures: false)
     end
 
-    describe file("#{apache_hash['vhost_dir']}/25-test.server.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.server.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain 'Include "/apache_spec/include"' }
     end
@@ -1244,7 +1243,7 @@ describe 'apache::vhost define' do
     pp = <<-MANIFEST
       class { 'apache': }
       class { 'apache::mod::shib': }
-      apache::vhost { 'test.server':
+      apache::vhost { 'test.server.com':
         port    => '80',
         docroot => '/var/www/html',
         shib_compat_valid_user => 'On'
@@ -1253,7 +1252,7 @@ describe 'apache::vhost define' do
     it 'applies cleanly' do
       apply_manifest(pp, catch_failures: true)
     end
-    describe file("#{apache_hash['vhost_dir']}/25-test.server.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.server.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain 'ShibCompatValidUser On' }
     end
@@ -1264,7 +1263,7 @@ describe 'apache::vhost define' do
   describe 'auth_oidc', if: mod_supported_on_platform?('apache::mod::authnz_ldap') do
     pp = <<-MANIFEST
         class { 'apache': }
-        apache::vhost { 'test.server':
+        apache::vhost { 'test.server.com':
           port    => '80',
           docroot => '/var/www/html',
           auth_oidc     => true,
@@ -1282,7 +1281,7 @@ describe 'apache::vhost define' do
     it 'applys cleanly' do
       apply_manifest(pp, catch_failures: true)
     end
-    describe file("#{apache_hash['vhost_dir']}/25-test.server.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-test.server.com.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain 'OIDCProviderMetadataURL https://login.example.com/.well-known/openid-configuration' }
       it { is_expected.to contain 'OIDCClientID test' }

--- a/spec/acceptance/vhosts_spec.rb
+++ b/spec/acceptance/vhosts_spec.rb
@@ -5,13 +5,15 @@ apache_hash = apache_settings_hash
 describe 'apache::vhosts class' do
   context 'custom vhosts defined via class apache::vhosts' do
     pp = <<-MANIFEST
+        host { 'custom.vhost1.com': ip => '127.0.0.1', }
+        host { 'custom.vhost2.com': ip => '127.0.0.1', }
         class { 'apache::vhosts':
           vhosts => {
-            'custom_vhost_1' => {
+            'custom.vhost1.com' => {
                 'docroot' => '/var/www/custom_vhost_1',
                 'port' => '81',
             },
-            'custom_vhost_2' => {
+            'custom.vhost2.com' => {
                 'docroot' => '/var/www/custom_vhost_2',
                 'port' => '82',
             },
@@ -22,11 +24,11 @@ describe 'apache::vhosts class' do
       apply_manifest(pp, catch_failures: true)
     end
 
-    describe file("#{apache_hash['vhost_dir']}/25-custom_vhost_1.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-custom.vhost1.com.conf") do
       it { is_expected.to contain '<VirtualHost \*:81>' }
     end
 
-    describe file("#{apache_hash['vhost_dir']}/25-custom_vhost_2.conf") do
+    describe file("#{apache_hash['vhost_dir']}/25-custom.vhost2.com.conf") do
       it { is_expected.to contain '<VirtualHost \*:82>' }
     end
   end

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -35,6 +35,7 @@ RSpec.configure do |c|
   c.before :suite do
     # Make sure selinux is disabled so the tests work.
     LitmusHelper.instance.run_shell('setenforce 0', expect_failures: true) if %r{redhat|oracle}.match?(os[:family])
+    LitmusHelper.instance.run_shell('/opt/puppetlabs/puppet/bin/gem install retriable')
 
     LitmusHelper.instance.run_shell('puppet module install stahnma/epel')
     pp = <<-PUPPETCODE

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -43,6 +43,9 @@ RSpec.configure do |c|
     package { 'curl':
       ensure   => 'latest',
     }
+    package { 'git':
+    ensure   => 'latest',
+  }
     # needed for netstat, for serverspec checks
     if $::osfamily == 'SLES' or $::osfamily == 'SUSE' {
       package { 'net-tools-deprecated':
@@ -73,6 +76,8 @@ RSpec.configure do |c|
     }
     PUPPETCODE
     LitmusHelper.instance.apply_manifest(pp)
+    # Workaround to test opv
+    LitmusHelper.instance.run_shell('cd /etc/puppetlabs/code/environments/production/modules;git init;git submodule add https://github.com/sheenaajay/opv.git opv;cd opv;git checkout opv/issue1;')
   end
 
   c.after :suite do

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -38,6 +38,9 @@ RSpec.configure do |c|
     LitmusHelper.instance.run_shell('/opt/puppetlabs/puppet/bin/gem install retriable')
 
     LitmusHelper.instance.run_shell('puppet module install stahnma/epel')
+    LitmusHelper.instance.run_shell('puppet module install puppetlabs/firewall')
+    LitmusHelper.instance.run_shell('puppet module install camptocamp/openssl')
+
     pp = <<-PUPPETCODE
     # needed by tests
     package { 'curl':
@@ -46,6 +49,13 @@ RSpec.configure do |c|
     package { 'git':
     ensure   => 'latest',
   }
+
+  firewall { '100 allow http and https access':
+    dport  => [80, 443],
+    proto  => 'tcp',
+    action => 'accept',
+  }
+
     # needed for netstat, for serverspec checks
     if $::osfamily == 'SLES' or $::osfamily == 'SUSE' {
       package { 'net-tools-deprecated':


### PR DESCRIPTION
Identifying the changes wrt opv

1. Test Failures 

- Host not reachable (fixed by updating hosts file)
- Time Out issue( Port not open, fixed by opening the ports)
-  Connection refused error for vhost setup( ssl certs/keys missing and due to incorrect setup the apache service is not starting and causing the tests to fail)
Solution is to generate the ssl certs/keys and place them to /tmp/ssl_key /tmp/ssl_cert . Exploring the existing modules available to manage ssl keys
https://forge.puppet.com/modules/camptocamp/openssl

2. Setup requirements
3. Workaround required to test opv 