### PR TITLE
pdksync - (maint) Remove SLES 11 SP1, 12 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -59,8 +59,6 @@
     {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
-        "11 SP1",
-        "12",
         "15"
       ]
     },


### PR DESCRIPTION
(maint) Remove RHEL 5 family support; Clean up OS naming in metadata.json
pdk version: `1.19.0.pre (47)` 
