### PR TITLE
Fix dav_svn for Debian 10

### DIFF
--- a/manifests/mod/dav_svn.pp
+++ b/manifests/mod/dav_svn.pp
@@ -21,15 +21,11 @@ class apache::mod::dav_svn (
 
   ::apache::mod { 'dav_svn': }
 
-  if $::osfamily == 'Debian' and ! ($::operatingsystemmajrelease in ['6', '9', '16.04', '18.04']) {
-    $loadfile_name = undef
-  } else {
-    $loadfile_name = 'dav_svn_authz_svn.load'
-  }
-
   if $authz_svn_enabled {
     ::apache::mod { 'authz_svn':
-      loadfile_name => $loadfile_name,
+      # authz_svn depends on symbols from the dav_svn module,
+      # therefore, make sure authz_svn is loaded after dav_svn.
+      loadfile_name => 'dav_svn_authz_svn.load',
       require       => Apache::Mod['dav_svn'],
     }
   }

--- a/spec/acceptance/mod_dav_svn_spec.rb
+++ b/spec/acceptance/mod_dav_svn_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+describe 'apache::mod::dav_svn class' do
+  context 'dav_svn module with authz_svn disabled' do
+    pp = <<-MANIFEST
+      class { 'apache': }
+      class { 'apache::mod::dav_svn':
+        authz_svn_enabled => false,
+      }
+    MANIFEST
+
+    it 'applies with no errors' do
+      apply_manifest(pp, catch_failures: true)
+    end
+
+    it 'applies a second time without changes' do
+      apply_manifest(pp, catch_changes: true)
+    end
+  end
+
+  context 'dav_svn module with authz_svn enabled' do
+    pp = <<-MANIFEST
+      class { 'apache': }
+      class { 'apache::mod::dav_svn':
+        authz_svn_enabled => true,
+      }
+    MANIFEST
+
+    it 'applies with no errors' do
+      apply_manifest(pp, catch_failures: true)
+    end
+
+    it 'applies a second time without changes' do
+      apply_manifest(pp, catch_changes: true)
+    end
+  end
+end

--- a/spec/classes/mod/dav_svn_spec.rb
+++ b/spec/classes/mod/dav_svn_spec.rb
@@ -24,7 +24,7 @@ describe 'apache::mod::dav_svn', type: :class do
         it { is_expected.to contain_apache__mod('dav_svn') }
         it { is_expected.to contain_package('libapache2-svn') }
         it { is_expected.to contain_apache__mod('authz_svn') }
-        it { is_expected.to contain_file('authz_svn.load').with_content(%r{LoadModule authz_svn_module}) }
+        it { is_expected.to contain_file('dav_svn_authz_svn.load').with_content(%r{LoadModule authz_svn_module}) }
       end
     end
     context 'on a RedHat OS' do


### PR DESCRIPTION
As far as I can tell Debian 10 still needs this work-around.