### PR TITLE
Fix HEADER* and README* wildcards in IndexIgnore

### DIFF
--- a/templates/mod/autoindex.conf.erb
+++ b/templates/mod/autoindex.conf.erb
@@ -53,4 +53,4 @@ DefaultIcon /<%= @icons_prefix %>/unknown.gif
 ReadmeName README.html
 HeaderName HEADER.html
 
-IndexIgnore .??* *~ *# HEADER* README* RCS CVS *,v *,t
+IndexIgnore .??* *~ *# HEADER.html README.html RCS CVS *,v *,t


### PR DESCRIPTION
The original intent of HEADER* and README* in the IndexIgnore was
probably to ignore the files that are included at the top (HeaderName) and
bottom (ReadmeName) of the index listing. But the wildcard will hide other
files, like README.txt, so use full filenames instead.