### PR TITLE
(MODULES-11061) mod_security custom rule functionality

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -5969,6 +5969,8 @@ The following parameters are available in the `apache::mod::security` class:
 * [`activated_rules`](#activated_rules)
 * [`modsec_dir`](#modsec_dir)
 * [`modsec_secruleengine`](#modsec_secruleengine)
+* [`custom_rules`](#custom_rules)
+* [`custom_rules_set`](#custom_rules_set)
 * [`audit_log_relevant_status`](#audit_log_relevant_status)
 * [`audit_log_parts`](#audit_log_parts)
 * [`audit_log_type`](#audit_log_type)
@@ -6041,6 +6043,23 @@ Configures the rules engine.
 
 Default value: `$apache::params::modsec_secruleengine`
 
+##### <a name="custom_rules"></a>`custom_rules`
+
+Data type: `Boolean`
+
+Enable Custom rules for security, this does not create or provide any rules rather it facilitate to add custom rules.
+If enabled, must provide `custom_rules_set`.
+
+Default value: `$apache::params::modsec_custom_rules`
+
+##### <a name="custom_rules_set"></a>`custom_rules_set`
+
+Data type: `[Array]`
+
+Customrules must be array of rules, for an example `['REMOTE_ADDR "^127.0.0.1" "id:199999,phase:1,nolog,allow,ctl:ruleEngine=off"']`.
+Configures the set of custom rules.
+
+Default value: `$apache::params::modsec_custom_rules_set`
 ##### <a name="audit_log_relevant_status"></a>`audit_log_relevant_status`
 
 Data type: `Any`

--- a/manifests/mod/security.pp
+++ b/manifests/mod/security.pp
@@ -97,6 +97,8 @@ class apache::mod::security (
   $version                     = $apache::params::modsec_version,
   $crs_package                 = $apache::params::modsec_crs_package,
   $activated_rules             = $apache::params::modsec_default_rules,
+  $custom_rules                = $apache::params::modsec_custom_rules,
+  $custom_rules_set            = $apache::params::modsec_custom_rules_set,
   $modsec_dir                  = $apache::params::modsec_dir,
   $modsec_secruleengine        = $apache::params::modsec_secruleengine,
   $audit_log_relevant_status   = '^(?:5|4(?!04))',
@@ -214,6 +216,27 @@ class apache::mod::security (
     force   => true,
     recurse => true,
     notify  => Class['apache::service'],
+  }
+
+  if $custom_rules {
+    # Template to add custom rule and included in security configuration
+    file {"${modsec_dir}/custom_rules":
+      ensure  => directory,
+      owner   => $apache::params::user,
+      group   => $apache::params::group,
+      mode    => $apache::file_mode,
+      require => File[$modsec_dir],
+    }
+
+    file { "${modsec_dir}/custom_rules/custom_01_rules.conf":
+      ensure  => file,
+      owner   => $apache::params::user,
+      group   => $apache::params::group,
+      mode    => $apache::file_mode,
+      content => template('apache/mod/security_custom.conf.erb'),
+      require => File["${modsec_dir}/custom_rules"],
+      notify  => Class['apache::service'],
+    }
   }
 
   if $manage_security_crs {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,6 +36,8 @@ class apache::params inherits ::apache::version {
 
   $modsec_audit_log_parts = 'ABIJDEFHZ'
   $modsec_audit_log_type = 'Serial'
+  $modsec_custom_rules = false
+  $modsec_custom_rules_set = undef
 
   # no client certs should be trusted for auth by default.
   $ssl_certs_dir          = undef

--- a/spec/classes/mod/security_spec.rb
+++ b/spec/classes/mod/security_spec.rb
@@ -103,6 +103,33 @@ describe 'apache::mod::security', type: :class do
 
             it { is_expected.not_to contain_file('/etc/httpd/modsecurity.d/security_crs.conf') }
           end
+          describe 'with custom parameters' do
+            let :params do
+              {
+                custom_rules: false,
+              }
+            end
+
+            it {
+              is_expected.not_to contain_file('/etc/httpd/modsecurity.d/custom_rules/custom_01_rules.conf')
+            }
+          end
+          describe 'with parameters' do
+            let :params do
+              {
+                custom_rules: true,
+                custom_rules_set: ['REMOTE_ADDR "^127.0.0.1" "id:199999,phase:1,nolog,allow,ctl:ruleEngine=off"'],
+              }
+            end
+
+            it {
+              is_expected.to contain_file('/etc/httpd/modsecurity.d/custom_rules').with(
+                ensure: 'directory', path: '/etc/httpd/modsecurity.d/custom_rules',
+                owner: 'apache', group: 'apache'
+              )
+            }
+            it { is_expected.to contain_file('/etc/httpd/modsecurity.d/custom_rules/custom_01_rules.conf').with_content %r{^\s*.*"id:199999,phase:1,nolog,allow,ctl:ruleEngine=off"$} }
+          end
         end
       when 'Debian'
         context 'on Debian based systems' do
@@ -187,6 +214,35 @@ describe 'apache::mod::security', type: :class do
                 )
               }
             end
+          end
+
+          describe 'with custom parameters' do
+            let :params do
+              {
+                custom_rules: false,
+              }
+            end
+
+            it {
+              is_expected.not_to contain_file('/etc/modsecurity/custom_rules/custom_01_rules.conf')
+            }
+          end
+
+          describe 'with parameters' do
+            let :params do
+              {
+                custom_rules: true,
+                custom_rules_set: ['REMOTE_ADDR "^127.0.0.1" "id:199999,phase:1,nolog,allow,ctl:ruleEngine=off"'],
+              }
+            end
+
+            it {
+              is_expected.to contain_file('/etc/modsecurity/custom_rules').with(
+                ensure: 'directory', path: '/etc/modsecurity/custom_rules',
+                owner: 'www-data', group: 'www-data'
+              )
+            }
+            it { is_expected.to contain_file('/etc/modsecurity/custom_rules/custom_01_rules.conf').with_content %r{\s*.*"id:199999,phase:1,nolog,allow,ctl:ruleEngine=off"$} }
           end
 
           describe 'with mod security version' do

--- a/templates/mod/security.conf.erb
+++ b/templates/mod/security.conf.erb
@@ -2,6 +2,9 @@
     # Default recommended configuration
     SecRuleEngine <%= @modsec_secruleengine %>
     SecRequestBodyAccess On
+  <%- if @custom_rules -%>
+    Include <%= @modsec_dir %>/custom_rules/*.conf
+  <%- end -%>
     SecRule REQUEST_HEADERS:Content-Type "text/xml" \
       "id:'200000',phase:1,t:none,t:lowercase,pass,nolog,ctl:requestBodyProcessor=XML"
     SecRequestBodyLimit <%= @secrequestbodylimit %>

--- a/templates/mod/security_custom.conf.erb
+++ b/templates/mod/security_custom.conf.erb
@@ -1,0 +1,6 @@
+# This file is managed by puppet, any direct modification will be overwritten.
+<% if defined?(@custom_rules_set) && ! @custom_rules_set.empty? -%>
+<% @custom_rules_set.each do |secrule| -%>
+SecRule <%= secrule %>
+<% end -%>
+<% end -%>


### PR DESCRIPTION
Basic Info
Module Version: 6.0.0
Puppet Version: 6.21.1
OS Name/Version: RHEL

Apache module activates the mod_security, but there is no way to manage custom rules.

For example, to override rules or create rules, etc.

Desired Behavior:

Allow adding custom rules to the security configuration.

Actual Behavior:

Functionality does not exist.