### PR TITLE
Add feature to reload apache service when content of ssl files has changed

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -109,6 +109,7 @@
 * `apache::confd::no_accf`: Manages the `no-accf.conf` file.
 * `apache::default_confd_files`: Helper for setting up default conf.d files.
 * `apache::default_mods`: Installs and congfigures default mods for Apache
+* `apache::mod::ssl::reload`: Manages the puppet_ssl folder for ssl file copies, which is needed to track changes for reloading service on changes
 * `apache::package`: Installs an Apache MPM.
 * `apache::params`: This class manages Apache parameters
 * `apache::php`: This class installs PHP for Apache.
@@ -207,6 +208,7 @@ The following parameters are available in the `apache` class:
 * [`default_ssl_crl_path`](#default_ssl_crl_path)
 * [`default_ssl_crl_check`](#default_ssl_crl_check)
 * [`default_ssl_key`](#default_ssl_key)
+* [`default_ssl_reload_on_change`](#default_ssl_reload_on_change)
 * [`default_ssl_vhost`](#default_ssl_vhost)
 * [`default_type`](#default_type)
 * [`default_vhost`](#default_vhost)
@@ -433,6 +435,14 @@ this parameter with your SSL key's location before deploying this server in a pr
 environment.
 
 Default value: `$apache::params::default_ssl_key`
+
+##### <a name="default_ssl_reload_on_change"></a>`default_ssl_reload_on_change`
+
+Data type: `Boolean`
+
+Enable reloading of apache if the content of ssl files have changed.
+
+Default value: ``false``
 
 ##### <a name="default_ssl_vhost"></a>`default_ssl_vhost`
 
@@ -6369,6 +6379,7 @@ The following parameters are available in the `apache::mod::ssl` class:
 * [`ssl_stapling`](#ssl_stapling)
 * [`ssl_stapling_return_errors`](#ssl_stapling_return_errors)
 * [`ssl_mutex`](#ssl_mutex)
+* [`ssl_reload_on_change`](#ssl_reload_on_change)
 * [`apache_version`](#apache_version)
 * [`package_name`](#package_name)
 * [`ssl_sessiontickets`](#ssl_sessiontickets)
@@ -6524,6 +6535,14 @@ Default based on the OS and/or Apache version:
 - Debian/Ubuntu + Apache < 2.4: 'file:${APACHE_RUN_DIR}/ssl_mutex'.
 
 Default value: ``undef``
+
+##### <a name="ssl_reload_on_change"></a>`ssl_reload_on_change`
+
+Data type: `Boolean`
+
+Enable reloading of apache if the content of ssl files have changed. It only affects ssl files configured here and not vhost ones.
+
+Default value: ``false``
 
 ##### <a name="apache_version"></a>`apache_version`
 
@@ -7780,6 +7799,7 @@ The following parameters are available in the `apache::vhost` defined type:
 * [`ssl_stapling_timeout`](#ssl_stapling_timeout)
 * [`ssl_stapling_return_errors`](#ssl_stapling_return_errors)
 * [`ssl_user_name`](#ssl_user_name)
+* [`ssl_reload_on_change`](#ssl_reload_on_change)
 * [`use_canonical_name`](#use_canonical_name)
 * [`define`](#define)
 * [`auth_oidc`](#auth_oidc)
@@ -10628,6 +10648,14 @@ Data type: `Optional[String]`
 Sets the [SSLUserName](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslusername) directive.
 
 Default value: ``undef``
+
+##### <a name="ssl_reload_on_change"></a>`ssl_reload_on_change`
+
+Data type: `Boolean`
+
+Enable reloading of apache if the content of ssl files have changed.
+
+Default value: `$apache::default_ssl_reload_on_change`
 
 ##### <a name="use_canonical_name"></a>`use_canonical_name`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,6 +91,9 @@
 #   this parameter with your SSL key's location before deploying this server in a production 
 #   environment.
 #
+# @param default_ssl_reload_on_change
+#   Enable reloading of apache if the content of ssl files have changed.
+#
 # @param default_ssl_vhost
 #   Configures a default SSL virtual host.
 #   If `true`, Puppet automatically configures the following virtual host using the 
@@ -472,6 +475,7 @@ class apache (
   $default_ssl_crl_path                                                 = undef,
   $default_ssl_crl                                                      = undef,
   $default_ssl_crl_check                                                = undef,
+  Boolean $default_ssl_reload_on_change                                 = false,
   $default_type                                                         = 'none',
   $dev_packages                                                         = $apache::params::dev_packages,
   $ip                                                                   = undef,

--- a/manifests/mod/ssl/reload.pp
+++ b/manifests/mod/ssl/reload.pp
@@ -1,0 +1,17 @@
+# @summary
+#   Manages the puppet_ssl folder for ssl file copies, which is needed to track changes for reloading service on changes
+#
+# @api private
+class apache::mod::ssl::reload () inherits ::apache::params {
+  file { $apache::params::puppet_ssl_dir:
+    ensure  => directory,
+    purge   => true,
+    recurse => true,
+    require => Package['httpd'],
+  }
+  file { 'README.txt':
+    path    => "${apache::params::puppet_ssl_dir}/README.txt",
+    content => 'This directory contains puppet managed copies of ssl files, so it can track changes and reload apache on changes.',
+    seltype => 'etc_t',
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -63,6 +63,7 @@ class apache::params inherits ::apache::version {
     $server_root          = "${httpd_root}/etc/httpd"
     $conf_dir             = "${httpd_dir}/conf"
     $confd_dir            = "${httpd_dir}/conf.d"
+    $puppet_ssl_dir       = "${httpd_dir}/puppet_ssl"
     $mod_dir              = $facts['operatingsystemmajrelease'] ? {
       '7'     => "${httpd_dir}/conf.modules.d",
       default => "${httpd_dir}/conf.d",
@@ -169,6 +170,7 @@ class apache::params inherits ::apache::version {
     $server_root          = '/etc/httpd'
     $conf_dir             = "${httpd_dir}/conf"
     $confd_dir            = "${httpd_dir}/conf.d"
+    $puppet_ssl_dir       = "${httpd_dir}/puppet_ssl"
     $conf_enabled         = undef
     if $::operatingsystem =~ /^[Aa]mazon$/ and $::operatingsystemmajrelease == '2' {
       # Amazon Linux 2 uses the /conf.modules.d/ dir
@@ -343,6 +345,7 @@ class apache::params inherits ::apache::version {
     $confd_dir           = "${httpd_dir}/conf.d"
     # Overwrite conf_enabled causes errors with Shibboleth when enabled on Ubuntu 18.04
     $conf_enabled        = undef #"${httpd_dir}/conf-enabled.d"
+    $puppet_ssl_dir      = "${httpd_dir}/puppet_ssl"
     $mod_dir             = "${httpd_dir}/mods-available"
     $mod_enable_dir      = "${httpd_dir}/mods-enabled"
     $vhost_dir           = "${httpd_dir}/sites-available"
@@ -546,6 +549,7 @@ class apache::params inherits ::apache::version {
     $conf_dir         = $httpd_dir
     $confd_dir        = "${httpd_dir}/Includes"
     $conf_enabled     = undef
+    $puppet_ssl_dir   = "${httpd_dir}/puppet_ssl"
     $mod_dir          = "${httpd_dir}/Modules"
     $mod_enable_dir   = undef
     $vhost_dir        = "${httpd_dir}/Vhosts"
@@ -619,6 +623,7 @@ class apache::params inherits ::apache::version {
     $conf_dir         = $httpd_dir
     $confd_dir        = "${httpd_dir}/conf.d"
     $conf_enabled     = undef
+    $puppet_ssl_dir   = "${httpd_dir}/puppet_ssl"
     $mod_dir          = "${httpd_dir}/modules.d"
     $mod_enable_dir   = undef
     $vhost_dir        = "${httpd_dir}/vhosts.d"
@@ -689,6 +694,7 @@ class apache::params inherits ::apache::version {
     $conf_dir            = $httpd_dir
     $confd_dir           = "${httpd_dir}/conf.d"
     $conf_enabled        = undef
+    $puppet_ssl_dir      = "${httpd_dir}/puppet_ssl"
     $mod_dir             = "${httpd_dir}/mods-available"
     $mod_enable_dir      = "${httpd_dir}/mods-enabled"
     $vhost_dir           = "${httpd_dir}/sites-available"

--- a/spec/acceptance/apache_ssl_spec.rb
+++ b/spec/acceptance/apache_ssl_spec.rb
@@ -48,6 +48,17 @@ describe 'apache ssl' do
 
   describe 'vhost ssl parameters' do
     pp = <<-MANIFEST
+        file { [
+          '/tmp/ssl_cert',
+          '/tmp/ssl_key',
+          '/tmp/ssl_chain',
+          '/tmp/ssl_ca',
+          '/tmp/ssl_crl',
+          ]:
+            ensure             => file,
+            before             => Class['apache']
+        }
+
         class { 'apache':
           service_ensure       => stopped,
         }
@@ -63,6 +74,7 @@ describe 'apache ssl' do
           ssl_crl              => '/tmp/ssl_crl',
           ssl_crl_check        => 'chain flag',
           ssl_certs_dir        => '/tmp',
+          ssl_reload_on_change => true,
           ssl_protocol         => 'test',
           ssl_cipher           => 'test',
           ssl_honorcipherorder => true,
@@ -98,6 +110,26 @@ describe 'apache ssl' do
       else
         it { is_expected.not_to contain 'SSLCARevocationCheck' }
       end
+    end
+
+    describe file("#{apache_hash['httpd_dir']}/puppet_ssl/test_ssl_tmp_ssl_cert") do
+      it { is_expected.to be_file }
+    end
+
+    describe file("#{apache_hash['httpd_dir']}/puppet_ssl/test_ssl_tmp_ssl_key") do
+      it { is_expected.to be_file }
+    end
+
+    describe file("#{apache_hash['httpd_dir']}/puppet_ssl/test_ssl_tmp_ssl_chain") do
+      it { is_expected.to be_file }
+    end
+
+    describe file("#{apache_hash['httpd_dir']}/puppet_ssl/test_ssl_tmp_ssl_ca") do
+      it { is_expected.to be_file }
+    end
+
+    describe file("#{apache_hash['httpd_dir']}/puppet_ssl/test_ssl_tmp_ssl_crl") do
+      it { is_expected.to be_file }
     end
   end
 

--- a/spec/classes/mod/ssl_spec.rb
+++ b/spec/classes/mod/ssl_spec.rb
@@ -127,6 +127,18 @@ describe 'apache::mod::ssl', type: :class do
       it { is_expected.to contain_file('ssl.conf').with_content(%r{^  SSLCACertificateFile}) }
     end
 
+    context 'setting ssl_cert with reload' do
+      let :params do
+        {
+          ssl_cert: '/etc/pki/some/path/localhost.crt',
+          ssl_reload_on_change: true,
+        }
+      end
+
+      it { is_expected.to contain_file('ssl.conf').with_content(%r{^  SSLCertificateFile}) }
+      it { is_expected.to contain_file('_etc_pki_some_path_localhost.crt') }
+    end
+
     context 'with Apache version < 2.4 - ssl_compression with default value' do
       let :params do
         {

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -71,7 +71,7 @@ describe 'apache::vhost', type: :define do
               'ssl_key'                     => '/ssl/key',
               'ssl_chain'                   => '/ssl/chain',
               'ssl_crl_path'                => '/ssl/crl',
-              'ssl_crl'                     => 'foo.crl',
+              'ssl_crl'                     => '/ssl/foo.crl',
               'ssl_certs_dir'               => '/ssl/certs',
               'ssl_protocol'                => 'SSLv2',
               'ssl_cipher'                  => 'HIGH',
@@ -88,6 +88,7 @@ describe 'apache::vhost', type: :define do
               'ssl_proxy_cipher_suite'      => 'HIGH',
               'ssl_proxy_protocol'          => 'TLSv1.2',
               'ssl_user_name'               => 'SSL_CLIENT_S_DN_CN',
+              'ssl_reload_on_change'        => true,
               'priority'                    => '30',
               'default_vhost'               => true,
               'servername'                  => 'example.com',
@@ -516,6 +517,10 @@ describe 'apache::vhost', type: :define do
               content: %r{^\s+SSLSessionCacheTimeout 300$},
             )
           }
+          it { is_expected.to contain_file('rspec.example.com_ssl_cert') }
+          it { is_expected.to contain_file('rspec.example.com_ssl_key') }
+          it { is_expected.to contain_file('rspec.example.com_ssl_chain') }
+          it { is_expected.to contain_file('rspec.example.com_ssl_foo.crl') }
           it { is_expected.to contain_class('apache::mod::mime') }
           it { is_expected.to contain_class('apache::mod::vhost_alias') }
           it { is_expected.to contain_class('apache::mod::wsgi') }
@@ -1859,6 +1864,10 @@ describe 'apache::vhost', type: :define do
           it { is_expected.not_to contain_class('apache::mod::proxy') }
           it { is_expected.not_to contain_class('apache::mod::proxy_http') }
           it { is_expected.not_to contain_class('apache::mod::headers') }
+          it { is_expected.not_to contain_file('rspec.example.com_ssl_cert') }
+          it { is_expected.not_to contain_file('rspec.example.com_ssl_key') }
+          it { is_expected.not_to contain_file('rspec.example.com_ssl_chain') }
+          it { is_expected.not_to contain_file('rspec.example.com_ssl_foo.crl') }
           it { is_expected.to contain_file('/var/www/foo') }
           it {
             is_expected.to contain_file('/tmp/logroot').with('ensure' => 'absent')

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -85,6 +85,7 @@ def apache_settings_hash
   apache = {}
   case osfamily
   when 'redhat', 'oracle'
+    apache['httpd_dir']        = '/etc/httpd'
     apache['confd_dir']        = '/etc/httpd/conf.d'
     apache['conf_file']        = '/etc/httpd/conf/httpd.conf'
     apache['ports_file']       = '/etc/httpd/conf/ports.conf'
@@ -115,6 +116,7 @@ def apache_settings_hash
       apache['mod_ssl_dir'] = apache['mod_dir']
     end
   when 'debian', 'ubuntu'
+    apache['httpd_dir']        = '/etc/apache2'
     apache['confd_dir']        = '/etc/apache2/conf.d'
     apache['mod_dir']          = '/etc/apache2/mods-available'
     apache['conf_file']        = '/etc/apache2/apache2.conf'
@@ -137,6 +139,7 @@ def apache_settings_hash
                         end
     apache['mod_ssl_dir']      = apache['mod_dir']
   when 'freebsd'
+    apache['httpd_dir']        = '/usr/local/etc/apache24'
     apache['confd_dir']        = '/usr/local/etc/apache24/Includes'
     apache['mod_dir']          = '/usr/local/etc/apache24/Modules'
     apache['conf_file']        = '/usr/local/etc/apache24/httpd.conf'
@@ -151,6 +154,7 @@ def apache_settings_hash
     apache['version']          = '2.2'
     apache['mod_ssl_dir']      = apache['mod_dir']
   when 'gentoo'
+    apache['httpd_dir']        = '/etc/apache2'
     apache['confd_dir']        = '/etc/apache2/conf.d'
     apache['mod_dir']          = '/etc/apache2/modules.d'
     apache['conf_file']        = '/etc/apache2/httpd.conf'
@@ -165,6 +169,7 @@ def apache_settings_hash
     apache['version']          = '2.4'
     apache['mod_ssl_dir']      = apache['mod_dir']
   when 'suse', 'sles'
+    apache['httpd_dir']        = '/etc/apache2'
     apache['confd_dir']        = '/etc/apache2/conf.d'
     apache['mod_dir']          = '/etc/apache2/mods-available'
     apache['conf_file']        = '/etc/apache2/httpd.conf'


### PR DESCRIPTION
This fixes issue MODULES-10847, which we also wanted to solve.

The solution with those helper files seems a bit odd, but the original ssl files could be managed by any means outside of the apache module or even outside of puppet, so this was the only way i could image to achieve it.

(Slightly offtopic: Let me add that this module gave me a love/hate relationship with spec/acceptance tests. First i blamed wrong tests to be the cause for failing, but in the end it was my own stupid code. Finally i could manage getting tests run green at my desktop - hope they will do in the modules CI setup as well.)