### PR TITLE
Update the default version of Apache for Amazon Linux 2

### DIFF
--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -837,7 +837,11 @@ class apache::mod::passenger (
 
   if $::osfamily == 'RedHat' and $manage_repo {
     if $::operatingsystem == 'Amazon' {
-      $baseurl = 'https://oss-binaries.phusionpassenger.com/yum/passenger/el/6Server/$basearch'
+      if $::operatingsystemmajrelease == '2' {
+        $baseurl = 'https://oss-binaries.phusionpassenger.com/yum/passenger/el/7Server/$basearch'
+      } else {
+        $baseurl = 'https://oss-binaries.phusionpassenger.com/yum/passenger/el/6Server/$basearch'
+      }
     } else {
       $baseurl = 'https://oss-binaries.phusionpassenger.com/yum/passenger/el/$releasever/$basearch'
     }

--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -838,9 +838,9 @@ class apache::mod::passenger (
   if $::osfamily == 'RedHat' and $manage_repo {
     if $::operatingsystem == 'Amazon' {
       if $::operatingsystemmajrelease == '2' {
-        $baseurl = 'https://oss-binaries.phusionpassenger.com/yum/passenger/el/7Server/$basearch'
+        $baseurl = 'https://oss-binaries.phusionpassenger.com/yum/passenger/el/7/$basearch'
       } else {
-        $baseurl = 'https://oss-binaries.phusionpassenger.com/yum/passenger/el/6Server/$basearch'
+        $baseurl = 'https://oss-binaries.phusionpassenger.com/yum/passenger/el/6/$basearch'
       }
     } else {
       $baseurl = 'https://oss-binaries.phusionpassenger.com/yum/passenger/el/$releasever/$basearch'

--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -11,8 +11,8 @@ class apache::version (
       if $scl_httpd_version {
         $default = $scl_httpd_version
       }
-      elsif ($::operatingsystem == 'Amazon') {
-        $default = '2.2'
+      elsif ($::operatingsystem == 'Amazon' and $::operatingsystemmajrelease == '2') {
+        $default = '2.4'
       } elsif ($::operatingsystem == 'Fedora' and versioncmp($facts['operatingsystemmajrelease'], '18') >= 0) or ($::operatingsystem != 'Fedora' and versioncmp($facts['operatingsystemmajrelease'], '7') >= 0) {
         $default = '2.4'
       } else {


### PR DESCRIPTION
- updated `$default` variable for Amazon Linux 2

The default `httpd` package version on the Amazon Linux 2 is `2.4`
```
Name        : httpd
Arch        : x86_64
Version     : 2.4.46
Release     : 1.amzn2
Size        : 1.3 M
Repo        : amzn2-core/2/x86_64
Summary     : Apache HTTP Server
URL         : https://httpd.apache.org/
License     : ASL 2.0
Description : The Apache HTTP Server is a powerful, efficient, and extensible
            : web server.
```
Based on the above we need to update the `$default` variable to support AL2