### PR TITLE
Improve/silence warning from pull-request #2154

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -2122,7 +2122,7 @@ define apache::vhost (
     module, the $use_servername_for_filenames will be removed and log/config file names will be derived from the
     sanitized $servername parameter when not explicitly defined.'
     warning($use_servername_for_filenames_warn_msg)
-  } elsif ! $use_port_for_filenames {
+  } elsif $use_servername_for_filenames and ! $use_port_for_filenames {
     $use_port_for_filenames_warn_msg = '
     It is possible for multiple virtual hosts to be configured using the same $servername but a different port. When
     using $use_servername_for_filenames, this can lead to duplicate resource declarations.

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -2111,7 +2111,7 @@ define apache::vhost (
     false => $name,
   }
 
-  if ! $use_servername_for_filenames and $name != $normalized_servername {
+  if ! $use_servername_for_filenames and $servername != $normalized_servername {
     $use_servername_for_filenames_warn_msg = '
     It is possible for the $name parameter to be defined with spaces in it. Although supported on POSIX systems, this
     can lead to cumbersome file names. The $servername attribute has stricter conditions from Apache (i.e. no spaces)


### PR DESCRIPTION
Hi,

pull-request #2154 did try to silence the warnings about servernames and filenames to cases where a problem actually exists.

However, there are two problems with that:

1) there is a check between "name" and "normalized_servername", when it actually should check for differences between "servername" and "normalized_servername".

2) even if that check is silenced, there is still the second warning about "use_port_for_filenames" not enabled. That warning should only be issued if "use_servername_for_filenames" is enabled.