### PR TITLE
Allow custom userdir directives

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6669,6 +6669,7 @@ The following parameters are available in the `apache::mod::userdir` class:
 
 * [`home`](#home)
 * [`dir`](#dir)
+* [`userdir`](#userdir)
 * [`disable_root`](#disable_root)
 * [`apache_version`](#apache_version)
 * [`path`](#path)
@@ -6692,6 +6693,14 @@ Data type: `Any`
 *Deprecated* Path from user's home directory to public directory.
 
 Default value: ``undef``
+
+##### <a name="userdir"></a>`userdir`
+
+Data type: `Any`
+
+Directory out of which per-user content is loaded. It may be any valid `UserDir` directive values.
+
+Default value: The value of `$path`
 
 ##### <a name="disable_root"></a>`disable_root`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6696,11 +6696,11 @@ Default value: ``undef``
 
 ##### <a name="userdir"></a>`userdir`
 
-Data type: `Any`
+Data type: `Optional[String[1]]`
 
-Directory out of which per-user content is loaded. It may be any valid `UserDir` directive values.
+Path or directory name to be used as the UserDir.
 
-Default value: The value of `$path`
+Default value: ``undef``
 
 ##### <a name="disable_root"></a>`disable_root`
 

--- a/manifests/mod/userdir.pp
+++ b/manifests/mod/userdir.pp
@@ -6,7 +6,10 @@
 #   
 # @param dir
 #   *Deprecated* Path from user's home directory to public directory.
-# 
+#
+# @param userdir
+#   Path or directory name to be used as the UserDir.
+#
 # @param disable_root
 #   Toggles whether to allow use of root directory.
 # 
@@ -33,6 +36,7 @@
 class apache::mod::userdir (
   $home = undef,
   $dir = undef,
+  $userdir = undef,
   $disable_root = true,
   $apache_version = undef,
   $path = '/home/*/public_html',
@@ -57,6 +61,11 @@ class apache::mod::userdir (
     $_path = "${_home}/*/${_dir}"
   } else {
     $_path = $path
+  }
+
+  $_userdir = $userdir ? {
+    undef   => $_path,
+    default => $userdir,
   }
 
   ::apache::mod { 'userdir': }

--- a/manifests/mod/userdir.pp
+++ b/manifests/mod/userdir.pp
@@ -36,7 +36,7 @@
 class apache::mod::userdir (
   $home = undef,
   $dir = undef,
-  $userdir = undef,
+  Optional[String[1]] $userdir = undef,
   $disable_root = true,
   $apache_version = undef,
   $path = '/home/*/public_html',
@@ -63,10 +63,7 @@ class apache::mod::userdir (
     $_path = $path
   }
 
-  $_userdir = $userdir ? {
-    undef   => $_path,
-    default => $userdir,
-  }
+  $_userdir = pick($userdir, $_path)
 
   ::apache::mod { 'userdir': }
 

--- a/spec/classes/mod/userdir_spec.rb
+++ b/spec/classes/mod/userdir_spec.rb
@@ -39,12 +39,23 @@ describe 'apache::mod::userdir', type: :class do
     context 'with path set to something' do
       let :params do
         {
-          path: 'public_html /usr/web http://www.example.com/',
+          path: '/home/*/*/public_html',
         }
       end
 
-      it { is_expected.to contain_file('userdir.conf').with_content(%r{^\s*UserDir\s+public_html /usr/web http://www\.example\.com/$}) }
-      it { is_expected.to contain_file('userdir.conf').with_content(%r{^\s*\<Directory\s+\"public_html /usr/web http://www\.example\.com/\"\>$}) }
+      it { is_expected.to contain_file('userdir.conf').with_content(%r{^\s*UserDir\s+/home/\*/\*/public_html$}) }
+      it { is_expected.to contain_file('userdir.conf').with_content(%r{^\s*\<Directory\s+\"/home/\*/\*/public_html\"\>$}) }
+    end
+    context 'with userdir set to something' do
+      let :params do
+        {
+          path: '/home/*/*/public_html',
+          userdir: 'public_html',
+        }
+      end
+
+      it { is_expected.to contain_file('userdir.conf').with_content(%r{^\s*UserDir\s+public_html$}) }
+      it { is_expected.to contain_file('userdir.conf').with_content(%r{^\s*\<Directory\s+\"/home/\*/\*/public_html\"\>$}) }
     end
     context 'with unmanaged_path set to true' do
       let :params do

--- a/templates/mod/userdir.conf.erb
+++ b/templates/mod/userdir.conf.erb
@@ -2,7 +2,7 @@
 <% if @disable_root -%>
   UserDir disabled root
 <% end -%>
-  UserDir <%= @_path %>
+  UserDir <%= @_userdir %>
 
 <%- if ! @unmanaged_path -%>
   <Directory "<%= @_path %>">


### PR DESCRIPTION
`UserDir` can be various forms of strings (see
https://httpd.apache.org/docs/2.4/howto/public_html.html) whereas
`Directory` must be an absolute path. This allows UserDir to be
specified separately.

The unit test showing multiple values for `$path` seems to be incorrect
according to https://httpd.apache.org/docs/2.4/mod/core.html#directory