### PR TITLE
(maint) Fix puppet-strings docs on apache::vhost

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -133,7 +133,8 @@ Apache server's or a virtual host's listening address and port.
 * [`apache::mod`](#apachemod): Installs packages for an Apache module that doesn't have a corresponding
 `apache::mod::<MODULE NAME>` class.
 * [`apache::namevirtualhost`](#apachenamevirtualhost): Enables name-based virtual hosts
-* [`apache::vhost`](#apachevhost)
+* [`apache::vhost`](#apachevhost): Allows specialised configurations for virtual hosts that possess requirements
+outside of the defaults.
 * [`apache::vhost::custom`](#apachevhostcustom): A wrapper around the `apache::custom_config` defined type.
 * [`apache::vhost::fragment`](#apachevhostfragment): Define a fragment within a vhost
 
@@ -7506,157 +7507,86 @@ directory. Titles can take the forms `\*`, `\*:\<PORT\>`, `\_default\_:\<PORT\>`
 
 ### <a name="apachevhost"></a>`apache::vhost`
 
-The apache::vhost class.
+The apache module allows a lot of flexibility in the setup and configuration of virtual hosts.
+This flexibility is due, in part, to `vhost` being a defined resource type, which allows Apache
+to evaluate it multiple times with different parameters.<br />
+The `apache::vhost` defined type allows you to have specialized configurations for virtual hosts
+that have requirements outside the defaults. You can set up a default virtual host within
+the base `::apache` class, as well as set a customized virtual host as the default.
+Customized virtual hosts have a lower numeric `priority` than the base class's, causing
+Apache to process the customized virtual host first.<br />
+The `apache::vhost` defined type uses `concat::fragment` to build the configuration file. To
+inject custom fragments for pieces of the configuration that the defined type doesn't
+inherently support, add a custom fragment.<br />
+For the custom fragment's `order` parameter, the `apache::vhost` defined type uses multiples
+of 10, so any `order` that isn't a multiple of 10 should work.<br />
+> **Note:** When creating an `apache::vhost`, it cannot be named `default` or `default-ssl`,
+because vhosts with these titles are always managed by the module. This means that you cannot
+override `Apache::Vhost['default']`  or `Apache::Vhost['default-ssl]` resources. An optional
+workaround is to create a vhost named something else, such as `my default`, and ensure that the
+`default` and `default_ssl` vhosts are set to `false`:
+
+#### Examples
+
+##### 
+
+```puppet
+class { 'apache':
+  default_vhost     => false,
+  default_ssl_vhost => false,
+}
+```
 
 #### Parameters
 
 The following parameters are available in the `apache::vhost` defined type:
 
-* [`docroot`](#docroot)
-* [`manage_docroot`](#manage_docroot)
-* [`virtual_docroot`](#virtual_docroot)
-* [`port`](#port)
-* [`ip`](#ip)
-* [`ip_based`](#ip_based)
-* [`add_listen`](#add_listen)
-* [`docroot_owner`](#docroot_owner)
-* [`docroot_group`](#docroot_group)
-* [`docroot_mode`](#docroot_mode)
-* [`protocols`](#protocols)
-* [`protocols_honor_order`](#protocols_honor_order)
-* [`serveradmin`](#serveradmin)
-* [`ssl`](#ssl)
-* [`ssl_cert`](#ssl_cert)
-* [`ssl_key`](#ssl_key)
-* [`ssl_chain`](#ssl_chain)
-* [`ssl_ca`](#ssl_ca)
-* [`ssl_crl_path`](#ssl_crl_path)
-* [`ssl_crl`](#ssl_crl)
-* [`ssl_crl_check`](#ssl_crl_check)
-* [`ssl_certs_dir`](#ssl_certs_dir)
-* [`ssl_protocol`](#ssl_protocol)
-* [`ssl_cipher`](#ssl_cipher)
-* [`ssl_honorcipherorder`](#ssl_honorcipherorder)
-* [`ssl_verify_client`](#ssl_verify_client)
-* [`ssl_verify_depth`](#ssl_verify_depth)
-* [`ssl_proxy_verify`](#ssl_proxy_verify)
-* [`ssl_proxy_verify_depth`](#ssl_proxy_verify_depth)
-* [`ssl_proxy_ca_cert`](#ssl_proxy_ca_cert)
-* [`ssl_proxy_check_peer_cn`](#ssl_proxy_check_peer_cn)
-* [`ssl_proxy_check_peer_name`](#ssl_proxy_check_peer_name)
-* [`ssl_proxy_check_peer_expire`](#ssl_proxy_check_peer_expire)
-* [`ssl_proxy_machine_cert`](#ssl_proxy_machine_cert)
-* [`ssl_proxy_machine_cert_chain`](#ssl_proxy_machine_cert_chain)
-* [`ssl_proxy_cipher_suite`](#ssl_proxy_cipher_suite)
-* [`ssl_proxy_protocol`](#ssl_proxy_protocol)
-* [`ssl_options`](#ssl_options)
-* [`ssl_openssl_conf_cmd`](#ssl_openssl_conf_cmd)
-* [`ssl_proxyengine`](#ssl_proxyengine)
-* [`ssl_stapling`](#ssl_stapling)
-* [`ssl_stapling_timeout`](#ssl_stapling_timeout)
-* [`ssl_stapling_return_errors`](#ssl_stapling_return_errors)
-* [`ssl_user_name`](#ssl_user_name)
-* [`priority`](#priority)
-* [`default_vhost`](#default_vhost)
-* [`servername`](#servername)
-* [`serveraliases`](#serveraliases)
-* [`options`](#options)
-* [`override`](#override)
-* [`directoryindex`](#directoryindex)
-* [`vhost_name`](#vhost_name)
-* [`logroot`](#logroot)
-* [`logroot_ensure`](#logroot_ensure)
-* [`logroot_mode`](#logroot_mode)
-* [`logroot_owner`](#logroot_owner)
-* [`logroot_group`](#logroot_group)
-* [`log_level`](#log_level)
+* [`apache_version`](#apache_version)
 * [`access_log`](#access_log)
+* [`access_log_env_var`](#access_log_env_var)
 * [`access_log_file`](#access_log_file)
+* [`access_log_format`](#access_log_format)
 * [`access_log_pipe`](#access_log_pipe)
 * [`access_log_syslog`](#access_log_syslog)
-* [`access_log_format`](#access_log_format)
-* [`access_log_env_var`](#access_log_env_var)
 * [`access_logs`](#access_logs)
-* [`use_servername_for_filenames`](#use_servername_for_filenames)
-* [`use_port_for_filenames`](#use_port_for_filenames)
+* [`add_default_charset`](#add_default_charset)
+* [`add_listen`](#add_listen)
+* [`use_optional_includes`](#use_optional_includes)
+* [`additional_includes`](#additional_includes)
 * [`aliases`](#aliases)
-* [`directories`](#directories)
+* [`allow_encoded_slashes`](#allow_encoded_slashes)
+* [`block`](#block)
+* [`cas_attribute_prefix`](#cas_attribute_prefix)
+* [`cas_attribute_delimiter`](#cas_attribute_delimiter)
+* [`cas_login_url`](#cas_login_url)
+* [`cas_root_proxied_as`](#cas_root_proxied_as)
+* [`cas_scrub_request_headers`](#cas_scrub_request_headers)
+* [`cas_sso_enabled`](#cas_sso_enabled)
+* [`cas_validate_saml`](#cas_validate_saml)
+* [`cas_validate_url`](#cas_validate_url)
+* [`cas_cookie_path`](#cas_cookie_path)
+* [`comment`](#comment)
+* [`custom_fragment`](#custom_fragment)
+* [`default_vhost`](#default_vhost)
+* [`directoryindex`](#directoryindex)
+* [`docroot`](#docroot)
+* [`docroot_group`](#docroot_group)
+* [`docroot_owner`](#docroot_owner)
+* [`docroot_mode`](#docroot_mode)
+* [`manage_docroot`](#manage_docroot)
 * [`error_log`](#error_log)
 * [`error_log_file`](#error_log_file)
 * [`error_log_pipe`](#error_log_pipe)
 * [`error_log_syslog`](#error_log_syslog)
 * [`error_log_format`](#error_log_format)
-* [`http_protocol_options`](#http_protocol_options)
-* [`modsec_audit_log`](#modsec_audit_log)
-* [`modsec_audit_log_file`](#modsec_audit_log_file)
-* [`modsec_audit_log_pipe`](#modsec_audit_log_pipe)
 * [`error_documents`](#error_documents)
-* [`fallbackresource`](#fallbackresource)
-* [`scriptalias`](#scriptalias)
-* [`scriptaliases`](#scriptaliases)
-* [`limitreqfieldsize`](#limitreqfieldsize)
-* [`limitreqfields`](#limitreqfields)
-* [`limitreqline`](#limitreqline)
-* [`limitreqbody`](#limitreqbody)
-* [`proxy_dest`](#proxy_dest)
-* [`proxy_dest_match`](#proxy_dest_match)
-* [`proxy_dest_reverse_match`](#proxy_dest_reverse_match)
-* [`proxy_pass`](#proxy_pass)
-* [`proxy_pass_match`](#proxy_pass_match)
-* [`proxy_requests`](#proxy_requests)
-* [`suphp_addhandler`](#suphp_addhandler)
-* [`suphp_engine`](#suphp_engine)
-* [`suphp_configpath`](#suphp_configpath)
-* [`php_flags`](#php_flags)
-* [`php_values`](#php_values)
-* [`php_admin_flags`](#php_admin_flags)
-* [`php_admin_values`](#php_admin_values)
-* [`no_proxy_uris`](#no_proxy_uris)
-* [`no_proxy_uris_match`](#no_proxy_uris_match)
-* [`proxy_preserve_host`](#proxy_preserve_host)
-* [`proxy_add_headers`](#proxy_add_headers)
-* [`proxy_error_override`](#proxy_error_override)
-* [`redirect_source`](#redirect_source)
-* [`redirect_dest`](#redirect_dest)
-* [`redirect_status`](#redirect_status)
-* [`redirectmatch_status`](#redirectmatch_status)
-* [`redirectmatch_regexp`](#redirectmatch_regexp)
-* [`redirectmatch_dest`](#redirectmatch_dest)
-* [`headers`](#headers)
-* [`request_headers`](#request_headers)
-* [`filters`](#filters)
-* [`rewrites`](#rewrites)
-* [`rewrite_base`](#rewrite_base)
-* [`rewrite_rule`](#rewrite_rule)
-* [`rewrite_cond`](#rewrite_cond)
-* [`rewrite_inherit`](#rewrite_inherit)
-* [`setenv`](#setenv)
-* [`setenvif`](#setenvif)
-* [`setenvifnocase`](#setenvifnocase)
-* [`block`](#block)
 * [`ensure`](#ensure)
-* [`wsgi_application_group`](#wsgi_application_group)
-* [`wsgi_daemon_process`](#wsgi_daemon_process)
-* [`wsgi_daemon_process_options`](#wsgi_daemon_process_options)
-* [`wsgi_import_script`](#wsgi_import_script)
-* [`wsgi_import_script_options`](#wsgi_import_script_options)
-* [`wsgi_process_group`](#wsgi_process_group)
-* [`wsgi_script_aliases_match`](#wsgi_script_aliases_match)
-* [`wsgi_script_aliases`](#wsgi_script_aliases)
-* [`wsgi_pass_authorization`](#wsgi_pass_authorization)
-* [`wsgi_chunked_request`](#wsgi_chunked_request)
-* [`custom_fragment`](#custom_fragment)
-* [`itk`](#itk)
-* [`action`](#action)
+* [`fallbackresource`](#fallbackresource)
 * [`fastcgi_server`](#fastcgi_server)
 * [`fastcgi_socket`](#fastcgi_socket)
-* [`fastcgi_dir`](#fastcgi_dir)
 * [`fastcgi_idle_timeout`](#fastcgi_idle_timeout)
-* [`additional_includes`](#additional_includes)
-* [`use_optional_includes`](#use_optional_includes)
-* [`apache_version`](#apache_version)
-* [`allow_encoded_slashes`](#allow_encoded_slashes)
-* [`suexec_user_group`](#suexec_user_group)
+* [`fastcgi_dir`](#fastcgi_dir)
+* [`filters`](#filters)
 * [`h2_copy_files`](#h2_copy_files)
 * [`h2_direct`](#h2_direct)
 * [`h2_early_hints`](#h2_early_hints)
@@ -7672,6 +7602,48 @@ The following parameters are available in the `apache::vhost` defined type:
 * [`h2_tls_warm_up_size`](#h2_tls_warm_up_size)
 * [`h2_upgrade`](#h2_upgrade)
 * [`h2_window_size`](#h2_window_size)
+* [`headers`](#headers)
+* [`ip`](#ip)
+* [`ip_based`](#ip_based)
+* [`itk`](#itk)
+* [`action`](#action)
+* [`jk_mounts`](#jk_mounts)
+* [`http_protocol_options`](#http_protocol_options)
+* [`keepalive`](#keepalive)
+* [`keepalive_timeout`](#keepalive_timeout)
+* [`max_keepalive_requests`](#max_keepalive_requests)
+* [`auth_kerb`](#auth_kerb)
+* [`krb_method_negotiate`](#krb_method_negotiate)
+* [`krb_method_k5passwd`](#krb_method_k5passwd)
+* [`krb_authoritative`](#krb_authoritative)
+* [`krb_auth_realms`](#krb_auth_realms)
+* [`krb_5keytab`](#krb_5keytab)
+* [`krb_local_user_mapping`](#krb_local_user_mapping)
+* [`krb_verify_kdc`](#krb_verify_kdc)
+* [`krb_servicename`](#krb_servicename)
+* [`krb_save_credentials`](#krb_save_credentials)
+* [`logroot`](#logroot)
+* [`logroot_ensure`](#logroot_ensure)
+* [`logroot_mode`](#logroot_mode)
+* [`logroot_owner`](#logroot_owner)
+* [`logroot_group`](#logroot_group)
+* [`log_level`](#log_level)
+* [`modsec_body_limit`](#modsec_body_limit)
+* [`modsec_disable_vhost`](#modsec_disable_vhost)
+* [`modsec_disable_ids`](#modsec_disable_ids)
+* [`modsec_disable_ips`](#modsec_disable_ips)
+* [`modsec_disable_msgs`](#modsec_disable_msgs)
+* [`modsec_disable_tags`](#modsec_disable_tags)
+* [`modsec_audit_log_file`](#modsec_audit_log_file)
+* [`modsec_audit_log_pipe`](#modsec_audit_log_pipe)
+* [`modsec_audit_log`](#modsec_audit_log)
+* [`no_proxy_uris`](#no_proxy_uris)
+* [`no_proxy_uris_match`](#no_proxy_uris_match)
+* [`proxy_preserve_host`](#proxy_preserve_host)
+* [`proxy_add_headers`](#proxy_add_headers)
+* [`proxy_error_override`](#proxy_error_override)
+* [`options`](#options)
+* [`override`](#override)
 * [`passenger_enabled`](#passenger_enabled)
 * [`passenger_base_uri`](#passenger_base_uri)
 * [`passenger_ruby`](#passenger_ruby)
@@ -7717,535 +7689,145 @@ The following parameters are available in the `apache::vhost` defined type:
 * [`passenger_app_log_file`](#passenger_app_log_file)
 * [`passenger_debugger`](#passenger_debugger)
 * [`passenger_lve_min_uid`](#passenger_lve_min_uid)
-* [`add_default_charset`](#add_default_charset)
-* [`modsec_disable_vhost`](#modsec_disable_vhost)
-* [`modsec_disable_ids`](#modsec_disable_ids)
-* [`modsec_disable_ips`](#modsec_disable_ips)
-* [`modsec_disable_msgs`](#modsec_disable_msgs)
-* [`modsec_disable_tags`](#modsec_disable_tags)
-* [`modsec_body_limit`](#modsec_body_limit)
-* [`jk_mounts`](#jk_mounts)
-* [`auth_kerb`](#auth_kerb)
-* [`krb_method_negotiate`](#krb_method_negotiate)
-* [`krb_method_k5passwd`](#krb_method_k5passwd)
-* [`krb_authoritative`](#krb_authoritative)
-* [`krb_auth_realms`](#krb_auth_realms)
-* [`krb_5keytab`](#krb_5keytab)
-* [`krb_local_user_mapping`](#krb_local_user_mapping)
-* [`krb_verify_kdc`](#krb_verify_kdc)
-* [`krb_servicename`](#krb_servicename)
-* [`krb_save_credentials`](#krb_save_credentials)
-* [`keepalive`](#keepalive)
-* [`keepalive_timeout`](#keepalive_timeout)
-* [`max_keepalive_requests`](#max_keepalive_requests)
-* [`cas_attribute_prefix`](#cas_attribute_prefix)
-* [`cas_attribute_delimiter`](#cas_attribute_delimiter)
-* [`cas_root_proxied_as`](#cas_root_proxied_as)
-* [`cas_scrub_request_headers`](#cas_scrub_request_headers)
-* [`cas_sso_enabled`](#cas_sso_enabled)
-* [`cas_login_url`](#cas_login_url)
-* [`cas_validate_url`](#cas_validate_url)
-* [`cas_validate_saml`](#cas_validate_saml)
-* [`cas_cookie_path`](#cas_cookie_path)
+* [`php_values`](#php_values)
+* [`php_flags`](#php_flags)
+* [`php_admin_values`](#php_admin_values)
+* [`php_admin_flags`](#php_admin_flags)
+* [`port`](#port)
+* [`priority`](#priority)
+* [`protocols`](#protocols)
+* [`protocols_honor_order`](#protocols_honor_order)
+* [`proxy_dest`](#proxy_dest)
+* [`proxy_pass`](#proxy_pass)
+* [`proxy_dest_match`](#proxy_dest_match)
+* [`proxy_dest_reverse_match`](#proxy_dest_reverse_match)
+* [`proxy_pass_match`](#proxy_pass_match)
+* [`redirect_dest`](#redirect_dest)
+* [`redirect_source`](#redirect_source)
+* [`redirect_status`](#redirect_status)
+* [`redirectmatch_regexp`](#redirectmatch_regexp)
+* [`redirectmatch_status`](#redirectmatch_status)
+* [`redirectmatch_dest`](#redirectmatch_dest)
+* [`request_headers`](#request_headers)
+* [`rewrites`](#rewrites)
+* [`rewrite_base`](#rewrite_base)
+* [`rewrite_rule`](#rewrite_rule)
+* [`rewrite_cond`](#rewrite_cond)
+* [`rewrite_inherit`](#rewrite_inherit)
+* [`scriptalias`](#scriptalias)
+* [`scriptaliases`](#scriptaliases)
+* [`serveradmin`](#serveradmin)
+* [`serveraliases`](#serveraliases)
+* [`servername`](#servername)
+* [`setenv`](#setenv)
+* [`setenvif`](#setenvif)
+* [`setenvifnocase`](#setenvifnocase)
+* [`suexec_user_group`](#suexec_user_group)
+* [`suphp_addhandler`](#suphp_addhandler)
+* [`suphp_configpath`](#suphp_configpath)
+* [`suphp_engine`](#suphp_engine)
+* [`vhost_name`](#vhost_name)
+* [`virtual_docroot`](#virtual_docroot)
+* [`wsgi_daemon_process`](#wsgi_daemon_process)
+* [`wsgi_daemon_process_options`](#wsgi_daemon_process_options)
+* [`wsgi_application_group`](#wsgi_application_group)
+* [`wsgi_import_script`](#wsgi_import_script)
+* [`wsgi_import_script_options`](#wsgi_import_script_options)
+* [`wsgi_chunked_request`](#wsgi_chunked_request)
+* [`wsgi_process_group`](#wsgi_process_group)
+* [`wsgi_script_aliases`](#wsgi_script_aliases)
+* [`wsgi_script_aliases_match`](#wsgi_script_aliases_match)
+* [`wsgi_pass_authorization`](#wsgi_pass_authorization)
+* [`directories`](#directories)
+* [`custom_fragment`](#custom_fragment)
+* [`error_documents`](#error_documents)
+* [`h2_copy_files`](#h2_copy_files)
+* [`h2_push_resource`](#h2_push_resource)
+* [`headers`](#headers)
+* [`options`](#options)
 * [`shib_compat_valid_user`](#shib_compat_valid_user)
+* [`ssl_options`](#ssl_options)
+* [`additional_includes`](#additional_includes)
+* [`gssapi`](#gssapi)
+* [`ssl`](#ssl)
+* [`ssl_ca`](#ssl_ca)
+* [`ssl_cert`](#ssl_cert)
+* [`ssl_protocol`](#ssl_protocol)
+* [`ssl_cipher`](#ssl_cipher)
+* [`ssl_honorcipherorder`](#ssl_honorcipherorder)
+* [`ssl_certs_dir`](#ssl_certs_dir)
+* [`ssl_chain`](#ssl_chain)
+* [`ssl_crl`](#ssl_crl)
+* [`ssl_crl_path`](#ssl_crl_path)
+* [`ssl_crl_check`](#ssl_crl_check)
+* [`ssl_key`](#ssl_key)
+* [`ssl_verify_client`](#ssl_verify_client)
+* [`ssl_verify_depth`](#ssl_verify_depth)
+* [`ssl_proxy_protocol`](#ssl_proxy_protocol)
+* [`ssl_proxy_verify`](#ssl_proxy_verify)
+* [`ssl_proxy_verify_depth`](#ssl_proxy_verify_depth)
+* [`ssl_proxy_cipher_suite`](#ssl_proxy_cipher_suite)
+* [`ssl_proxy_ca_cert`](#ssl_proxy_ca_cert)
+* [`ssl_proxy_machine_cert`](#ssl_proxy_machine_cert)
+* [`ssl_proxy_machine_cert_chain`](#ssl_proxy_machine_cert_chain)
+* [`ssl_proxy_check_peer_cn`](#ssl_proxy_check_peer_cn)
+* [`ssl_proxy_check_peer_name`](#ssl_proxy_check_peer_name)
+* [`ssl_proxy_check_peer_expire`](#ssl_proxy_check_peer_expire)
+* [`ssl_options`](#ssl_options)
+* [`ssl_openssl_conf_cmd`](#ssl_openssl_conf_cmd)
+* [`ssl_proxyengine`](#ssl_proxyengine)
+* [`ssl_stapling`](#ssl_stapling)
+* [`ssl_stapling_timeout`](#ssl_stapling_timeout)
+* [`ssl_stapling_return_errors`](#ssl_stapling_return_errors)
+* [`ssl_user_name`](#ssl_user_name)
 * [`use_canonical_name`](#use_canonical_name)
-* [`comment`](#comment)
 * [`define`](#define)
 * [`auth_oidc`](#auth_oidc)
 * [`oidc_settings`](#oidc_settings)
+* [`limitreqfields`](#limitreqfields)
+* [`limitreqfieldsize`](#limitreqfieldsize)
+* [`limitreqline`](#limitreqline)
+* [`limitreqbody`](#limitreqbody)
+* [`$use_servername_for_filenames`](#$use_servername_for_filenames)
+* [`$use_port_for_filenames`](#$use_port_for_filenames)
+* [`$mdomain`](#$mdomain)
+* [`use_servername_for_filenames`](#use_servername_for_filenames)
+* [`use_port_for_filenames`](#use_port_for_filenames)
+* [`proxy_requests`](#proxy_requests)
 * [`mdomain`](#mdomain)
 
-##### <a name="docroot"></a>`docroot`
-
-Data type: `Variant[Boolean,String]`
-
-
-
-##### <a name="manage_docroot"></a>`manage_docroot`
+##### <a name="apache_version"></a>`apache_version`
 
 Data type: `Any`
 
+Apache's version number as a string, such as '2.2' or '2.4'.
 
-
-Default value: ``true``
-
-##### <a name="virtual_docroot"></a>`virtual_docroot`
-
-Data type: `Any`
-
-
-
-Default value: ``false``
-
-##### <a name="port"></a>`port`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="ip"></a>`ip`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="ip_based"></a>`ip_based`
-
-Data type: `Boolean`
-
-
-
-Default value: ``false``
-
-##### <a name="add_listen"></a>`add_listen`
-
-Data type: `Any`
-
-
-
-Default value: ``true``
-
-##### <a name="docroot_owner"></a>`docroot_owner`
-
-Data type: `Any`
-
-
-
-Default value: `'root'`
-
-##### <a name="docroot_group"></a>`docroot_group`
-
-Data type: `Any`
-
-
-
-Default value: `$apache::params::root_group`
-
-##### <a name="docroot_mode"></a>`docroot_mode`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="protocols"></a>`protocols`
-
-Data type: `Array[Enum['h2', 'h2c', 'http/1.1']]`
-
-
-
-Default value: `[]`
-
-##### <a name="protocols_honor_order"></a>`protocols_honor_order`
-
-Data type: `Optional[Boolean]`
-
-
-
-Default value: ``undef``
-
-##### <a name="serveradmin"></a>`serveradmin`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="ssl"></a>`ssl`
-
-Data type: `Boolean`
-
-
-
-Default value: ``false``
-
-##### <a name="ssl_cert"></a>`ssl_cert`
-
-Data type: `Any`
-
-
-
-Default value: `$apache::default_ssl_cert`
-
-##### <a name="ssl_key"></a>`ssl_key`
-
-Data type: `Any`
-
-
-
-Default value: `$apache::default_ssl_key`
-
-##### <a name="ssl_chain"></a>`ssl_chain`
-
-Data type: `Any`
-
-
-
-Default value: `$apache::default_ssl_chain`
-
-##### <a name="ssl_ca"></a>`ssl_ca`
-
-Data type: `Any`
-
-
-
-Default value: `$apache::default_ssl_ca`
-
-##### <a name="ssl_crl_path"></a>`ssl_crl_path`
-
-Data type: `Any`
-
-
-
-Default value: `$apache::default_ssl_crl_path`
-
-##### <a name="ssl_crl"></a>`ssl_crl`
-
-Data type: `Any`
-
-
-
-Default value: `$apache::default_ssl_crl`
-
-##### <a name="ssl_crl_check"></a>`ssl_crl_check`
-
-Data type: `Any`
-
-
-
-Default value: `$apache::default_ssl_crl_check`
-
-##### <a name="ssl_certs_dir"></a>`ssl_certs_dir`
-
-Data type: `Any`
-
-
-
-Default value: `$apache::params::ssl_certs_dir`
-
-##### <a name="ssl_protocol"></a>`ssl_protocol`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="ssl_cipher"></a>`ssl_cipher`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="ssl_honorcipherorder"></a>`ssl_honorcipherorder`
-
-Data type: `Variant[Boolean, Enum['on', 'On', 'off', 'Off'], Undef]`
-
-
-
-Default value: ``undef``
-
-##### <a name="ssl_verify_client"></a>`ssl_verify_client`
-
-Data type: `Optional[Enum['none', 'optional', 'require', 'optional_no_ca']]`
-
-
-
-Default value: ``undef``
-
-##### <a name="ssl_verify_depth"></a>`ssl_verify_depth`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="ssl_proxy_verify"></a>`ssl_proxy_verify`
-
-Data type: `Optional[Enum['none', 'optional', 'require', 'optional_no_ca']]`
-
-
-
-Default value: ``undef``
-
-##### <a name="ssl_proxy_verify_depth"></a>`ssl_proxy_verify_depth`
-
-Data type: `Optional[Integer[0]]`
-
-
-
-Default value: ``undef``
-
-##### <a name="ssl_proxy_ca_cert"></a>`ssl_proxy_ca_cert`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="ssl_proxy_check_peer_cn"></a>`ssl_proxy_check_peer_cn`
-
-Data type: `Optional[Enum['on', 'off']]`
-
-
-
-Default value: ``undef``
-
-##### <a name="ssl_proxy_check_peer_name"></a>`ssl_proxy_check_peer_name`
-
-Data type: `Optional[Enum['on', 'off']]`
-
-
-
-Default value: ``undef``
-
-##### <a name="ssl_proxy_check_peer_expire"></a>`ssl_proxy_check_peer_expire`
-
-Data type: `Optional[Enum['on', 'off']]`
-
-
-
-Default value: ``undef``
-
-##### <a name="ssl_proxy_machine_cert"></a>`ssl_proxy_machine_cert`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="ssl_proxy_machine_cert_chain"></a>`ssl_proxy_machine_cert_chain`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="ssl_proxy_cipher_suite"></a>`ssl_proxy_cipher_suite`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="ssl_proxy_protocol"></a>`ssl_proxy_protocol`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="ssl_options"></a>`ssl_options`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="ssl_openssl_conf_cmd"></a>`ssl_openssl_conf_cmd`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="ssl_proxyengine"></a>`ssl_proxyengine`
-
-Data type: `Boolean`
-
-
-
-Default value: ``false``
-
-##### <a name="ssl_stapling"></a>`ssl_stapling`
-
-Data type: `Optional[Boolean]`
-
-
-
-Default value: ``undef``
-
-##### <a name="ssl_stapling_timeout"></a>`ssl_stapling_timeout`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="ssl_stapling_return_errors"></a>`ssl_stapling_return_errors`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="ssl_user_name"></a>`ssl_user_name`
-
-Data type: `Optional[String]`
-
-
-
-Default value: ``undef``
-
-##### <a name="priority"></a>`priority`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="default_vhost"></a>`default_vhost`
-
-Data type: `Boolean`
-
-
-
-Default value: ``false``
-
-##### <a name="servername"></a>`servername`
-
-Data type: `Any`
-
-
-
-Default value: `$name`
-
-##### <a name="serveraliases"></a>`serveraliases`
-
-Data type: `Any`
-
-
-
-Default value: `[]`
-
-##### <a name="options"></a>`options`
-
-Data type: `Any`
-
-
-
-Default value: `['Indexes','FollowSymLinks','MultiViews']`
-
-##### <a name="override"></a>`override`
-
-Data type: `Any`
-
-
-
-Default value: `['None']`
-
-##### <a name="directoryindex"></a>`directoryindex`
-
-Data type: `Any`
-
-
-
-Default value: `''`
-
-##### <a name="vhost_name"></a>`vhost_name`
-
-Data type: `Any`
-
-
-
-Default value: `'*'`
-
-##### <a name="logroot"></a>`logroot`
-
-Data type: `Any`
-
-
-
-Default value: `$apache::logroot`
-
-##### <a name="logroot_ensure"></a>`logroot_ensure`
-
-Data type: `Enum['directory', 'absent']`
-
-
-
-Default value: `'directory'`
-
-##### <a name="logroot_mode"></a>`logroot_mode`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="logroot_owner"></a>`logroot_owner`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="logroot_group"></a>`logroot_group`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="log_level"></a>`log_level`
-
-Data type: `Optional[Apache::LogLevel]`
-
-
-
-Default value: ``undef``
+Default value: `$apache::apache_version`
 
 ##### <a name="access_log"></a>`access_log`
 
 Data type: `Boolean`
 
-
+Determines whether to configure `*_access.log` directives (`*_file`,`*_pipe`, or `*_syslog`).
 
 Default value: ``true``
+
+##### <a name="access_log_env_var"></a>`access_log_env_var`
+
+Data type: `Any`
+
+Specifies that only requests with particular environment variables be logged.
+
+Default value: ``false``
 
 ##### <a name="access_log_file"></a>`access_log_file`
 
 Data type: `Any`
 
-
-
-Default value: ``false``
-
-##### <a name="access_log_pipe"></a>`access_log_pipe`
-
-Data type: `Any`
-
-
-
-Default value: ``false``
-
-##### <a name="access_log_syslog"></a>`access_log_syslog`
-
-Data type: `Any`
-
-
+Sets the filename of the `*_access.log` placed in `logroot`. Given a virtual host ---for
+instance, example.com--- it defaults to 'example.com_ssl.log' for
+[SSL-encrypted](https://httpd.apache.org/docs/current/ssl/index.html) virtual hosts and
+`example.com_access.log` for unencrypted virtual hosts.
 
 Default value: ``false``
 
@@ -8253,15 +7835,24 @@ Default value: ``false``
 
 Data type: `Any`
 
-
+Specifies the use of either a `LogFormat` nickname or a custom-formatted string for the
+access log.
 
 Default value: ``false``
 
-##### <a name="access_log_env_var"></a>`access_log_env_var`
+##### <a name="access_log_pipe"></a>`access_log_pipe`
 
 Data type: `Any`
 
+Specifies a pipe where Apache sends access log messages.
 
+Default value: ``false``
+
+##### <a name="access_log_syslog"></a>`access_log_syslog`
+
+Data type: `Any`
+
+Sends all access log messages to syslog.
 
 Default value: ``false``
 
@@ -8269,9 +7860,2878 @@ Default value: ``false``
 
 Data type: `Optional[Array]`
 
-
+Allows you to give a hash that specifies the state of each of the `access_log_*`
+directives shown above, i.e. `access_log_pipe` and `access_log_syslog`.
 
 Default value: ``undef``
+
+##### <a name="add_default_charset"></a>`add_default_charset`
+
+Data type: `Any`
+
+Sets a default media charset value for the `AddDefaultCharset` directive, which is
+added to `text/plain` and `text/html` responses.
+
+Default value: ``undef``
+
+##### <a name="add_listen"></a>`add_listen`
+
+Data type: `Any`
+
+Determines whether the virtual host creates a `Listen` statement.<br />
+Setting `add_listen` to `false` prevents the virtual host from creating a `Listen`
+statement. This is important when combining virtual hosts that aren't passed an `ip`
+parameter with those that are.
+
+Default value: ``true``
+
+##### <a name="use_optional_includes"></a>`use_optional_includes`
+
+Data type: `Any`
+
+Specifies whether Apache uses the `IncludeOptional` directive instead of `Include` for
+`additional_includes` in Apache 2.4 or newer.
+
+Default value: `$apache::use_optional_includes`
+
+##### <a name="additional_includes"></a>`additional_includes`
+
+Data type: `Any`
+
+Specifies paths to additional static, virtual host-specific Apache configuration files.
+You can use this parameter to implement a unique, custom configuration not supported by
+this module.
+
+Default value: `[]`
+
+##### <a name="aliases"></a>`aliases`
+
+Data type: `Any`
+
+Passes a list of [hashes][hash] to the virtual host to create `Alias`, `AliasMatch`,
+`ScriptAlias` or `ScriptAliasMatch` directives as per the `mod_alias` documentation.<br />
+For example:
+``` puppet
+aliases => [
+  { aliasmatch       => '^/image/(.*)\.jpg$',
+    path             => '/files/jpg.images/$1.jpg',
+  },
+  { alias            => '/image',
+    path             => '/ftp/pub/image',
+  },
+  { scriptaliasmatch => '^/cgi-bin(.*)',
+    path             => '/usr/local/share/cgi-bin$1',
+  },
+  { scriptalias      => '/nagios/cgi-bin/',
+    path             => '/usr/lib/nagios/cgi-bin/',
+  },
+  { alias            => '/nagios',
+    path             => '/usr/share/nagios/html',
+  },
+],
+```
+For the `alias`, `aliasmatch`, `scriptalias` and `scriptaliasmatch` keys to work, each needs
+a corresponding context, such as `<Directory /path/to/directory>` or
+`<Location /some/location/here>`. Puppet creates the directives in the order specified in
+the `aliases` parameter. As described in the `mod_alias` documentation, add more specific
+`alias`, `aliasmatch`, `scriptalias` or `scriptaliasmatch` parameters before the more
+general ones to avoid shadowing.<BR />
+> **Note**: Use the `aliases` parameter instead of the `scriptaliases` parameter because
+you can precisely control the order of various alias directives. Defining `ScriptAliases`
+using the `scriptaliases` parameter means *all* `ScriptAlias` directives will come after
+*all* `Alias` directives, which can lead to `Alias` directives shadowing `ScriptAlias`
+directives. This often causes problems; for example, this could cause problems with Nagios.<BR />
+If `apache::mod::passenger` is loaded and `PassengerHighPerformance` is `true`, the `Alias`
+directive might not be able to honor the `PassengerEnabled => off` statement. See
+[this article](http://www.conandalton.net/2010/06/passengerenabled-off-not-working.html) for details.
+
+Default value: ``undef``
+
+##### <a name="allow_encoded_slashes"></a>`allow_encoded_slashes`
+
+Data type: `Optional[Enum['on', 'off', 'nodecode']]`
+
+Sets the `AllowEncodedSlashes` declaration for the virtual host, overriding the server
+default. This modifies the virtual host responses to URLs with `\` and `/` characters. The
+default setting omits the declaration from the server configuration and selects the
+Apache default setting of `Off`.
+
+Default value: ``undef``
+
+##### <a name="block"></a>`block`
+
+Data type: `Any`
+
+Specifies the list of things to which Apache blocks access. Valid options are: `scm` (which
+blocks web access to `.svn`), `.git`, and `.bzr` directories.
+
+Default value: `[]`
+
+##### <a name="cas_attribute_prefix"></a>`cas_attribute_prefix`
+
+Data type: `Any`
+
+Adds a header with the value of this header being the attribute values when SAML
+validation is enabled.
+
+Default value: ``undef``
+
+##### <a name="cas_attribute_delimiter"></a>`cas_attribute_delimiter`
+
+Data type: `Any`
+
+Sets the delimiter between attribute values in the header created by `cas_attribute_prefix`.
+
+Default value: ``undef``
+
+##### <a name="cas_login_url"></a>`cas_login_url`
+
+Data type: `Any`
+
+Sets the URL to which the module redirects users when they attempt to access a
+CAS-protected resource and don't have an active session.
+
+Default value: ``undef``
+
+##### <a name="cas_root_proxied_as"></a>`cas_root_proxied_as`
+
+Data type: `Any`
+
+Sets the URL end users see when access to this Apache server is proxied per vhost.
+This URL should not include a trailing slash.
+
+Default value: ``undef``
+
+##### <a name="cas_scrub_request_headers"></a>`cas_scrub_request_headers`
+
+Data type: `Any`
+
+Remove inbound request headers that may have special meaning within mod_auth_cas.
+
+Default value: ``undef``
+
+##### <a name="cas_sso_enabled"></a>`cas_sso_enabled`
+
+Data type: `Any`
+
+Enables experimental support for single sign out (may mangle POST data).
+
+Default value: ``undef``
+
+##### <a name="cas_validate_saml"></a>`cas_validate_saml`
+
+Data type: `Any`
+
+Parse response from CAS server for SAML.
+
+Default value: ``undef``
+
+##### <a name="cas_validate_url"></a>`cas_validate_url`
+
+Data type: `Any`
+
+Sets the URL to use when validating a client-presented ticket in an HTTP query string.
+
+Default value: ``undef``
+
+##### <a name="cas_cookie_path"></a>`cas_cookie_path`
+
+Data type: `Any`
+
+Sets the location where information on the current session should be stored. This should
+be writable by the web server only.
+
+Default value: ``undef``
+
+##### <a name="comment"></a>`comment`
+
+Data type: `Optional[Variant[String,Array[String]]]`
+
+Adds comments to the header of the configuration file. Pass as string or an array of strings.
+For example:
+``` puppet
+comment => "Account number: 123B",
+```
+Or:
+``` puppet
+comment => [
+  "Customer: X",
+  "Frontend domain: x.example.org",
+]
+```
+
+Default value: ``undef``
+
+##### <a name="custom_fragment"></a>`custom_fragment`
+
+Data type: `Optional[String]`
+
+Passes a string of custom configuration directives to place at the end of the virtual
+host configuration.
+
+Default value: ``undef``
+
+##### <a name="default_vhost"></a>`default_vhost`
+
+Data type: `Boolean`
+
+Sets a given `apache::vhost` defined type as the default to serve requests that do not
+match any other `apache::vhost` defined types.
+
+Default value: ``false``
+
+##### <a name="directoryindex"></a>`directoryindex`
+
+Data type: `Any`
+
+Sets the list of resources to look for when a client requests an index of the directory
+by specifying a '/' at the end of the directory name. See the `DirectoryIndex` directive
+documentation for details.
+
+Default value: `''`
+
+##### <a name="docroot"></a>`docroot`
+
+Data type: `Variant[Boolean,String]`
+
+**Required**.<br />
+Sets the `DocumentRoot` location, from which Apache serves files.<br />
+If `docroot` and `manage_docroot` are both set to `false`, no `DocumentRoot` will be set
+and the accompanying `<Directory /path/to/directory>` block will not be created.
+
+##### <a name="docroot_group"></a>`docroot_group`
+
+Data type: `Any`
+
+Sets group access to the `docroot` directory.
+
+Default value: `$apache::params::root_group`
+
+##### <a name="docroot_owner"></a>`docroot_owner`
+
+Data type: `Any`
+
+Sets individual user access to the `docroot` directory.
+
+Default value: `'root'`
+
+##### <a name="docroot_mode"></a>`docroot_mode`
+
+Data type: `Any`
+
+Sets access permissions for the `docroot` directory, in numeric notation.
+
+Default value: ``undef``
+
+##### <a name="manage_docroot"></a>`manage_docroot`
+
+Data type: `Any`
+
+Determines whether Puppet manages the `docroot` directory.
+
+Default value: ``true``
+
+##### <a name="error_log"></a>`error_log`
+
+Data type: `Boolean`
+
+Specifies whether `*_error.log` directives should be configured.
+
+Default value: ``true``
+
+##### <a name="error_log_file"></a>`error_log_file`
+
+Data type: `Any`
+
+Points the virtual host's error logs to a `*_error.log` file. If this parameter is
+undefined, Puppet checks for values in `error_log_pipe`, then `error_log_syslog`.<br />
+If none of these parameters is set, given a virtual host `example.com`, Puppet defaults
+to `$logroot/example.com_error_ssl.log` for SSL virtual hosts and
+`$logroot/example.com_error.log` for non-SSL virtual hosts.
+
+Default value: ``undef``
+
+##### <a name="error_log_pipe"></a>`error_log_pipe`
+
+Data type: `Any`
+
+Specifies a pipe to send error log messages to.<br />
+This parameter has no effect if the `error_log_file` parameter has a value. If neither
+this parameter nor `error_log_file` has a value, Puppet then checks `error_log_syslog`.
+
+Default value: ``undef``
+
+##### <a name="error_log_syslog"></a>`error_log_syslog`
+
+Data type: `Any`
+
+Determines whether to send all error log messages to syslog.
+This parameter has no effect if either of the `error_log_file` or `error_log_pipe`
+parameters has a value. If none of these parameters has a value, given a virtual host
+`example.com`, Puppet defaults to `$logroot/example.com_error_ssl.log` for SSL virtual
+hosts and `$logroot/example.com_error.log` for non-SSL virtual hosts.
+
+Default value: ``undef``
+
+##### <a name="error_log_format"></a>`error_log_format`
+
+Data type: `Optional[
+    Array[
+      Variant[
+        String,
+        Hash[String, Enum['connection', 'request']]
+      ]
+    ]
+  ]`
+
+Sets the [ErrorLogFormat](https://httpd.apache.org/docs/current/mod/core.html#errorlogformat)
+format specification for error log entries inside virtual host
+For example:
+``` puppet
+apache::vhost { 'site.name.fdqn':
+  ...
+  error_log_format => [
+    '[%{uc}t] [%-m:%-l] [R:%L] [C:%{C}L] %7F: %E: %M',
+    { '[%{uc}t] [R:%L] Request %k on C:%{c}L pid:%P tid:%T' => 'request' },
+    { "[%{uc}t] [R:%L] UA:'%+{User-Agent}i'" => 'request' },
+    { "[%{uc}t] [R:%L] Referer:'%+{Referer}i'" => 'request' },
+    { '[%{uc}t] [C:%{c}L] local\ %a remote\ %A' => 'connection' },
+  ],
+}
+```
+
+Default value: ``undef``
+
+##### <a name="error_documents"></a>`error_documents`
+
+Data type: `Any`
+
+A list of hashes which can be used to override the
+[ErrorDocument](https://httpd.apache.org/docs/current/mod/core.html#errordocument)
+settings for this virtual host.<br />
+For example:
+``` puppet
+apache::vhost { 'sample.example.net':
+  error_documents => [
+    { 'error_code' => '503', 'document' => '/service-unavail' },
+    { 'error_code' => '407', 'document' => 'https://example.com/proxy/login' },
+  ],
+}
+```
+
+Default value: `[]`
+
+##### <a name="ensure"></a>`ensure`
+
+Data type: `Enum['absent', 'present']`
+
+Specifies if the virtual host is present or absent.<br />
+
+Default value: `'present'`
+
+##### <a name="fallbackresource"></a>`fallbackresource`
+
+Data type: `Optional[Variant[Stdlib::Absolutepath, Enum['disabled']]]`
+
+Sets the [FallbackResource](https://httpd.apache.org/docs/current/mod/mod_dir.html#fallbackresource)
+directive, which specifies an action to take for any URL that doesn't map to anything in
+your filesystem and would otherwise return 'HTTP 404 (Not Found)'. Values must either begin
+with a `/` or be `disabled`.
+
+Default value: ``undef``
+
+##### <a name="fastcgi_server"></a>`fastcgi_server`
+
+Data type: `Any`
+
+Specify an external FastCGI server to manage a connection to.
+
+Default value: ``undef``
+
+##### <a name="fastcgi_socket"></a>`fastcgi_socket`
+
+Data type: `Any`
+
+Specify the socket that will be used to communicate with an external FastCGI server.
+
+Default value: ``undef``
+
+##### <a name="fastcgi_idle_timeout"></a>`fastcgi_idle_timeout`
+
+Data type: `Any`
+
+If using fastcgi, this option sets the timeout for the server to respond.
+
+Default value: ``undef``
+
+##### <a name="fastcgi_dir"></a>`fastcgi_dir`
+
+Data type: `Any`
+
+Specify an internal FastCGI directory that is to be managed.
+
+Default value: ``undef``
+
+##### <a name="filters"></a>`filters`
+
+Data type: `Any`
+
+[Filters](https://httpd.apache.org/docs/current/mod/mod_filter.html) enable smart,
+context-sensitive configuration of output content filters.
+``` puppet
+apache::vhost { "$::fqdn":
+  filters => [
+    'FilterDeclare   COMPRESS',
+    'FilterProvider  COMPRESS DEFLATE resp=Content-Type $text/html',
+    'FilterChain     COMPRESS',
+    'FilterProtocol  COMPRESS DEFLATE change=yes;byteranges=no',
+  ],
+}
+```
+
+Default value: ``undef``
+
+##### <a name="h2_copy_files"></a>`h2_copy_files`
+
+Data type: `Optional[Boolean]`
+
+Sets the [H2CopyFiles](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2copyfiles)
+directive which influences how the requestion process pass files to the main connection.
+
+Default value: ``undef``
+
+##### <a name="h2_direct"></a>`h2_direct`
+
+Data type: `Optional[Boolean]`
+
+Sets the [H2Direct](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2direct)
+directive which toggles the usage of the HTTP/2 Direct Mode.
+
+Default value: ``undef``
+
+##### <a name="h2_early_hints"></a>`h2_early_hints`
+
+Data type: `Optional[Boolean]`
+
+Sets the [H2EarlyHints](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2earlyhints)
+directive which controls if HTTP status 103 interim responses are forwarded to
+the client or not.
+
+Default value: ``undef``
+
+##### <a name="h2_max_session_streams"></a>`h2_max_session_streams`
+
+Data type: `Optional[Integer]`
+
+Sets the [H2MaxSessionStreams](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2maxsessionstreams)
+directive which sets the maximum number of active streams per HTTP/2 session
+that the server allows.
+
+Default value: ``undef``
+
+##### <a name="h2_modern_tls_only"></a>`h2_modern_tls_only`
+
+Data type: `Optional[Boolean]`
+
+Sets the [H2ModernTLSOnly](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2moderntlsonly)
+directive which toggles the security checks on HTTP/2 connections in TLS mode.
+
+Default value: ``undef``
+
+##### <a name="h2_push"></a>`h2_push`
+
+Data type: `Optional[Boolean]`
+
+Sets the [H2Push](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2push)
+directive which toggles the usage of the HTTP/2 server push protocol feature.
+
+Default value: ``undef``
+
+##### <a name="h2_push_diary_size"></a>`h2_push_diary_size`
+
+Data type: `Optional[Integer]`
+
+Sets the [H2PushDiarySize](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2pushdiarysize)
+directive which toggles the maximum number of HTTP/2 server pushes that are
+remembered per HTTP/2 connection.
+
+Default value: ``undef``
+
+##### <a name="h2_push_priority"></a>`h2_push_priority`
+
+Data type: `Array[String]`
+
+Sets the [H2PushPriority](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2pushpriority)
+directive which defines the priority handling of pushed responses based on the
+content-type of the response.
+
+Default value: `[]`
+
+##### <a name="h2_push_resource"></a>`h2_push_resource`
+
+Data type: `Array[String]`
+
+Sets the [H2PushResource](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2pushresource)
+directive which declares resources for early pushing to the client.
+
+Default value: `[]`
+
+##### <a name="h2_serialize_headers"></a>`h2_serialize_headers`
+
+Data type: `Optional[Boolean]`
+
+Sets the [H2SerializeHeaders](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2serializeheaders)
+directive which toggles if HTTP/2 requests are serialized in HTTP/1.1
+format for processing by httpd core.
+
+Default value: ``undef``
+
+##### <a name="h2_stream_max_mem_size"></a>`h2_stream_max_mem_size`
+
+Data type: `Optional[Integer]`
+
+Sets the [H2StreamMaxMemSize](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2streammaxmemsize)
+directive which sets the maximum number of outgoing data bytes buffered in
+memory for an active stream.
+
+Default value: ``undef``
+
+##### <a name="h2_tls_cool_down_secs"></a>`h2_tls_cool_down_secs`
+
+Data type: `Optional[Integer]`
+
+Sets the [H2TLSCoolDownSecs](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2tlscooldownsecs)
+directive which sets the number of seconds of idle time on a TLS connection
+before the TLS write size falls back to a small (~1300 bytes) length.
+
+Default value: ``undef``
+
+##### <a name="h2_tls_warm_up_size"></a>`h2_tls_warm_up_size`
+
+Data type: `Optional[Integer]`
+
+Sets the [H2TLSWarmUpSize](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2tlswarmupsize)
+directive which sets the number of bytes to be sent in small TLS records (~1300
+bytes) until doing maximum sized writes (16k) on https: HTTP/2 connections.
+
+Default value: ``undef``
+
+##### <a name="h2_upgrade"></a>`h2_upgrade`
+
+Data type: `Optional[Boolean]`
+
+Sets the [H2Upgrade](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2upgrade)
+directive which toggles the usage of the HTTP/1.1 Upgrade method for switching
+to HTTP/2.
+
+Default value: ``undef``
+
+##### <a name="h2_window_size"></a>`h2_window_size`
+
+Data type: `Optional[Integer]`
+
+Sets the [H2WindowSize](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2windowsize)
+directive which sets the size of the window that is used for flow control from
+client to server and limits the amount of data the server has to buffer.
+
+Default value: ``undef``
+
+##### <a name="headers"></a>`headers`
+
+Data type: `Any`
+
+Adds lines to replace, merge, or remove response headers. See
+[Apache's mod_headers documentation](https://httpd.apache.org/docs/current/mod/mod_headers.html#header) for more information.
+
+Default value: ``undef``
+
+##### <a name="ip"></a>`ip`
+
+Data type: `Any`
+
+Sets the IP address the virtual host listens on. By default, uses Apache's default behavior
+of listening on all IPs.
+
+Default value: ``undef``
+
+##### <a name="ip_based"></a>`ip_based`
+
+Data type: `Boolean`
+
+Enables an [IP-based](https://httpd.apache.org/docs/current/vhosts/ip-based.html) virtual
+host. This parameter inhibits the creation of a NameVirtualHost directive, since those are
+used to funnel requests to name-based virtual hosts.
+
+Default value: ``false``
+
+##### <a name="itk"></a>`itk`
+
+Data type: `Optional[Hash]`
+
+Configures [ITK](http://mpm-itk.sesse.net/) in a hash.<br />
+Usage typically looks something like:
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot => '/path/to/directory',
+  itk     => {
+    user  => 'someuser',
+    group => 'somegroup',
+  },
+}
+```
+Valid values are: a hash, which can include the keys:
+* `user` + `group`
+* `assignuseridexpr`
+* `assigngroupidexpr`
+* `maxclientvhost`
+* `nice`
+* `limituidrange` (Linux 3.5.0 or newer)
+* `limitgidrange` (Linux 3.5.0 or newer)
+
+Default value: ``undef``
+
+##### <a name="action"></a>`action`
+
+Data type: `Any`
+
+Specifies whether you wish to configure mod_actions action directive which will
+activate cgi-script when triggered by a request.
+
+Default value: ``undef``
+
+##### <a name="jk_mounts"></a>`jk_mounts`
+
+Data type: `Any`
+
+Sets up a virtual host with `JkMount` and `JkUnMount` directives to handle the paths
+for URL mapping between Tomcat and Apache.<br />
+The parameter must be an array of hashes where each hash must contain the `worker`
+and either the `mount` or `unmount` keys.<br />
+Usage typically looks like:
+``` puppet
+apache::vhost { 'sample.example.net':
+  jk_mounts => [
+    { mount   => '/*',     worker => 'tcnode1', },
+    { unmount => '/*.jpg', worker => 'tcnode1', },
+  ],
+}
+```
+
+Default value: ``undef``
+
+##### <a name="http_protocol_options"></a>`http_protocol_options`
+
+Data type: `Optional[Pattern[/^((Strict|Unsafe)?\s*(\b(Registered|Lenient)Methods)?\s*(\b(Allow0\.9|Require1\.0))?)$/]]`
+
+Specifies the strictness of HTTP protocol checks.
+
+Default value: ``undef``
+
+##### <a name="keepalive"></a>`keepalive`
+
+Data type: `Optional[Enum['on', 'off']]`
+
+Determines whether to enable persistent HTTP connections with the `KeepAlive` directive
+for the virtual host. By default, the global, server-wide `KeepAlive` setting is in effect.<br />
+Use the `keepalive_timeout` and `max_keepalive_requests` parameters to set relevant options
+for the virtual host.
+
+Default value: ``undef``
+
+##### <a name="keepalive_timeout"></a>`keepalive_timeout`
+
+Data type: `Any`
+
+Sets the `KeepAliveTimeout` directive for the virtual host, which determines the amount
+of time to wait for subsequent requests on a persistent HTTP connection. By default, the
+global, server-wide `KeepAlive` setting is in effect.<br />
+This parameter is only relevant if either the global, server-wide `keepalive` parameter or
+the per-vhost `keepalive` parameter is enabled.
+
+Default value: ``undef``
+
+##### <a name="max_keepalive_requests"></a>`max_keepalive_requests`
+
+Data type: `Any`
+
+Limits the number of requests allowed per connection to the virtual host. By default,
+the global, server-wide `KeepAlive` setting is in effect.<br />
+This parameter is only relevant if either the global, server-wide `keepalive` parameter or
+the per-vhost `keepalive` parameter is enabled.
+
+Default value: ``undef``
+
+##### <a name="auth_kerb"></a>`auth_kerb`
+
+Data type: `Boolean`
+
+Enable `mod_auth_kerb` parameters for a virtual host.<br />
+Usage typically looks like:
+``` puppet
+apache::vhost { 'sample.example.net':
+  auth_kerb              => `true`,
+  krb_method_negotiate   => 'on',
+  krb_auth_realms        => ['EXAMPLE.ORG'],
+  krb_local_user_mapping => 'on',
+  directories            => {
+    path         => '/var/www/html',
+    auth_name    => 'Kerberos Login',
+    auth_type    => 'Kerberos',
+    auth_require => 'valid-user',
+  },
+}
+```
+
+Default value: ``false``
+
+##### <a name="krb_method_negotiate"></a>`krb_method_negotiate`
+
+Data type: `Any`
+
+Determines whether to use the Negotiate method.
+
+Default value: `'on'`
+
+##### <a name="krb_method_k5passwd"></a>`krb_method_k5passwd`
+
+Data type: `Any`
+
+Determines whether to use password-based authentication for Kerberos v5.
+
+Default value: `'on'`
+
+##### <a name="krb_authoritative"></a>`krb_authoritative`
+
+Data type: `Any`
+
+If set to `off`, authentication controls can be passed on to another module.
+
+Default value: `'on'`
+
+##### <a name="krb_auth_realms"></a>`krb_auth_realms`
+
+Data type: `Any`
+
+Specifies an array of Kerberos realms to use for authentication.
+
+Default value: `[]`
+
+##### <a name="krb_5keytab"></a>`krb_5keytab`
+
+Data type: `Any`
+
+Specifies the Kerberos v5 keytab file's location.
+
+Default value: ``undef``
+
+##### <a name="krb_local_user_mapping"></a>`krb_local_user_mapping`
+
+Data type: `Any`
+
+Strips @REALM from usernames for further use.
+
+Default value: ``undef``
+
+##### <a name="krb_verify_kdc"></a>`krb_verify_kdc`
+
+Data type: `Any`
+
+This option can be used to disable the verification tickets against local keytab to prevent
+KDC spoofing attacks.
+
+Default value: `'on'`
+
+##### <a name="krb_servicename"></a>`krb_servicename`
+
+Data type: `Any`
+
+Specifies the service name that will be used by Apache for authentication. Corresponding
+key of this name must be stored in the keytab.
+
+Default value: `'HTTP'`
+
+##### <a name="krb_save_credentials"></a>`krb_save_credentials`
+
+Data type: `Any`
+
+This option enables credential saving functionality.
+
+Default value: `'off'`
+
+##### <a name="logroot"></a>`logroot`
+
+Data type: `Any`
+
+Specifies the location of the virtual host's logfiles.
+
+Default value: `$apache::logroot`
+
+##### <a name="logroot_ensure"></a>`logroot_ensure`
+
+Data type: `Enum['directory', 'absent']`
+
+Determines whether or not to remove the logroot directory for a virtual host.
+
+Default value: `'directory'`
+
+##### <a name="logroot_mode"></a>`logroot_mode`
+
+Data type: `Any`
+
+Overrides the mode the logroot directory is set to. Do *not* grant write access to the
+directory the logs are stored in without being aware of the consequences; for more
+information, see [Apache's log security documentation](https://httpd.apache.org/docs/2.4/logs.html#security).
+
+Default value: ``undef``
+
+##### <a name="logroot_owner"></a>`logroot_owner`
+
+Data type: `Any`
+
+Sets individual user access to the logroot directory.
+
+Default value: ``undef``
+
+##### <a name="logroot_group"></a>`logroot_group`
+
+Data type: `Any`
+
+Sets group access to the `logroot` directory.
+
+Default value: ``undef``
+
+##### <a name="log_level"></a>`log_level`
+
+Data type: `Optional[Apache::LogLevel]`
+
+Specifies the verbosity of the error log.
+
+Default value: ``undef``
+
+##### <a name="modsec_body_limit"></a>`modsec_body_limit`
+
+Data type: `Any`
+
+Configures the maximum request body size (in bytes) ModSecurity accepts for buffering.
+
+Default value: ``undef``
+
+##### <a name="modsec_disable_vhost"></a>`modsec_disable_vhost`
+
+Data type: `Any`
+
+Disables `mod_security` on a virtual host. Only valid if `apache::mod::security` is included.
+
+Default value: ``undef``
+
+##### <a name="modsec_disable_ids"></a>`modsec_disable_ids`
+
+Data type: `Optional[Variant[Hash, Array]]`
+
+Removes `mod_security` IDs from the virtual host.<br />
+Also takes a hash allowing removal of an ID from a specific location.
+``` puppet
+apache::vhost { 'sample.example.net':
+  modsec_disable_ids => [ 90015, 90016 ],
+}
+```
+
+``` puppet
+apache::vhost { 'sample.example.net':
+  modsec_disable_ids => { '/location1' => [ 90015, 90016 ] },
+}
+```
+
+Default value: ``undef``
+
+##### <a name="modsec_disable_ips"></a>`modsec_disable_ips`
+
+Data type: `Any`
+
+Specifies an array of IP addresses to exclude from `mod_security` rule matching.
+
+Default value: ``undef``
+
+##### <a name="modsec_disable_msgs"></a>`modsec_disable_msgs`
+
+Data type: `Optional[Variant[Hash, Array]]`
+
+Array of mod_security Msgs to remove from the virtual host. Also takes a hash allowing
+removal of an Msg from a specific location.
+``` puppet
+apache::vhost { 'sample.example.net':
+  modsec_disable_msgs => ['Blind SQL Injection Attack', 'Session Fixation Attack'],
+}
+```
+``` puppet
+apache::vhost { 'sample.example.net':
+  modsec_disable_msgs => { '/location1' => ['Blind SQL Injection Attack', 'Session Fixation Attack'] },
+}
+```
+
+Default value: ``undef``
+
+##### <a name="modsec_disable_tags"></a>`modsec_disable_tags`
+
+Data type: `Optional[Variant[Hash, Array]]`
+
+Array of mod_security Tags to remove from the virtual host. Also takes a hash allowing
+removal of an Tag from a specific location.
+``` puppet
+apache::vhost { 'sample.example.net':
+  modsec_disable_tags => ['WEB_ATTACK/SQL_INJECTION', 'WEB_ATTACK/XSS'],
+}
+```
+``` puppet
+apache::vhost { 'sample.example.net':
+  modsec_disable_tags => { '/location1' => ['WEB_ATTACK/SQL_INJECTION', 'WEB_ATTACK/XSS'] },
+}
+```
+
+Default value: ``undef``
+
+##### <a name="modsec_audit_log_file"></a>`modsec_audit_log_file`
+
+Data type: `Any`
+
+If set, it is relative to `logroot`.<br />
+One of the parameters that determines how to send `mod_security` audit
+log ([SecAuditLog](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual#SecAuditLog)).
+If none of those parameters are set, the global audit log is used
+(`/var/log/httpd/modsec\_audit.log`; Debian and derivatives: `/var/log/apache2/modsec\_audit.log`; others: ).
+
+Default value: ``undef``
+
+##### <a name="modsec_audit_log_pipe"></a>`modsec_audit_log_pipe`
+
+Data type: `Any`
+
+If `modsec_audit_log_pipe` is set, it should start with a pipe. Example
+`|/path/to/mlogc /path/to/mlogc.conf`.<br />
+One of the parameters that determines how to send `mod_security` audit
+log ([SecAuditLog](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual#SecAuditLog)).
+If none of those parameters are set, the global audit log is used
+(`/var/log/httpd/modsec\_audit.log`; Debian and derivatives: `/var/log/apache2/modsec\_audit.log`; others: ).
+
+Default value: ``undef``
+
+##### <a name="modsec_audit_log"></a>`modsec_audit_log`
+
+Data type: `Any`
+
+If `modsec_audit_log` is `true`, given a virtual host ---for instance, example.com--- it
+defaults to `example.com\_security\_ssl.log` for SSL-encrypted virtual hosts
+and `example.com\_security.log` for unencrypted virtual hosts.<br />
+One of the parameters that determines how to send `mod_security` audit
+log ([SecAuditLog](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual#SecAuditLog)).<br />
+If none of those parameters are set, the global audit log is used
+(`/var/log/httpd/modsec\_audit.log`; Debian and derivatives: `/var/log/apache2/modsec\_audit.log`; others: ).
+
+Default value: ``undef``
+
+##### <a name="no_proxy_uris"></a>`no_proxy_uris`
+
+Data type: `Any`
+
+Specifies URLs you do not want to proxy. This parameter is meant to be used in combination
+with [`proxy_dest`](#proxy_dest).
+
+Default value: `[]`
+
+##### <a name="no_proxy_uris_match"></a>`no_proxy_uris_match`
+
+Data type: `Any`
+
+This directive is equivalent to `no_proxy_uris`, but takes regular expressions.
+
+Default value: `[]`
+
+##### <a name="proxy_preserve_host"></a>`proxy_preserve_host`
+
+Data type: `Any`
+
+Sets the [ProxyPreserveHost Directive](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypreservehost).<br />
+Setting this parameter to `true` enables the `Host:` line from an incoming request to be
+proxied to the host instead of hostname. Setting it to `false` sets this directive to 'Off'.
+
+Default value: ``false``
+
+##### <a name="proxy_add_headers"></a>`proxy_add_headers`
+
+Data type: `Any`
+
+Sets the [ProxyAddHeaders Directive](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxyaddheaders).<br />
+This parameter controlls whether proxy-related HTTP headers (X-Forwarded-For,
+X-Forwarded-Host and X-Forwarded-Server) get sent to the backend server.
+
+Default value: ``undef``
+
+##### <a name="proxy_error_override"></a>`proxy_error_override`
+
+Data type: `Any`
+
+Sets the [ProxyErrorOverride Directive](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxyerroroverride).
+This directive controls whether Apache should override error pages for proxied content.
+
+Default value: ``false``
+
+##### <a name="options"></a>`options`
+
+Data type: `Any`
+
+Sets the `Options` for the specified virtual host. For example:
+``` puppet
+apache::vhost { 'site.name.fdqn':
+  ...
+  options => ['Indexes','FollowSymLinks','MultiViews'],
+}
+```
+> **Note**: If you use the `directories` parameter of `apache::vhost`, 'Options',
+'Override', and 'DirectoryIndex' are ignored because they are parameters within `directories`.
+
+Default value: `['Indexes','FollowSymLinks','MultiViews']`
+
+##### <a name="override"></a>`override`
+
+Data type: `Any`
+
+Sets the overrides for the specified virtual host. Accepts an array of
+[AllowOverride](https://httpd.apache.org/docs/current/mod/core.html#allowoverride) arguments.
+
+Default value: `['None']`
+
+##### <a name="passenger_enabled"></a>`passenger_enabled`
+
+Data type: `Optional[Boolean]`
+
+Sets the value for the [PassengerEnabled](http://www.modrails.com/documentation/Users%20guide%20Apache.html#PassengerEnabled)
+directive to `on` or `off`. Requires `apache::mod::passenger` to be included.
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot     => '/path/to/directory',
+  directories => [
+    { path              => '/path/to/directory',
+      passenger_enabled => 'on',
+    },
+  ],
+}
+```
+> **Note:** There is an [issue](http://www.conandalton.net/2010/06/passengerenabled-off-not-working.html)
+using the PassengerEnabled directive with the PassengerHighPerformance directive.
+
+Default value: ``undef``
+
+##### <a name="passenger_base_uri"></a>`passenger_base_uri`
+
+Data type: `Optional[String]`
+
+Sets [PassengerBaseURI](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerbase_rui),
+ to specify that the given URI is a distinct application served by Passenger.
+
+Default value: ``undef``
+
+##### <a name="passenger_ruby"></a>`passenger_ruby`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+Sets [PassengerRuby](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerruby),
+specifying the Ruby interpreter to use when serving the relevant web applications.
+
+Default value: ``undef``
+
+##### <a name="passenger_python"></a>`passenger_python`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+Sets [PassengerPython](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerpython),
+specifying the Python interpreter to use when serving the relevant web applications.
+
+Default value: ``undef``
+
+##### <a name="passenger_nodejs"></a>`passenger_nodejs`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+Sets the [`PassengerNodejs`](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengernodejs),
+specifying Node.js command to use when serving the relevant web applications.
+
+Default value: ``undef``
+
+##### <a name="passenger_meteor_app_settings"></a>`passenger_meteor_app_settings`
+
+Data type: `Optional[String]`
+
+Sets [PassengerMeteorAppSettings](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengermeteorappsettings),
+specifying a JSON file with settings for the application when using a Meteor
+application in non-bundled mode.
+
+Default value: ``undef``
+
+##### <a name="passenger_app_env"></a>`passenger_app_env`
+
+Data type: `Optional[String]`
+
+Sets [PassengerAppEnv](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerappenv),
+the environment for the Passenger application. If not specified, defaults to the global
+setting or 'production'.
+
+Default value: ``undef``
+
+##### <a name="passenger_app_root"></a>`passenger_app_root`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+Sets [PassengerRoot](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerapproot),
+the location of the Passenger application root if different from the DocumentRoot.
+
+Default value: ``undef``
+
+##### <a name="passenger_app_group_name"></a>`passenger_app_group_name`
+
+Data type: `Optional[String]`
+
+Sets [PassengerAppGroupName](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerappgroupname),
+ the name of the application group that the current application should belong to.
+
+Default value: ``undef``
+
+##### <a name="passenger_app_start_command"></a>`passenger_app_start_command`
+
+Data type: `Optional[String]`
+
+Sets [PassengerAppStartCommand](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerappstartcommand),
+ how Passenger should start your app on a specific port.
+
+Default value: ``undef``
+
+##### <a name="passenger_app_type"></a>`passenger_app_type`
+
+Data type: `Optional[Enum['meteor', 'node', 'rack', 'wsgi']]`
+
+Sets [PassengerAppType](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerapptype),
+ to force Passenger to recognize the application as a specific type.
+
+Default value: ``undef``
+
+##### <a name="passenger_startup_file"></a>`passenger_startup_file`
+
+Data type: `Optional[String]`
+
+Sets the [PassengerStartupFile](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerstartupfile),
+path. This path is relative to the application root.
+
+Default value: ``undef``
+
+##### <a name="passenger_restart_dir"></a>`passenger_restart_dir`
+
+Data type: `Optional[String]`
+
+Sets the [PassengerRestartDir](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerrestartdir),
+ to customize the directory in which `restart.txt` is searched for.
+
+Default value: ``undef``
+
+##### <a name="passenger_spawn_method"></a>`passenger_spawn_method`
+
+Data type: `Optional[Enum['direct', 'smart']]`
+
+Sets [PassengerSpawnMethod](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerspawnmethod),
+whether Passenger spawns applications directly, or using a prefork copy-on-write mechanism.
+
+Default value: ``undef``
+
+##### <a name="passenger_load_shell_envvars"></a>`passenger_load_shell_envvars`
+
+Data type: `Optional[Boolean]`
+
+Sets [PassengerLoadShellEnvvars](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerloadshellenvvars),
+to enable or disable the loading of shell environment variables before spawning the application.
+
+Default value: ``undef``
+
+##### <a name="passenger_rolling_restarts"></a>`passenger_rolling_restarts`
+
+Data type: `Optional[Boolean]`
+
+Sets [PassengerRollingRestarts](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerrollingrestarts),
+to enable or disable support for zero-downtime application restarts through `restart.txt`.
+
+Default value: ``undef``
+
+##### <a name="passenger_resist_deployment_errors"></a>`passenger_resist_deployment_errors`
+
+Data type: `Optional[Boolean]`
+
+Sets [PassengerResistDeploymentErrors](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerresistdeploymenterrors),
+to enable or disable resistance against deployment errors.
+
+Default value: ``undef``
+
+##### <a name="passenger_user"></a>`passenger_user`
+
+Data type: `Optional[String]`
+
+Sets [PassengerUser](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengeruser),
+the running user for sandboxing applications.
+
+Default value: ``undef``
+
+##### <a name="passenger_group"></a>`passenger_group`
+
+Data type: `Optional[String]`
+
+Sets [PassengerGroup](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengergroup),
+the running group for sandboxing applications.
+
+Default value: ``undef``
+
+##### <a name="passenger_friendly_error_pages"></a>`passenger_friendly_error_pages`
+
+Data type: `Optional[Boolean]`
+
+Sets [PassengerFriendlyErrorPages](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerfriendlyerrorpages),
+which can display friendly error pages whenever an application fails to start. This
+friendly error page presents the startup error message, some suggestions for solving
+the problem, a backtrace and a dump of the environment variables.
+
+Default value: ``undef``
+
+##### <a name="passenger_min_instances"></a>`passenger_min_instances`
+
+Data type: `Optional[Integer]`
+
+Sets [PassengerMinInstances](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengermininstances),
+the minimum number of application processes to run.
+
+Default value: ``undef``
+
+##### <a name="passenger_max_instances"></a>`passenger_max_instances`
+
+Data type: `Optional[Integer]`
+
+Sets [PassengerMaxInstances](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengermaxinstances),
+the maximum number of application processes to run.
+
+Default value: ``undef``
+
+##### <a name="passenger_max_preloader_idle_time"></a>`passenger_max_preloader_idle_time`
+
+Data type: `Optional[Integer]`
+
+Sets [PassengerMaxPreloaderIdleTime](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengermaxpreloaderidletime),
+the maximum amount of time the preloader waits before shutting down an idle process.
+
+Default value: ``undef``
+
+##### <a name="passenger_force_max_concurrent_requests_per_process"></a>`passenger_force_max_concurrent_requests_per_process`
+
+Data type: `Optional[Integer]`
+
+Sets [PassengerForceMaxConcurrentRequestsPerProcess](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerforcemaxconcurrentrequestsperprocess),
+the maximum amount of concurrent requests the application can handle per process.
+
+Default value: ``undef``
+
+##### <a name="passenger_start_timeout"></a>`passenger_start_timeout`
+
+Data type: `Optional[Integer]`
+
+Sets [PassengerStartTimeout](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerstarttimeout),
+the timeout for the application startup.
+
+Default value: ``undef``
+
+##### <a name="passenger_concurrency_model"></a>`passenger_concurrency_model`
+
+Data type: `Optional[Enum['process', 'thread']]`
+
+Sets [PassengerConcurrencyModel](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerconcurrencyodel),
+to specify the I/O concurrency model that should be used for Ruby application processes.
+Passenger supports two concurrency models:<br />
+* `process` - single-threaded, multi-processed I/O concurrency.
+* `thread` - multi-threaded, multi-processed I/O concurrency.
+
+Default value: ``undef``
+
+##### <a name="passenger_thread_count"></a>`passenger_thread_count`
+
+Data type: `Optional[Integer]`
+
+Sets [PassengerThreadCount](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerthreadcount),
+the number of threads that Passenger should spawn per Ruby application process.<br />
+This option only has effect if PassengerConcurrencyModel is `thread`.
+
+Default value: ``undef``
+
+##### <a name="passenger_max_requests"></a>`passenger_max_requests`
+
+Data type: `Optional[Integer]`
+
+Sets [PassengerMaxRequests](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengermaxrequests),
+the maximum number of requests an application process will process.
+
+Default value: ``undef``
+
+##### <a name="passenger_max_request_time"></a>`passenger_max_request_time`
+
+Data type: `Optional[Integer]`
+
+Sets [PassengerMaxRequestTime](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengermaxrequesttime),
+the maximum amount of time, in seconds, that an application process may take to
+process a request.
+
+Default value: ``undef``
+
+##### <a name="passenger_memory_limit"></a>`passenger_memory_limit`
+
+Data type: `Optional[Integer]`
+
+Sets [PassengerMemoryLimit](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengermemorylimit),
+the maximum amount of memory that an application process may use, in megabytes.
+
+Default value: ``undef``
+
+##### <a name="passenger_stat_throttle_rate"></a>`passenger_stat_throttle_rate`
+
+Data type: `Optional[Integer]`
+
+Sets [PassengerStatThrottleRate](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerstatthrottlerate),
+to set a limit, in seconds, on how often Passenger will perform it's filesystem checks.
+
+Default value: ``undef``
+
+##### <a name="passenger_pre_start"></a>`passenger_pre_start`
+
+Data type: `Optional[Variant[String,Array[String]]]`
+
+Sets [PassengerPreStart](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerprestart),
+the URL of the application if pre-starting is required.
+
+Default value: ``undef``
+
+##### <a name="passenger_high_performance"></a>`passenger_high_performance`
+
+Data type: `Optional[Boolean]`
+
+Sets [PassengerHighPerformance](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerhighperformance),
+to enhance performance in return for reduced compatibility.
+
+Default value: ``undef``
+
+##### <a name="passenger_buffer_upload"></a>`passenger_buffer_upload`
+
+Data type: `Optional[Boolean]`
+
+Sets [PassengerBufferUpload](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerbufferupload),
+to buffer HTTP client request bodies before they are sent to the application.
+
+Default value: ``undef``
+
+##### <a name="passenger_buffer_response"></a>`passenger_buffer_response`
+
+Data type: `Optional[Boolean]`
+
+Sets [PassengerBufferResponse](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerbufferresponse),
+to buffer Happlication-generated responses.
+
+Default value: ``undef``
+
+##### <a name="passenger_error_override"></a>`passenger_error_override`
+
+Data type: `Optional[Boolean]`
+
+Sets [PassengerErrorOverride](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengererroroverride),
+to specify whether Apache will intercept and handle response with HTTP status codes of
+400 and higher.
+
+Default value: ``undef``
+
+##### <a name="passenger_max_request_queue_size"></a>`passenger_max_request_queue_size`
+
+Data type: `Optional[Integer]`
+
+Sets [PassengerMaxRequestQueueSize](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengermaxrequestqueuesize),
+to specify the maximum amount of requests that are allowed to queue whenever the maximum
+concurrent request limit is reached. If the queue is already at this specified limit, then
+Passenger immediately sends a "503 Service Unavailable" error to any incoming requests.<br />
+A value of 0 means that the queue size is unbounded.
+
+Default value: ``undef``
+
+##### <a name="passenger_max_request_queue_time"></a>`passenger_max_request_queue_time`
+
+Data type: `Optional[Integer]`
+
+Sets [PassengerMaxRequestQueueTime](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengermaxrequestqueuetime),
+to specify the maximum amount of time that requests are allowed to stay in the queue
+whenever the maximum concurrent request limit is reached. If a request reaches this specified
+limit, then Passenger immeaditly sends a "504 Gateway Timeout" error for that request.<br />
+A value of 0 means that the queue time is unbounded.
+
+Default value: ``undef``
+
+##### <a name="passenger_sticky_sessions"></a>`passenger_sticky_sessions`
+
+Data type: `Optional[Boolean]`
+
+Sets [PassengerStickySessions](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerstickysessions),
+to specify that, whenever possible, all requests sent by a client will be routed to the same
+originating application process.
+
+Default value: ``undef``
+
+##### <a name="passenger_sticky_sessions_cookie_name"></a>`passenger_sticky_sessions_cookie_name`
+
+Data type: `Optional[String]`
+
+Sets [PassengerStickySessionsCookieName](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerstickysessionscookiename),
+to specify the name of the sticky sessions cookie.
+
+Default value: ``undef``
+
+##### <a name="passenger_sticky_sessions_cookie_attributes"></a>`passenger_sticky_sessions_cookie_attributes`
+
+Data type: `Optional[String]`
+
+Sets [PassengerStickySessionsCookieAttributes](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerstickysessionscookieattributes),
+the attributes of the sticky sessions cookie.
+
+Default value: ``undef``
+
+##### <a name="passenger_allow_encoded_slashes"></a>`passenger_allow_encoded_slashes`
+
+Data type: `Optional[Boolean]`
+
+Sets [PassengerAllowEncodedSlashes](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerallowencodedslashes),
+to allow URLs with encoded slashes. Please note that this feature will not work properly
+unless Apache's `AllowEncodedSlashes` is also enabled.
+
+Default value: ``undef``
+
+##### <a name="passenger_app_log_file"></a>`passenger_app_log_file`
+
+Data type: `Optional[String]`
+
+Sets [PassengerAppLogFile](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerapplogfile),
+app specific messages logged to a different file in addition to Passenger log file.
+
+Default value: ``undef``
+
+##### <a name="passenger_debugger"></a>`passenger_debugger`
+
+Data type: `Optional[Boolean]`
+
+Sets [PassengerDebugger](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerdebugger),
+to turn support for Ruby application debugging on or off.
+
+Default value: ``undef``
+
+##### <a name="passenger_lve_min_uid"></a>`passenger_lve_min_uid`
+
+Data type: `Optional[Integer]`
+
+Sets [PassengerLveMinUid](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerlveminuid),
+to only allow the spawning of application processes with UIDs equal to, or higher than, this
+specified value on LVE-enabled kernels.
+
+Default value: ``undef``
+
+##### <a name="php_values"></a>`php_values`
+
+Data type: `Any`
+
+Allows per-virtual host setting [`php_value`s](http://php.net/manual/en/configuration.changes.php).
+These flags or values can be overwritten by a user or an application.
+Within a vhost declaration:
+``` puppet
+  php_values    => [ 'include_path ".:/usr/local/example-app/include"' ],
+```
+
+Default value: `{}`
+
+##### <a name="php_flags"></a>`php_flags`
+
+Data type: `Any`
+
+Allows per-virtual host setting [`php_flags\``](http://php.net/manual/en/configuration.changes.php).
+These flags or values can be overwritten by a user or an application.
+
+Default value: `{}`
+
+##### <a name="php_admin_values"></a>`php_admin_values`
+
+Data type: `Any`
+
+Allows per-virtual host setting [`php_admin_value`](http://php.net/manual/en/configuration.changes.php).
+These flags or values cannot be overwritten by a user or an application.
+
+Default value: `{}`
+
+##### <a name="php_admin_flags"></a>`php_admin_flags`
+
+Data type: `Any`
+
+Allows per-virtual host setting [`php_admin_flag`](http://php.net/manual/en/configuration.changes.php).
+These flags or values cannot be overwritten by a user or an application.
+
+Default value: `{}`
+
+##### <a name="port"></a>`port`
+
+Data type: `Any`
+
+Sets the port the host is configured on. The module's defaults ensure the host listens
+on port 80 for non-SSL virtual hosts and port 443 for SSL virtual hosts. The host only
+listens on the port set in this parameter.
+
+Default value: ``undef``
+
+##### <a name="priority"></a>`priority`
+
+Data type: `Any`
+
+Sets the relative load-order for Apache HTTPD VirtualHost configuration files.<br />
+If nothing matches the priority, the first name-based virtual host is used. Likewise,
+passing a higher priority causes the alphabetically first name-based virtual host to be
+used if no other names match.<br />
+> **Note:** You should not need to use this parameter. However, if you do use it, be
+aware that the `default_vhost` parameter for `apache::vhost` passes a priority of '15'.<br />
+To omit the priority prefix in file names, pass a priority of `false`.
+
+Default value: ``undef``
+
+##### <a name="protocols"></a>`protocols`
+
+Data type: `Array[Enum['h2', 'h2c', 'http/1.1']]`
+
+Sets the [Protocols](https://httpd.apache.org/docs/current/en/mod/core.html#protocols)
+directive, which lists available protocols for the virutal host.
+
+Default value: `[]`
+
+##### <a name="protocols_honor_order"></a>`protocols_honor_order`
+
+Data type: `Optional[Boolean]`
+
+Sets the [ProtocolsHonorOrder](https://httpd.apache.org/docs/current/en/mod/core.html#protocolshonororder)
+directive which determines wether the order of Protocols sets precedence during negotiation.
+
+Default value: ``undef``
+
+##### <a name="proxy_dest"></a>`proxy_dest`
+
+Data type: `Any`
+
+Specifies the destination address of a [ProxyPass](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypass) configuration.
+
+Default value: ``undef``
+
+##### <a name="proxy_pass"></a>`proxy_pass`
+
+Data type: `Any`
+
+Specifies an array of `path => URI` values for a [ProxyPass](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypass)
+configuration. Optionally, parameters can be added as an array.
+``` puppet
+apache::vhost { 'site.name.fdqn':
+  ...
+  proxy_pass => [
+    { 'path' => '/a', 'url' => 'http://backend-a/' },
+    { 'path' => '/b', 'url' => 'http://backend-b/' },
+    { 'path' => '/c', 'url' => 'http://backend-a/c', 'params' => {'max'=>20, 'ttl'=>120, 'retry'=>300}},
+    { 'path' => '/l', 'url' => 'http://backend-xy',
+      'reverse_urls' => ['http://backend-x', 'http://backend-y'] },
+    { 'path' => '/d', 'url' => 'http://backend-a/d',
+      'params' => { 'retry' => '0', 'timeout' => '5' }, },
+    { 'path' => '/e', 'url' => 'http://backend-a/e',
+      'keywords' => ['nocanon', 'interpolate'] },
+    { 'path' => '/f', 'url' => 'http://backend-f/',
+      'setenv' => ['proxy-nokeepalive 1','force-proxy-request-1.0 1']},
+    { 'path' => '/g', 'url' => 'http://backend-g/',
+      'reverse_cookies' => [{'path' => '/g', 'url' => 'http://backend-g/',}, {'domain' => 'http://backend-g', 'url' => 'http:://backend-g',},], },
+    { 'path' => '/h', 'url' => 'http://backend-h/h',
+      'no_proxy_uris' => ['/h/admin', '/h/server-status'] },
+  ],
+}
+```
+* `reverse_urls`. *Optional.* This setting is useful when used with `mod_proxy_balancer`. Values: an array or string.
+* `reverse_cookies`. *Optional.* Sets `ProxyPassReverseCookiePath` and `ProxyPassReverseCookieDomain`.
+* `params`. *Optional.* Allows for ProxyPass key-value parameters, such as connection settings.
+* `setenv`. *Optional.* Sets [environment variables](https://httpd.apache.org/docs/current/mod/mod_proxy.html#envsettings) for the proxy directive. Values: array.
+
+Default value: ``undef``
+
+##### <a name="proxy_dest_match"></a>`proxy_dest_match`
+
+Data type: `Any`
+
+This directive is equivalent to `proxy_dest`, but takes regular expressions, see
+[ProxyPassMatch](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassmatch)
+for details.
+
+Default value: ``undef``
+
+##### <a name="proxy_dest_reverse_match"></a>`proxy_dest_reverse_match`
+
+Data type: `Any`
+
+Allows you to pass a ProxyPassReverse if `proxy_dest_match` is specified. See
+[ProxyPassReverse](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassreverse)
+for details.
+
+Default value: ``undef``
+
+##### <a name="proxy_pass_match"></a>`proxy_pass_match`
+
+Data type: `Any`
+
+This directive is equivalent to `proxy_pass`, but takes regular expressions, see
+[ProxyPassMatch](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassmatch)
+for details.
+
+Default value: ``undef``
+
+##### <a name="redirect_dest"></a>`redirect_dest`
+
+Data type: `Any`
+
+Specifies the address to redirect to.
+
+Default value: ``undef``
+
+##### <a name="redirect_source"></a>`redirect_source`
+
+Data type: `Any`
+
+Specifies the source URIs that redirect to the destination specified in `redirect_dest`.
+If more than one item for redirect is supplied, the source and destination must be the same
+length, and the items are order-dependent.
+``` puppet
+apache::vhost { 'site.name.fdqn':
+  ...
+  redirect_source => ['/images','/downloads'],
+  redirect_dest   => ['http://img.example.com/','http://downloads.example.com/'],
+}
+```
+
+Default value: `'/'`
+
+##### <a name="redirect_status"></a>`redirect_status`
+
+Data type: `Any`
+
+Specifies the status to append to the redirect.
+``` puppet
+  apache::vhost { 'site.name.fdqn':
+  ...
+  redirect_status => ['temp','permanent'],
+}
+```
+
+Default value: ``undef``
+
+##### <a name="redirectmatch_regexp"></a>`redirectmatch_regexp`
+
+Data type: `Any`
+
+Determines which server status should be raised for a given regular expression
+and where to forward the user to. Entered as an array alongside redirectmatch_status
+and redirectmatch_dest.
+``` puppet
+apache::vhost { 'site.name.fdqn':
+  ...
+  redirectmatch_status => ['404','404'],
+  redirectmatch_regexp => ['\.git(/.*|$)/','\.svn(/.*|$)'],
+  redirectmatch_dest => ['http://www.example.com/$1','http://www.example.com/$2'],
+}
+```
+
+Default value: ``undef``
+
+##### <a name="redirectmatch_status"></a>`redirectmatch_status`
+
+Data type: `Any`
+
+Determines which server status should be raised for a given regular expression
+and where to forward the user to. Entered as an array alongside redirectmatch_regexp
+and redirectmatch_dest.
+``` puppet
+apache::vhost { 'site.name.fdqn':
+  ...
+  redirectmatch_status => ['404','404'],
+  redirectmatch_regexp => ['\.git(/.*|$)/','\.svn(/.*|$)'],
+  redirectmatch_dest => ['http://www.example.com/$1','http://www.example.com/$2'],
+}
+```
+
+Default value: ``undef``
+
+##### <a name="redirectmatch_dest"></a>`redirectmatch_dest`
+
+Data type: `Any`
+
+Determines which server status should be raised for a given regular expression
+and where to forward the user to. Entered as an array alongside redirectmatch_status
+and redirectmatch_regexp.
+``` puppet
+apache::vhost { 'site.name.fdqn':
+  ...
+  redirectmatch_status => ['404','404'],
+  redirectmatch_regexp => ['\.git(/.*|$)/','\.svn(/.*|$)'],
+  redirectmatch_dest => ['http://www.example.com/$1','http://www.example.com/$2'],
+}
+```
+
+Default value: ``undef``
+
+##### <a name="request_headers"></a>`request_headers`
+
+Data type: `Any`
+
+Modifies collected [request headers](https://httpd.apache.org/docs/current/mod/mod_headers.html#requestheader)
+in various ways, including adding additional request headers, removing request headers,
+and so on.
+``` puppet
+apache::vhost { 'site.name.fdqn':
+  ...
+  request_headers => [
+    'append MirrorID "mirror 12"',
+    'unset MirrorID',
+  ],
+}
+```
+
+Default value: ``undef``
+
+##### <a name="rewrites"></a>`rewrites`
+
+Data type: `Optional[Array]`
+
+Creates URL rewrite rules. Expects an array of hashes.<br />
+Valid Hash keys include `comment`, `rewrite_base`, `rewrite_cond`, `rewrite_rule`
+or `rewrite_map`.<br />
+For example, you can specify that anyone trying to access index.html is served welcome.html
+``` puppet
+apache::vhost { 'site.name.fdqn':
+  ...
+  rewrites => [ { rewrite_rule => ['^index\.html$ welcome.html'] } ]
+}
+```
+The parameter allows rewrite conditions that, when `true`, execute the associated rule.
+For instance, if you wanted to rewrite URLs only if the visitor is using IE
+``` puppet
+apache::vhost { 'site.name.fdqn':
+  ...
+  rewrites => [
+    {
+      comment      => 'redirect IE',
+      rewrite_cond => ['%{HTTP_USER_AGENT} ^MSIE'],
+      rewrite_rule => ['^index\.html$ welcome.html'],
+    },
+  ],
+}
+```
+You can also apply multiple conditions. For instance, rewrite index.html to welcome.html
+only when the browser is Lynx or Mozilla (version 1 or 2)
+``` puppet
+apache::vhost { 'site.name.fdqn':
+  ...
+  rewrites => [
+    {
+      comment      => 'Lynx or Mozilla v1/2',
+      rewrite_cond => ['%{HTTP_USER_AGENT} ^Lynx/ [OR]', '%{HTTP_USER_AGENT} ^Mozilla/[12]'],
+      rewrite_rule => ['^index\.html$ welcome.html'],
+    },
+  ],
+}
+```
+Multiple rewrites and conditions are also possible
+``` puppet
+apache::vhost { 'site.name.fdqn':
+  ...
+  rewrites => [
+    {
+      comment      => 'Lynx or Mozilla v1/2',
+      rewrite_cond => ['%{HTTP_USER_AGENT} ^Lynx/ [OR]', '%{HTTP_USER_AGENT} ^Mozilla/[12]'],
+      rewrite_rule => ['^index\.html$ welcome.html'],
+    },
+    {
+      comment      => 'Internet Explorer',
+      rewrite_cond => ['%{HTTP_USER_AGENT} ^MSIE'],
+      rewrite_rule => ['^index\.html$ /index.IE.html [L]'],
+    },
+    {
+      rewrite_base => /apps/,
+      rewrite_rule => ['^index\.cgi$ index.php', '^index\.html$ index.php', '^index\.asp$ index.html'],
+    },
+    { comment      => 'Rewrite to lower case',
+      rewrite_cond => ['%{REQUEST_URI} [A-Z]'],
+      rewrite_map  => ['lc int:tolower'],
+      rewrite_rule => ['(.*) ${lc:$1} [R=301,L]'],
+    },
+  ],
+}
+```
+Refer to the [`mod_rewrite` documentation](https://httpd.apache.org/docs/2.4/mod/mod_rewrite.html)
+for more details on what is possible with rewrite rules and conditions.<br />
+> **Note**: If you include rewrites in your directories, also include `apache::mod::rewrite`
+and consider setting the rewrites using the `rewrites` parameter in `apache::vhost` rather
+than setting the rewrites in the virtual host's directories.
+
+Default value: ``undef``
+
+##### <a name="rewrite_base"></a>`rewrite_base`
+
+Data type: `Any`
+
+The parameter [`rewrite_base`](https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewritebase)
+specifies the URL prefix to be used for per-directory (htaccess) RewriteRule directives
+that substitue a relative path.
+
+Default value: ``undef``
+
+##### <a name="rewrite_rule"></a>`rewrite_rule`
+
+Data type: `Any`
+
+The parameter [`rewrite_rile`](https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewriterule)
+allows the user to define the rules that will be used by the rewrite engine.
+
+Default value: ``undef``
+
+##### <a name="rewrite_cond"></a>`rewrite_cond`
+
+Data type: `Any`
+
+The parameter [`rewrite_cond`](https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewritecond)
+defines a rule condition, that when satisfied will implement that rule within the
+rewrite engine.
+
+Default value: ``undef``
+
+##### <a name="rewrite_inherit"></a>`rewrite_inherit`
+
+Data type: `Any`
+
+Determines whether the virtual host inherits global rewrite rules.<br />
+Rewrite rules may be specified globally (in `$conf_file` or `$confd_dir`) or
+inside the virtual host `.conf` file. By default, virtual hosts do not inherit
+global settings. To activate inheritance, specify the `rewrites` parameter and set
+`rewrite_inherit` parameter to `true`:
+``` puppet
+apache::vhost { 'site.name.fdqn':
+  ...
+  rewrites => [
+    <rules>,
+  ],
+  rewrite_inherit => `true`,
+}
+```
+> **Note**: The `rewrites` parameter is **required** for this to have effect<br />
+Apache activates global `Rewrite` rules inheritance if the virtual host files contains
+the following directives:
+``` ApacheConf
+RewriteEngine On
+RewriteOptions Inherit
+```
+Refer to the official [`mod_rewrite`](https://httpd.apache.org/docs/2.2/mod/mod_rewrite.html)
+documentation, section "Rewriting in Virtual Hosts".
+
+Default value: ``false``
+
+##### <a name="scriptalias"></a>`scriptalias`
+
+Data type: `Any`
+
+Defines a directory of CGI scripts to be aliased to the path '/cgi-bin', such as
+'/usr/scripts'.
+
+Default value: ``undef``
+
+##### <a name="scriptaliases"></a>`scriptaliases`
+
+Data type: `Any`
+
+> **Note**: This parameter is deprecated in favor of the `aliases` parameter.<br />
+Passes an array of hashes to the virtual host to create either ScriptAlias or
+ScriptAliasMatch statements per the `mod_alias` documentation.
+``` puppet
+scriptaliases => [
+  {
+    alias => '/myscript',
+    path  => '/usr/share/myscript',
+  },
+  {
+    aliasmatch => '^/foo(.*)',
+    path       => '/usr/share/fooscripts$1',
+  },
+  {
+    aliasmatch => '^/bar/(.*)',
+    path       => '/usr/share/bar/wrapper.sh/$1',
+  },
+  {
+    alias => '/neatscript',
+    path  => '/usr/share/neatscript',
+  },
+]
+```
+The ScriptAlias and ScriptAliasMatch directives are created in the order specified.
+As with [Alias and AliasMatch](#aliases) directives, specify more specific aliases
+before more general ones to avoid shadowing.
+
+Default value: `[]`
+
+##### <a name="serveradmin"></a>`serveradmin`
+
+Data type: `Any`
+
+Specifies the email address Apache displays when it renders one of its error pages.
+
+Default value: ``undef``
+
+##### <a name="serveraliases"></a>`serveraliases`
+
+Data type: `Any`
+
+Sets the [ServerAliases](https://httpd.apache.org/docs/current/mod/core.html#serveralias)
+of the site.
+
+Default value: `[]`
+
+##### <a name="servername"></a>`servername`
+
+Data type: `Any`
+
+Sets the servername corresponding to the hostname you connect to the virtual host at.
+
+Default value: `$name`
+
+##### <a name="setenv"></a>`setenv`
+
+Data type: `Any`
+
+Used by HTTPD to set environment variables for virtual hosts.<br />
+Example:
+``` puppet
+apache::vhost { 'setenv.example.com':
+  setenv => ['SPECIAL_PATH /foo/bin'],
+}
+```
+
+Default value: `[]`
+
+##### <a name="setenvif"></a>`setenvif`
+
+Data type: `Any`
+
+Used by HTTPD to conditionally set environment variables for virtual hosts.
+
+Default value: `[]`
+
+##### <a name="setenvifnocase"></a>`setenvifnocase`
+
+Data type: `Any`
+
+Used by HTTPD to conditionally set environment variables for virtual hosts (caseless matching).
+
+Default value: `[]`
+
+##### <a name="suexec_user_group"></a>`suexec_user_group`
+
+Data type: `Optional[Pattern[/^[\w-]+ [\w-]+$/]]`
+
+Allows the spcification of user and group execution privileges for CGI programs through
+inclusion of the `mod_suexec` module.
+
+Default value: ``undef``
+
+##### <a name="suphp_addhandler"></a>`suphp_addhandler`
+
+Data type: `Any`
+
+Sets up a virtual host with [suPHP](http://suphp.org/DocumentationView.html?file=apache/CONFIG)
+working together with suphp_configpath and suphp_engine.<br />
+An example virtual host configuration with suPHP:
+``` puppet
+apache::vhost { 'suphp.example.com':
+  port             => '80',
+  docroot          => '/home/appuser/myphpapp',
+  suphp_addhandler => 'x-httpd-php',
+  suphp_engine     => 'on',
+  suphp_configpath => '/etc/php5/apache2',
+  directories      => { path => '/home/appuser/myphpapp',
+    'suphp'        => { user => 'myappuser', group => 'myappgroup' },
+  }
+}
+```
+
+Default value: `$apache::params::suphp_addhandler`
+
+##### <a name="suphp_configpath"></a>`suphp_configpath`
+
+Data type: `Any`
+
+Sets up a virtual host with [suPHP](http://suphp.org/DocumentationView.html?file=apache/CONFIG)
+working together with suphp_addhandler and suphp_engine.<br />
+An example virtual host configuration with suPHP:
+``` puppet
+apache::vhost { 'suphp.example.com':
+  port             => '80',
+  docroot          => '/home/appuser/myphpapp',
+  suphp_addhandler => 'x-httpd-php',
+  suphp_engine     => 'on',
+  suphp_configpath => '/etc/php5/apache2',
+  directories      => { path => '/home/appuser/myphpapp',
+    'suphp'        => { user => 'myappuser', group => 'myappgroup' },
+  }
+}
+```
+
+Default value: `$apache::params::suphp_configpath`
+
+##### <a name="suphp_engine"></a>`suphp_engine`
+
+Data type: `Enum['on', 'off']`
+
+Sets up a virtual host with [suPHP](http://suphp.org/DocumentationView.html?file=apache/CONFIG)
+working together with suphp_configpath and suphp_addhandler.<br />
+An example virtual host configuration with suPHP:
+``` puppet
+apache::vhost { 'suphp.example.com':
+  port             => '80',
+  docroot          => '/home/appuser/myphpapp',
+  suphp_addhandler => 'x-httpd-php',
+  suphp_engine     => 'on',
+  suphp_configpath => '/etc/php5/apache2',
+  directories      => { path => '/home/appuser/myphpapp',
+    'suphp'        => { user => 'myappuser', group => 'myappgroup' },
+  }
+}
+```
+
+Default value: `$apache::params::suphp_engine`
+
+##### <a name="vhost_name"></a>`vhost_name`
+
+Data type: `Any`
+
+Enables name-based virtual hosting. If no IP is passed to the virtual host, but the
+virtual host is assigned a port, then the virtual host name is `vhost_name:port`.
+If the virtual host has no assigned IP or port, the virtual host name is set to the
+title of the resource.
+
+Default value: `'*'`
+
+##### <a name="virtual_docroot"></a>`virtual_docroot`
+
+Data type: `Any`
+
+Sets up a virtual host with a wildcard alias subdomain mapped to a directory with the
+same name. For example, `http://example.com` would map to `/var/www/example.com`.
+``` puppet
+apache::vhost { 'subdomain.loc':
+  vhost_name      => '*',
+  port            => '80',
+  virtual_docroot => '/var/www/%-2+',
+  docroot         => '/var/www',
+  serveraliases   => ['*.loc',],
+}
+```
+
+Default value: ``false``
+
+##### <a name="wsgi_daemon_process"></a>`wsgi_daemon_process`
+
+Data type: `Optional[Variant[String,Hash]]`
+
+Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
+wsgi_daemon_process_options, wsgi_process_group,
+wsgi_script_aliases and wsgi_pass_authorization.<br />
+A hash that sets the name of the WSGI daemon, accepting
+[certain keys](http://modwsgi.readthedocs.org/en/latest/configuration-directives/WSGIDaemonProcess.html).<br />
+An example virtual host configuration with WSGI:
+``` puppet
+apache::vhost { 'wsgi.example.com':
+  port                        => '80',
+  docroot                     => '/var/www/pythonapp',
+  wsgi_daemon_process         => 'wsgi',
+  wsgi_daemon_process_options =>
+    { processes    => '2',
+      threads      => '15',
+      display-name => '%{GROUP}',
+    },
+  wsgi_process_group          => 'wsgi',
+  wsgi_script_aliases         => { '/' => '/var/www/demo.wsgi' },
+  wsgi_chunked_request        => 'On',
+}
+```
+
+Default value: ``undef``
+
+##### <a name="wsgi_daemon_process_options"></a>`wsgi_daemon_process_options`
+
+Data type: `Optional[Hash]`
+
+Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
+wsgi_daemon_process, wsgi_process_group,
+wsgi_script_aliases and wsgi_pass_authorization.<br />
+Sets the group ID that the virtual host runs under.
+
+Default value: ``undef``
+
+##### <a name="wsgi_application_group"></a>`wsgi_application_group`
+
+Data type: `Any`
+
+Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
+wsgi_daemon_process, wsgi_daemon_process_options, wsgi_process_group,
+and wsgi_pass_authorization.<br />
+This parameter defines the [`WSGIApplicationGroup directive`](https://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIApplicationGroup.html),
+thus allowing you to specify which application group the WSGI application belongs to,
+with all WSGI applications within the same group executing within the context of the
+same Python sub interpreter.
+
+Default value: ``undef``
+
+##### <a name="wsgi_import_script"></a>`wsgi_import_script`
+
+Data type: `Any`
+
+Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
+wsgi_daemon_process, wsgi_daemon_process_options, wsgi_process_group,
+and wsgi_pass_authorization.<br />
+This parameter defines the [`WSGIImportScript directive`](https://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIImportScript.html),
+which can be used in order to specify a script file to be loaded upon a process starting.
+
+Default value: ``undef``
+
+##### <a name="wsgi_import_script_options"></a>`wsgi_import_script_options`
+
+Data type: `Optional[Hash]`
+
+Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
+wsgi_daemon_process, wsgi_daemon_process_options, wsgi_process_group,
+and wsgi_pass_authorization.<br />
+This parameter defines the [`WSGIImportScript directive`](https://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIImportScript.html),
+which can be used in order to specify a script file to be loaded upon a process starting.<br />
+Specifies the process and aplication groups of the script.
+
+Default value: ``undef``
+
+##### <a name="wsgi_chunked_request"></a>`wsgi_chunked_request`
+
+Data type: `Any`
+
+Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
+wsgi_daemon_process, wsgi_daemon_process_options, wsgi_process_group,
+and wsgi_pass_authorization.<br />
+This parameter defines the [`WSGIChunkedRequest directive`](https://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIChunkedRequest.html),
+allowing you to enable support for chunked request content.<br />
+WSGI is technically incapable of supporting chunked request content without all chunked
+request content having first been read in and buffered.
+
+Default value: ``undef``
+
+##### <a name="wsgi_process_group"></a>`wsgi_process_group`
+
+Data type: `Any`
+
+Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
+wsgi_daemon_process, wsgi_daemon_process_options,
+wsgi_script_aliases and wsgi_pass_authorization.<br />
+Requires a hash of web paths to filesystem `.wsgi paths/`.
+
+Default value: ``undef``
+
+##### <a name="wsgi_script_aliases"></a>`wsgi_script_aliases`
+
+Data type: `Optional[Hash]`
+
+Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
+wsgi_daemon_process, wsgi_daemon_process_options, wsgi_process_group,
+and wsgi_pass_authorization.<br />
+Uses the WSGI application to handle authorization instead of Apache when set to `On`.<br />
+For more information, see mod_wsgi's [WSGIPassAuthorization documentation](https://modwsgi.readthedocs.org/en/latest/configuration-directives/WSGIPassAuthorization.html).
+
+Default value: ``undef``
+
+##### <a name="wsgi_script_aliases_match"></a>`wsgi_script_aliases_match`
+
+Data type: `Optional[Hash]`
+
+Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
+wsgi_daemon_process, wsgi_daemon_process_options, wsgi_process_group,
+and wsgi_pass_authorization.<br />
+Uses the WSGI application to handle authorization instead of Apache when set to `On`.<br />
+This directive is similar to `wsgi_script_aliases`, but makes use of regular expressions
+in place of simple prefix matching.<br />
+For more information, see mod_wsgi's [WSGIPassAuthorization documentation](https://modwsgi.readthedocs.org/en/latest/configuration-directives/WSGIPassAuthorization.html).
+
+Default value: ``undef``
+
+##### <a name="wsgi_pass_authorization"></a>`wsgi_pass_authorization`
+
+Data type: `Optional[Enum['on', 'off', 'On', 'Off']]`
+
+Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
+wsgi_daemon_process, wsgi_daemon_process_options, wsgi_process_group and
+wsgi_script_aliases.<br />
+Enables support for chunked requests.
+
+Default value: ``undef``
+
+##### <a name="directories"></a>`directories`
+
+Data type: `Optional[Variant[Hash, Array[Variant[Array,Hash]]]]`
+
+The `directories` parameter within the `apache::vhost` class passes an array of hashes
+to the virtual host to create [Directory](https://httpd.apache.org/docs/current/mod/core.html#directory),
+[File](https://httpd.apache.org/docs/current/mod/core.html#files), and
+[Location](https://httpd.apache.org/docs/current/mod/core.html#location) directive blocks.
+These blocks take the form, `< Directory /path/to/directory>...< /Directory>`.<br />
+The `path` key sets the path for the directory, files, and location blocks. Its value
+must be a path for the `directory`, `files`, and `location` providers, or a regex for
+the `directorymatch`, `filesmatch`, or `locationmatch` providers. Each hash passed to
+`directories` **must** contain `path` as one of the keys.<br />
+The `provider` key is optional. If missing, this key defaults to `directory`.
+ Values: `directory`, `files`, `proxy`, `location`, `directorymatch`, `filesmatch`,
+`proxymatch` or `locationmatch`. If you set `provider` to `directorymatch`, it
+uses the keyword `DirectoryMatch` in the Apache config file.<br />
+An example use of `directories`:
+``` puppet
+apache::vhost { 'files.example.net':
+  docroot     => '/var/www/files',
+  directories => [
+    { 'path'     => '/var/www/files',
+      'provider' => 'files',
+      'deny'     => 'from all',
+    },
+  ],
+}
+```
+> **Note:** At least one directory should match the `docroot` parameter. After you
+start declaring directories, `apache::vhost` assumes that all required Directory blocks
+will be declared. If not defined, a single default Directory block is created that matches
+the `docroot` parameter.<br />
+Available handlers, represented as keys, should be placed within the `directory`,
+`files`, or `location` hashes. This looks like
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot     => '/path/to/directory',
+  directories => [ { path => '/path/to/directory', handler => value } ],
+}
+```
+Any handlers you do not set in these hashes are considered `undefined` within Puppet and
+are not added to the virtual host, resulting in the module using their default values.
+
+Default value: ``undef``
+
+##### <a name="custom_fragment"></a>`custom_fragment`
+
+Pass a string of custom configuration directives to be placed at the end of the directory
+configuration.
+``` puppet
+apache::vhost { 'monitor':
+  ...
+  directories => [
+    {
+      path => '/path/to/directory',
+      custom_fragment => '
+<Location /balancer-manager>
+  SetHandler balancer-manager
+  Order allow,deny
+  Allow from all
+</Location>
+<Location /server-status>
+  SetHandler server-status
+  Order allow,deny
+  Allow from all
+</Location>
+ProxyStatus On',
+    },
+  ]
+}
+```
+
+Default value: ``undef``
+
+##### <a name="error_documents"></a>`error_documents`
+
+An array of hashes used to override the [ErrorDocument](https://httpd.apache.org/docs/current/mod/core.html#errordocument)
+settings for the directory.
+``` puppet
+apache::vhost { 'sample.example.net':
+  directories => [
+    { path            => '/srv/www',
+      error_documents => [
+        { 'error_code' => '503',
+          'document'   => '/service-unavail',
+        },
+      ],
+    },
+  ],
+}
+```
+
+Default value: `[]`
+
+##### <a name="h2_copy_files"></a>`h2_copy_files`
+
+Sets the [H2CopyFiles](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2copyfiles) directive.<br />
+Note that you must declare `class {'apache::mod::http2': }` before using this directive.
+
+Default value: ``undef``
+
+##### <a name="h2_push_resource"></a>`h2_push_resource`
+
+Sets the [H2PushResource](https://httpd.apache.org/docs/current/mod/mod_http2.html#h2pushresource) directive.<br />
+Note that you must declare `class {'apache::mod::http2': }` before using this directive.
+
+Default value: `[]`
+
+##### <a name="headers"></a>`headers`
+
+Adds lines for [Header](https://httpd.apache.org/docs/current/mod/mod_headers.html#header) directives.
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot     => '/path/to/directory',
+  directories => {
+    path    => '/path/to/directory',
+    headers => 'Set X-Robots-Tag "noindex, noarchive, nosnippet"',
+  },
+}
+```
+
+Default value: ``undef``
+
+##### <a name="options"></a>`options`
+
+Lists the [Options](https://httpd.apache.org/docs/current/mod/core.html#options) for the
+given Directory block.
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot     => '/path/to/directory',
+  directories => [
+    { path    => '/path/to/directory',
+      options => ['Indexes','FollowSymLinks','MultiViews'],
+    },
+  ],
+}
+```
+
+Default value: `['Indexes','FollowSymLinks','MultiViews']`
+
+##### <a name="shib_compat_valid_user"></a>`shib_compat_valid_user`
+
+Data type: `Optional[String]`
+
+Default is Off, matching the behavior prior to this command's existence. Addresses a conflict
+when using Shibboleth in conjunction with other auth/auth modules by restoring `standard`
+Apache behavior when processing the `valid-user` and `user` Require rules. See the
+[`mod_shib`documentation](https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPApacheConfig#NativeSPApacheConfig-Server/VirtualHostOptions),
+and [NativeSPhtaccess](https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPhtaccess)
+topic for more details. This key is disabled if `apache::mod::shib` is not defined.
+
+Default value: ``undef``
+
+##### <a name="ssl_options"></a>`ssl_options`
+
+Data type: `Any`
+
+String or list of [SSLOptions](https://httpd.apache.org/docs/current/mod/mod_ssl.html#ssloptions),
+which configure SSL engine run-time options. This handler takes precedence over SSLOptions
+set in the parent block of the virtual host.
+``` puppet
+apache::vhost { 'secure.example.net':
+  docroot     => '/path/to/directory',
+  directories => [
+    { path        => '/path/to/directory',
+      ssl_options => '+ExportCertData',
+    },
+    { path        => '/path/to/different/dir',
+      ssl_options => ['-StdEnvVars', '+ExportCertData'],
+    },
+  ],
+}
+```
+
+Default value: ``undef``
+
+##### <a name="additional_includes"></a>`additional_includes`
+
+Specifies paths to additional static, specific Apache configuration files in virtual
+host directories.
+``` puppet
+apache::vhost { 'sample.example.net':
+  docroot     => '/path/to/directory',
+  directories => [
+    { path  => '/path/to/different/dir',
+      additional_includes => ['/custom/path/includes', '/custom/path/another_includes',],
+    },
+  ],
+}
+```
+
+Default value: `[]`
+
+##### <a name="gssapi"></a>`gssapi`
+
+Specfies mod_auth_gssapi parameters for particular directories in a virtual host directory
+```puppet
+ include apache::mod::auth_gssapi
+ apache::vhost { 'sample.example.net':
+   docroot     => '/path/to/directory',
+   directories => [
+     { path   => '/path/to/different/dir',
+       gssapi => {
+         credstore => 'keytab:/foo/bar.keytab',
+         localname => 'Off',
+         sslonly   => 'On',
+       }
+     },
+   ],
+ }
+ ```
+
+##### <a name="ssl"></a>`ssl`
+
+Data type: `Boolean`
+
+Enables SSL for the virtual host. SSL virtual hosts only respond to HTTPS queries.
+
+Default value: ``false``
+
+##### <a name="ssl_ca"></a>`ssl_ca`
+
+Data type: `Any`
+
+Specifies the SSL certificate authority to be used to verify client certificates used
+for authentication.
+
+Default value: `$apache::default_ssl_ca`
+
+##### <a name="ssl_cert"></a>`ssl_cert`
+
+Data type: `Any`
+
+Specifies the SSL certification.
+
+Default value: `$apache::default_ssl_cert`
+
+##### <a name="ssl_protocol"></a>`ssl_protocol`
+
+Data type: `Any`
+
+Specifies [SSLProtocol](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslprotocol).
+Expects an array or space separated string of accepted protocols.
+
+Default value: ``undef``
+
+##### <a name="ssl_cipher"></a>`ssl_cipher`
+
+Data type: `Any`
+
+Specifies [SSLCipherSuite](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslciphersuite).
+
+Default value: ``undef``
+
+##### <a name="ssl_honorcipherorder"></a>`ssl_honorcipherorder`
+
+Data type: `Variant[Boolean, Enum['on', 'On', 'off', 'Off'], Undef]`
+
+Sets [SSLHonorCipherOrder](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslhonorcipherorder),
+to cause Apache to use the server's preferred order of ciphers rather than the client's
+preferred order.
+
+Default value: ``undef``
+
+##### <a name="ssl_certs_dir"></a>`ssl_certs_dir`
+
+Data type: `Any`
+
+Specifies the location of the SSL certification directory to verify client certs.
+
+Default value: `$apache::params::ssl_certs_dir`
+
+##### <a name="ssl_chain"></a>`ssl_chain`
+
+Data type: `Any`
+
+Specifies the SSL chain. This default works out of the box, but it must be updated in
+the base `apache` class with your specific certificate information before being used in
+production.
+
+Default value: `$apache::default_ssl_chain`
+
+##### <a name="ssl_crl"></a>`ssl_crl`
+
+Data type: `Any`
+
+Specifies the certificate revocation list to use. (This default works out of the box but
+must be updated in the base `apache` class with your specific certificate information
+before being used in production.)
+
+Default value: `$apache::default_ssl_crl`
+
+##### <a name="ssl_crl_path"></a>`ssl_crl_path`
+
+Data type: `Any`
+
+Specifies the location of the certificate revocation list to verify certificates for
+client authentication with. (This default works out of the box but must be updated in
+the base `apache` class with your specific certificate information before being used in
+production.)
+
+Default value: `$apache::default_ssl_crl_path`
+
+##### <a name="ssl_crl_check"></a>`ssl_crl_check`
+
+Data type: `Any`
+
+Sets the certificate revocation check level via the [SSLCARevocationCheck directive](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslcarevocationcheck)
+for ssl client authentication. The default works out of the box but must be specified when
+using CRLs in production. Only applicable to Apache 2.4 or higher; the value is ignored on
+older versions.
+
+Default value: `$apache::default_ssl_crl_check`
+
+##### <a name="ssl_key"></a>`ssl_key`
+
+Data type: `Any`
+
+Specifies the SSL key.<br />
+Defaults are based on your operating system. Default work out of the box but must be
+updated in the base `apache` class with your specific certificate information before
+being used in production.
+
+Default value: `$apache::default_ssl_key`
+
+##### <a name="ssl_verify_client"></a>`ssl_verify_client`
+
+Data type: `Optional[Enum['none', 'optional', 'require', 'optional_no_ca']]`
+
+Sets the [SSLVerifyClient](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslverifyclient)
+directive, which sets the certificate verification level for client authentication.
+``` puppet
+apache::vhost { 'sample.example.net':
+  ...
+  ssl_verify_client => 'optional',
+}
+```
+
+Default value: ``undef``
+
+##### <a name="ssl_verify_depth"></a>`ssl_verify_depth`
+
+Data type: `Any`
+
+Sets the [SSLVerifyDepth](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslverifydepth)
+directive, which specifies the maximum depth of CA certificates in client certificate
+verification. You must set `ssl_verify_client` for it to take effect.
+``` puppet
+apache::vhost { 'sample.example.net':
+  ...
+  ssl_verify_client => 'require',
+  ssl_verify_depth => 1,
+}
+```
+
+Default value: ``undef``
+
+##### <a name="ssl_proxy_protocol"></a>`ssl_proxy_protocol`
+
+Data type: `Any`
+
+Sets the [SSLProxyProtocol](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxyprotocol)
+directive, which controls which SSL protocol flavors `mod_ssl` should use when establishing
+its server environment for proxy. It connects to servers using only one of the provided
+protocols.
+
+Default value: ``undef``
+
+##### <a name="ssl_proxy_verify"></a>`ssl_proxy_verify`
+
+Data type: `Optional[Enum['none', 'optional', 'require', 'optional_no_ca']]`
+
+Sets the [SSLProxyVerify](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxyverify)
+directive, which configures certificate verification of the remote server when a proxy is
+configured to forward requests to a remote SSL server.
+
+Default value: ``undef``
+
+##### <a name="ssl_proxy_verify_depth"></a>`ssl_proxy_verify_depth`
+
+Data type: `Optional[Integer[0]]`
+
+Sets the [SSLProxyVerifyDepth](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxyverifydepth)
+directive, which configures how deeply mod_ssl should verify before deciding that the
+remote server does not have a valid certificate.<br />
+A depth of 0 means that only self-signed remote server certificates are accepted,
+the default depth of 1 means the remote server certificate can be self-signed or
+signed by a CA that is directly known to the server.
+
+Default value: ``undef``
+
+##### <a name="ssl_proxy_cipher_suite"></a>`ssl_proxy_cipher_suite`
+
+Data type: `Any`
+
+Sets the [SSLProxyCipherSuite](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxyciphersuite)
+directive, which controls cipher suites supported for ssl proxy traffic.
+
+Default value: ``undef``
+
+##### <a name="ssl_proxy_ca_cert"></a>`ssl_proxy_ca_cert`
+
+Data type: `Any`
+
+Sets the [SSLProxyCACertificateFile](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxycacertificatefile)
+directive, which specifies an all-in-one file where you can assemble the Certificates
+of Certification Authorities (CA) whose remote servers you deal with. These are used
+for Remote Server Authentication. This file should be a concatenation of the PEM-encoded
+certificate files in order of preference.
+
+Default value: ``undef``
+
+##### <a name="ssl_proxy_machine_cert"></a>`ssl_proxy_machine_cert`
+
+Data type: `Any`
+
+Sets the [SSLProxyMachineCertificateFile](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxymachinecertificatefile)
+directive, which specifies an all-in-one file where you keep the certs and keys used
+for this server to authenticate itself to remote servers. This file should be a
+concatenation of the PEM-encoded certificate files in order of preference.
+``` puppet
+apache::vhost { 'sample.example.net':
+  ...
+  ssl_proxy_machine_cert => '/etc/httpd/ssl/client_certificate.pem',
+}
+```
+
+Default value: ``undef``
+
+##### <a name="ssl_proxy_machine_cert_chain"></a>`ssl_proxy_machine_cert_chain`
+
+Data type: `Any`
+
+Sets the [SSLProxyMachineCertificateChainFile](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxymachinecertificatechainfile)
+directive, which specifies an all-in-one file where you keep the certificate chain for
+all of the client certs in use. This directive will be needed if the remote server
+presents a list of CA certificates that are not direct signers of one of the configured
+client certificates. This referenced file is simply the concatenation of the various
+PEM-encoded certificate files. Upon startup, each client certificate configured will be
+examined and a chain of trust will be constructed.
+
+Default value: ``undef``
+
+##### <a name="ssl_proxy_check_peer_cn"></a>`ssl_proxy_check_peer_cn`
+
+Data type: `Optional[Enum['on', 'off']]`
+
+Sets the [SSLProxyCheckPeerCN](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxycheckpeercn)
+directive, which specifies whether the remote server certificate's CN field is compared
+against the hostname of the request URL.
+
+Default value: ``undef``
+
+##### <a name="ssl_proxy_check_peer_name"></a>`ssl_proxy_check_peer_name`
+
+Data type: `Optional[Enum['on', 'off']]`
+
+Sets the [SSLProxyCheckPeerName](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxycheckpeername)
+directive, which specifies whether the remote server certificate's CN field is compared
+against the hostname of the request URL.
+
+Default value: ``undef``
+
+##### <a name="ssl_proxy_check_peer_expire"></a>`ssl_proxy_check_peer_expire`
+
+Data type: `Optional[Enum['on', 'off']]`
+
+Sets the [SSLProxyCheckPeerExpire](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxycheckpeerexpire)
+directive, which specifies whether the remote server certificate is checked for expiration
+or not.
+
+Default value: ``undef``
+
+##### <a name="ssl_options"></a>`ssl_options`
+
+Sets the [SSLOptions](https://httpd.apache.org/docs/current/mod/mod_ssl.html#ssloptions)
+directive, which configures various SSL engine run-time options. This is the global
+setting for the given virtual host and can be a string or an array.<br />
+A string:
+``` puppet
+apache::vhost { 'sample.example.net':
+  ...
+  ssl_options => '+ExportCertData',
+}
+```
+An array:
+``` puppet
+apache::vhost { 'sample.example.net':
+  ...
+  ssl_options => ['+StrictRequire', '+ExportCertData'],
+}
+```
+
+Default value: ``undef``
+
+##### <a name="ssl_openssl_conf_cmd"></a>`ssl_openssl_conf_cmd`
+
+Data type: `Any`
+
+Sets the [SSLOpenSSLConfCmd](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslopensslconfcmd)
+directive, which provides direct configuration of OpenSSL parameters.
+
+Default value: ``undef``
+
+##### <a name="ssl_proxyengine"></a>`ssl_proxyengine`
+
+Data type: `Boolean`
+
+Specifies whether or not to use [SSLProxyEngine](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslproxyengine).
+
+Default value: ``false``
+
+##### <a name="ssl_stapling"></a>`ssl_stapling`
+
+Data type: `Optional[Boolean]`
+
+Specifies whether or not to use [SSLUseStapling](http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslusestapling).
+By default, uses what is set globally.<br />
+This parameter only applies to Apache 2.4 or higher and is ignored on older versions.
+
+Default value: ``undef``
+
+##### <a name="ssl_stapling_timeout"></a>`ssl_stapling_timeout`
+
+Data type: `Any`
+
+Can be used to set the [SSLStaplingResponderTimeout](http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslstaplingrespondertimeout) directive.<br />
+This parameter only applies to Apache 2.4 or higher and is ignored on older versions.
+
+Default value: ``undef``
+
+##### <a name="ssl_stapling_return_errors"></a>`ssl_stapling_return_errors`
+
+Data type: `Any`
+
+Can be used to set the [SSLStaplingReturnResponderErrors](http://httpd.apache.org/docs/current/mod/mod_ssl.html#sslstaplingreturnrespondererrors) directive.<br />
+This parameter only applies to Apache 2.4 or higher and is ignored on older versions.
+
+Default value: ``undef``
+
+##### <a name="ssl_user_name"></a>`ssl_user_name`
+
+Data type: `Optional[String]`
+
+Sets the [SSLUserName](https://httpd.apache.org/docs/current/mod/mod_ssl.html#sslusername) directive.
+
+Default value: ``undef``
+
+##### <a name="use_canonical_name"></a>`use_canonical_name`
+
+Data type: `Optional[Enum['On', 'on', 'Off', 'off', 'DNS', 'dns']]`
+
+Specifies whether to use the [`UseCanonicalName directive`](https://httpd.apache.org/docs/2.4/mod/core.html#usecanonicalname),
+which allows you to configure how the server determines it's own name and port.
+
+Default value: ``undef``
+
+##### <a name="define"></a>`define`
+
+Data type: `Hash`
+
+this lets you define configuration variables inside a vhost using [`Define`](https://httpd.apache.org/docs/2.4/mod/core.html#define),
+these can then be used to replace configuration values. All Defines are Undefined at the end of the VirtualHost.
+
+Default value: `{}`
+
+##### <a name="auth_oidc"></a>`auth_oidc`
+
+Data type: `Boolean`
+
+Enable `mod_auth_openidc` parameters for OpenID Connect authentication.
+
+Default value: ``false``
+
+##### <a name="oidc_settings"></a>`oidc_settings`
+
+Data type: `Optional[Apache::OIDCSettings]`
+
+An Apache::OIDCSettings Struct containing (mod_auth_openidc settings)[https://github.com/zmartzone/mod_auth_openidc/blob/master/auth_openidc.conf].
+
+Default value: ``undef``
+
+##### <a name="limitreqfields"></a>`limitreqfields`
+
+Data type: `Optional[Integer]`
+
+The `limitreqfields` parameter sets the maximum number of request header fields in
+an HTTP request. This directive gives the server administrator greater control over
+abnormal client request behavior, which may be useful for avoiding some forms of
+denial-of-service attacks. The value should be increased if normal clients see an error
+response from the server that indicates too many fields were sent in the request.
+
+Default value: ``undef``
+
+##### <a name="limitreqfieldsize"></a>`limitreqfieldsize`
+
+Data type: `Optional[Integer]`
+
+The `limitreqfieldsize` parameter sets the maximum ammount of _bytes_ that will
+be allowed within a request header.
+
+Default value: ``undef``
+
+##### <a name="limitreqline"></a>`limitreqline`
+
+Data type: `Optional[Integer]`
+
+Limit the size of the HTTP request line that will be accepted from the client
+This directive sets the number of bytes that will be allowed on the HTTP
+request-line. The LimitRequestLine directive allows the server administrator
+to set the limit on the allowed size of a client's HTTP request-line. Since
+the request-line consists of the HTTP method, URI, and protocol version, the
+LimitRequestLine directive places a restriction on the length of a request-URI
+allowed for a request on the server. A server needs this value to be large
+enough to hold any of its resource names, including any information that might
+be passed in the query part of a GET request.
+
+Default value: ``undef``
+
+##### <a name="limitreqbody"></a>`limitreqbody`
+
+Data type: `Optional[Integer]`
+
+Restricts the total size of the HTTP request body sent from the client
+The LimitRequestBody directive allows the user to set a limit on the allowed
+size of an HTTP request message body within the context in which the
+directive is given (server, per-directory, per-file or per-location). If the
+client request exceeds that limit, the server will return an error response
+instead of servicing the request.
+
+Default value: ``undef``
+
+##### <a name="$use_servername_for_filenames"></a>`$use_servername_for_filenames`
+
+When set to true, default log / config file names will be derived from the sanitized
+value of the $servername parameter.
+When set to false (default), the existing behaviour of using the $name parameter
+will remain.
+
+##### <a name="$use_port_for_filenames"></a>`$use_port_for_filenames`
+
+When set to true and use_servername_for_filenames is also set to true, default log /
+config file names will be derived from the sanitized value of both the $servername and
+$port parameters.
+When set to false (default), the port is not included in the file names and may lead to
+duplicate declarations if two virtual hosts use the same domain.
+
+##### <a name="$mdomain"></a>`$mdomain`
+
+All the names in the list are managed as one Managed Domain (MD). mod_md will request
+one single certificate that is valid for all these names.
 
 ##### <a name="use_servername_for_filenames"></a>`use_servername_for_filenames`
 
@@ -8289,205 +10749,6 @@ Data type: `Optional[Boolean]`
 
 Default value: ``false``
 
-##### <a name="aliases"></a>`aliases`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="directories"></a>`directories`
-
-Data type: `Optional[Variant[Hash, Array[Variant[Array,Hash]]]]`
-
-
-
-Default value: ``undef``
-
-##### <a name="error_log"></a>`error_log`
-
-Data type: `Boolean`
-
-
-
-Default value: ``true``
-
-##### <a name="error_log_file"></a>`error_log_file`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="error_log_pipe"></a>`error_log_pipe`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="error_log_syslog"></a>`error_log_syslog`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="error_log_format"></a>`error_log_format`
-
-Data type: `Optional[
-    Array[
-      Variant[
-        String,
-        Hash[String, Enum['connection', 'request']]
-      ]
-    ]
-  ]`
-
-
-
-Default value: ``undef``
-
-##### <a name="http_protocol_options"></a>`http_protocol_options`
-
-Data type: `Optional[Pattern[/^((Strict|Unsafe)?\s*(\b(Registered|Lenient)Methods)?\s*(\b(Allow0\.9|Require1\.0))?)$/]]`
-
-
-
-Default value: ``undef``
-
-##### <a name="modsec_audit_log"></a>`modsec_audit_log`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="modsec_audit_log_file"></a>`modsec_audit_log_file`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="modsec_audit_log_pipe"></a>`modsec_audit_log_pipe`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="error_documents"></a>`error_documents`
-
-Data type: `Any`
-
-
-
-Default value: `[]`
-
-##### <a name="fallbackresource"></a>`fallbackresource`
-
-Data type: `Optional[Variant[Stdlib::Absolutepath, Enum['disabled']]]`
-
-
-
-Default value: ``undef``
-
-##### <a name="scriptalias"></a>`scriptalias`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="scriptaliases"></a>`scriptaliases`
-
-Data type: `Any`
-
-
-
-Default value: `[]`
-
-##### <a name="limitreqfieldsize"></a>`limitreqfieldsize`
-
-Data type: `Optional[Integer]`
-
-
-
-Default value: ``undef``
-
-##### <a name="limitreqfields"></a>`limitreqfields`
-
-Data type: `Optional[Integer]`
-
-
-
-Default value: ``undef``
-
-##### <a name="limitreqline"></a>`limitreqline`
-
-Data type: `Optional[Integer]`
-
-
-
-Default value: ``undef``
-
-##### <a name="limitreqbody"></a>`limitreqbody`
-
-Data type: `Optional[Integer]`
-
-
-
-Default value: ``undef``
-
-##### <a name="proxy_dest"></a>`proxy_dest`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="proxy_dest_match"></a>`proxy_dest_match`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="proxy_dest_reverse_match"></a>`proxy_dest_reverse_match`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="proxy_pass"></a>`proxy_pass`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="proxy_pass_match"></a>`proxy_pass_match`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
 ##### <a name="proxy_requests"></a>`proxy_requests`
 
 Data type: `Boolean`
@@ -8495,1198 +10756,6 @@ Data type: `Boolean`
 
 
 Default value: ``false``
-
-##### <a name="suphp_addhandler"></a>`suphp_addhandler`
-
-Data type: `Any`
-
-
-
-Default value: `$apache::params::suphp_addhandler`
-
-##### <a name="suphp_engine"></a>`suphp_engine`
-
-Data type: `Enum['on', 'off']`
-
-
-
-Default value: `$apache::params::suphp_engine`
-
-##### <a name="suphp_configpath"></a>`suphp_configpath`
-
-Data type: `Any`
-
-
-
-Default value: `$apache::params::suphp_configpath`
-
-##### <a name="php_flags"></a>`php_flags`
-
-Data type: `Any`
-
-
-
-Default value: `{}`
-
-##### <a name="php_values"></a>`php_values`
-
-Data type: `Any`
-
-
-
-Default value: `{}`
-
-##### <a name="php_admin_flags"></a>`php_admin_flags`
-
-Data type: `Any`
-
-
-
-Default value: `{}`
-
-##### <a name="php_admin_values"></a>`php_admin_values`
-
-Data type: `Any`
-
-
-
-Default value: `{}`
-
-##### <a name="no_proxy_uris"></a>`no_proxy_uris`
-
-Data type: `Any`
-
-
-
-Default value: `[]`
-
-##### <a name="no_proxy_uris_match"></a>`no_proxy_uris_match`
-
-Data type: `Any`
-
-
-
-Default value: `[]`
-
-##### <a name="proxy_preserve_host"></a>`proxy_preserve_host`
-
-Data type: `Any`
-
-
-
-Default value: ``false``
-
-##### <a name="proxy_add_headers"></a>`proxy_add_headers`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="proxy_error_override"></a>`proxy_error_override`
-
-Data type: `Any`
-
-
-
-Default value: ``false``
-
-##### <a name="redirect_source"></a>`redirect_source`
-
-Data type: `Any`
-
-
-
-Default value: `'/'`
-
-##### <a name="redirect_dest"></a>`redirect_dest`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="redirect_status"></a>`redirect_status`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="redirectmatch_status"></a>`redirectmatch_status`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="redirectmatch_regexp"></a>`redirectmatch_regexp`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="redirectmatch_dest"></a>`redirectmatch_dest`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="headers"></a>`headers`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="request_headers"></a>`request_headers`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="filters"></a>`filters`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="rewrites"></a>`rewrites`
-
-Data type: `Optional[Array]`
-
-
-
-Default value: ``undef``
-
-##### <a name="rewrite_base"></a>`rewrite_base`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="rewrite_rule"></a>`rewrite_rule`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="rewrite_cond"></a>`rewrite_cond`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="rewrite_inherit"></a>`rewrite_inherit`
-
-Data type: `Any`
-
-
-
-Default value: ``false``
-
-##### <a name="setenv"></a>`setenv`
-
-Data type: `Any`
-
-
-
-Default value: `[]`
-
-##### <a name="setenvif"></a>`setenvif`
-
-Data type: `Any`
-
-
-
-Default value: `[]`
-
-##### <a name="setenvifnocase"></a>`setenvifnocase`
-
-Data type: `Any`
-
-
-
-Default value: `[]`
-
-##### <a name="block"></a>`block`
-
-Data type: `Any`
-
-
-
-Default value: `[]`
-
-##### <a name="ensure"></a>`ensure`
-
-Data type: `Enum['absent', 'present']`
-
-
-
-Default value: `'present'`
-
-##### <a name="wsgi_application_group"></a>`wsgi_application_group`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="wsgi_daemon_process"></a>`wsgi_daemon_process`
-
-Data type: `Optional[Variant[String,Hash]]`
-
-
-
-Default value: ``undef``
-
-##### <a name="wsgi_daemon_process_options"></a>`wsgi_daemon_process_options`
-
-Data type: `Optional[Hash]`
-
-
-
-Default value: ``undef``
-
-##### <a name="wsgi_import_script"></a>`wsgi_import_script`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="wsgi_import_script_options"></a>`wsgi_import_script_options`
-
-Data type: `Optional[Hash]`
-
-
-
-Default value: ``undef``
-
-##### <a name="wsgi_process_group"></a>`wsgi_process_group`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="wsgi_script_aliases_match"></a>`wsgi_script_aliases_match`
-
-Data type: `Optional[Hash]`
-
-
-
-Default value: ``undef``
-
-##### <a name="wsgi_script_aliases"></a>`wsgi_script_aliases`
-
-Data type: `Optional[Hash]`
-
-
-
-Default value: ``undef``
-
-##### <a name="wsgi_pass_authorization"></a>`wsgi_pass_authorization`
-
-Data type: `Optional[Enum['on', 'off', 'On', 'Off']]`
-
-
-
-Default value: ``undef``
-
-##### <a name="wsgi_chunked_request"></a>`wsgi_chunked_request`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="custom_fragment"></a>`custom_fragment`
-
-Data type: `Optional[String]`
-
-
-
-Default value: ``undef``
-
-##### <a name="itk"></a>`itk`
-
-Data type: `Optional[Hash]`
-
-
-
-Default value: ``undef``
-
-##### <a name="action"></a>`action`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="fastcgi_server"></a>`fastcgi_server`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="fastcgi_socket"></a>`fastcgi_socket`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="fastcgi_dir"></a>`fastcgi_dir`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="fastcgi_idle_timeout"></a>`fastcgi_idle_timeout`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="additional_includes"></a>`additional_includes`
-
-Data type: `Any`
-
-
-
-Default value: `[]`
-
-##### <a name="use_optional_includes"></a>`use_optional_includes`
-
-Data type: `Any`
-
-
-
-Default value: `$apache::use_optional_includes`
-
-##### <a name="apache_version"></a>`apache_version`
-
-Data type: `Any`
-
-
-
-Default value: `$apache::apache_version`
-
-##### <a name="allow_encoded_slashes"></a>`allow_encoded_slashes`
-
-Data type: `Optional[Enum['on', 'off', 'nodecode']]`
-
-
-
-Default value: ``undef``
-
-##### <a name="suexec_user_group"></a>`suexec_user_group`
-
-Data type: `Optional[Pattern[/^[\w-]+ [\w-]+$/]]`
-
-
-
-Default value: ``undef``
-
-##### <a name="h2_copy_files"></a>`h2_copy_files`
-
-Data type: `Optional[Boolean]`
-
-
-
-Default value: ``undef``
-
-##### <a name="h2_direct"></a>`h2_direct`
-
-Data type: `Optional[Boolean]`
-
-
-
-Default value: ``undef``
-
-##### <a name="h2_early_hints"></a>`h2_early_hints`
-
-Data type: `Optional[Boolean]`
-
-
-
-Default value: ``undef``
-
-##### <a name="h2_max_session_streams"></a>`h2_max_session_streams`
-
-Data type: `Optional[Integer]`
-
-
-
-Default value: ``undef``
-
-##### <a name="h2_modern_tls_only"></a>`h2_modern_tls_only`
-
-Data type: `Optional[Boolean]`
-
-
-
-Default value: ``undef``
-
-##### <a name="h2_push"></a>`h2_push`
-
-Data type: `Optional[Boolean]`
-
-
-
-Default value: ``undef``
-
-##### <a name="h2_push_diary_size"></a>`h2_push_diary_size`
-
-Data type: `Optional[Integer]`
-
-
-
-Default value: ``undef``
-
-##### <a name="h2_push_priority"></a>`h2_push_priority`
-
-Data type: `Array[String]`
-
-
-
-Default value: `[]`
-
-##### <a name="h2_push_resource"></a>`h2_push_resource`
-
-Data type: `Array[String]`
-
-
-
-Default value: `[]`
-
-##### <a name="h2_serialize_headers"></a>`h2_serialize_headers`
-
-Data type: `Optional[Boolean]`
-
-
-
-Default value: ``undef``
-
-##### <a name="h2_stream_max_mem_size"></a>`h2_stream_max_mem_size`
-
-Data type: `Optional[Integer]`
-
-
-
-Default value: ``undef``
-
-##### <a name="h2_tls_cool_down_secs"></a>`h2_tls_cool_down_secs`
-
-Data type: `Optional[Integer]`
-
-
-
-Default value: ``undef``
-
-##### <a name="h2_tls_warm_up_size"></a>`h2_tls_warm_up_size`
-
-Data type: `Optional[Integer]`
-
-
-
-Default value: ``undef``
-
-##### <a name="h2_upgrade"></a>`h2_upgrade`
-
-Data type: `Optional[Boolean]`
-
-
-
-Default value: ``undef``
-
-##### <a name="h2_window_size"></a>`h2_window_size`
-
-Data type: `Optional[Integer]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_enabled"></a>`passenger_enabled`
-
-Data type: `Optional[Boolean]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_base_uri"></a>`passenger_base_uri`
-
-Data type: `Optional[String]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_ruby"></a>`passenger_ruby`
-
-Data type: `Optional[Stdlib::Absolutepath]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_python"></a>`passenger_python`
-
-Data type: `Optional[Stdlib::Absolutepath]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_nodejs"></a>`passenger_nodejs`
-
-Data type: `Optional[Stdlib::Absolutepath]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_meteor_app_settings"></a>`passenger_meteor_app_settings`
-
-Data type: `Optional[String]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_app_env"></a>`passenger_app_env`
-
-Data type: `Optional[String]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_app_root"></a>`passenger_app_root`
-
-Data type: `Optional[Stdlib::Absolutepath]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_app_group_name"></a>`passenger_app_group_name`
-
-Data type: `Optional[String]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_app_start_command"></a>`passenger_app_start_command`
-
-Data type: `Optional[String]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_app_type"></a>`passenger_app_type`
-
-Data type: `Optional[Enum['meteor', 'node', 'rack', 'wsgi']]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_startup_file"></a>`passenger_startup_file`
-
-Data type: `Optional[String]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_restart_dir"></a>`passenger_restart_dir`
-
-Data type: `Optional[String]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_spawn_method"></a>`passenger_spawn_method`
-
-Data type: `Optional[Enum['direct', 'smart']]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_load_shell_envvars"></a>`passenger_load_shell_envvars`
-
-Data type: `Optional[Boolean]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_rolling_restarts"></a>`passenger_rolling_restarts`
-
-Data type: `Optional[Boolean]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_resist_deployment_errors"></a>`passenger_resist_deployment_errors`
-
-Data type: `Optional[Boolean]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_user"></a>`passenger_user`
-
-Data type: `Optional[String]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_group"></a>`passenger_group`
-
-Data type: `Optional[String]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_friendly_error_pages"></a>`passenger_friendly_error_pages`
-
-Data type: `Optional[Boolean]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_min_instances"></a>`passenger_min_instances`
-
-Data type: `Optional[Integer]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_max_instances"></a>`passenger_max_instances`
-
-Data type: `Optional[Integer]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_max_preloader_idle_time"></a>`passenger_max_preloader_idle_time`
-
-Data type: `Optional[Integer]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_force_max_concurrent_requests_per_process"></a>`passenger_force_max_concurrent_requests_per_process`
-
-Data type: `Optional[Integer]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_start_timeout"></a>`passenger_start_timeout`
-
-Data type: `Optional[Integer]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_concurrency_model"></a>`passenger_concurrency_model`
-
-Data type: `Optional[Enum['process', 'thread']]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_thread_count"></a>`passenger_thread_count`
-
-Data type: `Optional[Integer]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_max_requests"></a>`passenger_max_requests`
-
-Data type: `Optional[Integer]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_max_request_time"></a>`passenger_max_request_time`
-
-Data type: `Optional[Integer]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_memory_limit"></a>`passenger_memory_limit`
-
-Data type: `Optional[Integer]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_stat_throttle_rate"></a>`passenger_stat_throttle_rate`
-
-Data type: `Optional[Integer]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_pre_start"></a>`passenger_pre_start`
-
-Data type: `Optional[Variant[String,Array[String]]]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_high_performance"></a>`passenger_high_performance`
-
-Data type: `Optional[Boolean]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_buffer_upload"></a>`passenger_buffer_upload`
-
-Data type: `Optional[Boolean]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_buffer_response"></a>`passenger_buffer_response`
-
-Data type: `Optional[Boolean]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_error_override"></a>`passenger_error_override`
-
-Data type: `Optional[Boolean]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_max_request_queue_size"></a>`passenger_max_request_queue_size`
-
-Data type: `Optional[Integer]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_max_request_queue_time"></a>`passenger_max_request_queue_time`
-
-Data type: `Optional[Integer]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_sticky_sessions"></a>`passenger_sticky_sessions`
-
-Data type: `Optional[Boolean]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_sticky_sessions_cookie_name"></a>`passenger_sticky_sessions_cookie_name`
-
-Data type: `Optional[String]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_sticky_sessions_cookie_attributes"></a>`passenger_sticky_sessions_cookie_attributes`
-
-Data type: `Optional[String]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_allow_encoded_slashes"></a>`passenger_allow_encoded_slashes`
-
-Data type: `Optional[Boolean]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_app_log_file"></a>`passenger_app_log_file`
-
-Data type: `Optional[String]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_debugger"></a>`passenger_debugger`
-
-Data type: `Optional[Boolean]`
-
-
-
-Default value: ``undef``
-
-##### <a name="passenger_lve_min_uid"></a>`passenger_lve_min_uid`
-
-Data type: `Optional[Integer]`
-
-
-
-Default value: ``undef``
-
-##### <a name="add_default_charset"></a>`add_default_charset`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="modsec_disable_vhost"></a>`modsec_disable_vhost`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="modsec_disable_ids"></a>`modsec_disable_ids`
-
-Data type: `Optional[Variant[Hash, Array]]`
-
-
-
-Default value: ``undef``
-
-##### <a name="modsec_disable_ips"></a>`modsec_disable_ips`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="modsec_disable_msgs"></a>`modsec_disable_msgs`
-
-Data type: `Optional[Variant[Hash, Array]]`
-
-
-
-Default value: ``undef``
-
-##### <a name="modsec_disable_tags"></a>`modsec_disable_tags`
-
-Data type: `Optional[Variant[Hash, Array]]`
-
-
-
-Default value: ``undef``
-
-##### <a name="modsec_body_limit"></a>`modsec_body_limit`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="jk_mounts"></a>`jk_mounts`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="auth_kerb"></a>`auth_kerb`
-
-Data type: `Boolean`
-
-
-
-Default value: ``false``
-
-##### <a name="krb_method_negotiate"></a>`krb_method_negotiate`
-
-Data type: `Any`
-
-
-
-Default value: `'on'`
-
-##### <a name="krb_method_k5passwd"></a>`krb_method_k5passwd`
-
-Data type: `Any`
-
-
-
-Default value: `'on'`
-
-##### <a name="krb_authoritative"></a>`krb_authoritative`
-
-Data type: `Any`
-
-
-
-Default value: `'on'`
-
-##### <a name="krb_auth_realms"></a>`krb_auth_realms`
-
-Data type: `Any`
-
-
-
-Default value: `[]`
-
-##### <a name="krb_5keytab"></a>`krb_5keytab`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="krb_local_user_mapping"></a>`krb_local_user_mapping`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="krb_verify_kdc"></a>`krb_verify_kdc`
-
-Data type: `Any`
-
-
-
-Default value: `'on'`
-
-##### <a name="krb_servicename"></a>`krb_servicename`
-
-Data type: `Any`
-
-
-
-Default value: `'HTTP'`
-
-##### <a name="krb_save_credentials"></a>`krb_save_credentials`
-
-Data type: `Any`
-
-
-
-Default value: `'off'`
-
-##### <a name="keepalive"></a>`keepalive`
-
-Data type: `Optional[Enum['on', 'off']]`
-
-
-
-Default value: ``undef``
-
-##### <a name="keepalive_timeout"></a>`keepalive_timeout`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="max_keepalive_requests"></a>`max_keepalive_requests`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="cas_attribute_prefix"></a>`cas_attribute_prefix`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="cas_attribute_delimiter"></a>`cas_attribute_delimiter`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="cas_root_proxied_as"></a>`cas_root_proxied_as`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="cas_scrub_request_headers"></a>`cas_scrub_request_headers`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="cas_sso_enabled"></a>`cas_sso_enabled`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="cas_login_url"></a>`cas_login_url`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="cas_validate_url"></a>`cas_validate_url`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="cas_validate_saml"></a>`cas_validate_saml`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="cas_cookie_path"></a>`cas_cookie_path`
-
-Data type: `Any`
-
-
-
-Default value: ``undef``
-
-##### <a name="shib_compat_valid_user"></a>`shib_compat_valid_user`
-
-Data type: `Optional[String]`
-
-
-
-Default value: ``undef``
-
-##### <a name="use_canonical_name"></a>`use_canonical_name`
-
-Data type: `Optional[Enum['On', 'on', 'Off', 'off', 'DNS', 'dns']]`
-
-
-
-Default value: ``undef``
-
-##### <a name="comment"></a>`comment`
-
-Data type: `Optional[Variant[String,Array[String]]]`
-
-
-
-Default value: ``undef``
-
-##### <a name="define"></a>`define`
-
-Data type: `Hash`
-
-
-
-Default value: `{}`
-
-##### <a name="auth_oidc"></a>`auth_oidc`
-
-Data type: `Boolean`
-
-
-
-Default value: ``false``
-
-##### <a name="oidc_settings"></a>`oidc_settings`
-
-Data type: `Optional[Apache::OIDCSettings]`
-
-
-
-Default value: ``undef``
 
 ##### <a name="mdomain"></a>`mdomain`
 

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1739,7 +1739,6 @@
 # @param $mdomain
 #   All the names in the list are managed as one Managed Domain (MD). mod_md will request
 #   one single certificate that is valid for all these names.
-
 define apache::vhost (
   Variant[Boolean,String] $docroot,
   $manage_docroot                                                                   = true,


### PR DESCRIPTION
With this empty line between the commend and the define, puppet-strings doesn't consider the comment as a documentation string. That means all the documentation that is written doesn't show up in REFERENCE.md.

I can't regenerate REFERENCE.md due to a missing puppet-module-posix-default-r3.0 gem so somebody else has to do that.

It was found in https://github.com/puppetlabs/puppetlabs-apache/pull/2157/files#r663838497 and introduced in 7e233fe7cc108605384506f11083aeea6e3a2464.