### PR TITLE
(MODULES-10899) Load php module with the right libphp file

### DIFF
--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -67,7 +67,10 @@ class apache::mod::php (
     $_lib = "librh-php${_php_version_no_dot}-php${_php_major}.so"
   } else {
     # Controls php version and libphp prefix
-    $_lib = "${libphp_prefix}${php_version}.so"
+    $_lib = $_php_major ? {
+      '8'     => "${libphp_prefix}.so",
+      default => "${libphp_prefix}${php_version}.so",
+    }
   }
   $_module_id = $_php_major ? {
     '5'     => 'php5_module',

--- a/spec/classes/mod/php_spec.rb
+++ b/spec/classes/mod/php_spec.rb
@@ -72,7 +72,7 @@ describe 'apache::mod::php', type: :class do
               it { is_expected.to contain_package('libapache2-mod-php8.0') }
               it {
                 is_expected.to contain_file('php.load').with(
-                  content: "LoadModule php_module /usr/lib/apache2/modules/libphp8.0.so\n",
+                  content: "LoadModule php_module /usr/lib/apache2/modules/libphp.so\n",
                 )
               }
             end


### PR DESCRIPTION
Request for a review
The configuration file is updated in the required format for php_version 8 (/etc/httpd/conf.modules.d/php.load)
` LoadModule php_module modules/libphp.so`
Unit tests are updated to reflect the change.