### PR TITLE
Add an apache::vhost::proxy define

### DIFF
--- a/manifests/vhost/custom.pp
+++ b/manifests/vhost/custom.pp
@@ -18,7 +18,7 @@
 define apache::vhost::custom (
   $content,
   $ensure = 'present',
-  $priority = '25',
+  Variant[Integer,String,Boolean] $priority = '25',
   $verify_config = true,
 ) {
   include apache

--- a/manifests/vhost/fragment.pp
+++ b/manifests/vhost/fragment.pp
@@ -56,7 +56,7 @@
 define apache::vhost::fragment (
   String[1] $vhost,
   Optional[Integer[0]] $port = undef,
-  $priority = undef,
+  Optional[Variant[Integer,String,Boolean]] $priority = undef,
   Optional[String] $content = undef,
   Integer[0] $order = 900,
 ) {

--- a/manifests/vhost/proxy.pp
+++ b/manifests/vhost/proxy.pp
@@ -106,7 +106,7 @@
 #
 define apache::vhost::proxy (
   String[1] $vhost,
-  $priority = undef,
+  Optional[Variant[Integer,String,Boolean]] $priority = undef,
   Integer[0] $order = 170,
   Optional[Stdlib::Port] $port = undef,
   Optional[String[1]] $proxy_dest = undef,

--- a/manifests/vhost/proxy.pp
+++ b/manifests/vhost/proxy.pp
@@ -1,0 +1,81 @@
+# @summary Configure a reverse reverse proxy for a vhost
+#
+# @param proxy_dest
+#   Specifies the destination address of a [ProxyPass](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypass) configuration.
+#
+# @param proxy_pass
+#   Specifies an array of `path => URI` values for a [ProxyPass](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypass)
+#   configuration. Optionally, parameters can be added as an array.
+#   ``` puppet
+#   apache::vhost { 'site.name.fdqn':
+#     …
+#     proxy_pass => [
+#       { 'path' => '/a', 'url' => 'http://backend-a/' },
+#       { 'path' => '/b', 'url' => 'http://backend-b/' },
+#       { 'path' => '/c', 'url' => 'http://backend-a/c', 'params' => {'max'=>20, 'ttl'=>120, 'retry'=>300}},
+#       { 'path' => '/l', 'url' => 'http://backend-xy',
+#         'reverse_urls' => ['http://backend-x', 'http://backend-y'] },
+#       { 'path' => '/d', 'url' => 'http://backend-a/d',
+#         'params' => { 'retry' => '0', 'timeout' => '5' }, },
+#       { 'path' => '/e', 'url' => 'http://backend-a/e',
+#         'keywords' => ['nocanon', 'interpolate'] },
+#       { 'path' => '/f', 'url' => 'http://backend-f/',
+#         'setenv' => ['proxy-nokeepalive 1','force-proxy-request-1.0 1']},
+#       { 'path' => '/g', 'url' => 'http://backend-g/',
+#         'reverse_cookies' => [{'path' => '/g', 'url' => 'http://backend-g/',}, {'domain' => 'http://backend-g', 'url' => 'http:://backend-g',},], },
+#       { 'path' => '/h', 'url' => 'http://backend-h/h',
+#         'no_proxy_uris' => ['/h/admin', '/h/server-status'] },
+#     ],
+#   }
+#   ```
+#   * `reverse_urls`. *Optional.* This setting is useful when used with `mod_proxy_balancer`. Values: an array or string.
+#   * `reverse_cookies`. *Optional.* Sets `ProxyPassReverseCookiePath` and `ProxyPassReverseCookieDomain`.
+#   * `params`. *Optional.* Allows for ProxyPass key-value parameters, such as connection settings.
+#   * `setenv`. *Optional.* Sets [environment variables](https://httpd.apache.org/docs/current/mod/mod_proxy.html#envsettings) for the proxy directive. Values: array.
+#
+# @param proxy_dest_match
+#   This directive is equivalent to `proxy_dest`, but takes regular expressions, see
+#   [ProxyPassMatch](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassmatch)
+#   for details.
+#
+# @param proxy_dest_reverse_match
+#   Allows you to pass a ProxyPassReverse if `proxy_dest_match` is specified. See
+#   [ProxyPassReverse](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassreverse)
+#   for details.
+#
+# @param proxy_pass_match
+#   This directive is equivalent to `proxy_pass`, but takes regular expressions, see
+#   [ProxyPassMatch](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassmatch)
+#   for details.
+define apache::vhost::proxy(
+  String[1] $vhost,
+  $priority = undef,
+  Integer[0] $order = 170,
+  Optional[Stdlib::Port] $port = undef,
+  Optional[String[1]] $proxy_dest = undef,
+  Optional[Array[Apache::Vhost::ProxyPass]] $proxy_pass = undef,
+  Optional[Array[Apache::Vhost::ProxyPass]] $proxy_pass_match = undef,
+  Optional[String[1]] $proxy_dest_match = undef,
+  Optional[String[1]] $proxy_dest_reverse_match = undef,
+  Boolean $proxy_requests = false,
+  Boolean $proxy_preserve_host = false,
+  Optional[Boolean] $proxy_add_headers = undef,
+  Boolean $proxy_error_override = false,
+  Variant[Array[String[1]], String[1]] $no_proxy_uris = [],
+  Variant[Array[String[1]], String[1]] $no_proxy_uris_match = [],
+) {
+  include apache::mod::proxy
+  include apache::mod::proxy_http
+
+  unless $proxy_dest or $proxy_pass or $proxy_pass_match or $proxy_dest_match {
+    fail('At least one of proxy_dest, proxy_pass, proxy_pass_match or proxy_dest_match must be given')
+  }
+
+  apache::vhost::fragment { "${name}-proxy":
+    vhost    => $vhost,
+    port     => $port,
+    priority => $priority,
+    order    => $order,
+    content  => template('apache/vhost/_proxy.erb'),
+  }
+}

--- a/manifests/vhost/proxy.pp
+++ b/manifests/vhost/proxy.pp
@@ -104,7 +104,7 @@
 #     ],
 #   }
 #
-define apache::vhost::proxy(
+define apache::vhost::proxy (
   String[1] $vhost,
   $priority = undef,
   Integer[0] $order = 170,

--- a/manifests/vhost/proxy.pp
+++ b/manifests/vhost/proxy.pp
@@ -1,14 +1,90 @@
-# @summary Configure a reverse reverse proxy for a vhost
+# @summary Configure a reverse proxy for a vhost
+#
+# @param vhost
+#   The title of the vhost resource to which reverse proxy configuration will
+#   be appended.
+#
+# @param priority
+#   Set the priority to match the one `apache::vhost` sets. This must match the
+#   one `apache::vhost` sets or else the vhost's `concat` resource won't be found.
+#
+# @param order
+#   The order in which the `concat::fragment` containing the proxy configuration
+#   will be inserted. Useful when multiple fragments will be attached to a single
+#   vhost's configuration.
+#
+# @param port
+#   Set the port to match the one `apache::vhost` sets. This must match the one
+#   `apache::vhost` sets or else the vhost's `concat` resource won't be found.
 #
 # @param proxy_dest
-#   Specifies the destination address of a [ProxyPass](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypass) configuration.
+#   Specifies the destination address of a [ProxyPass](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypass) configuration for the `/` path.
+#
+# @param proxy_dest_match
+#   This directive is equivalent to `proxy_dest`, but takes regular expressions, see
+#   [ProxyPassMatch](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassmatch)
+#   for details.
+#
+# @param proxy_dest_reverse_match
+#   Allows you to pass a ProxyPassReverse if `proxy_dest_match` is specified. See
+#   [ProxyPassReverse](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassreverse)
+#   for details.
+#
+# @param no_proxy_uris
+#   Paths to be excluded from reverse proxying. Only valid when already using `proxy_dest`
+#   or `proxy_dest_match` to map the `/` path, otherwise it will be absent in the final
+#   vhost configuration file. In that case, instead add `no_proxy_uris => [uri1, uri2, ...]`
+#   to the `Apache::Vhost::ProxyPass` definitions passed via the `proxy_pass` parameter.
+#   See examples for this class, or refer to documentation for the `Apache::Vhost::ProxyPass`
+#   data type. This configuration uses the [ProxyPass](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypass) directive with `!`.
+#
+# @param no_proxy_uris_match
+#   This directive is equivalent to `no_proxy_uris` but takes regular expressions,
+#   as it instead uses [ProxyPassMatch](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassmatch).
 #
 # @param proxy_pass
 #   Specifies an array of `path => URI` values for a [ProxyPass](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypass)
-#   configuration. Optionally, parameters can be added as an array.
-#   ``` puppet
-#   apache::vhost { 'site.name.fdqn':
-#     …
+#   configuration.
+#   See the documentation for the Apache::Vhost::ProxyPass data type for a detailed
+#   description of the structure including optional parameters.
+#
+# @param proxy_pass_match
+#   This directive is equivalent to `proxy_pass`, but takes regular expressions, see
+#   [ProxyPassMatch](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassmatch)
+#   for details.
+#
+# @param proxy_requests
+#   Enables forward (standard) proxy requests. See [ProxyRequests](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxyrequests) for details.
+#
+# @param proxy_preserve_host
+#   When enabled, pass the `Host:` line from the incoming request to the proxied host.
+#   See [ProxyPreserveHost](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypreservehost) for details.
+#
+# @param proxy_add_headers
+#   Add X-Forwarded-For, X-Forwarded-Host, and X-Forwarded-Server HTTP headers.
+#   See [ProxyAddHeaders](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxyaddheaders) for details.
+#
+# @param proxy_error_override
+#   Override error pages from the proxied host. The current Puppet implementation
+#   supports enabling or disabling the directive, but not specifying a custom list
+#   of status codes. See [ProxyErrorOverride](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxyerroroverride) for details.
+#
+# @example Simple configuration proxying "/" but not "/admin"
+#   include apache
+#   apache::vhost { 'basic-proxy-vhost':
+#   }
+#   apache::vhost::proxy { 'proxy-to-backend-server':
+#     vhost => 'basic-proxy-vhost',
+#     proxy_dest => 'http://backend-server/',
+#     no_proxy_uris => '/admin',
+#   }
+#
+# @example Granular configuration using `Apache::Vhost::ProxyPass` data type
+#   include apache
+#   apache::vhost { 'myvhost':
+#   }
+#   apache::vhost::proxy { 'myvhost-proxy':
+#     vhost      => 'myvhost',
 #     proxy_pass => [
 #       { 'path' => '/a', 'url' => 'http://backend-a/' },
 #       { 'path' => '/b', 'url' => 'http://backend-b/' },
@@ -27,42 +103,23 @@
 #         'no_proxy_uris' => ['/h/admin', '/h/server-status'] },
 #     ],
 #   }
-#   ```
-#   * `reverse_urls`. *Optional.* This setting is useful when used with `mod_proxy_balancer`. Values: an array or string.
-#   * `reverse_cookies`. *Optional.* Sets `ProxyPassReverseCookiePath` and `ProxyPassReverseCookieDomain`.
-#   * `params`. *Optional.* Allows for ProxyPass key-value parameters, such as connection settings.
-#   * `setenv`. *Optional.* Sets [environment variables](https://httpd.apache.org/docs/current/mod/mod_proxy.html#envsettings) for the proxy directive. Values: array.
 #
-# @param proxy_dest_match
-#   This directive is equivalent to `proxy_dest`, but takes regular expressions, see
-#   [ProxyPassMatch](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassmatch)
-#   for details.
-#
-# @param proxy_dest_reverse_match
-#   Allows you to pass a ProxyPassReverse if `proxy_dest_match` is specified. See
-#   [ProxyPassReverse](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassreverse)
-#   for details.
-#
-# @param proxy_pass_match
-#   This directive is equivalent to `proxy_pass`, but takes regular expressions, see
-#   [ProxyPassMatch](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassmatch)
-#   for details.
 define apache::vhost::proxy(
   String[1] $vhost,
   $priority = undef,
   Integer[0] $order = 170,
   Optional[Stdlib::Port] $port = undef,
   Optional[String[1]] $proxy_dest = undef,
-  Optional[Array[Apache::Vhost::ProxyPass]] $proxy_pass = undef,
-  Optional[Array[Apache::Vhost::ProxyPass]] $proxy_pass_match = undef,
   Optional[String[1]] $proxy_dest_match = undef,
   Optional[String[1]] $proxy_dest_reverse_match = undef,
+  Variant[Array[String[1]], String[1]] $no_proxy_uris = [],
+  Variant[Array[String[1]], String[1]] $no_proxy_uris_match = [],
+  Optional[Array[Apache::Vhost::ProxyPass]] $proxy_pass = undef,
+  Optional[Array[Apache::Vhost::ProxyPass]] $proxy_pass_match = undef,
   Boolean $proxy_requests = false,
   Boolean $proxy_preserve_host = false,
   Optional[Boolean] $proxy_add_headers = undef,
   Boolean $proxy_error_override = false,
-  Variant[Array[String[1]], String[1]] $no_proxy_uris = [],
-  Variant[Array[String[1]], String[1]] $no_proxy_uris_match = [],
 ) {
   include apache::mod::proxy
   include apache::mod::proxy_http

--- a/spec/defines/vhost_proxy_spec.rb
+++ b/spec/defines/vhost_proxy_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'apache::vhost::proxy' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:title) { 'myproxy' }
+
+      context 'adding to the default vhost' do
+        let(:pre_condition) { 'include apache' }
+
+        let(:params) do
+          {
+            vhost: 'default',
+            port: 80,
+            priority: '15',
+          }
+        end
+
+        context 'without any parameters' do
+          it { is_expected.to compile.and_raise_error(%r{At least one of}) }
+        end
+
+        context 'with proxy_dest' do
+          let(:params) do
+            super().merge(
+              proxy_pass: [
+                {
+                  path: '/',
+                  url: 'http://localhost:8080/',
+                },
+              ],
+            )
+          end
+
+          it 'creates a concat fragment' do
+            is_expected.to compile.with_all_deps
+            is_expected.to contain_concat('15-default-80.conf')
+            is_expected.to create_concat__fragment('default-myproxy-proxy')
+              .with_target('15-default-80.conf')
+              .with_order(170)
+              .with_content(
+                Regexp.new(<<~CONTENT),
+                  \n\s\s## Proxy rules
+                  \s\sProxyRequests Off
+                  \s\sProxyPreserveHost Off
+                  \s\sProxyPass / http://localhost:8080/
+                  \s\sProxyPassReverse / http://localhost:8080/
+                CONTENT
+              )
+          end
+        end
+      end
+    end
+  end
+end

--- a/types/vhost/proxypass.pp
+++ b/types/vhost/proxypass.pp
@@ -1,4 +1,80 @@
-# @summary A proxy pass definition for in an Apache vhost
+# @summary Struct representing reverse proxy configuration for an Apache vhost, used by the Apache::Vhost::Proxy defined resource type.
+#
+# @param [String[1]] path
+#   The virtual path on the local server to map.
+#
+# @param [String[1]] url
+#   The URL to which the path and its children will be mapped.
+#
+# @param [Optional[Hash]] params
+#   Optional [ProxyPass](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypass) key-value parameters, such as connection settings.
+#
+# @param [Array[String[1]]] reverse_urls
+#   Optional (but usually recommended) URLs for [ProxyPassReverse](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassreverse) configuration.
+#   Allows Apache to adjust certain headers on HTTP redirect responses, to prevent
+#   redirects on the back-end from bypassing the reverse proxy.
+#
+# @param [Optional[Array[Hash]]] reverse_cookies
+#   Optional Array of Hashes, each representing a ProxyPassReverseCookieDomain or
+#   ProxyPassReverseCookiePath configuration. These are similar to ProxyPassReverse but
+#   operate on Domain or Path strings respectively in Set-Cookie headers. Each Hash
+#   must contain one `url => value` pair, and exactly one `path => value` or `domain => value`
+#   pair, representing the internal domain or internal path.
+# @option reverse_cookies [String[1]] :url
+#   Required partial URL representing public domain or public path.
+# @option reverse_cookies [Optional[String[1]]] :path
+#   Internal path for [ProxyPassReverseCookiePath](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassreversecookiepath) configuration.
+# @option reverse_cookies [Optional[String[1]]] :domain
+#   Internal domain for [ProxyPassReverseCookieDomain](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassreversecookiedomain) configuration.
+#
+# @param [Optional[Array[String[1]]]] keywords
+#   Array of optional keywords such as `nocanon`, `interpolate`, or `noquery` supported
+#   by [ProxyPass](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypass) (refer
+#   to subsection under heading "Additional ProxyPass Keywords").
+#
+# @param [Optional[Array[String[1]]]] setenv
+#   Optional Array of Strings of the form "${env_var_name} ${value}".
+#   Uses [SetEnv](https://httpd.apache.org/docs/current/mod/mod_env.html#setenv) to make [Protocol Adjustments](https://httpd.apache.org/docs/current/mod/mod_proxy.html#envsettings) to mod_proxy in the virtual
+# host context. Because the implementation uses SetEnv, you must `include apache::mod::env`;
+# for the same reason, this cannot set the newer `no-proxy` environment variable, which
+# would require an implementation using SetEnvIf.
+#
+# @param [Optional[Array[String[1]]]] no_proxy_uris
+#   Optional Array of paths to exclude from proxying, using the `!` directive to [ProxyPass](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypass).
+#
+# @param [Optional[Array[String[1]]]] no_proxy_uris_match
+#   Similar to `no_proxy_uris` but uses [ProxyPassMatch](https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypassmatch) to allow regular
+#   expressions.
+#
+# @example Basic example
+#   { 'path' => '/a', 'url' => 'http://backend-a/', }
+#
+# @example With parameters
+#   { 'path' => '/b', 'url' => 'http://backend-a/b',
+#     'params' => {'max'=>20, 'ttl'=>120, 'retry'=>300,}, }
+#
+# @example With ProxyPassReverse
+#   { 'path' => '/l', 'url' => 'http://backend-xy',
+#     'reverse_urls' => ['http://backend-x', 'http://backend-y'], }
+#
+# @example With additional keywords
+#   { 'path' => '/e', 'url' => 'http://backend-a/e',
+#     'keywords' => ['nocanon', 'interpolate'], }
+#
+# @example With mod_proxy environment variables
+#   { 'path' => '/f', 'url' => 'http://backend-f/',
+#     'setenv' => ['proxy-nokeepalive 1','force-proxy-request-1.0 1'], }
+#
+# @example With ProxyPassReverseCookieDomain and ProxyPassReverseCookiePath
+#   { 'path' => '/g', 'url' => 'http://backend-g/',
+#     'reverse_cookies' => [{'path' => '/g', 'url' => 'http://backend-g/',}, {'domain' => 'http://backend-g', 'url' => 'http:://backend-g',}], }
+#
+# @example With exclusions
+#   { 'path' => '/h', 'url' => 'http://backend-h/h',
+#     'no_proxy_uris' => ['/h/admin', '/h/server-status'], }
+#
+# @see https://httpd.apache.org/docs/current/mod/mod_proxy.html for additional documentation.
+#
 type Apache::Vhost::ProxyPass = Struct[{
   path                          => String[1],
   url                           => String[1],

--- a/types/vhost/proxypass.pp
+++ b/types/vhost/proxypass.pp
@@ -1,0 +1,16 @@
+# @summary A proxy pass definition for in an Apache vhost
+type Apache::Vhost::ProxyPass = Struct[{
+  path                          => String[1],
+  url                           => String[1],
+  Optional[params]              => Hash[String[1], Variant[String[1], Integer]],
+  Optional[keywords]            => Array[String[1]],
+  Optional[reverse_cookies]     => Array[Struct[{
+    url    => String[1],
+    path   => Optional[String[1]],
+    domain => Optional[String[1]],
+  }]],
+  Optional[reverse_urls]        => Array[String[1]],
+  Optional[setenv]              => Array[String[1]],
+  Optional[no_proxy_uris]       => Array[String[1]],
+  Optional[no_proxy_uris_match] => Array[String[1]],
+}]


### PR DESCRIPTION
This builds on apache::vhost::fragment with a more specialized type for
a reverse proxy setup. This reuses the same template as apache::vhost
but has data types. The types are stricter, but this leads to a clearer
API. For example, it doesn't accept String and Array[String] but in that
case always wants an Array.

The old parameters on vhost remain and can continue to be used.