### PR TITLE
pdksync - (IAC-1709) - Add Support for Debian 11

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -53,7 +53,8 @@
       "operatingsystemrelease": [
         "8",
         "9",
-        "10"
+        "10",
+        "11"
       ]
     },
     {


### PR DESCRIPTION
(IAC-1709) - Add Support for Debian 11
pdk version: `2.1.0` 
