### PR TITLE
Use correct PHP version for Debian Bullseye

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -397,6 +397,7 @@ class apache::params inherits ::apache::version {
         '9'     => '7.0', # Debian Stretch
         '16.04' => '7.0', # Ubuntu Xenial
         '10'    => '7.3', # Debian Buster
+        '11'    => '7.4', # Debian Bullseye
         '20.04' => '7.4', # Ubuntu Foccal Fossal
         default => '7.2', # Ubuntu Bionic, Cosmic and Disco
       }

--- a/spec/classes/mod/php_spec.rb
+++ b/spec/classes/mod/php_spec.rb
@@ -76,6 +76,29 @@ describe 'apache::mod::php', type: :class do
                 )
               }
             end
+          when '11'
+            context 'on bullseye' do
+              it { is_expected.to contain_apache__mod('php7.4') }
+              it { is_expected.to contain_package('libapache2-mod-php7.4') }
+              it {
+                is_expected.to contain_file('php7.4.load').with(
+                  content: "LoadModule php7_module /usr/lib/apache2/modules/libphp7.4.so\n",
+                )
+              }
+            end
+            context 'on bullseye with experimental php8.0' do
+              let :params do
+                { php_version: '8.0' }
+              end
+
+              it { is_expected.to contain_apache__mod('php') }
+              it { is_expected.to contain_package('libapache2-mod-php8.0') }
+              it {
+                is_expected.to contain_file('php.load').with(
+                  content: "LoadModule php_module /usr/lib/apache2/modules/libphp.so\n",
+                )
+              }
+            end
           when '16.04'
             context 'on stretch' do
               let :params do


### PR DESCRIPTION
Debian Bullseye uses PHP 7.4 by default. Without adding it in params.pp, PHP 7.2 is used and will fail to install.