### PR TITLE
Debian 11: fix typo in `versioncmp()` / set default php to 7.4

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -392,7 +392,7 @@ class apache::params inherits ::apache::version {
         'wsgi'                  => 'libapache2-mod-wsgi',
         'xsendfile'             => 'libapache2-mod-xsendfile',
       }
-    } elsif ($::operatingsystem == 'Ubuntu') or ($::operatingsystem == 'Debian' and versioncmp($facts['os']['release']['major'], '11') < 0) {
+    } elsif ($::operatingsystem == 'Ubuntu') or ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '11') < 0) {
       $php_version = $facts['operatingsystemmajrelease'] ? {
         '9'     => '7.0', # Debian Stretch
         '16.04' => '7.0', # Ubuntu Xenial

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -392,7 +392,7 @@ class apache::params inherits ::apache::version {
         'wsgi'                  => 'libapache2-mod-wsgi',
         'xsendfile'             => 'libapache2-mod-xsendfile',
       }
-    } elsif ($::operatingsystem == 'Ubuntu') or ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '11') < 0) {
+    } elsif ($::operatingsystem == 'Ubuntu') or ($::operatingsystem == 'Debian' and versioncmp($facts['os']['release']['major'], '11') < 0) {
       $php_version = $facts['operatingsystemmajrelease'] ? {
         '9'     => '7.0', # Debian Stretch
         '16.04' => '7.0', # Ubuntu Xenial

--- a/spec/classes/mod/php_spec.rb
+++ b/spec/classes/mod/php_spec.rb
@@ -76,6 +76,29 @@ describe 'apache::mod::php', type: :class do
                 )
               }
             end
+          when '11'
+            context 'on bullseye' do
+              it { is_expected.to contain_apache__mod('php7.4') }
+              it { is_expected.to contain_package('libapache2-mod-php7.4') }
+              it {
+                is_expected.to contain_file('php7.4.load').with(
+                  content: "LoadModule php7_module /usr/lib/apache2/modules/libphp7.4.so\n",
+                )
+              }
+            end
+            context 'on bullseye with experimental php8.0' do
+              let :params do
+                { php_version: '8.0' }
+              end
+
+              it { is_expected.to contain_apache__mod('php') }
+              it { is_expected.to contain_package('libapache2-mod-php8.0') }
+              it {
+                is_expected.to contain_file('php.load').with(
+                  content: "LoadModule php_module /usr/lib/apache2/modules/libphp.so\n",
+                )
+              }
+            end
           when '16.04'
             context 'on stretch' do
               let :params do


### PR DESCRIPTION
tl;dr `$::operatingsystemrelease` is different from
`$::operatingsystemmajrelease`. `$::operatingsystemmajrelease` returns
'11.0' on Debian 11, whereas `$::operatingsystemmajrelease` is `11`.
In addition `versioncmp()` says that `'11.0'` is greater than `11`.

Without this change, the module sets the default PHP version on Debian
11 to 7.2, but the actual default in Debian is 7.4:
* https://packages.debian.org/bullseye/php

The 7.2 currently comes from the default entry in the selector
statement:
* https://github.com/puppetlabs/puppetlabs-apache/blob/main/manifests/params.pp#L401

To test:

```puppet
notify { "operatingsystemrelease compared to 11: ${versioncmp($::operatingsystemrelease, '11')}":}
notify { "operatingsystemmajrelease compared to 11: ${versioncmp($::operatingsystemmajrelease, '11')}":}
notify { "operatingsystemrelease: ${::operatingsystemrelease}":}
notify { "operatingsystemmajrelease: ${::operatingsystemmajrelease}":}
```

which produces:

```terminal
puppet apply test.pp
Notice: Compiled catalog for blal in environment production in 0.02 seconds
Notice: operatingsystemrelease compared to 11: 1
Notice: /Stage[main]/Main/Notify[operatingsystemrelease compared to 11: 1]/message: defined 'message' as 'operatingsystemrelease compared to 11: 1'
Notice: operatingsystemmajrelease compared to 11: 0
Notice: /Stage[main]/Main/Notify[operatingsystemmajrelease compared to 11: 0]/message: defined 'message' as 'operatingsystemmajrelease compared to 11: 0'
Notice: operatingsystemrelease: 11.0
Notice: /Stage[main]/Main/Notify[operatingsystemrelease: 11.0]/message: defined 'message' as 'operatingsystemrelease: 11.0'
Notice: operatingsystemmajrelease: 11.0
Notice: /Stage[main]/Main/Notify[operatingsystemmajrelease: 11.0]/message: defined 'message' as 'operatingsystemmajrelease: 11'
Notice: Applied catalog in 0.01 seconds
```

```terminal
:~> facter operatingsystemmajrelease
11
:~> facter operatingsystemrelease
11.0
```

The spec tests are copied from https://github.com/puppetlabs/puppetlabs-apache/pull/2181
Co-authored-by: Kienan Stewart <kienan.stewart@burntworld.ca>