### PR TITLE
Enforce SELinux in acceptance tests

### DIFF
--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -11,13 +11,6 @@ case $facts['os']['family'] {
     }
   }
   'RedHat': {
-    # Make sure selinux is disabled so the tests work.
-    if $facts['os']['selinux']['enabled'] {
-      exec { 'setenforce 0':
-        path => $facts['path'],
-      }
-    }
-
     if $facts['selinux'] {
       $semanage_package = $facts['os']['release']['major'] ? {
         '6'     => 'policycoreutils-python',


### PR DESCRIPTION
This attempts to unify SELinux handling in the tests. It moves the package installation to the acceptance spec helper to reduce duplication. It then makes the set_apache_defaults line idempotent and restorecon_apache correctly chained. This works around [PUP-10548] which is that Puppet doesn't reload file contexts within a run. That means it must first create the file(s) and then run restorecon to get correct contexts.

I'm not entirely sure if this will work.

[PUP-10548]: https://tickets.puppetlabs.com/browse/PUP-10548