### PR TITLE
(FM-8483) reenable the testcases

### DIFF
--- a/spec/acceptance/apache_parameters_spec.rb
+++ b/spec/acceptance/apache_parameters_spec.rb
@@ -53,7 +53,7 @@ describe 'apache parameters' do
       apply_manifest(pp, catch_failures: true)
     end
 
-    describe service(apache_hash['service_name']), skip: 'FM-8483' do
+    describe service(apache_hash['service_name']) do
       it { is_expected.to be_running }
       it { is_expected.to be_enabled }
     end
@@ -70,7 +70,7 @@ describe 'apache parameters' do
       apply_manifest(pp, catch_failures: true)
     end
 
-    describe service(apache_hash['service_name']), skip: 'FM-8483' do
+    describe service(apache_hash['service_name']) do
       it { is_expected.not_to be_running }
       it { is_expected.not_to be_enabled }
     end
@@ -88,7 +88,7 @@ describe 'apache parameters' do
       apply_manifest(pp, catch_failures: true)
     end
 
-    describe service(apache_hash['service_name']), skip: 'FM-8483' do
+    describe service(apache_hash['service_name']) do
       it { is_expected.not_to be_running }
       it { is_expected.not_to be_enabled }
     end

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -28,7 +28,7 @@ describe 'apache class' do
       it { is_expected.to be_installed }
     end
 
-    describe service(apache_hash['service_name']), skip: 'FM-8483' do
+    describe service(apache_hash['service_name']) do
       it { is_expected.to be_enabled }
       it { is_expected.to be_running }
     end
@@ -77,7 +77,7 @@ describe 'apache class' do
       idempotent_apply(pp)
     end
 
-    describe service(apache_hash['service_name']), skip: 'FM-8483' do
+    describe service(apache_hash['service_name']) do
       it { is_expected.to be_enabled }
       it { is_expected.to be_running }
     end

--- a/spec/acceptance/default_mods_spec.rb
+++ b/spec/acceptance/default_mods_spec.rb
@@ -17,7 +17,7 @@ describe 'apache::default_mods class' do
       idempotent_apply(pp)
     end
 
-    describe service(apache_hash['service_name']), skip: 'FM-8483' do
+    describe service(apache_hash['service_name']) do
       it { is_expected.to be_running }
     end
   end
@@ -56,7 +56,7 @@ describe 'apache::default_mods class' do
       end
     end
 
-    describe service(apache_hash['service_name']), skip: 'FM-8483' do
+    describe service(apache_hash['service_name']) do
       it { is_expected.not_to be_running }
     end
   end
@@ -89,7 +89,7 @@ describe 'apache::default_mods class' do
       idempotent_apply(pp)
     end
 
-    describe service(apache_hash['service_name']), skip: 'FM-8483' do
+    describe service(apache_hash['service_name']) do
       it { is_expected.to be_running }
     end
   end
@@ -108,7 +108,7 @@ describe 'apache::default_mods class' do
       idempotent_apply(pp)
     end
 
-    describe service(apache_hash['service_name']), skip: 'FM-8483' do
+    describe service(apache_hash['service_name']) do
       it { is_expected.to be_running }
     end
 

--- a/spec/acceptance/itk_spec.rb
+++ b/spec/acceptance/itk_spec.rb
@@ -43,7 +43,7 @@ describe 'apache::mod::itk class', if: service_name && mod_supported_on_platform
     end
   end
 
-  describe service(service_name), skip: 'FM-8483' do
+  describe service(service_name) do
     it { is_expected.to be_running }
     it { is_expected.to be_enabled }
   end

--- a/spec/acceptance/prefork_worker_spec.rb
+++ b/spec/acceptance/prefork_worker_spec.rb
@@ -18,7 +18,7 @@ describe 'prefork_worker_spec.rb', if: mod_supported_on_platform?('apache::mod::
       end
     end
 
-    describe service(apache_hash['service_name']), skip: 'FM-8483' do
+    describe service(apache_hash['service_name']) do
       it { is_expected.to be_running }
       it { is_expected.to be_enabled }
     end
@@ -39,7 +39,7 @@ describe 'prefork_worker_spec.rb', if: mod_supported_on_platform?('apache::mod::
       end
     end
 
-    describe service(apache_hash['service_name']), skip: 'FM-8483' do
+    describe service(apache_hash['service_name']) do
       it { is_expected.to be_running }
       it { is_expected.to be_enabled }
     end
@@ -61,7 +61,7 @@ describe 'prefork_worker_spec.rb', if: mod_supported_on_platform?('apache::mod::
       end
     end
 
-    describe service(apache_hash['service_name']), skip: 'FM-8483' do
+    describe service(apache_hash['service_name']) do
       it { is_expected.to be_running }
       it { is_expected.to be_enabled }
     end

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -179,7 +179,7 @@ describe 'apache::vhost define' do
       apply_manifest(pp, catch_failures: true)
     end
 
-    describe service(apache_hash['service_name']), skip: 'FM-8483' do
+    describe service(apache_hash['service_name']) do
       it { is_expected.to be_enabled }
       it { is_expected.to be_running }
     end
@@ -247,7 +247,7 @@ describe 'apache::vhost define' do
       apply_manifest(pp, catch_failures: true)
     end
 
-    describe service(apache_hash['service_name']), skip: 'FM-8483' do
+    describe service(apache_hash['service_name']) do
       it { is_expected.to be_enabled }
       it { is_expected.to be_running }
     end
@@ -307,7 +307,7 @@ describe 'apache::vhost define' do
         apply_manifest(pp, catch_failures: true)
       end
 
-      describe service(apache_hash['service_name']), skip: 'FM-8483' do
+      describe service(apache_hash['service_name']) do
         it { is_expected.to be_enabled }
         it { is_expected.to be_running }
       end
@@ -369,7 +369,7 @@ describe 'apache::vhost define' do
         apply_manifest(pp_one, catch_failures: true)
       end
 
-      describe service(apache_hash['service_name']), skip: 'FM-8483' do
+      describe service(apache_hash['service_name']) do
         it { is_expected.to be_enabled }
         it { is_expected.to be_running }
       end
@@ -411,7 +411,7 @@ describe 'apache::vhost define' do
         apply_manifest(pp_two, catch_failures: true)
       end
 
-      describe service(apache_hash['service_name']), skip: 'FM-8483' do
+      describe service(apache_hash['service_name']) do
         it { is_expected.to be_enabled }
         it { is_expected.to be_running }
       end
@@ -487,7 +487,7 @@ describe 'apache::vhost define' do
         apply_manifest(pp_two, catch_failures: true)
       end
 
-      describe service(apache_hash['service_name']), skip: 'FM-8483' do
+      describe service(apache_hash['service_name']) do
         it { is_expected.to be_enabled }
         it { is_expected.to be_running }
 
@@ -528,7 +528,7 @@ describe 'apache::vhost define' do
       apply_manifest(pp, catch_failures: true)
     end
 
-    describe service(apache_hash['service_name']), skip: 'FM-8483' do
+    describe service(apache_hash['service_name']) do
       it { is_expected.to be_enabled }
       it { is_expected.to be_running }
     end
@@ -574,7 +574,7 @@ describe 'apache::vhost define' do
                      ), catch_failures: true)
     end
 
-    describe service(apache_hash['service_name']), skip: 'FM-8483' do
+    describe service(apache_hash['service_name']) do
       it { is_expected.to be_enabled }
       it { is_expected.to be_running }
     end
@@ -619,7 +619,7 @@ describe 'apache::vhost define' do
                     ), catch_failures: true)
     end
 
-    describe service(apache_hash['service_name']), skip: 'FM-8483' do
+    describe service(apache_hash['service_name']) do
       it { is_expected.to be_enabled }
       it { is_expected.to be_running }
     end


### PR DESCRIPTION
Opened PR to enable the tests.
The tests are passing from the latest release of specinfra supports service testing commands on all OS
