### PR TITLE
Allow `docroot` with `mod_vhost_alias` `virtual_docroot`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7756,6 +7756,7 @@ The following parameters are available in the `apache::vhost` defined type:
 * [`suphp_engine`](#suphp_engine)
 * [`vhost_name`](#vhost_name)
 * [`virtual_docroot`](#virtual_docroot)
+* [`virtual_use_default_docroot`](#virtual_use_default_docroot)
 * [`wsgi_daemon_process`](#wsgi_daemon_process)
 * [`wsgi_daemon_process_options`](#wsgi_daemon_process_options)
 * [`wsgi_application_group`](#wsgi_application_group)
@@ -9957,6 +9958,8 @@ Data type: `Any`
 
 Sets up a virtual host with a wildcard alias subdomain mapped to a directory with the
 same name. For example, `http://example.com` would map to `/var/www/example.com`.
+Note that the `DocumentRoot` directive will not be present even though there is a value
+set for `docroot` in the manifest. See [`virtual_use_default_docroot`](#virtual_use_default_docroot) to change this behavior.
 ``` puppet
 apache::vhost { 'subdomain.loc':
   vhost_name      => '*',
@@ -9964,6 +9967,25 @@ apache::vhost { 'subdomain.loc':
   virtual_docroot => '/var/www/%-2+',
   docroot         => '/var/www',
   serveraliases   => ['*.loc',],
+}
+```
+
+Default value: ``false``
+
+##### <a name="virtual_use_default_docroot"></a>`virtual_use_default_docroot`
+
+Data type: `Any`
+
+By default, when using `virtual_docroot`, the value of `docroot` is ignored. Setting this
+to `true` will mean both directives will be added to the configuration.
+``` puppet
+apache::vhost { 'subdomain.loc':
+  vhost_name                  => '*',
+  port                        => '80',
+  virtual_docroot             => '/var/www/%-2+',
+  docroot                     => '/var/www',
+  virtual_use_default_docroot => true,
+  serveraliases               => ['*.loc',],
 }
 ```
 

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1221,6 +1221,8 @@
 # @param virtual_docroot
 #   Sets up a virtual host with a wildcard alias subdomain mapped to a directory with the 
 #   same name. For example, `http://example.com` would map to `/var/www/example.com`.
+#   Note that the `DocumentRoot` directive will not be present even though there is a value
+#   set for `docroot` in the manifest. See [`virtual_use_default_docroot`](#virtual_use_default_docroot) to change this behavior.
 #   ``` puppet
 #   apache::vhost { 'subdomain.loc':
 #     vhost_name      => '*',
@@ -1231,6 +1233,20 @@
 #   }
 #   ```
 # 
+# @param virtual_use_default_docroot
+#   By default, when using `virtual_docroot`, the value of `docroot` is ignored. Setting this
+#   to `true` will mean both directives will be added to the configuration.
+#   ``` puppet
+#   apache::vhost { 'subdomain.loc':
+#     vhost_name                  => '*',
+#     port                        => '80',
+#     virtual_docroot             => '/var/www/%-2+',
+#     docroot                     => '/var/www',
+#     virtual_use_default_docroot => true,
+#     serveraliases               => ['*.loc',],
+#   }
+#   ```
+#
 # @param wsgi_daemon_process
 #   Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
 #   wsgi_daemon_process_options, wsgi_process_group, 

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1746,6 +1746,7 @@ define apache::vhost (
   Variant[Boolean,String] $docroot,
   $manage_docroot                                                                   = true,
   $virtual_docroot                                                                  = false,
+  $virtual_use_default_docroot                                                      = false,
   $port                                                                             = undef,
   $ip                                                                               = undef,
   Boolean $ip_based                                                                 = false,
@@ -2429,6 +2430,7 @@ define apache::vhost (
 
   # Template uses:
   # - $virtual_docroot
+  # - $virtual_use_default_docroot
   # - $docroot
   if $docroot {
     concat::fragment { "${name}-docroot":

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -1761,6 +1761,8 @@ describe 'apache::vhost', type: :define do
             is_expected.to contain_concat__fragment('rspec.example.com-docroot').with(
               content: %r{^\s+VirtualDocumentRoot "/var/www/sites/%0"$},
             )
+          }
+          it {
             is_expected.not_to contain_concat__fragment('rspec.example.com-docroot').with(
               content: %r{^\s+DocumentRoot "/var/www/html"$},
             )
@@ -1780,6 +1782,8 @@ describe 'apache::vhost', type: :define do
             is_expected.to contain_concat__fragment('rspec.example.com-docroot').with(
               content: %r{^\s+VirtualDocumentRoot "/var/www/sites/%0"$},
             )
+          }
+          it {
             is_expected.to contain_concat__fragment('rspec.example.com-docroot').with(
               content: %r{^\s+DocumentRoot "/var/www/html"$},
             )

--- a/templates/vhost/_docroot.erb
+++ b/templates/vhost/_docroot.erb
@@ -2,6 +2,7 @@
   ## Vhost docroot
 <% if @virtual_docroot -%>
   VirtualDocumentRoot "<%= @virtual_docroot %>"
-<% elsif @docroot -%>
+<% end -%>
+<% if @docroot and ((not @virtual_docroot) or @virtual_use_default_docroot) -%>
   DocumentRoot "<%= @docroot %>"
 <% end -%>


### PR DESCRIPTION
DocumentRoot is used for other directives when a Virtual Document Root is not found.  
For backwards compatibility, `docroot` is still ignored unless you set the `virtual_use_default_docroot` to `true`.

For example, to show a custom 404 message, you might use mod_rewrite, but that needs a `DocumentRoot` to be set:
```
# ************************************
# Vhost template in module puppetlabs-apache
# Managed by Puppet
# ************************************
#
<VirtualHost *:80>
  ServerName projects.example.com

  ## Vhost docroot
  VirtualDocumentRoot "/var/www/projects/_webroots/%0"
  DocumentRoot "/var/www/projects/_webroots"

  ## Directories, there should at least be a declaration for /fs/www/projects/_webroots

  <Directory "/fs/www/projects">
    Options FollowSymLinks MultiViews Indexes
    AllowOverride None
    Require all granted
  </Directory>

  ## Logging
  ErrorLog "/var/log/httpd/projects.cs.umd.edu_error.log"

  ## Rewrite rules
  RewriteEngine On

  #Show errors for missing sites
  RewriteCond %{HTTP_HOST} "^([^:/]*)(:.+)?" [NC]
  RewriteCond '/var/www/projects/_webroots/%1' !-d
  RewriteRule (.*) /default-site/index.php [L]


  UseCanonicalName Off
</VirtualHost>
```