### PR TITLE
Show `allow_override` key in docs.

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -10157,6 +10157,11 @@ apache::vhost { 'files.example.net':
       'provider' => 'files',
       'deny'     => 'from all',
     },
+    { 'path'           => '/var/www/html',
+      'provider'       => 'directory',
+      'options'        => ['-Indexes'],
+      'allow_override' => ['All'],
+    },
   ],
 }
 ```

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1356,9 +1356,10 @@
 #   apache::vhost { 'files.example.net':
 #     docroot     => '/var/www/files',
 #     directories => [
-#       { 'path'     => '/var/www/files',
-#         'provider' => 'files',
-#         'deny'     => 'from all',
+#       { 'path'           => '/var/www/files',
+#         'provider'       => 'files',
+#         'deny'           => 'from all',
+#         'allow_override' => ['All'],
 #       },
 #     ],
 #   }

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1361,6 +1361,11 @@
 #         'deny'           => 'from all',
 #         'allow_override' => ['All'],
 #       },
+#       { 'path'           => '/var/www/html',
+#         'provider'       => 'directory',
+#         'options'        => ['-Indexes'],
+#         'allow_override' => ['All'],
+#       },
 #     ],
 #   }
 #   ```

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1356,10 +1356,9 @@
 #   apache::vhost { 'files.example.net':
 #     docroot     => '/var/www/files',
 #     directories => [
-#       { 'path'           => '/var/www/files',
-#         'provider'       => 'files',
-#         'deny'           => 'from all',
-#         'allow_override' => ['All'],
+#       { 'path'     => '/var/www/files',
+#         'provider' => 'files',
+#         'deny'     => 'from all',
 #       },
 #       { 'path'           => '/var/www/html',
 #         'provider'       => 'directory',


### PR DESCRIPTION
For the main virtual host configuration, there is a parameter `override` for this: https://forge.puppet.com/modules/puppetlabs/apache/reference#override

However in the directories parameter, it needs to be set to `allow_override`.

It is confusing to have two different names for the same thing, but changing it at this point would probably break people's settings. At least we can document its usage in the example.