### PR TITLE
mod_auth_gssapi: Add support for `GssapiBasicAuth`.

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1509,6 +1509,7 @@
 #     directories => [
 #       { path   => '/path/to/different/dir',
 #         gssapi => {
+#           basicauth => 'On',
 #           credstore => 'keytab:/foo/bar.keytab',
 #           localname => 'Off',
 #           sslonly   => 'On',

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -252,6 +252,7 @@ describe 'apache::vhost', type: :define do
                   'passenger_app_log_file'                              => '/tmp/app.log',
                   'passenger_debugger'                                  => false,
                   'gssapi'                                              => {
+                    'basicauth' => 'On',
                     'credstore' => 'keytab:/foo/bar.keytab',
                     'localname' => 'On',
                     'sslonly'   => 'Off',
@@ -941,6 +942,11 @@ describe 'apache::vhost', type: :define do
           it {
             is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
               content: %r{^\s+PassengerDebugger\sOff$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
+              content: %r{^\s+GssapiBasicAuth\sOn$},
             )
           }
           it {

--- a/templates/vhost/_gssapi.epp
+++ b/templates/vhost/_gssapi.epp
@@ -5,7 +5,7 @@
   Optional[Enum['On','Off']] $sslonly   = undef,
   Optional[Enum['On','Off']] $localname = undef,
 |%>
-# mod_auth_gssapi configuration
+    # mod_auth_gssapi configuration
 <% if $basicauth { -%>
     GssapiBasicAuth <%= $basicauth %>
 <% } -%>

--- a/templates/vhost/_gssapi.epp
+++ b/templates/vhost/_gssapi.epp
@@ -1,10 +1,14 @@
 <%|
   # https://github.com/gssapi/mod_auth_gssapi
+  Optional[Enum['On','Off']] $basicauth = undef,
   Optional[String[1]]        $credstore = undef,
   Optional[Enum['On','Off']] $sslonly   = undef,
   Optional[Enum['On','Off']] $localname = undef,
 |%>
 # mod_auth_gssapi configuration
+<% if $basicauth { -%>
+    GssapiBasicAuth <%= $basicauth %>
+<% } -%>
 <% if $sslonly { -%>
     GssapiSSLonly <%= $sslonly %>
 <% } -%>


### PR DESCRIPTION
This adds support for the `GssapiBasicAuth` setting
which allows to fall back to basic auth if `NEGOTIATE` fails.