### PR TITLE
Allow additional settings for GSSAPI in Vhost

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1477,6 +1477,8 @@
 #         gssapi => {
 #           acceptor_name            => '{HOSTNAME}',
 #           allowed_mech             => ['krb5', 'iakerb', 'ntlmssp'],
+#           authname                 => 'Kerberos 5',
+#           authtype                 => 'GSSAPI',
 #           basic_auth               => true,
 #           basic_auth_mech          => ['krb5', 'iakerb', 'ntlmssp'],
 #           basic_ticket_timeout     => 300,

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -273,6 +273,8 @@ describe 'apache::vhost', type: :define do
                   'gssapi'                                              => {
                     'acceptor_name'            => '{HOSTNAME}',
                     'allowed_mech'             => ['krb5', 'iakerb', 'ntlmssp'],
+                    'authname'                 => 'Kerberos 5',
+                    'authtype'                 => 'GSSAPI',
                     'basic_auth'               => true,
                     'basic_auth_mech'          => ['krb5', 'iakerb', 'ntlmssp'],
                     'basic_ticket_timeout'     => 300,

--- a/templates/vhost/_gssapi.epp
+++ b/templates/vhost/_gssapi.epp
@@ -5,6 +5,8 @@
   Optional[Boolean]                                       $basic_auth = undef,
   Optional[Array[Enum['krb5','iakerb','ntlmssp']]]        $basic_auth_mech = undef,
   Optional[[Integer[1]]]                                  $basic_ticket_timeout = undef,
+  Optional[String[1]]                                     $authname = undef,
+  Optional[String[1]]                                     $authtype = undef,
   Optional[Boolean]                                       $connection_bound = undef,
   Optional[Struct[{
     Optional['ccache']        => Array[Stdlib::Unixpath],
@@ -41,6 +43,12 @@
   <%- $allowed_mech.each |$mech| { -%>
     GssapiAllowedMech <%= $mech %>
   <%- } -%>
+<%- } -%>
+<%- if $authname { -%>
+    AuthName "<%= $authname %>"
+<%- } -%>
+<%- if $authtype { -%>
+    AuthType <%= $authtype %>
 <%- } -%>
 <%- if $basic_auth { -%>
     GssapiBasicAuth On


### PR DESCRIPTION
Adding config items:
- allowedmech
- authname
- authtype
- basicauth