### PR TITLE
Drop Apache 2.2 support with Gentoo

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -738,19 +738,13 @@ class apache (
     if $::osfamily == 'gentoo' {
       $error_documents_path = '/usr/share/apache2/error'
       if $default_mods =~ Array {
-        if versioncmp($apache_version, '2.4') >= 0 {
-          if defined('apache::mod::ssl') {
-            ::portage::makeconf { 'apache2_modules':
-              content => concat($default_mods, ['authz_core', 'socache_shmcb']),
-            }
-          } else {
-            ::portage::makeconf { 'apache2_modules':
-              content => concat($default_mods, 'authz_core'),
-            }
+        if defined('apache::mod::ssl') {
+          ::portage::makeconf { 'apache2_modules':
+            content => concat($default_mods, ['authz_core', 'socache_shmcb']),
           }
         } else {
           ::portage::makeconf { 'apache2_modules':
-            content => $default_mods,
+            content => concat($default_mods, 'authz_core'),
           }
         }
       }

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -152,7 +152,7 @@ def apache_settings_hash
     apache['service_name']     = 'apache24'
     apache['package_name']     = 'apache24'
     apache['error_log']        = 'http-error.log'
-    apache['version']          = '2.2'
+    apache['version']          = '2.4'
     apache['mod_ssl_dir']      = apache['mod_dir']
   when 'gentoo'
     apache['httpd_dir']        = '/etc/apache2'


### PR DESCRIPTION
It was dropped in https://github.com/gentoo/gentoo/commit/872597ae0890e11ac15718f655935f1b0c9e0dbd.

Also sets the Apache version to 2.4 in FreeBSD acceptance. See invidivual commits for details.