### PR TITLE
Support ProxyPassMatch within a LocationMatch container

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1351,6 +1351,8 @@
 #    Values: `directory`, `files`, `proxy`, `location`, `directorymatch`, `filesmatch`, 
 #   `proxymatch` or `locationmatch`. If you set `provider` to `directorymatch`, it 
 #   uses the keyword `DirectoryMatch` in the Apache config file.<br />
+#   proxy_pass and proxy_pass_match are supported like their parameters to apache::vhost, and will
+#   be rendered without their path parameter as this will be inherited from the Location/LocationMatch container.
 #   An example use of `directories`:
 #   ``` puppet
 #   apache::vhost { 'files.example.net':

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -709,6 +709,11 @@ describe 'apache::vhost', type: :define do
           }
           it {
             is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
+              content: %r{^\s+ProxyPassMatch http://backend-b/ retry=0 timeout=5 noquery interpolate$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
               content: %r{^\s+Options\sIndexes\sFollowSymLinks\sMultiViews$},
             )
           }

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -210,6 +210,20 @@ describe 'apache::vhost', type: :define do
                   ],
                 },
                 {
+                  'path'       => '^/proxy',
+                  'provider'   => 'locationmatch',
+                  'proxy_pass' => [
+                    {
+                      'url'             => 'http://backend-b/',
+                      'keywords'        => ['noquery', 'interpolate'],
+                      'params' => {
+                        'retry'   => '0',
+                        'timeout' => '5',
+                      },
+                    },
+                  ],
+                },
+                {
                   'path'                                                => '/var/www/node-app/public',
                   'passenger_enabled'                                   => true,
                   'passenger_base_uri'                                  => '/app',

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -500,6 +500,18 @@
         <%- end -%>
       <% end -%>
     <%- end -%>
+    <%# In a directory context, ProxyPassMatch is only valid for LocationMatch, and its first argument is the regex -%>
+    <%# argument to LocationMatch -%>
+    <%- if directory['proxy_pass_match'] and directory['provider'] and directory['provider'] == 'locationmatch' -%>
+      <%- directory['proxy_pass_match'].flatten.compact.each do |proxy| -%>
+    ProxyPassMatch <%= proxy['url'] -%>
+        <%- if proxy['params'] -%>
+          <%- proxy['params'].keys.sort.each do |key| -%> <%= key %>=<%= proxy['params'][key] -%>
+          <%- end -%>
+        <%- end -%>
+        <%- if proxy['keywords'] %> <%= proxy['keywords'].join(' ') -%>
+        <%- end %>
+    <%- end -%>
     <%- if directory['custom_fragment'] -%>
     <%= directory['custom_fragment'] %>
     <%- end -%>

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -472,11 +472,10 @@
         <%# If the proxy hash has a match key that evaluates to true, use ProxyPassMatch -%>
         <%# Otherwise default to ProxyPass -%>
         <%- if not proxy.key?('match') or not proxy['match'] -%>
-    ProxyPass 
+    ProxyPass <%= proxy['url'] -%>
         <%- else -%>
-    ProxyPassMatch 
+    ProxyPassMatch <%= proxy['url'] -%>
         <%- end -%>
-        <%= proxy['url'] -%>
         <%- if proxy['params'] -%>
           <%- proxy['params'].keys.sort.each do |key| -%> <%= key %>=<%= proxy['params'][key] -%>
           <%- end -%>

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -467,15 +467,18 @@
         <%- end -%>
       <%- end -%>
     <%- end -%>
-    <%- if directory['proxy_pass'] and directory['provider'] and directory['provider'].match('location') -%>
-      <%- directory['proxy_pass'].flatten.compact.each do |proxy| -%>
-        <%# If the proxy hash has a match key that evaluates to true, use ProxyPassMatch -%>
-        <%# Otherwise default to ProxyPass -%>
-        <%- if not proxy.key?('match') or not proxy['match'] -%>
-    ProxyPass <%= proxy['url'] -%>
-        <%- else -%>
-    ProxyPassMatch <%= proxy['url'] -%>
-        <%- end -%>
+    <%- if (directory['proxy_pass'] or directory['proxy_pass_match'] and directory['provider'] and directory['provider'].match('location') -%>
+      <%# Detect whether we have a proxy_pass_match or proxy_pass dictionary. Only one of those in a Location is valid so no need -%>
+      <%# to handle both in one stanza -%>
+      <%- if directory['proxy_pass_match']
+            proxy_pass = 'ProxyPassMatch'
+            directory_proxy_pass = directory['proxy_pass_match']
+          else
+            proxy_pass = 'ProxyPass'
+            directory_proxy_pass = directory['proxy_pass']
+          end -%>
+      <%- directory_proxy_pass.flatten.compact.each do |proxy| -%>
+    <%= proxy_pass -%> <%= proxy['url'] -%>
         <%- if proxy['params'] -%>
           <%- proxy['params'].keys.sort.each do |key| -%> <%= key %>=<%= proxy['params'][key] -%>
           <%- end -%>

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -511,6 +511,7 @@
         <%- end -%>
         <%- if proxy['keywords'] %> <%= proxy['keywords'].join(' ') -%>
         <%- end %>
+      <%- end -%>
     <%- end -%>
     <%- if directory['custom_fragment'] -%>
     <%= directory['custom_fragment'] %>

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -469,7 +469,14 @@
     <%- end -%>
     <%- if directory['proxy_pass'] and directory['provider'] and directory['provider'].match('location') -%>
       <%- directory['proxy_pass'].flatten.compact.each do |proxy| -%>
-    ProxyPass <%= proxy['url'] -%>
+        <%# If the proxy hash has a match key that evaluates to true, use ProxyPassMatch -%>
+        <%# Otherwise default to ProxyPass -%>
+        <%- if not proxy.key?('match') or not proxy['match'] -%>
+    ProxyPass 
+        <%- else -%>
+    ProxyPassMatch 
+        <%- end -%>
+        <%= proxy['url'] -%>
         <%- if proxy['params'] -%>
           <%- proxy['params'].keys.sort.each do |key| -%> <%= key %>=<%= proxy['params'][key] -%>
           <%- end -%>
@@ -499,19 +506,6 @@
           <%- end -%>
         <%- end -%>
       <% end -%>
-    <%- end -%>
-    <%# In a directory context, ProxyPassMatch is only valid for LocationMatch, and its first argument is the regex -%>
-    <%# argument to LocationMatch -%>
-    <%- if directory['proxy_pass_match'] and directory['provider'] and directory['provider'] == 'locationmatch' -%>
-      <%- directory['proxy_pass_match'].flatten.compact.each do |proxy| -%>
-    ProxyPassMatch <%= proxy['url'] -%>
-        <%- if proxy['params'] -%>
-          <%- proxy['params'].keys.sort.each do |key| -%> <%= key %>=<%= proxy['params'][key] -%>
-          <%- end -%>
-        <%- end -%>
-        <%- if proxy['keywords'] %> <%= proxy['keywords'].join(' ') -%>
-        <%- end %>
-      <%- end -%>
     <%- end -%>
     <%- if directory['custom_fragment'] -%>
     <%= directory['custom_fragment'] %>

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -468,6 +468,7 @@
       <%- end -%>
     <%- end -%>
     <%- if (directory['proxy_pass'] or directory['proxy_pass_match']) and directory['provider'] and directory['provider'].match('location') -%>
+      <%# In a Location container, only one of ProxyPass or ProxyPassMatch are allowed, so only need to handle on case at a time -%>
          <%- if directory['proxy_pass_match']
                proxy_pass = 'ProxyPassMatch'
                directory_proxy_pass = directory['proxy_pass_match']

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -467,16 +467,14 @@
         <%- end -%>
       <%- end -%>
     <%- end -%>
-    <%- if (directory['proxy_pass'] or directory['proxy_pass_match'] and directory['provider'] and directory['provider'].match('location') -%>
-      <%# Detect whether we have a proxy_pass_match or proxy_pass dictionary. Only one of those in a Location is valid so no need -%>
-      <%# to handle both in one stanza -%>
-      <%- if directory['proxy_pass_match']
-            proxy_pass = 'ProxyPassMatch'
-            directory_proxy_pass = directory['proxy_pass_match']
-          else
-            proxy_pass = 'ProxyPass'
-            directory_proxy_pass = directory['proxy_pass']
-          end -%>
+    <%- if (directory['proxy_pass'] or directory['proxy_pass_match']) and directory['provider'] and directory['provider'].match('location') -%>
+         <%- if directory['proxy_pass_match']
+               proxy_pass = 'ProxyPassMatch'
+               directory_proxy_pass = directory['proxy_pass_match']
+             else
+               proxy_pass = 'ProxyPass'
+               directory_proxy_pass = directory['proxy_pass']
+             end -%>
       <%- directory_proxy_pass.flatten.compact.each do |proxy| -%>
     <%= proxy_pass -%> <%= proxy['url'] -%>
         <%- if proxy['params'] -%>


### PR DESCRIPTION
Apache httpd supports placing `ProxyPass` and `ProxyPassMatch` directives either at virtual host scope, or inside a `Location`/`LocationMatch` container. When placed inside a container, the path parameter is omitted and inherited from the container's path. For `Location` containers, this is a simple URI, while `LocationMatch` allows the path to be regex. While `ProxyPass` can go into a `LocationMatch` container, the inherited path is interpreted as a string rather than a regex, which limits its utility.

While the puppetlabs-apache module (via its `apache::vhost` type) supports both `ProxyPass` and `ProxyPassMatch` at virtual host scope, currently it only supports `ProxyPass` inside a `Location`/`LocationMatch` container, which means that it isn't possible to use the regex-aware `LocationMatch` container type. This pull request enhances the `vhost/_directories.erb` template to support the same `proxy_pass_match` dictionary at `Location`/`LocationMatch` scope that `apache::vhost` type supports at virtual host scope.

I couldn't find any documentation for the existing `ProxyPass` support in `apache::vhost`'s `directories` array, so I added a short blurb to the `apache::vhost` Puppet Strings.

I added what I thought would be a decent simple test case, though I confess I'm not a rspec expert so it might bear special review.