### PR TITLE
Drop Apache 2.0 compatibility code

### DIFF
--- a/manifests/mod/proxy_connect.pp
+++ b/manifests/mod/proxy_connect.pp
@@ -1,18 +1,9 @@
 # @summary
 #   Installs `mod_proxy_connect`.
-# 
-# @param apache_version
-#   Used to verify that the Apache version you have requested is compatible with the module.
-# 
 # @see https://httpd.apache.org/docs/current/mod/mod_proxy_connect.html for additional documentation.
 #
-class apache::mod::proxy_connect (
-  $apache_version  = undef,
-) {
+class apache::mod::proxy_connect {
   include apache
-  $_apache_version = pick($apache_version, $apache::apache_version)
-  if versioncmp($_apache_version, '2.2') >= 0 {
-    Class['::apache::mod::proxy'] -> Class['::apache::mod::proxy_connect']
-    ::apache::mod { 'proxy_connect': }
-  }
+  Class['apache::mod::proxy'] -> Class['apache::mod::proxy_connect']
+  apache::mod { 'proxy_connect': }
 }

--- a/spec/classes/mod/proxy_connect_spec.rb
+++ b/spec/classes/mod/proxy_connect_spec.rb
@@ -11,31 +11,5 @@ describe 'apache::mod::proxy_connect', type: :class do
 
   include_examples 'a mod class, without including apache'
 
-  context 'with Apache version < 2.2' do
-    let :params do
-      {
-        apache_version: '2.1',
-      }
-    end
-
-    it { is_expected.not_to contain_apache__mod('proxy_connect') }
-  end
-  context 'with Apache version = 2.2' do
-    let :params do
-      {
-        apache_version: '2.2',
-      }
-    end
-
-    it { is_expected.to contain_apache__mod('proxy_connect') }
-  end
-  context 'with Apache version >= 2.4' do
-    let :params do
-      {
-        apache_version: '2.4',
-      }
-    end
-
-    it { is_expected.to contain_apache__mod('proxy_connect') }
-  end
+  it { is_expected.to contain_apache__mod('proxy_connect') }
 end


### PR DESCRIPTION
It's safe to assume the version is >= 2.2 so the conditional can be dropped.