### PR TITLE
Restructure MPM disabling

### DIFF
--- a/manifests/mpm.pp
+++ b/manifests/mpm.pp
@@ -85,9 +85,6 @@ define apache::mpm (
       }
 
       if $mpm == 'itk' {
-        include apache::mpm::disable_mpm_event
-        include apache::mpm::disable_mpm_worker
-
         package { 'libapache2-mpm-itk':
           ensure => present,
           before => [
@@ -97,14 +94,16 @@ define apache::mpm (
         }
       }
 
-      if $mpm == 'prefork' {
-        include apache::mpm::disable_mpm_event
+      unless $mpm in ['itk', 'prefork'] {
+        include apache::mpm::disable_mpm_prefork
+      }
+
+      if $mpm != 'worker' {
         include apache::mpm::disable_mpm_worker
       }
 
-      if $mpm == 'worker' {
+      if $mpm != 'event' {
         include apache::mpm::disable_mpm_event
-        include apache::mpm::disable_mpm_prefork
       }
     }
 


### PR DESCRIPTION
This takes the approach of listing the disabling steps once rather than repeating it for every mpm.

I wasn't quite sure on the prefork disabling. Does prefork need to stay enabled for itk?