### PR TITLE
Add support for PassengerPreloadBundler

### DIFF
--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -120,6 +120,9 @@
 # @param passenger_load_shell_envvars
 #   Enables or disables the loading of shell environment variables before spawning the application.
 #
+# @param passenger_preload_bundler
+#   Enables or disables loading bundler before loading your Ruby app.
+#
 # @param passenger_log_file
 #   File path to log file. By default Passenger log messages are written to the Apache global error log.
 #
@@ -343,6 +346,7 @@ class apache::mod::passenger (
   $passenger_installed_version                                                               = undef,
   $passenger_instance_registry_dir                                                           = undef,
   $passenger_load_shell_envvars                                                              = undef,
+  Optional[Boolean] $passenger_preload_bundler                                               = undef,
   Optional[Stdlib::Absolutepath] $passenger_log_file                                         = undef,
   $passenger_log_level                                                                       = undef,
   $passenger_lve_min_uid                                                                     = undef,
@@ -544,6 +548,11 @@ class apache::mod::passenger (
     if $passenger_load_shell_envvars {
       if (versioncmp($passenger_installed_version, '4.0.20') < 0) {
         fail("Passenger config option :: passenger_load_shell_envvars is not introduced until version 4.0.20 :: ${passenger_installed_version} is the version reported")
+      }
+    }
+    if $passenger_preload_bundler {
+      if (versioncmp($passenger_installed_version, '6.0.13') < 0) {
+        fail("Passenger config option :: passenger_preload_bundler is not introduced until version 6.0.13 :: ${passenger_installed_version} is the version reported")
       }
     }
     if $passenger_log_file {
@@ -901,6 +910,7 @@ class apache::mod::passenger (
   # - $passenger_high_performance : since 2.0.0.
   # - $passenger_instance_registry_dir : since 5.0.0.
   # - $passenger_load_shell_envvars : since 4.0.20.
+  # - $passenger_preload_bundler : since 6.0.13
   # - $passenger_log_file : since 5.0.5.
   # - $passenger_log_level : since 3.0.0.
   # - $passenger_lve_min_uid : since 5.0.28.

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -684,6 +684,10 @@
 # @param passenger_load_shell_envvars
 #   Sets [PassengerLoadShellEnvvars](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerloadshellenvvars),
 #   to enable or disable the loading of shell environment variables before spawning the application.
+#
+# @param passenger_preload_bundler
+#   Sets [PassengerPreloadBundler](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerpreloadbundler),
+#   to enable or disable the loading of bundler before loading the application.
 # 
 # @param passenger_rolling_restarts
 #   Sets [PassengerRollingRestarts](https://www.phusionpassenger.com/docs/references/config_reference/apache/#passengerrollingrestarts),
@@ -1950,6 +1954,7 @@ define apache::vhost (
   Optional[String] $passenger_restart_dir                                           = undef,
   Optional[Enum['direct', 'smart']] $passenger_spawn_method                         = undef,
   Optional[Boolean] $passenger_load_shell_envvars                                   = undef,
+  Optional[Boolean] $passenger_preload_bundler                                      = undef,
   Optional[Boolean] $passenger_rolling_restarts                                     = undef,
   Optional[Boolean] $passenger_resist_deployment_errors                             = undef,
   Optional[String] $passenger_user                                                  = undef,
@@ -2086,7 +2091,7 @@ define apache::vhost (
     include apache::mod::suexec
   }
 
-  if $passenger_enabled != undef or $passenger_start_timeout != undef or $passenger_ruby != undef or $passenger_python != undef or $passenger_nodejs != undef or $passenger_meteor_app_settings != undef or $passenger_app_env != undef or $passenger_app_root != undef or $passenger_app_group_name != undef or $passenger_app_start_command != undef or $passenger_app_type != undef or $passenger_startup_file != undef or $passenger_restart_dir != undef or $passenger_spawn_method != undef or $passenger_load_shell_envvars != undef or $passenger_rolling_restarts != undef or $passenger_resist_deployment_errors != undef or $passenger_min_instances != undef or $passenger_max_instances != undef or $passenger_max_preloader_idle_time != undef or $passenger_force_max_concurrent_requests_per_process != undef or $passenger_concurrency_model != undef or $passenger_thread_count != undef or $passenger_high_performance != undef or $passenger_max_request_queue_size != undef or $passenger_max_request_queue_time != undef or $passenger_user != undef or $passenger_group != undef or $passenger_friendly_error_pages != undef or $passenger_buffer_upload != undef or $passenger_buffer_response != undef or $passenger_allow_encoded_slashes != undef or $passenger_lve_min_uid != undef or $passenger_base_uri != undef or $passenger_error_override != undef or $passenger_sticky_sessions != undef or $passenger_sticky_sessions_cookie_name != undef or $passenger_sticky_sessions_cookie_attributes != undef or $passenger_app_log_file != undef or $passenger_debugger != undef or $passenger_max_requests != undef or $passenger_max_request_time != undef or $passenger_memory_limit != undef {
+  if $passenger_enabled != undef or $passenger_start_timeout != undef or $passenger_ruby != undef or $passenger_python != undef or $passenger_nodejs != undef or $passenger_meteor_app_settings != undef or $passenger_app_env != undef or $passenger_app_root != undef or $passenger_app_group_name != undef or $passenger_app_start_command != undef or $passenger_app_type != undef or $passenger_startup_file != undef or $passenger_restart_dir != undef or $passenger_spawn_method != undef or $passenger_load_shell_envvars != undef or $passenger_preload_bundler != undef or $passenger_rolling_restarts != undef or $passenger_resist_deployment_errors != undef or $passenger_min_instances != undef or $passenger_max_instances != undef or $passenger_max_preloader_idle_time != undef or $passenger_force_max_concurrent_requests_per_process != undef or $passenger_concurrency_model != undef or $passenger_thread_count != undef or $passenger_high_performance != undef or $passenger_max_request_queue_size != undef or $passenger_max_request_queue_time != undef or $passenger_user != undef or $passenger_group != undef or $passenger_friendly_error_pages != undef or $passenger_buffer_upload != undef or $passenger_buffer_response != undef or $passenger_allow_encoded_slashes != undef or $passenger_lve_min_uid != undef or $passenger_base_uri != undef or $passenger_error_override != undef or $passenger_sticky_sessions != undef or $passenger_sticky_sessions_cookie_name != undef or $passenger_sticky_sessions_cookie_attributes != undef or $passenger_app_log_file != undef or $passenger_debugger != undef or $passenger_max_requests != undef or $passenger_max_request_time != undef or $passenger_memory_limit != undef {
     include apache::mod::passenger
   }
 
@@ -2893,6 +2898,7 @@ define apache::vhost (
   # - $passenger_restart_dir
   # - $passenger_spawn_method
   # - $passenger_load_shell_envvars
+  # - $passenger_preload_bundler
   # - $passenger_rolling_restarts
   # - $passenger_resist_deployment_errors
   # - $passenger_min_instances
@@ -2921,7 +2927,7 @@ define apache::vhost (
   # - $passenger_max_requests
   # - $passenger_max_request_time
   # - $passenger_memory_limit
-  if $passenger_enabled != undef or $passenger_start_timeout != undef or $passenger_ruby != undef or $passenger_python != undef or $passenger_nodejs != undef or $passenger_meteor_app_settings != undef or $passenger_app_env != undef or $passenger_app_root != undef or $passenger_app_group_name != undef or $passenger_app_start_command != undef or $passenger_app_type != undef or $passenger_startup_file != undef or $passenger_restart_dir != undef or $passenger_spawn_method != undef or $passenger_load_shell_envvars != undef or $passenger_rolling_restarts != undef or $passenger_resist_deployment_errors != undef or $passenger_min_instances != undef or $passenger_max_instances != undef or $passenger_max_preloader_idle_time != undef or $passenger_force_max_concurrent_requests_per_process != undef or $passenger_concurrency_model != undef or $passenger_thread_count != undef or $passenger_high_performance != undef or $passenger_max_request_queue_size != undef or $passenger_max_request_queue_time != undef or $passenger_user != undef or $passenger_group != undef or $passenger_friendly_error_pages != undef or $passenger_buffer_upload != undef or $passenger_buffer_response != undef or $passenger_allow_encoded_slashes != undef or $passenger_lve_min_uid != undef or $passenger_base_uri != undef or $passenger_error_override != undef or $passenger_sticky_sessions != undef or $passenger_sticky_sessions_cookie_name != undef or $passenger_sticky_sessions_cookie_attributes != undef or $passenger_app_log_file != undef or $passenger_debugger != undef or $passenger_max_requests != undef or $passenger_max_request_time != undef or $passenger_memory_limit != undef {
+  if $passenger_enabled != undef or $passenger_start_timeout != undef or $passenger_ruby != undef or $passenger_python != undef or $passenger_nodejs != undef or $passenger_meteor_app_settings != undef or $passenger_app_env != undef or $passenger_app_root != undef or $passenger_app_group_name != undef or $passenger_app_start_command != undef or $passenger_app_type != undef or $passenger_startup_file != undef or $passenger_restart_dir != undef or $passenger_spawn_method != undef or $passenger_load_shell_envvars != undef or $passenger_preload_bundler != undef or $passenger_rolling_restarts != undef or $passenger_resist_deployment_errors != undef or $passenger_min_instances != undef or $passenger_max_instances != undef or $passenger_max_preloader_idle_time != undef or $passenger_force_max_concurrent_requests_per_process != undef or $passenger_concurrency_model != undef or $passenger_thread_count != undef or $passenger_high_performance != undef or $passenger_max_request_queue_size != undef or $passenger_max_request_queue_time != undef or $passenger_user != undef or $passenger_group != undef or $passenger_friendly_error_pages != undef or $passenger_buffer_upload != undef or $passenger_buffer_response != undef or $passenger_allow_encoded_slashes != undef or $passenger_lve_min_uid != undef or $passenger_base_uri != undef or $passenger_error_override != undef or $passenger_sticky_sessions != undef or $passenger_sticky_sessions_cookie_name != undef or $passenger_sticky_sessions_cookie_attributes != undef or $passenger_app_log_file != undef or $passenger_debugger != undef or $passenger_max_requests != undef or $passenger_max_request_time != undef or $passenger_memory_limit != undef {
     concat::fragment { "${name}-passenger":
       target  => "${priority_real}${filename}.conf",
       order   => 300,

--- a/spec/acceptance/mod_php_spec.rb
+++ b/spec/acceptance/mod_php_spec.rb
@@ -44,7 +44,7 @@ describe 'apache::mod::php class', if: mod_supported_on_platform?('apache::mod::
       describe file("#{apache_hash['mod_dir']}/php7.4.conf") do
         it { is_expected.to contain 'DirectoryIndex index.php' }
       end
-    elsif os[:family] == 'redhat' && os[:release] =~ %r{^8\.}
+    elsif os[:family] == 'redhat' && os[:release] =~ %r{^8\b}
       describe file("#{apache_hash['mod_dir']}/php7.conf") do
         it { is_expected.to contain 'DirectoryIndex index.php' }
       end

--- a/spec/classes/mod/passenger_spec.rb
+++ b/spec/classes/mod/passenger_spec.rb
@@ -52,6 +52,7 @@ describe 'apache::mod::passenger', type: :class do
             'passenger_high_performance' => { type: 'OnOff', pass_opt: :PassengerHighPerformance },
             'passenger_instance_registry_dir' => { type: 'FullPath', pass_opt: :PassengerInstanceRegistryDir },
             'passenger_load_shell_envvars' => { type: 'OnOff', pass_opt: :PassengerLoadShellEnvvars },
+            'passenger_preload_bundler' => { type: 'Boolean', pass_opt: :PassengerPreloadBundler },
             'passenger_log_file' => { type: 'FullPath', pass_opt: :PassengerLogFile },
             'passenger_log_level' => { type: 'Integer', pass_opt: :PassengerLogLevel },
             'passenger_lve_min_uid' => { type: 'Integer', pass_opt: :PassengerLveMinUid },

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -225,6 +225,7 @@ describe 'apache::vhost', type: :define do
                   'passenger_startup_file'                              => 'start.js',
                   'passenger_restart_dir'                               => 'temp',
                   'passenger_load_shell_envvars'                        => false,
+                  'passenger_preload_bundler'                           => false,
                   'passenger_rolling_restarts'                          => false,
                   'passenger_resist_deployment_errors'                  => false,
                   'passenger_user'                                      => 'nodeuser',
@@ -440,6 +441,7 @@ describe 'apache::vhost', type: :define do
               'passenger_restart_dir'                 => 'tmp',
               'passenger_spawn_method'                => 'direct',
               'passenger_load_shell_envvars'          => false,
+              'passenger_preload_bundler'             => false,
               'passenger_rolling_restarts'            => false,
               'passenger_resist_deployment_errors'    => true,
               'passenger_user'                        => 'sandbox',
@@ -821,6 +823,11 @@ describe 'apache::vhost', type: :define do
           it {
             is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
               content: %r{^\s+PassengerLoadShellEnvvars\sOff$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-directories').with(
+              content: %r{^\s+PassengerPreloadBundler\sOff$},
             )
           }
           it {
@@ -1343,6 +1350,11 @@ describe 'apache::vhost', type: :define do
           it {
             is_expected.to contain_concat__fragment('rspec.example.com-passenger').with(
               content: %r{^\s+PassengerLoadShellEnvvars\sOff$},
+            )
+          }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-passenger').with(
+              content: %r{^\s+PassengerPreloadBundler\sOff$},
             )
           }
           it {

--- a/templates/mod/passenger.conf.erb
+++ b/templates/mod/passenger.conf.erb
@@ -88,6 +88,9 @@
   <%- if @passenger_load_shell_envvars -%>
   PassengerLoadShellEnvvars <%= @passenger_load_shell_envvars %>
   <%- end -%>
+  <%- unless @passenger_preload_bundler.nil? -%>
+  PassengerPreloadBundler <%= scope.call_function('apache::bool2httpd', [@passenger_preload_bundler]) %>
+  <%- end -%>
   <%- if @passenger_log_file -%>
   PassengerLogFile "<%= @passenger_log_file %>"
   <%- end -%>

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -132,6 +132,9 @@
     <%- unless directory['passenger_load_shell_envvars'].nil? -%>
     PassengerLoadShellEnvvars <%= scope.call_function('apache::bool2httpd', [directory['passenger_load_shell_envvars']]) %>
     <%- end -%>
+    <%- unless directory['passenger_preload_bundler'].nil? -%>
+    PassengerPreloadBundler <%= scope.call_function('apache::bool2httpd', [directory['passenger_preload_bundler']]) %>
+    <%- end -%>
     <%- unless directory['passenger_rolling_restarts'].nil? -%>
     PassengerRollingRestarts <%= scope.call_function('apache::bool2httpd', [directory['passenger_rolling_restarts']]) %>
     <%- end -%>

--- a/templates/vhost/_passenger.erb
+++ b/templates/vhost/_passenger.erb
@@ -46,6 +46,9 @@
 <% unless @passenger_load_shell_envvars.nil? -%>
   PassengerLoadShellEnvvars <%= scope.call_function('apache::bool2httpd', [@passenger_load_shell_envvars]) %>
 <% end -%>
+<% unless @passenger_preload_bundler.nil? -%>
+  PassengerPreloadBundler <%= scope.call_function('apache::bool2httpd', [@passenger_preload_bundler]) %>
+<% end -%>
 <% unless @passenger_rolling_restarts.nil? -%>
   PassengerRollingRestarts <%= scope.call_function('apache::bool2httpd', [@passenger_rolling_restarts]) %>
 <% end -%>


### PR DESCRIPTION
The latest passenger include a new option to load ruby bundles earlier,
working around deployment issues.  See:
* https://github.com/phusion/passenger/issues/2410
* https://github.com/phusion/passenger/issues/2409
