### PR TITLE
Drop support for Fedora < 18

### DIFF
--- a/manifests/version.pp
+++ b/manifests/version.pp
@@ -13,7 +13,7 @@ class apache::version (
       }
       elsif ($::operatingsystem == 'Amazon' and $::operatingsystemmajrelease == '2') {
         $default = '2.4'
-      } elsif ($::operatingsystem == 'Fedora' and versioncmp($facts['operatingsystemmajrelease'], '18') >= 0) or ($::operatingsystem != 'Fedora' and versioncmp($facts['operatingsystemmajrelease'], '7') >= 0) {
+      } elsif $::operatingsystem == 'Fedora' or versioncmp($facts['operatingsystemmajrelease'], '7') >= 0 {
         $default = '2.4'
       } else {
         $default = '2.2'

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -629,21 +629,10 @@ describe 'apache', type: :class do
       it { is_expected.to contain_file('/etc/httpd/conf/httpd.conf').with_content %r{^HostnameLookups Double\n} }
     end
 
-    context 'on Fedora 21' do
-      include_examples 'Fedora 21'
+    context 'on Fedora 28' do
+      include_examples 'Fedora 28'
 
       it { is_expected.to contain_class('apache').with_apache_version('2.4') }
-    end
-    context 'on Fedora Rawhide' do
-      include_examples 'Fedora Rawhide'
-
-      it { is_expected.to contain_class('apache').with_apache_version('2.4') }
-    end
-    # kinda obsolete
-    context 'on Fedora 17' do
-      include_examples 'Fedora 17'
-
-      it { is_expected.to contain_class('apache').with_apache_version('2.2') }
     end
   end
   context 'on a FreeBSD OS' do

--- a/spec/classes/mod/wsgi_spec.rb
+++ b/spec/classes/mod/wsgi_spec.rb
@@ -141,7 +141,7 @@ describe 'apache::mod::wsgi', type: :class do
   end
   context 'overriding mod_libs' do
     context 'on a RedHat OS', :compile do
-      include_examples 'Fedora 28'
+      include_examples 'RedHat 8'
       let :pre_condition do
         <<-MANIFEST
         include apache::params

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -57,34 +57,6 @@ shared_context 'RedHat 8' do
   let(:facts) { on_supported_os['redhat-8-x86_64'] }
 end
 
-shared_context 'Fedora 17' do
-  let :facts do
-    {
-      id: 'root',
-      kernel: 'Linux',
-      osfamily: 'RedHat',
-      operatingsystem: 'Fedora',
-      operatingsystemrelease: '17',
-      operatingsystemmajrelease: '17',
-      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    }
-  end
-end
-
-shared_context 'Fedora 21' do
-  let :facts do
-    {
-      id: 'root',
-      kernel: 'Linux',
-      osfamily: 'RedHat',
-      operatingsystem: 'Fedora',
-      operatingsystemrelease: '21',
-      operatingsystemmajrelease: '21',
-      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    }
-  end
-end
-
 shared_context 'Fedora 28' do
   let :facts do
     {
@@ -94,20 +66,6 @@ shared_context 'Fedora 28' do
       operatingsystem: 'Fedora',
       operatingsystemrelease: '28',
       operatingsystemmajrelease: '28',
-      path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-    }
-  end
-end
-
-shared_context 'Fedora Rawhide' do
-  let :facts do
-    {
-      id: 'root',
-      kernel: 'Linux',
-      osfamily: 'RedHat',
-      operatingsystem: 'Fedora',
-      operatingsystemrelease: 'Rawhide',
-      operatingsystemmajrelease: 'Rawhide',
       path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
     }
   end


### PR DESCRIPTION
The goal of this PR is to simplify Fedora handling. By now it can be assumed every Fedora is on Apache 2.4 and most users can be expected to run on Red Hat. Fedora isn't formally in metadata.json so this is best effort anyway. Users do not lose anything by this change, but for developers there is less code to maintain.