### PR TITLE
[Issue 2247] fix datatype of vhost:headers from String to Array

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1853,7 +1853,7 @@ define apache::vhost (
   Optional[Variant[Array[String],String]] $redirectmatch_status                       = undef,
   Optional[Variant[Array[String],String]] $redirectmatch_regexp                       = undef,
   Optional[Variant[Array[String],String]] $redirectmatch_dest                         = undef,
-  Optional[String] $headers                                                           = undef,
+  Array[String] $headers                                                              = [],
   Optional[Array[String]] $request_headers                                            = undef,
   Optional[Array[String]] $filters                                                    = undef,
   Optional[Array] $rewrites                                                           = undef,

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -2260,7 +2260,7 @@ define apache::vhost (
   }
 
   # Check if mod_headers is required to process $headers/$request_headers
-  if ($headers and ! empty($headers)) or ( $request_headers and ! empty($request_headers)){
+  if ($headers and ! empty ($headers)) or ($request_headers and ! empty($request_headers)) {
     if ! defined(Class['apache::mod::headers']) {
       include apache::mod::headers
     }

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1853,7 +1853,7 @@ define apache::vhost (
   Optional[Variant[Array[String],String]] $redirectmatch_status                       = undef,
   Optional[Variant[Array[String],String]] $redirectmatch_regexp                       = undef,
   Optional[Variant[Array[String],String]] $redirectmatch_dest                         = undef,
-  Array[String] $headers                                                              = [],
+  Optional[Array[String]] $headers                                                    = undef,
   Optional[Array[String]] $request_headers                                            = undef,
   Optional[Array[String]] $filters                                                    = undef,
   Optional[Array] $rewrites                                                           = undef,
@@ -2260,7 +2260,7 @@ define apache::vhost (
   }
 
   # Check if mod_headers is required to process $headers/$request_headers
-  if $headers or $request_headers {
+  if ($headers and ! empty($headers)) or ( $request_headers and ! empty($request_headers)){
     if ! defined(Class['apache::mod::headers']) {
       include apache::mod::headers
     }

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1409,7 +1409,7 @@
 #     docroot     => '/path/to/directory',
 #     directories => {
 #       path    => '/path/to/directory',
-#       headers => 'Set X-Robots-Tag "noindex, noarchive, nosnippet"',
+#       headers => ['Set X-Robots-Tag "noindex, noarchive, nosnippet"'],
 #     },
 #   }
 #   ```

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -385,7 +385,7 @@ describe 'apache::vhost', type: :define do
               'redirectmatch_status'        => ['404'],
               'redirectmatch_regexp'        => ['\.git$'],
               'redirectmatch_dest'          => ['http://www.example.com'],
-              'headers'                     => 'Set X-Robots-Tag "noindex, noarchive, nosnippet"',
+              'headers'                     => ['Set X-Robots-Tag "noindex, noarchive, nosnippet"', 'Accept: text/html'],
               'request_headers'             => ['append MirrorID "mirror 12"'],
               'rewrites'                    => [
                 {


### PR DESCRIPTION
Fix wrong introduction of Dataype String to headers parameter
The code requires the parameter to be Array[String] to work properly