### PR TITLE
Better data types on apache::vhost parameters

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1853,8 +1853,8 @@ define apache::vhost (
   Optional[Variant[Array[String],String]] $redirectmatch_status                       = undef,
   Optional[Variant[Array[String],String]] $redirectmatch_regexp                       = undef,
   Optional[Variant[Array[String],String]] $redirectmatch_dest                         = undef,
-  Optional[String] $headers                                                           = undef,
-  Optional[Array[String]] $request_headers                                            = undef,
+  Array[String[1]] $headers                                                           = [],
+  Array[String[1]] $request_headers                                                   = [],
   Optional[Array[String]] $filters                                                    = undef,
   Optional[Array] $rewrites                                                           = undef,
   Optional[String] $rewrite_base                                                      = undef,
@@ -2259,13 +2259,6 @@ define apache::vhost (
     }
   }
 
-  # Check if mod_headers is required to process $headers/$request_headers
-  if $headers or $request_headers {
-    if ! defined(Class['apache::mod::headers']) {
-      include apache::mod::headers
-    }
-  }
-
   # Check if mod_filter is required to process $filters
   if $filters {
     if ! defined(Class['apache::mod::filter']) {
@@ -2534,7 +2527,9 @@ define apache::vhost (
 
   # Template uses:
   # - $headers
-  if $headers and ! empty($headers) {
+  if ! empty($headers) and $ensure == 'present' {
+    include apache::mod::headers
+
     concat::fragment { "${name}-header":
       target  => "${priority_real}${filename}.conf",
       order   => 140,
@@ -2544,7 +2539,9 @@ define apache::vhost (
 
   # Template uses:
   # - $request_headers
-  if $request_headers and ! empty($request_headers) {
+  if ! empty($request_headers) and $ensure == 'present' {
+    include apache::mod::headers
+
     concat::fragment { "${name}-requestheader":
       target  => "${priority_real}${filename}.conf",
       order   => 150,

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1958,7 +1958,7 @@ define apache::vhost (
   Optional[Variant[Hash, Array]] $modsec_disable_msgs                                 = undef,
   Optional[Variant[Hash, Array]] $modsec_disable_tags                                 = undef,
   Optional[String] $modsec_body_limit                                                 = undef,
-  Optional[Array[Hash]] $jk_mounts                                                    = undef,
+  Array[Hash] $jk_mounts                                                              = [],
   Boolean $auth_kerb                                                                  = false,
   Enum['on', 'off'] $krb_method_negotiate                                             = 'on',
   Enum['on', 'off'] $krb_method_k5passwd                                              = 'on',
@@ -2898,7 +2898,9 @@ define apache::vhost (
 
   # Template uses:
   # - $jk_mounts
-  if $jk_mounts and ! empty($jk_mounts) {
+  if !empty($jk_mounts) and $ensure == 'present' {
+    include apache::mod::jk
+
     concat::fragment { "${name}-jk_mounts":
       target  => "${priority_real}${filename}.conf",
       order   => 340,

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1954,7 +1954,7 @@ define apache::vhost (
   Optional[String] $add_default_charset                                               = undef,
   Boolean $modsec_disable_vhost                                                       = false,
   Optional[Variant[Hash, Array]] $modsec_disable_ids                                  = undef,
-  Optional[Array[String]] $modsec_disable_ips                                         = undef,
+  Array[String[1]] $modsec_disable_ips                                                = [],
   Optional[Variant[Hash, Array]] $modsec_disable_msgs                                 = undef,
   Optional[Variant[Hash, Array]] $modsec_disable_tags                                 = undef,
   Optional[String] $modsec_body_limit                                                 = undef,
@@ -2876,7 +2876,7 @@ define apache::vhost (
   # - $modsec_disable_tags
   # - $modsec_body_limit
   # - $modsec_audit_log_destination
-  if $modsec_disable_vhost or $modsec_disable_ids or $modsec_disable_ips or $modsec_disable_msgs or $modsec_disable_tags or $modsec_audit_log_destination {
+  if $modsec_disable_vhost or $modsec_disable_ids or !empty($modsec_disable_ips) or $modsec_disable_msgs or $modsec_disable_tags or $modsec_audit_log_destination {
     concat::fragment { "${name}-security":
       target  => "${priority_real}${filename}.conf",
       order   => 320,

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1855,7 +1855,7 @@ define apache::vhost (
   Optional[Variant[Array[String],String]] $redirectmatch_dest                         = undef,
   Array[String[1]] $headers                                                           = [],
   Array[String[1]] $request_headers                                                   = [],
-  Optional[Array[String]] $filters                                                    = undef,
+  Array[String[1]] $filters                                                           = [],
   Optional[Array] $rewrites                                                           = undef,
   Optional[String] $rewrite_base                                                      = undef,
   Optional[Variant[Array[String],String]] $rewrite_rule                               = undef,
@@ -2256,13 +2256,6 @@ define apache::vhost (
   if $fastcgi_server and $fastcgi_socket {
     if ! defined(Class['apache::mod::fastcgi']) {
       include apache::mod::fastcgi
-    }
-  }
-
-  # Check if mod_filter is required to process $filters
-  if $filters {
-    if ! defined(Class['apache::mod::filter']) {
-      include apache::mod::filter
     }
   }
 
@@ -2906,7 +2899,9 @@ define apache::vhost (
 
   # Template uses:
   # - $filters
-  if $filters and ! empty($filters) {
+  if ! empty($filters) and $ensure == 'present' {
+    include apache::mod::filter
+
     concat::fragment { "${name}-filters":
       target  => "${priority_real}${filename}.conf",
       order   => 330,

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1800,7 +1800,7 @@ define apache::vhost (
   Variant[Boolean,String] $access_log_syslog                                          = false,
   Variant[Boolean,String] $access_log_format                                          = false,
   Variant[Boolean,String] $access_log_env_var                                         = false,
-  Optional[Array] $access_logs                                                        = undef,
+  Optional[Array[Hash]] $access_logs                                                  = undef,
   Boolean $use_servername_for_filenames                                               = false,
   Boolean $use_port_for_filenames                                                     = false,
   Optional[Variant[Array[Hash],Hash,String]] $aliases                                 = undef,
@@ -2459,13 +2459,12 @@ define apache::vhost (
   }
 
   # Template uses:
-  # - $access_log
+  # - $_access_logs
   # - $_access_log_env_var
   # - $access_log_destination
   # - $_access_log_format
   # - $_access_log_env_var
-  # - $access_logs
-  if $access_log or $access_logs {
+  if !empty($_access_logs) {
     concat::fragment { "${name}-access_log":
       target  => "${priority_real}${filename}.conf",
       order   => 100,

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -403,7 +403,7 @@ describe 'apache::vhost', type: :define do
               ],
               'rewrite_base'                => '/',
               'rewrite_rule'                => '^index\.html$ welcome.html',
-              'rewrite_cond'                => '%{HTTP_USER_AGENT} ^MSIE',
+              'rewrite_cond'                => ['%{HTTP_USER_AGENT} ^MSIE'],
               'rewrite_inherit'             => true,
               'setenv'                      => ['FOO=/bin/true'],
               'setenvif'                    => 'Request_URI "\.gif$" object_is_image=gif',

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -385,7 +385,7 @@ describe 'apache::vhost', type: :define do
               'redirectmatch_status'        => ['404'],
               'redirectmatch_regexp'        => ['\.git$'],
               'redirectmatch_dest'          => ['http://www.example.com'],
-              'headers'                     => 'Set X-Robots-Tag "noindex, noarchive, nosnippet"',
+              'headers'                     => ['Set X-Robots-Tag "noindex, noarchive, nosnippet"'],
               'request_headers'             => ['append MirrorID "mirror 12"'],
               'rewrites'                    => [
                 {

--- a/templates/vhost/_filters.erb
+++ b/templates/vhost/_filters.erb
@@ -1,10 +1,8 @@
-<% if @filters and ! @filters.empty? -%>
+<% unless @filters.empty? -%>
 
   ## Filter module rules
   ## as per http://httpd.apache.org/docs/2.2/mod/mod_filter.html
-  <%- Array(@filters).each do |filter| -%>
-    <%- if filter != '' -%>
+  <%- @filters.each do |filter| -%>
   <%= filter %>
-    <%- end -%>
   <%- end -%>
 <% end -%>

--- a/templates/vhost/_header.erb
+++ b/templates/vhost/_header.erb
@@ -1,10 +1,8 @@
-<% if @headers and ! @headers.empty? -%>
+<% unless @headers.empty? -%>
 
   ## Header rules
-  ## as per http://httpd.apache.org/docs/2.2/mod/mod_headers.html#header
-  <%- Array(@headers).each do |header_statement| -%>
-    <%- if header_statement != '' -%>
+  ## as per http://httpd.apache.org/docs/2.4/mod/mod_headers.html#header
+  <%- @headers.each do |header_statement| -%>
   Header <%= header_statement %>
-    <%- end -%>
   <%- end -%>
 <% end -%>

--- a/templates/vhost/_jk_mounts.erb
+++ b/templates/vhost/_jk_mounts.erb
@@ -1,12 +1,10 @@
-<% if @jk_mounts and not @jk_mounts.empty? -%>
+<% unless @jk_mounts.empty? -%>
 
   <%- @jk_mounts.each do |jk| -%>
-    <%- if jk.is_a?(Hash) -%>
-      <%- if jk.has_key?('mount') and jk.has_key?('worker') -%>
+    <%- if jk.has_key?('mount') and jk.has_key?('worker') -%>
   JkMount   <%= jk['mount'] %> <%= jk['worker'] %>
-      <%- elsif jk.has_key?('unmount') and jk.has_key?('worker') -%>
+    <%- elsif jk.has_key?('unmount') and jk.has_key?('worker') -%>
   JkUnMount <%= jk['unmount'] %> <%= jk['worker'] %>
-      <%- end -%>
     <%- end -%>
   <%- end -%>
 <% end -%>

--- a/templates/vhost/_requestheader.erb
+++ b/templates/vhost/_requestheader.erb
@@ -1,10 +1,8 @@
-<% if @request_headers and ! @request_headers.empty? -%>
+<% unless @request_headers.empty? -%>
 
   ## Request header rules
-  ## as per http://httpd.apache.org/docs/2.2/mod/mod_headers.html#requestheader
-  <%- Array(@request_headers).each do |request_statement| -%>
-    <%- if request_statement != '' -%>
+  ## as per http://httpd.apache.org/docs/2.4/mod/mod_headers.html#requestheader
+  <%- @request_headers.each do |request_statement| -%>
   RequestHeader <%= request_statement %>
-    <%- end -%>
   <%- end -%>
 <% end -%>

--- a/templates/vhost/_rewrite.erb
+++ b/templates/vhost/_rewrite.erb
@@ -8,7 +8,7 @@
   RewriteBase <%= @rewrite_base %>
   <%- end -%>
 
-  <%- [@rewrites].flatten.compact.each do |rewrite_details| -%>
+  <%- @rewrites.each do |rewrite_details| -%>
     <%- if rewrite_details['comment'] -%>
   #<%= rewrite_details['comment'] %>
     <%- end -%>
@@ -44,10 +44,8 @@
   <%- if @rewrite_base -%>
   RewriteBase <%= @rewrite_base %>
   <%- end -%>
-  <%- if @rewrite_cond -%>
-    <%- Array(@rewrite_cond).each do |cond| -%>
+    <%- @rewrite_cond.each do |cond| -%>
   RewriteCond <%= cond %>
-    <%- end -%>
   <%- end -%>
   RewriteRule <%= @rewrite_rule %>
 <%- end -%>

--- a/templates/vhost/_security.erb
+++ b/templates/vhost/_security.erb
@@ -14,9 +14,8 @@
   </LocationMatch>
 <%   end -%>
 <% end -%>
-<% ips = Array(@modsec_disable_ips).join(',') %>
-<% if ips != '' %>
-  SecRule REMOTE_ADDR "<%= ips %>" "nolog,allow,id:1234123455"
+<% unless @modsec_disable_ips.empty? %>
+  SecRule REMOTE_ADDR "<%= @modsec_disable_ips.join(',') %>" "nolog,allow,id:1234123455"
   SecAction  "phase:2,pass,nolog,id:1234123456"
 <% end -%>
 <% if @_modsec_disable_msgs.is_a?(Hash) -%>


### PR DESCRIPTION
This tightens data types where needed and does some additional minor cleanups around module inclusion. See individual commits for details.

Replaces https://github.com/puppetlabs/puppetlabs-apache/pull/2251 which had some CI problems. No actual difference in code.