### PR TITLE
Use a stricter data type on apache::vhost::aliases

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1803,7 +1803,7 @@ define apache::vhost (
   Optional[Array[Hash]] $access_logs                                                  = undef,
   Boolean $use_servername_for_filenames                                               = false,
   Boolean $use_port_for_filenames                                                     = false,
-  Optional[Variant[Array[Hash],Hash,String]] $aliases                                 = undef,
+  Array[Hash[String[1], String[1]]] $aliases                                          = [],
   Optional[Variant[Hash, Array[Variant[Array,Hash]]]] $directories                    = undef,
   Boolean $error_log                                                                  = true,
   Optional[String] $error_log_file                                                    = undef,
@@ -2222,7 +2222,6 @@ define apache::vhost (
 
   # Load mod_alias if needed and not yet loaded
   if ($scriptalias or $scriptaliases != [])
-  or ($aliases and $aliases != [])
   or ($redirect_source and $redirect_dest)
   or ($redirectmatch_regexp or $redirectmatch_status or $redirectmatch_dest) {
     if ! defined(Class['apache::mod::alias'])  and ($ensure == 'present') {
@@ -2376,7 +2375,9 @@ define apache::vhost (
 
   # Template uses:
   # - $aliases
-  if $aliases and ! empty($aliases) {
+  if ! empty($aliases) and $ensure == 'present' {
+    include apache::mod::alias
+
     concat::fragment { "${name}-aliases":
       target  => "${priority_real}${filename}.conf",
       order   => 20,

--- a/spec/acceptance/default_mods_spec.rb
+++ b/spec/acceptance/default_mods_spec.rb
@@ -38,10 +38,12 @@ describe 'apache::default_mods class' do
           }
           apache::vhost { 'defaults.example.com':
             docroot     => '#{apache_hash['doc_root']}/defaults',
-            aliases     => {
-              alias => '/css',
-              path  => '#{apache_hash['doc_root']}/css',
-            },
+            aliases     => [
+              {
+                alias => '/css',
+                path  => '#{apache_hash['doc_root']}/css',
+              },
+            ],
             directories => [
             {
                 'path'            => "#{apache_hash['doc_root']}/admin",
@@ -76,10 +78,12 @@ describe 'apache::default_mods class' do
         }
         apache::vhost { 'defaults.example.com':
           docroot => '#{apache_hash['doc_root']}/defaults',
-          aliases => {
-            alias => '/css',
-            path  => '#{apache_hash['doc_root']}/css',
-          },
+          aliases => [
+            {
+              alias => '/css',
+              path  => '#{apache_hash['doc_root']}/css',
+            },
+          ],
           setenv  => 'TEST1 one',
         }
       MANIFEST

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -104,12 +104,17 @@ describe 'apache::vhost', type: :define do
               'logroot_owner'               => 'root',
               'logroot_group'               => 'root',
               'log_level'                   => 'crit',
+              'aliases'                     => [
+                {
+                  'alias' => '/image',
+                  'path'  => '/rspec/image',
+                },
+              ],
               'access_log'                  => false,
               'access_log_file'             => 'httpd_access_log',
               'access_log_syslog'           => true,
               'access_log_format'           => '%h %l %u %t \"%r\" %>s %b',
               'access_log_env_var'          => '',
-              'aliases'                     => '/image',
               'directories'                 => [
                 {
                   'path'     => '/var/www/files',
@@ -619,7 +624,11 @@ describe 'apache::vhost', type: :define do
             )
           }
           it { is_expected.to contain_concat__fragment('rspec.example.com-docroot') }
-          it { is_expected.to contain_concat__fragment('rspec.example.com-aliases') }
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-aliases').with(
+              content: %r{^\s+Alias /image "/rspec/image"$},
+            )
+          }
           it { is_expected.to contain_concat__fragment('rspec.example.com-itk') }
           it { is_expected.to contain_concat__fragment('rspec.example.com-fallbackresource') }
           it { is_expected.to contain_concat__fragment('rspec.example.com-directories') }

--- a/templates/vhost/_aliases.erb
+++ b/templates/vhost/_aliases.erb
@@ -1,16 +1,14 @@
-<% if @aliases and ! @aliases.empty? -%>
   ## Alias declarations for resources outside the DocumentRoot
-  <%- [@aliases].flatten.compact.each do |alias_statement| -%>
-    <%- if alias_statement["path"] != '' -%>
-      <%- if alias_statement["alias"] and alias_statement["alias"] != '' -%>
+  <%- @aliases.each do |alias_statement| -%>
+    <%- if alias_statement["path"] -%>
+      <%- if alias_statement["alias"] -%>
   Alias <%= alias_statement["alias"] %> "<%= alias_statement["path"] %>"
-      <%- elsif alias_statement["aliasmatch"] and alias_statement["aliasmatch"] != '' -%>
+      <%- elsif alias_statement["aliasmatch"] -%>
   AliasMatch <%= alias_statement["aliasmatch"] %> "<%= alias_statement["path"] %>"
-      <%- elsif alias_statement["scriptalias"] and alias_statement["scriptalias"] != '' -%>
+      <%- elsif alias_statement["scriptalias"] -%>
   ScriptAlias <%= alias_statement["scriptalias"] %> "<%= alias_statement["path"] %>"
-      <%- elsif alias_statement["scriptaliasmatch"] and alias_statement["scriptaliasmatch"] != '' -%>
+      <%- elsif alias_statement["scriptaliasmatch"] -%>
   ScriptAliasMatch <%= alias_statement["scriptaliasmatch"] %> "<%= alias_statement["path"] %>"
       <%- end -%>
     <%- end -%>
   <%- end -%>
-<% end -%>


### PR DESCRIPTION
This also implements a real test on the rendered template. It appears it was passing in something invalid ever since it was introduced in f1d64a0a0b71af0102d10da69e333aa9ac5a15f5.