### PR TITLE
Allow vhosts to have a string priority again

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1730,7 +1730,7 @@ define apache::vhost (
   Optional[Integer] $ssl_stapling_timeout                                             = undef,
   Optional[Enum['on', 'off']] $ssl_stapling_return_errors                             = undef,
   Optional[String] $ssl_user_name                                                     = undef,
-  Optional[Variant[Integer, Boolean]] $priority                                       = undef,
+  Optional[Apache::Vhost::Priority] $priority                                         = undef,
   Boolean $default_vhost                                                              = false,
   Optional[String] $servername                                                        = $name,
   Variant[Array[String], String] $serveraliases                                       = [],

--- a/manifests/vhost/custom.pp
+++ b/manifests/vhost/custom.pp
@@ -18,7 +18,7 @@
 define apache::vhost::custom (
   String $content,
   String $ensure                      = 'present',
-  Variant[Integer, Boolean] $priority = 25,
+  Apache::Vhost::Priority $priority   = 25,
   Boolean $verify_config              = true,
 ) {
   include apache

--- a/manifests/vhost/fragment.pp
+++ b/manifests/vhost/fragment.pp
@@ -59,7 +59,7 @@
 define apache::vhost::fragment (
   String[1] $vhost,
   Optional[Stdlib::Port] $port                  = undef,
-  Optional[Variant[Integer, Boolean]] $priority = undef,
+  Optional[Apache::Vhost::Priority] $priority   = undef,
   Optional[String] $content                     = undef,
   Integer[0] $order                             = 900,
 ) {

--- a/manifests/vhost/proxy.pp
+++ b/manifests/vhost/proxy.pp
@@ -106,7 +106,7 @@
 #
 define apache::vhost::proxy (
   String[1] $vhost,
-  Optional[Variant[Integer, Boolean]] $priority               = undef,
+  Optional[Apache::Vhost::Priority] $priority                 = undef,
   Integer[0] $order                                           = 170,
   Optional[Stdlib::Port] $port                                = undef,
   Optional[String[1]] $proxy_dest                             = undef,

--- a/spec/type_aliases/vhost_priority_spec.rb
+++ b/spec/type_aliases/vhost_priority_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Apache::Vhost::Priority' do
+  # Pattern
+  it { is_expected.to allow_value('10') }
+  it { is_expected.to allow_value('010') }
+  it { is_expected.not_to allow_value('') }
+  it { is_expected.not_to allow_value('a') }
+  it { is_expected.not_to allow_value('a1') }
+  it { is_expected.not_to allow_value('1a') }
+
+  # Integer
+  it { is_expected.to allow_value(0) }
+  it { is_expected.to allow_value(1) }
+
+  # Boolean
+  it { is_expected.to allow_value(true) } # Technically an illegal value
+  it { is_expected.to allow_value(false) }
+
+  it { is_expected.not_to allow_value(nil) }
+end

--- a/types/vhost/priority.pp
+++ b/types/vhost/priority.pp
@@ -1,0 +1,2 @@
+# @summary The priority on vhost
+type Apache::Vhost::Priority = Variant[Pattern[/^\d+$/], Integer, Boolean]


### PR DESCRIPTION
In f41251e336fa3e7c31c19968ccee74121cf71e47 the type was narrowed to no longer allow strings, but this can cause problems.

Sorting is alphabetical and you need to format it for the correct sorting. So to make sure 2 loads before 10 you need to format it as 02.  While the vhost can do some printf style magic to change 2 to 02, it must then also know what the highest number is. Otherwise 100 is sorted before 20. By allowing strings, you allow the caller to fix this.

A type alias is introduced to reduce duplication and make it easier to track.

Fixes: f41251e336fa3e7c31c19968ccee74121cf71e47