### PR TITLE
Disable mod_php on EL9

### DIFF
--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -21,10 +21,11 @@
 #   UNIX group of the root user
 #
 # @param php_version
-#   The php version
+#   The php version. This is a required parameter, but optional allows showing a clear error message
 #
 # @param libphp_prefix
 #
+# @note Unsupported platforms: RedHat: 9
 class apache::mod::php (
   Optional[String] $package_name = undef,
   String $package_ensure         = 'present',
@@ -37,6 +38,10 @@ class apache::mod::php (
   Optional[String] $php_version  = $apache::params::php_version,
   String $libphp_prefix          = 'libphp'
 ) inherits apache::params {
+  unless $php_version {
+    fail("${facts['os']['name']} ${facts['os']['release']['major']} does not support mod_php")
+  }
+
   include apache
   if (versioncmp($php_version, '8') < 0) {
     $mod = "php${php_version}"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -197,7 +197,7 @@ class apache::params inherits apache::version {
     $passenger_ruby       = undef
     $passenger_default_ruby = undef
     $php_version = $facts['os']['release']['major'] ? {
-      '9'     => '8', # RedHat9
+      '9'     => undef, # RedHat 9 doesn't ship mod_php
       '8'     => '7', # RedHat8
       default => '5', # RedHat5, RedHat6, RedHat7
     }

--- a/spec/acceptance/mod_php_spec.rb
+++ b/spec/acceptance/mod_php_spec.rb
@@ -3,101 +3,94 @@
 require 'spec_helper_acceptance'
 apache_hash = apache_settings_hash
 
-# Temporary exclusion pending resolution of https://github.com/puppetlabs/puppetlabs-apache/issues/2261
-unless os[:family] == 'redhat' && os[:release].to_i == 9
-  describe 'apache::mod::php class', if: mod_supported_on_platform?('apache::mod::php') do
-    context 'default php config' do
-      pp = <<-MANIFEST
-          class { 'apache':
-            mpm_module => 'prefork',
-          }
-          class { 'apache::mod::php': }
-          apache::vhost { 'php.example.com':
-            port    => 80,
-            docroot => '#{apache_hash['doc_root']}/php',
-          }
-          host { 'php.example.com': ip => '127.0.0.1', }
-          file { '#{apache_hash['doc_root']}/php/index.php':
-            ensure  => file,
-            content => "<?php phpinfo(); ?>\\n",
-          }
-      MANIFEST
-      it 'succeeds in puppeting php' do
-        apply_manifest(pp, catch_failures: true)
-      end
-
-      if os[:family] == 'debian' && os[:release] =~ %r{^9\.}
-        describe file("#{apache_hash['mod_dir']}/php7.0.conf") do
-          it { is_expected.to contain 'DirectoryIndex index.php' }
-        end
-      elsif os[:family] == 'debian' && os[:release] =~ %r{^10\.}
-        describe file("#{apache_hash['mod_dir']}/php7.3.conf") do
-          it { is_expected.to contain 'DirectoryIndex index.php' }
-        end
-      elsif os[:family] == 'debian' && os[:release] =~ %r{^11\.}
-        describe file("#{apache_hash['mod_dir']}/php7.4.conf") do
-          it { is_expected.to contain 'DirectoryIndex index.php' }
-        end
-      elsif os[:family] == 'ubuntu' && os[:release] == '18.04'
-        describe file("#{apache_hash['mod_dir']}/php7.2.conf") do
-          it { is_expected.to contain 'DirectoryIndex index.php' }
-        end
-      elsif os[:family] == 'ubuntu' && os[:release] == '20.04'
-        describe file("#{apache_hash['mod_dir']}/php7.4.conf") do
-          it { is_expected.to contain 'DirectoryIndex index.php' }
-        end
-      elsif os[:family] == 'redhat' && os[:release] =~ %r{^(9)\b}
-        describe file("#{apache_hash['mod_dir']}/php.conf") do
-          it { is_expected.to contain 'DirectoryIndex index.php' }
-        end
-      elsif os[:family] == 'redhat' && os[:release] =~ %r{^(8)\b}
-        describe file("#{apache_hash['mod_dir']}/php7.conf") do
-          it { is_expected.to contain 'DirectoryIndex index.php' }
-        end
-      elsif os[:family] == 'sles' && os[:release].to_i >= 15
-        describe file("#{apache_hash['mod_dir']}/php7.conf") do
-          it { is_expected.to contain 'DirectoryIndex index.php' }
-        end
-      else
-        describe file("#{apache_hash['mod_dir']}/php5.conf") do
-          it { is_expected.to contain 'DirectoryIndex index.php' }
-        end
-      end
+describe 'apache::mod::php class', if: mod_supported_on_platform?('apache::mod::php') do
+  context 'default php config' do
+    pp = <<-MANIFEST
+        class { 'apache':
+          mpm_module => 'prefork',
+        }
+        class { 'apache::mod::php': }
+        apache::vhost { 'php.example.com':
+          port    => 80,
+          docroot => '#{apache_hash['doc_root']}/php',
+        }
+        host { 'php.example.com': ip => '127.0.0.1', }
+        file { '#{apache_hash['doc_root']}/php/index.php':
+          ensure  => file,
+          content => "<?php phpinfo(); ?>\\n",
+        }
+    MANIFEST
+    it 'succeeds in puppeting php' do
+      apply_manifest(pp, catch_failures: true)
     end
 
-    context 'custom extensions, php_flag, php_value, php_admin_flag, and php_admin_value' do
-      pp = <<-MANIFEST
-          class { 'apache':
-            mpm_module => 'prefork',
-          }
-          class { 'apache::mod::php':
-          extensions => ['.php','.php5'],
+    if os[:family] == 'debian' && os[:release] =~ %r{^9\.}
+      describe file("#{apache_hash['mod_dir']}/php7.0.conf") do
+        it { is_expected.to contain 'DirectoryIndex index.php' }
+      end
+    elsif os[:family] == 'debian' && os[:release] =~ %r{^10\.}
+      describe file("#{apache_hash['mod_dir']}/php7.3.conf") do
+        it { is_expected.to contain 'DirectoryIndex index.php' }
+      end
+    elsif os[:family] == 'debian' && os[:release] =~ %r{^11\.}
+      describe file("#{apache_hash['mod_dir']}/php7.4.conf") do
+        it { is_expected.to contain 'DirectoryIndex index.php' }
+      end
+    elsif os[:family] == 'ubuntu' && os[:release] == '18.04'
+      describe file("#{apache_hash['mod_dir']}/php7.2.conf") do
+        it { is_expected.to contain 'DirectoryIndex index.php' }
+      end
+    elsif os[:family] == 'ubuntu' && os[:release] == '20.04'
+      describe file("#{apache_hash['mod_dir']}/php7.4.conf") do
+        it { is_expected.to contain 'DirectoryIndex index.php' }
+      end
+    elsif os[:family] == 'redhat' && os[:release] =~ %r{^(8)\b}
+      describe file("#{apache_hash['mod_dir']}/php7.conf") do
+        it { is_expected.to contain 'DirectoryIndex index.php' }
+      end
+    elsif os[:family] == 'sles' && os[:release].to_i >= 15
+      describe file("#{apache_hash['mod_dir']}/php7.conf") do
+        it { is_expected.to contain 'DirectoryIndex index.php' }
+      end
+    else
+      describe file("#{apache_hash['mod_dir']}/php5.conf") do
+        it { is_expected.to contain 'DirectoryIndex index.php' }
+      end
+    end
+  end
+
+  context 'custom extensions, php_flag, php_value, php_admin_flag, and php_admin_value' do
+    pp = <<-MANIFEST
+        class { 'apache':
+          mpm_module => 'prefork',
         }
+        class { 'apache::mod::php':
+        extensions => ['.php','.php5'],
+      }
 
-          apache::vhost { 'php.example.com':
-            port             => 80,
-            docroot          => '#{apache_hash['doc_root']}/php',
-            php_values       => { 'include_path' => '.:/usr/share/pear:/usr/bin/php', },
-            php_flags        => { 'display_errors' => 'on', },
-            php_admin_values => { 'open_basedir' => '/var/www/php/:/usr/share/pear/', },
-            php_admin_flags  => { 'engine' => 'on', },
-          }
-          host { 'php.example.com': ip => '127.0.0.1', }
-          file { '#{apache_hash['doc_root']}/php/index.php5':
-            ensure  => file,
-            content => "<?php phpinfo(); ?>\\n",
-          }
-      MANIFEST
-      it 'succeeds in puppeting php' do
-        apply_manifest(pp, catch_failures: true)
-      end
+        apache::vhost { 'php.example.com':
+          port             => 80,
+          docroot          => '#{apache_hash['doc_root']}/php',
+          php_values       => { 'include_path' => '.:/usr/share/pear:/usr/bin/php', },
+          php_flags        => { 'display_errors' => 'on', },
+          php_admin_values => { 'open_basedir' => '/var/www/php/:/usr/share/pear/', },
+          php_admin_flags  => { 'engine' => 'on', },
+        }
+        host { 'php.example.com': ip => '127.0.0.1', }
+        file { '#{apache_hash['doc_root']}/php/index.php5':
+          ensure  => file,
+          content => "<?php phpinfo(); ?>\\n",
+        }
+    MANIFEST
+    it 'succeeds in puppeting php' do
+      apply_manifest(pp, catch_failures: true)
+    end
 
-      describe file("#{apache_hash['vhost_dir']}/25-php.example.com.conf") do
-        it { is_expected.to contain '  php_flag display_errors on' }
-        it { is_expected.to contain '  php_value include_path ".:/usr/share/pear:/usr/bin/php"' }
-        it { is_expected.to contain '  php_admin_flag engine on' }
-        it { is_expected.to contain '  php_admin_value open_basedir /var/www/php/:/usr/share/pear/' }
-      end
+    describe file("#{apache_hash['vhost_dir']}/25-php.example.com.conf") do
+      it { is_expected.to contain '  php_flag display_errors on' }
+      it { is_expected.to contain '  php_value include_path ".:/usr/share/pear:/usr/bin/php"' }
+      it { is_expected.to contain '  php_admin_flag engine on' }
+      it { is_expected.to contain '  php_admin_value open_basedir /var/www/php/:/usr/share/pear/' }
     end
   end
 end

--- a/spec/classes/mod/php_spec.rb
+++ b/spec/classes/mod/php_spec.rb
@@ -93,115 +93,120 @@ describe 'apache::mod::php', type: :class do
           end
         end
       when 'RedHat'
-        describe 'on a RedHat OS' do
-          context 'with default params' do
-            let :pre_condition do
-              'class { "apache": }'
-            end
+        case facts[:os]['release']['major']
+        when '9'
+          it { is_expected.to compile.and_raise_error(%r{RedHat 9 does not support mod_php}) }
+        else
+          describe 'on a RedHat OS' do
+            context 'with default params' do
+              let :pre_condition do
+                'class { "apache": }'
+              end
 
-            it { is_expected.to contain_class('apache::params') }
-            it { is_expected.to contain_package('php') }
-            if facts[:os]['release']['major'].to_i < 8
-              it { is_expected.to contain_apache__mod('php5') }
-              it { is_expected.to contain_file('php5.load').with(content: "LoadModule php5_module modules/libphp5.so\n") }
-            elsif facts[:os]['release']['major'].to_i == 8
-              it { is_expected.to contain_apache__mod('php7') }
-              it { is_expected.to contain_file('php7.load').with(content: "LoadModule php7_module modules/libphp7.so\n") }
-            elsif facts[:os]['release']['major'].to_i >= 9
-              it { is_expected.to contain_apache__mod('php') }
-              it { is_expected.to contain_file('php.load').with(content: "LoadModule php_module modules/libphp.so\n") }
+              it { is_expected.to contain_class('apache::params') }
+              it { is_expected.to contain_package('php') }
+              if facts[:os]['release']['major'].to_i < 8
+                it { is_expected.to contain_apache__mod('php5') }
+                it { is_expected.to contain_file('php5.load').with(content: "LoadModule php5_module modules/libphp5.so\n") }
+              elsif facts[:os]['release']['major'].to_i == 8
+                it { is_expected.to contain_apache__mod('php7') }
+                it { is_expected.to contain_file('php7.load').with(content: "LoadModule php7_module modules/libphp7.so\n") }
+              elsif facts[:os]['release']['major'].to_i >= 9
+                it { is_expected.to contain_apache__mod('php') }
+                it { is_expected.to contain_file('php.load').with(content: "LoadModule php_module modules/libphp.so\n") }
+              end
             end
-          end
-          context 'with alternative package name' do
-            let :pre_condition do
-              'class { "apache": }'
-            end
-            let :params do
-              { package_name: 'php54' }
-            end
-
-            it { is_expected.to contain_package('php54') }
-          end
-          context 'with alternative path' do
-            let :pre_condition do
-              'class { "apache": }'
-            end
-            let :params do
-              { path: 'alternative-path' }
-            end
-
-            it { is_expected.to contain_package('php') }
-            if facts[:os]['release']['major'].to_i < 8
-              it { is_expected.to contain_apache__mod('php5') }
-              it { is_expected.to contain_file('php5.load').with(content: "LoadModule php5_module alternative-path\n") }
-            elsif facts[:os]['release']['major'].to_i == 8
-              it { is_expected.to contain_apache__mod('php7') }
-              it { is_expected.to contain_file('php7.load').with(content: "LoadModule php7_module alternative-path\n") }
-            elsif facts[:os]['release']['major'].to_i >= 9
-              it { is_expected.to contain_apache__mod('php') }
-              it { is_expected.to contain_file('php.load').with(content: "LoadModule php_module alternative-path\n") }
-            end
-          end
-          context 'with alternative extensions' do
-            let :pre_condition do
-              'class { "apache": }'
-            end
-            let :params do
-              {
-                extensions: ['.php', '.php5'],
-              }
-            end
-
-            it { is_expected.to contain_file('php5.conf').with_content(Regexp.new(Regexp.escape('<FilesMatch ".+(\.php|\.php5)$">'))) } if facts[:os]['release']['major'].to_i < 8
-          end
-          if facts[:os]['release']['major'].to_i > 5
-            context 'with specific version' do
+            context 'with alternative package name' do
               let :pre_condition do
                 'class { "apache": }'
               end
               let :params do
-                { package_ensure: '5.3.13' }
+                { package_name: 'php54' }
               end
 
-              it {
-                is_expected.to contain_package('php').with(
-                  ensure: '5.3.13',
-                )
-              }
+              it { is_expected.to contain_package('php54') }
             end
-          end
-          context 'with mpm_module => prefork' do
-            it { is_expected.to contain_class('apache::params') }
-            it { is_expected.to contain_class('apache::mod::prefork') }
-            it { is_expected.to contain_package('php') }
-            if facts[:os]['release']['major'].to_i < 8
-              it { is_expected.to contain_apache__mod('php5') }
-              it { is_expected.to contain_file('php5.load').with(content: "LoadModule php5_module modules/libphp5.so\n") }
-            elsif facts[:os]['release']['major'].to_i == 8
-              it { is_expected.to contain_apache__mod('php7') }
-              it { is_expected.to contain_file('php7.load').with(content: "LoadModule php7_module modules/libphp7.so\n") }
-            elsif facts[:os]['release']['major'].to_i >= 9
-              it { is_expected.to contain_apache__mod('php') }
-              it { is_expected.to contain_file('php.load').with(content: "LoadModule php_module modules/libphp.so\n") }
-            end
-          end
-          context 'with mpm_module => itk' do
-            let :pre_condition do
-              'class { "apache": mpm_module => itk, }'
-            end
+            context 'with alternative path' do
+              let :pre_condition do
+                'class { "apache": }'
+              end
+              let :params do
+                { path: 'alternative-path' }
+              end
 
-            it { is_expected.to contain_class('apache::params') }
-            it { is_expected.to contain_class('apache::mod::itk') }
-            it { is_expected.to contain_package('php') }
-            if facts[:os]['release']['major'].to_i < 8
-              it { is_expected.to contain_apache__mod('php5') }
-              it { is_expected.to contain_file('php5.load').with(content: "LoadModule php5_module modules/libphp5.so\n") }
-            elsif facts[:os]['release']['major'].to_i == 8
-              it { is_expected.to contain_apache__mod('php7') }
-              it { is_expected.to contain_file('php7.load').with(content: "LoadModule php7_module modules/libphp7.so\n") }
-            elsif facts[:os]['release']['major'].to_i >= 9
-              it { is_expected.to contain_apache__mod('php') }
-              it { is_expected.to contain_file('php.load').with(content: "LoadModule php_module modules/libphp.so\n") }
+              it { is_expected.to contain_package('php') }
+              if facts[:os]['release']['major'].to_i < 8
+                it { is_expected.to contain_apache__mod('php5') }
+                it { is_expected.to contain_file('php5.load').with(content: "LoadModule php5_module alternative-path\n") }
+              elsif facts[:os]['release']['major'].to_i == 8
+                it { is_expected.to contain_apache__mod('php7') }
+                it { is_expected.to contain_file('php7.load').with(content: "LoadModule php7_module alternative-path\n") }
+              elsif facts[:os]['release']['major'].to_i >= 9
+                it { is_expected.to contain_apache__mod('php') }
+                it { is_expected.to contain_file('php.load').with(content: "LoadModule php_module alternative-path\n") }
+              end
+            end
+            context 'with alternative extensions' do
+              let :pre_condition do
+                'class { "apache": }'
+              end
+              let :params do
+                {
+                  extensions: ['.php', '.php5'],
+                }
+              end
+
+              it { is_expected.to contain_file('php5.conf').with_content(Regexp.new(Regexp.escape('<FilesMatch ".+(\.php|\.php5)$">'))) } if facts[:os]['release']['major'].to_i < 8
+            end
+            if facts[:os]['release']['major'].to_i > 5
+              context 'with specific version' do
+                let :pre_condition do
+                  'class { "apache": }'
+                end
+                let :params do
+                  { package_ensure: '5.3.13' }
+                end
+
+                it {
+                  is_expected.to contain_package('php').with(
+                    ensure: '5.3.13',
+                  )
+                }
+              end
+            end
+            context 'with mpm_module => prefork' do
+              it { is_expected.to contain_class('apache::params') }
+              it { is_expected.to contain_class('apache::mod::prefork') }
+              it { is_expected.to contain_package('php') }
+              if facts[:os]['release']['major'].to_i < 8
+                it { is_expected.to contain_apache__mod('php5') }
+                it { is_expected.to contain_file('php5.load').with(content: "LoadModule php5_module modules/libphp5.so\n") }
+              elsif facts[:os]['release']['major'].to_i == 8
+                it { is_expected.to contain_apache__mod('php7') }
+                it { is_expected.to contain_file('php7.load').with(content: "LoadModule php7_module modules/libphp7.so\n") }
+              elsif facts[:os]['release']['major'].to_i >= 9
+                it { is_expected.to contain_apache__mod('php') }
+                it { is_expected.to contain_file('php.load').with(content: "LoadModule php_module modules/libphp.so\n") }
+              end
+            end
+            context 'with mpm_module => itk' do
+              let :pre_condition do
+                'class { "apache": mpm_module => itk, }'
+              end
+
+              it { is_expected.to contain_class('apache::params') }
+              it { is_expected.to contain_class('apache::mod::itk') }
+              it { is_expected.to contain_package('php') }
+              if facts[:os]['release']['major'].to_i < 8
+                it { is_expected.to contain_apache__mod('php5') }
+                it { is_expected.to contain_file('php5.load').with(content: "LoadModule php5_module modules/libphp5.so\n") }
+              elsif facts[:os]['release']['major'].to_i == 8
+                it { is_expected.to contain_apache__mod('php7') }
+                it { is_expected.to contain_file('php7.load').with(content: "LoadModule php7_module modules/libphp7.so\n") }
+              elsif facts[:os]['release']['major'].to_i >= 9
+                it { is_expected.to contain_apache__mod('php') }
+                it { is_expected.to contain_file('php.load').with(content: "LoadModule php_module modules/libphp.so\n") }
+              end
             end
           end
         end


### PR DESCRIPTION
EL 9 doesn't ship mod_php, so this is uninstallable. By making it a required parameter (which effectively was already the case) and setting the version to undef the catalog fails to compile by default. This still allows users to set it if they build a mod_php somehow.

EL 9 users should use php-fpm instead.

A draft right now to see which tests fail.

Fixes: edbdb65b06418779aa30ebe6cf0948007cc51a29