### PR TITLE
Support for mod_php on Ubuntu 22.04

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -350,6 +350,7 @@ class apache::params inherits apache::version {
         '9'     => '7.0', # Debian Stretch
         '10'    => '7.3', # Debian Buster
         '20.04' => '7.4', # Ubuntu Foccal Fossal
+        '22.04' => '8.1', # Ubuntu Jellyfish
         default => '7.2', # Ubuntu Bionic, Cosmic and Disco
       }
       $mod_packages = {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -349,6 +349,7 @@ class apache::params inherits apache::version {
       $php_version = $facts['os']['release']['major'] ? {
         '9'     => '7.0', # Debian Stretch
         '10'    => '7.3', # Debian Buster
+        '16.04' => '7.0', # Ubuntu Xenial Xerus
         '20.04' => '7.4', # Ubuntu Foccal Fossal
         '22.04' => '8.1', # Ubuntu Jellyfish
         default => '7.2', # Ubuntu Bionic, Cosmic and Disco

--- a/metadata.json
+++ b/metadata.json
@@ -67,7 +67,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "18.04",
-        "20.04"
+        "20.04",
+        "22.04"
       ]
     },
     {


### PR DESCRIPTION
# Summary

Fixes #2259 

# Changes

- Added PHP version for Ubuntu 22.04 (and 16.04) to the `$php_version` mapping in `params.pp`.
- In `mod/php.pp` added conditions for Red Hat family that has a specific behavior with PHP 8.x modules name convention.

# Tests

Tested with the following Puppet code:

```
class { 'apache':
  mpm_module => 'prefork',
}
class { 'apache::mod::php': }
```

To validate that PHP works:

```
# Don't do this in production servers!
echo "<?php phpinfo(); ?>" > /var/www/html/phpinfo.php
```

Then open http://<sandbox_ip>/phpinfo.php

Works on:
- Ubuntu 16.04
- Ubuntu 18.04
- Ubuntu 20.04
- Ubuntu 22.04
- CentOS 7
- CentOS 8
- Debian 11

I could not test SLES because it's not free. I tried openSuse Leap 15.4 but the module does not seems to work for other reasons.