### PR TITLE
Remove auth_kerb and nss from Debian Bullseye

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -385,7 +385,6 @@ class apache::params inherits apache::version {
       $mod_packages = {
         'apreq2'                => 'libapache2-mod-apreq2',
         'auth_cas'              => 'libapache2-mod-auth-cas',
-        'auth_kerb'             => 'libapache2-mod-auth-kerb',
         'auth_openidc'          => 'libapache2-mod-auth-openidc',
         'auth_gssapi'           => 'libapache2-mod-auth-gssapi',
         'auth_mellon'           => 'libapache2-mod-auth-mellon',
@@ -396,7 +395,6 @@ class apache::params inherits apache::version {
         'intercept_form_submit' => 'libapache2-mod-intercept-form-submit',
         'jk'                    => 'libapache2-mod-jk',
         'lookup_identity'       => 'libapache2-mod-lookup-identity',
-        'nss'                   => 'libapache2-mod-nss',
         'pagespeed'             => 'mod-pagespeed-stable',
         'passenger'             => 'libapache2-mod-passenger',
         'perl'                  => 'libapache2-mod-perl2',

--- a/spec/classes/mod/auth_kerb_spec.rb
+++ b/spec/classes/mod/auth_kerb_spec.rb
@@ -7,7 +7,7 @@ describe 'apache::mod::auth_kerb', type: :class do
 
   context 'default configuration with parameters' do
     context 'on a Debian OS', :compile do
-      include_examples 'Debian 11'
+      include_examples 'Debian 10'
 
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('auth_kerb') }

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -37,6 +37,10 @@ shared_context 'a mod class, without including apache' do
   let(:facts) { on_supported_os['debian-10-x86_64'] }
 end
 
+shared_context 'Debian 10' do
+  let(:facts) { on_supported_os['debian-10-x86_64'] }
+end
+
 shared_context 'Debian 11' do
   let(:facts) { on_supported_os['debian-11-x86_64'] }
 end


### PR DESCRIPTION
libapache2-mod-auth-kerb is unavailable in Debian Bullseye[1]
libapache2-mod-auth-kerb was removed in Debian Buster[2]

[1]: https://packages.debian.org/buster/libapache2-mod-auth-kerb
[2]: https://packages.debian.org/stretch/libapache2-mod-nss