### PR TITLE
Manage DNF module for mod_auth_openidc

### DIFF
--- a/manifests/mod/auth_basic.pp
+++ b/manifests/mod/auth_basic.pp
@@ -4,5 +4,6 @@
 # @see https://httpd.apache.org/docs/current/mod/mod_auth_basic.html for additional documentation.
 #
 class apache::mod::auth_basic {
+  include apache::mod::authn_core
   ::apache::mod { 'auth_basic': }
 }

--- a/manifests/mod/auth_cas.pp
+++ b/manifests/mod/auth_cas.pp
@@ -115,6 +115,7 @@ class apache::mod::auth_cas (
   }
 
   include apache
+  include apache::mod::authn_core
   ::apache::mod { 'auth_cas': }
 
   file { $cas_cookie_path:

--- a/manifests/mod/auth_mellon.pp
+++ b/manifests/mod/auth_mellon.pp
@@ -34,6 +34,7 @@ class apache::mod::auth_mellon (
   Optional[Integer] $mellon_post_count                  = undef
 ) inherits apache::params {
   include apache
+  include apache::mod::authn_core
   ::apache::mod { 'auth_mellon': }
 
   # Template uses

--- a/manifests/mod/auth_openidc.pp
+++ b/manifests/mod/auth_openidc.pp
@@ -5,6 +5,7 @@
 #
 class apache::mod::auth_openidc inherits apache::params {
   include apache
+  include apache::mod::authn_core
   include apache::mod::authz_user
   apache::mod { 'auth_openidc': }
 }

--- a/manifests/mod/auth_openidc.pp
+++ b/manifests/mod/auth_openidc.pp
@@ -1,11 +1,30 @@
 # @summary
 #   Installs and configures `mod_auth_openidc`.
-# 
-# @see https://github.com/zmartzone/mod_auth_openidc for additional documentation.
 #
-class apache::mod::auth_openidc inherits apache::params {
+# @param manage_dnf_module Whether to manage the DNF module
+# @param dnf_module_ensure The DNF module name to ensure. Only relevant if manage_dnf_module is set to true.
+# @param dnf_module_name The DNF module name to manage. Only relevant if manage_dnf_module is set to true.
+#
+# @see https://github.com/zmartzone/mod_auth_openidc for additional documentation.
+# @note Unsupported platforms: OracleLinux: 6; RedHat: 6; Scientific: 6; SLES: all
+#
+class apache::mod::auth_openidc (
+  Boolean $manage_dnf_module = $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '8',
+  String[1] $dnf_module_ensure = 'present',
+  String[1] $dnf_module_name = 'mod_auth_openidc',
+) {
   include apache
   include apache::mod::authn_core
   include apache::mod::authz_user
+
   apache::mod { 'auth_openidc': }
+
+  if $manage_dnf_module {
+    package { 'dnf-module-mod_auth_openidc':
+      ensure   => $dnf_module_ensure,
+      name     => $dnf_module_name,
+      provider => 'dnfmodule',
+      before   => Apache::Mod['auth_openidc'],
+    }
+  }
 }

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1945,7 +1945,7 @@ define apache::vhost (
   Optional[Variant[String, Array[String]]] $comment                                   = undef,
   Hash $define                                                                        = {},
   Boolean $auth_oidc                                                                  = false,
-  Optional[Apache::OIDCSettings] $oidc_settings                                       = undef,
+  Apache::OIDCSettings $oidc_settings                                                 = {},
   Optional[Variant[Boolean, String]] $mdomain                                         = undef,
   Optional[Variant[String[1], Array[String[1]]]] $userdir                             = undef,
 ) {

--- a/spec/acceptance/auth_openidc_spec.rb
+++ b/spec/acceptance/auth_openidc_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+describe 'apache::mod::auth_openidc', if: mod_supported_on_platform?('apache::mod::auth_openidc') do
+  pp = <<-MANIFEST
+    include apache
+    apache::vhost { 'example.com':
+      docroot       => '/var/www/example.com',
+      port          => 80,
+      auth_oidc     => true,
+      oidc_settings => {
+        'ProviderMetadataURL'       => 'https://login.example.com/.well-known/openid-configuration',
+        'ClientID'                  => 'test',
+        'RedirectURI'               => 'https://login.example.com/redirect_uri',
+        'ProviderTokenEndpointAuth' => 'client_secret_basic',
+        'RemoteUserClaim'           => 'sub',
+        'ClientSecret'              => 'aae053a9-4abf-4824-8956-e94b2af335c8',
+        'CryptoPassphrase'          => '4ad1bb46-9979-450e-ae58-c696967df3cd',
+       },
+    }
+  MANIFEST
+
+  it 'succeeds in configuring a virtual host using mod_auth_openidc' do
+    apply_manifest(pp, catch_failures: true)
+  end
+
+  it 'is idempotent' do
+    apply_manifest(pp, catch_changes: true)
+  end
+end

--- a/spec/classes/mod/auth_cas_spec.rb
+++ b/spec/classes/mod/auth_cas_spec.rb
@@ -27,6 +27,7 @@ describe 'apache::mod::auth_cas', type: :class do
       include_examples 'Debian 11'
 
       it { is_expected.to contain_class('apache::params') }
+      it { is_expected.to contain_class('apache::mod::authn_core') }
       it { is_expected.to contain_apache__mod('auth_cas') }
       it { is_expected.to contain_package('libapache2-mod-auth-cas') }
       it { is_expected.to contain_file('auth_cas.conf').with_path('/etc/apache2/mods-available/auth_cas.conf') }
@@ -36,6 +37,7 @@ describe 'apache::mod::auth_cas', type: :class do
       include_examples 'RedHat 6'
 
       it { is_expected.to contain_class('apache::params') }
+      it { is_expected.to contain_class('apache::mod::authn_core') }
       it { is_expected.to contain_apache__mod('auth_cas') }
       it { is_expected.to contain_package('mod_auth_cas') }
       it { is_expected.to contain_file('auth_cas.conf').with_path('/etc/httpd/conf.d/auth_cas.conf') }
@@ -50,6 +52,7 @@ describe 'apache::mod::auth_cas', type: :class do
       include_examples 'RedHat 6'
 
       it { is_expected.to contain_class('apache::params') }
+      it { is_expected.to contain_class('apache::mod::authn_core') }
       it { is_expected.to contain_apache__mod('auth_cas') }
       it { is_expected.to contain_package('mod_auth_cas') }
       it { is_expected.to contain_file('auth_cas.conf').with_path('/etc/httpd/conf.d/auth_cas.conf') }

--- a/spec/classes/mod/auth_gssapi_spec.rb
+++ b/spec/classes/mod/auth_gssapi_spec.rb
@@ -10,6 +10,7 @@ describe 'apache::mod::auth_gssapi', type: :class do
       include_examples 'Debian 11'
 
       it { is_expected.to contain_class('apache::params') }
+      it { is_expected.to contain_class('apache::mod::authn_core') }
       it { is_expected.to contain_apache__mod('auth_gssapi') }
       it { is_expected.to contain_package('libapache2-mod-auth-gssapi') }
     end
@@ -17,6 +18,7 @@ describe 'apache::mod::auth_gssapi', type: :class do
       include_examples 'RedHat 6'
 
       it { is_expected.to contain_class('apache::params') }
+      it { is_expected.to contain_class('apache::mod::authn_core') }
       it { is_expected.to contain_apache__mod('auth_gssapi') }
       it { is_expected.to contain_package('mod_auth_gssapi') }
     end
@@ -24,6 +26,7 @@ describe 'apache::mod::auth_gssapi', type: :class do
       include_examples 'FreeBSD 9'
 
       it { is_expected.to contain_class('apache::params') }
+      it { is_expected.to contain_class('apache::mod::authn_core') }
       it { is_expected.to contain_apache__mod('auth_gssapi') }
       it { is_expected.to contain_package('www/mod_auth_gssapi') }
     end
@@ -31,6 +34,7 @@ describe 'apache::mod::auth_gssapi', type: :class do
       include_examples 'Gentoo'
 
       it { is_expected.to contain_class('apache::params') }
+      it { is_expected.to contain_class('apache::mod::authn_core') }
       it { is_expected.to contain_apache__mod('auth_gssapi') }
       it { is_expected.to contain_package('www-apache/mod_auth_gssapi') }
     end

--- a/spec/classes/mod/auth_kerb_spec.rb
+++ b/spec/classes/mod/auth_kerb_spec.rb
@@ -10,6 +10,7 @@ describe 'apache::mod::auth_kerb', type: :class do
       include_examples 'Debian 11'
 
       it { is_expected.to contain_class('apache::params') }
+      it { is_expected.to contain_class('apache::mod::authn_core') }
       it { is_expected.to contain_apache__mod('auth_kerb') }
       it { is_expected.to contain_package('libapache2-mod-auth-kerb') }
     end
@@ -17,6 +18,7 @@ describe 'apache::mod::auth_kerb', type: :class do
       include_examples 'RedHat 6'
 
       it { is_expected.to contain_class('apache::params') }
+      it { is_expected.to contain_class('apache::mod::authn_core') }
       it { is_expected.to contain_apache__mod('auth_kerb') }
       it { is_expected.to contain_package('mod_auth_kerb') }
     end
@@ -24,6 +26,7 @@ describe 'apache::mod::auth_kerb', type: :class do
       include_examples 'FreeBSD 9'
 
       it { is_expected.to contain_class('apache::params') }
+      it { is_expected.to contain_class('apache::mod::authn_core') }
       it { is_expected.to contain_apache__mod('auth_kerb') }
       it { is_expected.to contain_package('www/mod_auth_kerb2') }
     end
@@ -31,6 +34,7 @@ describe 'apache::mod::auth_kerb', type: :class do
       include_examples 'Gentoo'
 
       it { is_expected.to contain_class('apache::params') }
+      it { is_expected.to contain_class('apache::mod::authn_core') }
       it { is_expected.to contain_apache__mod('auth_kerb') }
       it { is_expected.to contain_package('www-apache/mod_auth_kerb') }
     end
@@ -49,6 +53,7 @@ describe 'apache::mod::auth_kerb', type: :class do
         MANIFEST
       end
 
+      it { is_expected.to contain_class('apache::mod::authn_core') }
       it { is_expected.to contain_apache__mod('auth_kerb') }
       it { is_expected.to contain_package('httpd24-mod_auth_kerb') }
       it { is_expected.not_to contain_package('mod_auth_kerb') }

--- a/spec/classes/mod/auth_mellon_spec.rb
+++ b/spec/classes/mod/auth_mellon_spec.rb
@@ -9,6 +9,7 @@ describe 'apache::mod::auth_mellon', type: :class do
     include_examples 'Debian 11'
 
     describe 'with no parameters' do
+      it { is_expected.to contain_class('apache::mod::authn_core') }
       it { is_expected.to contain_apache__mod('auth_mellon') }
       it { is_expected.to contain_package('libapache2-mod-auth-mellon') }
       it { is_expected.to contain_file('auth_mellon.conf').with_path('/etc/apache2/mods-available/auth_mellon.conf') }
@@ -38,6 +39,7 @@ describe 'apache::mod::auth_mellon', type: :class do
     include_examples 'RedHat 6'
 
     describe 'with no parameters' do
+      it { is_expected.to contain_class('apache::mod::authn_core') }
       it { is_expected.to contain_apache__mod('auth_mellon') }
       it { is_expected.to contain_package('mod_auth_mellon') }
       it { is_expected.to contain_file('auth_mellon.conf').with_path('/etc/httpd/conf.d/auth_mellon.conf') }

--- a/spec/classes/mod/auth_openidc_spec.rb
+++ b/spec/classes/mod/auth_openidc_spec.rb
@@ -10,6 +10,8 @@ describe 'apache::mod::auth_openidc', type: :class do
       include_examples 'Debian 11'
 
       it { is_expected.to contain_class('apache::params') }
+      it { is_expected.to contain_class('apache::mod::authn_core') }
+      it { is_expected.to contain_class('apache::mod::authz_user') }
       it { is_expected.to contain_apache__mod('auth_openidc') }
       it { is_expected.to contain_package('libapache2-mod-auth-openidc') }
     end
@@ -17,6 +19,8 @@ describe 'apache::mod::auth_openidc', type: :class do
       include_examples 'RedHat 6'
 
       it { is_expected.to contain_class('apache::params') }
+      it { is_expected.to contain_class('apache::mod::authn_core') }
+      it { is_expected.to contain_class('apache::mod::authz_user') }
       it { is_expected.to contain_apache__mod('auth_openidc') }
       it { is_expected.to contain_package('mod_auth_openidc') }
     end
@@ -24,6 +28,8 @@ describe 'apache::mod::auth_openidc', type: :class do
       include_examples 'FreeBSD 9'
 
       it { is_expected.to contain_class('apache::params') }
+      it { is_expected.to contain_class('apache::mod::authn_core') }
+      it { is_expected.to contain_class('apache::mod::authz_user') }
       it { is_expected.to contain_apache__mod('auth_openidc') }
       it { is_expected.to contain_package('www/mod_auth_openidc') }
     end
@@ -42,6 +48,9 @@ describe 'apache::mod::auth_openidc', type: :class do
         MANIFEST
       end
 
+      it { is_expected.to contain_class('apache::params') }
+      it { is_expected.to contain_class('apache::mod::authn_core') }
+      it { is_expected.to contain_class('apache::mod::authz_user') }
       it { is_expected.to contain_apache__mod('auth_openidc') }
       it { is_expected.to contain_package('httpd24-mod_auth_openidc') }
       it { is_expected.not_to contain_package('mod_auth_openidc') }

--- a/spec/classes/mod/auth_openidc_spec.rb
+++ b/spec/classes/mod/auth_openidc_spec.rb
@@ -9,29 +9,43 @@ describe 'apache::mod::auth_openidc', type: :class do
     context 'on a Debian OS', :compile do
       include_examples 'Debian 11'
 
-      it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_class('apache::mod::authn_core') }
       it { is_expected.to contain_class('apache::mod::authz_user') }
       it { is_expected.to contain_apache__mod('auth_openidc') }
       it { is_expected.to contain_package('libapache2-mod-auth-openidc') }
+      it { is_expected.not_to contain_package('dnf-module-mod_auth_openidc') }
     end
-    context 'on a RedHat OS', :compile do
-      include_examples 'RedHat 6'
+    context 'on RedHat 7', :compile do
+      include_examples 'RedHat 7'
 
-      it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_class('apache::mod::authn_core') }
       it { is_expected.to contain_class('apache::mod::authz_user') }
       it { is_expected.to contain_apache__mod('auth_openidc') }
       it { is_expected.to contain_package('mod_auth_openidc') }
+      it { is_expected.not_to contain_package('dnf-module-mod_auth_openidc') }
+    end
+    context 'on RedHat 8', :compile do
+      include_examples 'RedHat 8'
+
+      it { is_expected.to contain_class('apache::mod::authn_core') }
+      it { is_expected.to contain_class('apache::mod::authz_user') }
+      it { is_expected.to contain_apache__mod('auth_openidc') }
+      it { is_expected.to contain_package('mod_auth_openidc') }
+      it do
+        is_expected.to contain_package('dnf-module-mod_auth_openidc')
+          .with_ensure('present')
+          .with_name('mod_auth_openidc')
+          .that_comes_before('Package[mod_auth_openidc]')
+      end
     end
     context 'on a FreeBSD OS', :compile do
       include_examples 'FreeBSD 9'
 
-      it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_class('apache::mod::authn_core') }
       it { is_expected.to contain_class('apache::mod::authz_user') }
       it { is_expected.to contain_apache__mod('auth_openidc') }
       it { is_expected.to contain_package('www/mod_auth_openidc') }
+      it { is_expected.not_to contain_package('dnf-module-mod_auth_openidc') }
     end
   end
   context 'overriding mod_packages' do
@@ -48,7 +62,6 @@ describe 'apache::mod::auth_openidc', type: :class do
         MANIFEST
       end
 
-      it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_class('apache::mod::authn_core') }
       it { is_expected.to contain_class('apache::mod::authz_user') }
       it { is_expected.to contain_apache__mod('auth_openidc') }


### PR DESCRIPTION
On EL 8 mod_auth_openidc is in a DNF module that must be enabled. Otherwise the package is uninstallable. This is verified by adding an acceptance test for the class.

The inheritance on apache::params is removed since it was redundant. That is only needed if a class parameter uses apache::params.

$oidc_settings on apache::vhost is changed to have a default. The template expects one and With that it's impossible to miscompile. The alternative is to implement a fail() inside the code if it is empty, but this provides some safety.