### PR TITLE
Allow custom_config to have a string priority again

### DIFF
--- a/manifests/custom_config.pp
+++ b/manifests/custom_config.pp
@@ -52,7 +52,7 @@ define apache::custom_config (
   Enum['absent', 'present'] $ensure     = 'present',
   Stdlib::Absolutepath $confdir         = $apache::confd_dir,
   Optional[String] $content             = undef,
-  Variant[Integer, Boolean] $priority   = 25,
+  Apache::Vhost::Priority $priority     = 25,
   Optional[String] $source              = undef,
   String $verify_command                = $apache::params::verify_command,
   Boolean $verify_config                = true,


### PR DESCRIPTION
cc: @ekohl 

Same reason as c11ab1fdce6ab11cbcb1d55deadf1531191c9e35 for vhosts - reusing Apache::Vhost::Priority data type.

In f41251e the type was narrowed to no
longer allow strings, but this can cause problems.

Sorting is alphabetical and you need to format it for the correct
sorting. So to make sure 2 loads before 10 you need to format it as 02.
While the custom_config can do some printf style magic to change 2 to 02, it
must then also know what the highest number is. Otherwise 100 is sorted
before 20. By allowing strings, you allow the caller to fix this.

A type alias is introduced to reduce duplication and make it easier to
track.

Fixes: f41251e

