### PR TITLE
fix duplicate definition of auth_basic-mod

### DIFF
--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -139,7 +139,7 @@ class apache::default_mods (
     include apache::mod::mime
     include apache::mod::negotiation
     include apache::mod::setenvif
-    ::apache::mod { 'auth_basic': }
+    include apache::mod::auth_basic
 
     if versioncmp($apache_version, '2.4') >= 0 {
       # filter is needed by mod_deflate


### PR DESCRIPTION
Pull-Request #2252 breaks the usage of auth_basic in a vhost, because the module is
declared twice:

Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Resource Statement, Duplicate declaration: Apache::Mod[auth_basic] is already declared at (file: /etc/puppetlabs/code/environments/module_updates/modules/apache/manifests/default_mods.pp, line: 142); cannot redeclare (file: /etc/puppetlabs/code/environments/module_updates/modules/apache/manifests/mod/auth_basic.pp, line: 7) (file: /etc/puppetlabs/code/environments/module_updates/modules/apache/manifests/mod/auth_basic.pp, line: 7, column: 3) (file: /etc/puppetlabs/code/environments/module_updates/site-modules/rx_apache/manifests/vhost.pp, line: 336) on node ...

fix it by including the appropriate class in defaults_mods, instead of
just defining the module