### PR TITLE
Use more mod classes in default_mods

### DIFF
--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -124,9 +124,6 @@ class apache::default_mods (
     include apache::mod::setenvif
     include apache::mod::auth_basic
 
-    # filter is needed by mod_deflate
-    include apache::mod::filter
-
     # authz_core is needed for 'Require' directive
     ::apache::mod { 'authz_core':
       id => 'authz_core_module',
@@ -145,16 +142,10 @@ class apache::default_mods (
     ::apache::mod { 'authz_core':
       id => 'authz_core_module',
     }
-
-    # filter is needed by mod_deflate
-    include apache::mod::filter
   } else {
     # authz_core is needed for 'Require' directive
     ::apache::mod { 'authz_core':
       id => 'authz_core_module',
     }
-
-    # filter is needed by mod_deflate
-    include apache::mod::filter
   }
 }

--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -114,6 +114,7 @@ class apache::default_mods (
     }
     include apache::mod::alias
     include apache::mod::authn_file
+    include apache::mod::authz_core
     include apache::mod::autoindex
     include apache::mod::dav
     include apache::mod::dav_fs
@@ -124,11 +125,6 @@ class apache::default_mods (
     include apache::mod::setenvif
     include apache::mod::auth_basic
 
-    # authz_core is needed for 'Require' directive
-    ::apache::mod { 'authz_core':
-      id => 'authz_core_module',
-    }
-
     # lots of stuff seems to break without access_compat
     ::apache::mod { 'access_compat': }
 
@@ -138,14 +134,8 @@ class apache::default_mods (
   } elsif $mods {
     ::apache::default_mods::load { $mods: }
 
-    # authz_core is needed for 'Require' directive
-    ::apache::mod { 'authz_core':
-      id => 'authz_core_module',
-    }
+    include apache::mod::authz_core
   } else {
-    # authz_core is needed for 'Require' directive
-    ::apache::mod { 'authz_core':
-      id => 'authz_core_module',
-    }
+    include apache::mod::authz_core
   }
 }

--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -48,6 +48,7 @@ class apache::default_mods (
         include apache::mod::authn_core
         include apache::mod::cache
         include apache::mod::ext_filter
+        include apache::mod::include
         include apache::mod::mime
         include apache::mod::mime_magic
         include apache::mod::rewrite
@@ -60,7 +61,6 @@ class apache::default_mods (
         ::apache::mod { 'authz_dbm': }
         ::apache::mod { 'authz_owner': }
         ::apache::mod { 'expires': }
-        ::apache::mod { 'include': }
         ::apache::mod { 'logio': }
         ::apache::mod { 'substitute': }
         ::apache::mod { 'usertrack': }
@@ -71,6 +71,7 @@ class apache::default_mods (
         include apache::mod::cache
         include apache::mod::disk_cache
         include apache::mod::headers
+        include apache::mod::include
         include apache::mod::info
         include apache::mod::mime_magic
         include apache::mod::reqtimeout
@@ -93,7 +94,6 @@ class apache::default_mods (
         ::apache::mod { 'expires': }
         ::apache::mod { 'file_cache': }
         ::apache::mod { 'imagemap': }
-        ::apache::mod { 'include': }
         ::apache::mod { 'logio': }
         ::apache::mod { 'request': }
         ::apache::mod { 'session': }

--- a/manifests/mod/authz_core.pp
+++ b/manifests/mod/authz_core.pp
@@ -1,0 +1,13 @@
+# @summary
+#   Installs `mod_authz_core`.
+# 
+# @param apache_version
+#   The version of apache being run.
+# 
+# @see https://httpd.apache.org/docs/current/mod/mod_authz_core.html for additional documentation.
+#
+class apache::mod::authz_core {
+  apache::mod { 'authz_core':
+    id => 'authz_core_module',
+  }
+}

--- a/manifests/mod/deflate.pp
+++ b/manifests/mod/deflate.pp
@@ -24,6 +24,8 @@ class apache::mod::deflate (
   }
 ) {
   include apache
+  include apache::mod::filter
+
   ::apache::mod { 'deflate': }
 
   file { 'deflate.conf':

--- a/spec/classes/mod/deflate_spec.rb
+++ b/spec/classes/mod/deflate_spec.rb
@@ -5,6 +5,7 @@ require 'spec_helper'
 # This function is called inside the OS specific contexts
 def general_deflate_specs
   it { is_expected.to contain_apache__mod('deflate') }
+  it { is_expected.to contain_class('apache::mod::filter') }
 
   expected = "AddOutputFilterByType DEFLATE application/rss+xml\n"\
   "AddOutputFilterByType DEFLATE application/x-javascript\n"\


### PR DESCRIPTION
The goal is to remove duplication and make it easy to use mod classes where needed. This makes using the module without default mods easier. It also removes duplication.

This is a draft because apache::mod::expires creates a config by default, which is probably not what we want out of the box. I'd like to see a discusion on how to best resolve this.