### PR TITLE
Allow setting icons_path to false so no alias will be set for it

### DIFF
--- a/manifests/mod/alias.pp
+++ b/manifests/mod/alias.pp
@@ -22,11 +22,11 @@
 # @see https://httpd.apache.org/docs/current/mod/mod_alias.html for additional documentation.
 #
 class apache::mod::alias (
-  Optional[String] $apache_version  = undef,
-  String $icons_options             = 'Indexes MultiViews',
+  Optional[String] $apache_version                   = undef,
+  String $icons_options                              = 'Indexes MultiViews',
   # set icons_path to false to disable the alias
-  Stdlib::Absolutepath $icons_path  = $apache::params::alias_icons_path,
-  String $icons_prefix              = $apache::params::icons_prefix
+  Variant[Boolean, Stdlib::Absolutepath] $icons_path = $apache::params::alias_icons_path,
+  String $icons_prefix                               = $apache::params::icons_prefix
 ) inherits apache::params {
   include apache
   $_apache_version = pick($apache_version, $apache::apache_version)

--- a/spec/classes/mod/alias_spec.rb
+++ b/spec/classes/mod/alias_spec.rb
@@ -60,6 +60,21 @@ describe 'apache::mod::alias', type: :class do
       it { is_expected.to contain_apache__mod('alias') }
       it { is_expected.to contain_file('alias.conf').with(content: %r{Alias \/apache-icons\/ "\/usr\/share\/httpd\/icons\/"}) }
     end
+    context 'with icons path as false', :compile do
+      let :pre_condition do
+        'class { apache: default_mods => false }'
+      end
+      let :params do
+        {
+          'icons_path' => false,
+        }
+      end
+
+      include_examples 'RedHat 7'
+
+      it { is_expected.to contain_apache__mod('alias') }
+      it { is_expected.not_to contain_file('alias.conf') }
+    end
     context 'on a FreeBSD OS', :compile do
       include_examples 'FreeBSD 10'
 


### PR DESCRIPTION
with the commit f41251e336fa3e7c31c19968ccee74121cf71e47, icons_path set to false does not work.
This commit fixes that.