### PR TITLE
Fix deprecation warning about performing a regex comparison on a hash

### DIFF
--- a/templates/vhost/_require.erb
+++ b/templates/vhost/_require.erb
@@ -1,6 +1,6 @@
 <%- _item = scope.lookupvar('_template_scope')[:item] -%>
 <%- if scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
-  <%- if _item['require'] && _item['require'] != '' && _item['require'] !~ /unmanaged/i -%>
+  <%- if _item['require'] && !(_item['require'].is_a?(String) && (_item['require'] == '' || _item['require'] =~ /unmanaged/i)) -%>
     <%- if _item['require'].is_a?(Hash) -%>
       <%- case _item['require']['enforce'].downcase
           when 'all','none','any' then -%>


### PR DESCRIPTION
I'm getting warnings like this for each `puppet agent` run:
```
templates/vhost/_require.erb:3: warning: deprecated Object#=~ is called on Hash; it always returns nil
```
This PR changes the logic to only performing the regex comparison when [the `requires` value](https://github.com/puppetlabs/puppetlabs-apache/blob/main/REFERENCE.md#requires) is a string.