### PR TITLE
WIP: vhost::proxy_dest_reverse_match is a hash

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1794,7 +1794,7 @@ define apache::vhost (
   Optional[Integer] $limitreqbody                                                     = undef,
   Optional[String] $proxy_dest                                                        = undef,
   Optional[String] $proxy_dest_match                                                  = undef,
-  Optional[String] $proxy_dest_reverse_match                                          = undef,
+  Optional[Variant[Array[Hash], Hash]] $proxy_dest_reverse_match                      = undef,
   Optional[Variant[Array[Hash], Hash]] $proxy_pass                                    = undef,
   Optional[Variant[Array[Hash], Hash]] $proxy_pass_match                              = undef,
   Boolean $proxy_requests                                                             = false,

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -1287,6 +1287,27 @@ describe 'apache::vhost', type: :define do
             ).with_content(%r{## Proxy rules})
           }
         end
+
+        context 'proxy_dest_reverse_match' do
+          let :params do
+            {
+              'docroot' => '/rspec/docroot',
+              'proxy_pass_match' => [
+                {
+                  'path'     => '/',
+                  'url'      => 'http://localhost:8081/',
+                },
+              ],
+            }
+          end
+
+          it {
+            is_expected.to contain_concat__fragment('rspec.example.com-proxy').with_content(
+              %r{^\s*ProxyPassReverse / http://localhost:8081/$},
+            ).with_content(%r{## Proxy rules})
+          }
+        end
+
         context 'proxy_dest_match' do
           let :params do
             {

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -1292,7 +1292,7 @@ describe 'apache::vhost', type: :define do
           let :params do
             {
               'docroot' => '/rspec/docroot',
-              'proxy_pass_match' => [
+              'proxy_dest_reverse_match' => [
                 {
                   'path'     => '/',
                   'url'      => 'http://localhost:8081/',


### PR DESCRIPTION
Support

```puppet
apache::vhost{'myvhost':
  proxy_dest_reverse_match => [
   { 'path' => '/', 'url' => 'http://localhost:8081/' },
  ],
}
```

which has been in use since years.

Since version 8 this was incorrectly forced to be a string.