### PR TITLE
Allow RewriteInherit with empty rewrites

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -2514,11 +2514,12 @@ define apache::vhost (
 
   # Template uses:
   # - $rewrites
+  # - $rewrite_inherit
   # - $rewrite_base
   # - $rewrite_rule
   # - $rewrite_cond
   # - $rewrite_map
-  if (! empty($rewrites) or $rewrite_rule) and $ensure == 'present' {
+  if (! empty($rewrites) or $rewrite_rule or $rewrite_inherit) and $ensure == 'present' {
     include apache::mod::rewrite
 
     concat::fragment { "${name}-rewrite":

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -1690,26 +1690,26 @@ describe 'apache::vhost', type: :define do
             it { is_expected.to raise_error(Puppet::Error) }
           end
           context 'empty rewrites' do
-            let(:params) {
+            let(:params) do
               super().merge(
                 'rewrite_inherit' => false,
-                'rewrites' => []
+                'rewrites' => [],
               )
-            }
+            end
 
-            it { 
+            it {
               is_expected.to compile
               is_expected.not_to contain_concat__fragment('rspec.example.com-rewrite')
-            }            
+            }
           end
           context 'empty rewrites_with_rewrite_inherit' do
-            let(:params) {
+            let(:params) do
               super().merge(
                 'rewrite_inherit' => true,
-                'rewrites' => []
+                'rewrites' => [],
               )
-            }
-  
+            end
+
             it {
               is_expected.to contain_concat__fragment('rspec.example.com-rewrite').with(
                 content: %r{^\s+RewriteOptions Inherit$},

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -1690,10 +1690,33 @@ describe 'apache::vhost', type: :define do
             it { is_expected.to raise_error(Puppet::Error) }
           end
           context 'empty rewrites' do
-            let(:params) { super().merge('rewrites' => []) }
+            let(:params) {
+              super().merge(
+                'rewrite_inherit' => false,
+                'rewrites' => []
+              )
+            }
 
-            it { is_expected.to compile }
+            it { 
+              is_expected.to compile
+              is_expected.not_to contain_concat__fragment('rspec.example.com-rewrite')
+            }            
           end
+          context 'empty rewrites_with_rewrite_inherit' do
+            let(:params) {
+              super().merge(
+                'rewrite_inherit' => true,
+                'rewrites' => []
+              )
+            }
+  
+            it {
+              is_expected.to contain_concat__fragment('rspec.example.com-rewrite').with(
+                content: %r{^\s+RewriteOptions Inherit$},
+              )
+            }
+          end
+
           context 'bad error_log_format flag' do
             let :params do
               super().merge(


### PR DESCRIPTION
There are cases where you want to exclusively inherit RewriteRules from e.g. global scope without specifying vHost-specific rewrites - which is now allowed again.