### PR TITLE
Simplify the logic in _require.erb

### DIFF
--- a/templates/vhost/_require.erb
+++ b/templates/vhost/_require.erb
@@ -20,8 +20,7 @@
   <%- end -%>
   <%- if _item['auth_require'] -%>
     Require <%= _item['auth_require'] %>
-  <%- end -%>
-  <%- if !(_item['require'] && _item['require'] != '') && _item['require'] !~ /unmanaged/i && !(_item['auth_require']) -%>
+  <%- elsif !_item['require'] || _item['require'] == '' -%>
     Require all granted
   <%- end -%>
 <%- else -%>


### PR DESCRIPTION
If we take the expression:

```ruby
!(_item['require'] && _item['require'] != '') && _item['require'] !~ /unmanaged/i && !(_item['auth_require'])
```

This is hard to read, but equal to:

```ruby
(!_item['require'] || _item['require'] == '') && _item['require'] !~ /unmanaged/i && !(_item['auth_require'])
```

This makes it easier to see that item must be `nil` or `''`. Those will never match `/unmanaged/i` so it can be simplified to:

```ruby
(!_item['require'] || _item['require'] == '') && !(_item['auth_require'])
```

Just before it is a block that already checks the last section, so it can be reduced to an elsif on that block.