### PR TITLE
fix directory empty options if an empty array is being used

### DIFF
--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -859,6 +859,10 @@ describe 'apache::vhost define' do
         docroot    => '/tmp',
         options    => ['Indexes','FollowSymLinks', 'ExecCGI'],
       }
+      apache::vhost { 'test.empty_options':
+        docroot    => '/tmp',
+        options    => [],
+      }
     MANIFEST
     it 'applies cleanly' do
       apply_manifest(pp, catch_failures: true)
@@ -948,6 +952,10 @@ describe 'apache::vhost define' do
     describe file("#{apache_hash['vhost_dir']}/25-test.options.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain 'Options Indexes FollowSymLinks ExecCGI' }
+    end
+    describe file("#{apache_hash['vhost_dir']}/25-test.empty_options.conf") do
+      it { is_expected.to be_file }
+      it { is_expected.not_to contain 'Options' }
     end
   end
 

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -37,7 +37,7 @@
     <%- if ! directory['geoip_enable'].nil? -%>
     GeoIPEnable <%= scope.call_function('apache::bool2httpd', [directory['geoip_enable']]) %>
     <%- end -%>
-    <%- if directory['options'] -%>
+    <%- if directory['options'] && Array(directory['options']).any? -%>
     Options <%= Array(directory['options']).join(' ') %>
     <%- end -%>
     <%- if provider == 'Directory' -%>


### PR DESCRIPTION
puppetlabs-apache 6.5.1 with `options => false`

```
  <Directory "/var/www/html/myapp">
    AllowOverride None
    Require all granted
  </Directory>
```

puppetlabs-apache latest with `options => []`

```
   <Directory "/var/www/html/myapp">
     Options
     AllowOverride None
     Require all granted
   </Directory>
```