### PR TITLE
(MAINT) Removing support for CentOS 8

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -30,8 +30,7 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7",
-        "8"
+        "7"
       ]
     },
     {


### PR DESCRIPTION
Prior to this commit the metadata.json file for this module listed OSs that are not supported by puppet agent as supported. This commit aims to refactor the metadata.json file to only list OSs that are supported by puppet agent.