### PR TITLE
Clean up SELinux handling in acceptance testing.

### DIFF
--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -18,6 +18,17 @@ case $facts['os']['family'] {
       }
     }
 
+    if $facts['selinux'] {
+      $semanage_package = $facts['os']['release']['major'] ? {
+        '6'     => 'policycoreutils-python',
+        '7'     => 'policycoreutils-python',
+        default => 'policycoreutils-python-utils',
+      }
+      package { $semanage_package:
+        ensure => installed,
+      }
+    }
+
     if versioncmp($facts['os']['release']['major'], '8') >= 0 {
       package { 'iproute':
         ensure => installed,


### PR DESCRIPTION
This attempts to unify SELinux handling in the tests. It moves the package installation to the acceptance spec helper to reduce duplication. It then makes the set_apache_defaults line idempotent and restorecon_apache correctly chained. This works around [PUP-10548] which is that Puppet doesn't reload file contexts within a run. That means it must first create the file(s) and then run restorecon to get correct contexts.

[PUP-10548]: https://tickets.puppetlabs.com/browse/PUP-10548