### PR TITLE
fix rewrite rules being ignored

### DIFF
--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -738,7 +738,6 @@ describe 'apache::vhost', type: :define do
               .with_content(%r{^\s+RewriteOptions Inherit$})
               .with_content(%r{^\s+RewriteBase /})
               .with_content(%r{^\s+RewriteRule ^index\.html$ welcome.html$})
-            )
           }
           it { is_expected.to contain_concat__fragment('rspec.example.com-scriptalias') }
           it { is_expected.to contain_concat__fragment('rspec.example.com-serveralias') }

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -379,7 +379,7 @@ describe 'apache::vhost', type: :define do
               'request_headers'             => ['append MirrorID "mirror 12"'],
               'rewrites'                    => [
                 {
-                  'rewrite_rule' => ['^index\.html$ rewrites.html'],
+                  'rewrite_rule' => ['^index.html$ rewrites.html'],
                 },
               ],
               'filters' => [
@@ -392,7 +392,7 @@ describe 'apache::vhost', type: :define do
                 'FilterProtocol COMPRESS  DEFLATE change=yes;byteranges=no',
               ],
               'rewrite_base'                => '/',
-              'rewrite_rule'                => '^index\.html$ welcome.html',
+              'rewrite_rule'                => '^index.html$ welcome.html',
               'rewrite_cond'                => ['%{HTTP_USER_AGENT} ^MSIE'],
               'rewrite_inherit'             => true,
               'setenv'                      => ['FOO=/bin/true'],
@@ -737,7 +737,7 @@ describe 'apache::vhost', type: :define do
               .with_content(%r{^\s+RewriteEngine On$})
               .with_content(%r{^\s+RewriteOptions Inherit$})
               .with_content(%r{^\s+RewriteBase /})
-              .with_content(%r{^\s+RewriteRule ^index\.html$ welcome.html$})
+              .with_content(%r{^\s+RewriteRule \^index\.html\$ rewrites.html$})
           }
           it { is_expected.to contain_concat__fragment('rspec.example.com-scriptalias') }
           it { is_expected.to contain_concat__fragment('rspec.example.com-serveralias') }
@@ -1817,7 +1817,7 @@ describe 'apache::vhost', type: :define do
               is_expected.not_to contain_concat__fragment('rspec.example.com-rewrite')
                 .with_content(%r{^\s+RewriteOptions Inherit$})
                 .with_content(%r{^\s+RewriteEngine On$})
-                .with_content(%r{^\s+RewriteRule ^index\.html$ welcome.html$})
+                .with_content(%r{^\s+RewriteRule \^index\.html\$ welcome.html$})
             }
           end
           context 'empty rewrites_without_rewrite_inherit' do
@@ -1831,7 +1831,7 @@ describe 'apache::vhost', type: :define do
             it {
               is_expected.not_to contain_concat__fragment('rspec.example.com-rewrite')
                 .with_content(%r{^\s+RewriteEngine On$})
-                .with_content(%r{^\s+RewriteRule ^index\.html$ welcome.html$})
+                .with_content(%r{^\s+RewriteRule \^index\.html\$ welcome.html$})
                 .without(content: %r{^\s+RewriteOptions Inherit$})
             }
           end

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -1814,7 +1814,7 @@ describe 'apache::vhost', type: :define do
             end
 
             it {
-              is_expected.to contain_concat__fragment('rspec.example.com-rewrite')
+              is_expected.not_to contain_concat__fragment('rspec.example.com-rewrite')
                 .with_content(%r{^\s+RewriteOptions Inherit$})
                 .with_content(%r{^\s+RewriteEngine On$})
                 .with_content(%r{^\s+RewriteRule ^index\.html$ welcome.html$})
@@ -1829,7 +1829,7 @@ describe 'apache::vhost', type: :define do
             end
 
             it {
-              is_expected.to contain_concat__fragment('rspec.example.com-rewrite')
+              is_expected.not_to contain_concat__fragment('rspec.example.com-rewrite')
                 .with_content(%r{^\s+RewriteEngine On$})
                 .with_content(%r{^\s+RewriteRule ^index\.html$ welcome.html$})
                 .without(content: %r{^\s+RewriteOptions Inherit$})

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -1832,7 +1832,7 @@ describe 'apache::vhost', type: :define do
               is_expected.to contain_concat__fragment('rspec.example.com-rewrite')
                 .with_content(%r{^\s+RewriteEngine On$})
                 .with_content(%r{^\s+RewriteRule ^index\.html$ welcome.html$})
-                .without( content: %r{^\s+RewriteOptions Inherit$})
+                .without(content: %r{^\s+RewriteOptions Inherit$})
             }
           end
 

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -379,7 +379,7 @@ describe 'apache::vhost', type: :define do
               'request_headers'             => ['append MirrorID "mirror 12"'],
               'rewrites'                    => [
                 {
-                  'rewrite_rule' => ['^index\.html$ welcome.html'],
+                  'rewrite_rule' => ['^index\.html$ rewrites.html'],
                 },
               ],
               'filters' => [
@@ -733,8 +733,11 @@ describe 'apache::vhost', type: :define do
           }
           it { is_expected.to contain_concat__fragment('rspec.example.com-redirect') }
           it {
-            is_expected.to contain_concat__fragment('rspec.example.com-rewrite').with(
-              content: %r{^\s+RewriteOptions Inherit$},
+            is_expected.to contain_concat__fragment('rspec.example.com-rewrite')
+              .with_content(%r{^\s+RewriteEngine On$})
+              .with_content(%r{^\s+RewriteOptions Inherit$})
+              .with_content(%r{^\s+RewriteBase /})
+              .with_content(%r{^\s+RewriteRule ^index\.html$ welcome.html$})
             )
           }
           it { is_expected.to contain_concat__fragment('rspec.example.com-scriptalias') }
@@ -1812,9 +1815,25 @@ describe 'apache::vhost', type: :define do
             end
 
             it {
-              is_expected.to contain_concat__fragment('rspec.example.com-rewrite').with(
-                content: %r{^\s+RewriteOptions Inherit$},
+              is_expected.to contain_concat__fragment('rspec.example.com-rewrite')
+                .with_content(%r{^\s+RewriteOptions Inherit$})
+                .with_content(%r{^\s+RewriteEngine On$})
+                .with_content(%r{^\s+RewriteRule ^index\.html$ welcome.html$})
+            }
+          end
+          context 'empty rewrites_without_rewrite_inherit' do
+            let(:params) do
+              super().merge(
+                'rewrite_inherit' => false,
+                'rewrites' => [],
               )
+            end
+
+            it {
+              is_expected.to contain_concat__fragment('rspec.example.com-rewrite')
+                .with_content(%r{^\s+RewriteEngine On$})
+                .with_content(%r{^\s+RewriteRule ^index\.html$ welcome.html$})
+                .without( content: %r{^\s+RewriteOptions Inherit$})
             }
           end
 

--- a/templates/vhost/_rewrite.erb
+++ b/templates/vhost/_rewrite.erb
@@ -1,4 +1,4 @@
-<%- if @rewrites -%>
+<%- if @rewrite_inherit or not @rewrites.empty? -%>
   ## Rewrite rules
   RewriteEngine On
   <%- if @rewrite_inherit -%>
@@ -38,7 +38,7 @@
   <%- end -%>
 <%- end -%>
 <%# reverse compatibility -%>
-<% if @rewrite_rule and !@rewrites -%>
+<% if @rewrite_rule and @rewrites.empty? -%>
   ## Rewrite rules
   RewriteEngine On
   <%- if @rewrite_base -%>

--- a/templates/vhost/_rewrite.erb
+++ b/templates/vhost/_rewrite.erb
@@ -1,4 +1,4 @@
-<%- if @rewrite_inherit or not @rewrites.empty? -%>
+<%- if @rewrite_inherit or !@rewrites.empty? -%>
   ## Rewrite rules
   RewriteEngine On
   <%- if @rewrite_inherit -%>


### PR DESCRIPTION
In 7b22dae the default value for $rewrites was changed from undef to [] in manifests/vhost.pp. This results in templates_vhost/_rewrite.erb always evaluating to false (boolean check on an empty array variable is still true) unless $rewrites is explicitly set to undef. This results in the content of $rewrite_rule being ignored.

closes: #2318