### PR TITLE
(CONT-173) - Updating deprecated facter instances

### DIFF
--- a/lib/facter/apache_version.rb
+++ b/lib/facter/apache_version.rb
@@ -5,17 +5,17 @@ Facter.add(:apache_version) do
   setcode do
     apache_version = nil
 
-    if Facter::Util::Resolution.which('httpd')
-      apache_version = Facter::Util::Resolution.exec('httpd -V 2>&1')
+    if Facter::Core::Execution.which('httpd')
+      apache_version = Facter::Core::Execution.execute('httpd -V 2>&1')
       Facter.debug "Matching httpd '#{apache_version}'"
-    elsif Facter::Util::Resolution.which('apache2')
-      apache_version = Facter::Util::Resolution.exec('apache2 -V 2>&1')
+    elsif Facter::Core::Execution.which('apache2')
+      apache_version = Facter::Core::Execution.execute('apache2 -V 2>&1')
       Facter.debug "Matching apache2 '#{apache_version}'"
-    elsif Facter::Util::Resolution.which('apachectl')
-      apache_version = Facter::Util::Resolution.exec('apachectl -v 2>&1')
+    elsif Facter::Core::Execution.which('apachectl')
+      apache_version = Facter::Core::Execution.execute('apachectl -v 2>&1')
       Facter.debug "Matching apachectl '#{apache_version}'"
-    elsif Facter::Util::Resolution.which('apache2ctl')
-      apache_version = Facter::Util::Resolution.exec('apache2ctl -v 2>&1')
+    elsif Facter::Core::Execution.which('apache2ctl')
+      apache_version = Facter::Core::Execution.execute('apache2ctl -v 2>&1')
       Facter.debug "Matching apache2ctl '#{apache_version}'"
     end
 

--- a/spec/unit/facter/util/fact_apache_version_spec.rb
+++ b/spec/unit/facter/util/fact_apache_version_spec.rb
@@ -10,8 +10,8 @@ describe Facter::Util::Fact do
     context 'with value' do
       before :each do
         allow(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
-        expect(Facter::Util::Resolution).to receive(:which).with('httpd') { true }
-        expect(Facter::Util::Resolution).to receive(:exec).with('httpd -V 2>&1') {
+        expect(Facter::Core::Execution).to receive(:which).with('httpd') { true }
+        expect(Facter::Core::Execution).to receive(:execute).with('httpd -V 2>&1') {
           'Server version: Apache/2.4.16 (Unix)
            Server built:   Jul 31 2015 15:53:26'
         }
@@ -26,8 +26,8 @@ describe Facter::Util::Fact do
     context 'with value' do
       before :each do
         allow(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
-        expect(Facter::Util::Resolution).to receive(:which).with('httpd') { true }
-        expect(Facter::Util::Resolution).to receive(:exec).with('httpd -V 2>&1') {
+        expect(Facter::Core::Execution).to receive(:which).with('httpd') { true }
+        expect(Facter::Core::Execution).to receive(:execute).with('httpd -V 2>&1') {
           'Server version: Apache/2.4.6 ()
            Server built:   Nov 21 2015 05:34:59'
         }


### PR DESCRIPTION
Prior to this commit, this module contained instances of Facter::Util::Resolution.exec and Facter::Util::Resolution.which, which are deprecated. This commit aims to replace these exec helpers with their supported Facter::Core::Execution counterparts.

This commit:
- Replaced all Facter::Util::Resolution instances with corresponding Facter::Core::Execution exec helpers