### PR TITLE
Support setting SSLProxyCipherSuite on mod_ssl

### DIFF
--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -40,6 +40,9 @@
 # @param ssl_proxy_protocol
 #   Configure usable SSL protocol flavors for proxy usage.
 #
+# @param ssl_proxy_cipher_suite
+#   Configure usable SSL ciphers for proxy usage. Equivalent to ssl_cipher but for proxy connections.
+#
 # @param ssl_pass_phrase_dialog
 #   Type of pass phrase dialog for encrypted private keys.
 #
@@ -99,6 +102,7 @@ class apache::mod::ssl (
   Variant[Boolean, Enum['on', 'off']] $ssl_honorcipherorder = true,
   Array[String] $ssl_protocol                               = $apache::params::ssl_protocol,
   Array $ssl_proxy_protocol                                 = [],
+  Optional[String[1]] $ssl_proxy_cipher_suite               = undef,
   String $ssl_pass_phrase_dialog                            = 'builtin',
   Integer $ssl_random_seed_bytes                            = 512,
   String $ssl_sessioncache                                  = $apache::params::ssl_sessioncache,

--- a/spec/classes/mod/ssl_spec.rb
+++ b/spec/classes/mod/ssl_spec.rb
@@ -17,8 +17,22 @@ describe 'apache::mod::ssl', type: :class do
       it { is_expected.to contain_class('apache::params') }
       it { is_expected.to contain_apache__mod('ssl') }
       it { is_expected.to contain_package('mod_ssl') }
-      it { is_expected.to contain_file('ssl.conf').with_path('/etc/httpd/conf.modules.d/ssl.conf') }
-      it { is_expected.to contain_file('ssl.conf').with_content(%r{SSLProtocol all}) }
+      it {
+        is_expected.to contain_file('ssl.conf')
+          .with_path('/etc/httpd/conf.modules.d/ssl.conf')
+          .with_content(%r{SSLProtocol all})
+          .without_content(%r{SSLProxyCipherSuite})
+      }
+
+      context 'with ssl_proxy_cipher_suite' do
+        let(:params) do
+          {
+            ssl_proxy_cipher_suite: 'PROFILE=system',
+          }
+        end
+
+        it { is_expected.to contain_file('ssl.conf').with_content(%r{SSLProxyCipherSuite PROFILE=system}) }
+      end
     end
 
     context '7 OS with custom directories for PR#1635' do

--- a/templates/mod/ssl.conf.erb
+++ b/templates/mod/ssl.conf.erb
@@ -44,6 +44,9 @@
 <% if not @ssl_proxy_protocol.empty? -%>
   SSLProxyProtocol <%= @ssl_proxy_protocol.compact.join(' ') %>
 <% end -%>
+<% if @ssl_proxy_cipher_suite -%>
+  SSLProxyCipherSuite <%= @ssl_proxy_cipher_suite %>
+<% end -%>
 <% if @ssl_options -%>
   SSLOptions <%= @ssl_options.compact.join(' ') %>
 <% end -%>


### PR DESCRIPTION
While it is a parameter for apache::vhost, this allows setting it server wide just like SSLCipherSuite.