### PR TITLE
Automatically enable mod_http2 if needed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -827,6 +827,10 @@ class apache (
       include "::apache::mod::${mpm_module}"
     }
 
+    if 'h2' in $protocols or 'h2c' in $protocols {
+      include apache::mod::http2
+    }
+
     $default_vhost_ensure = $default_vhost ? {
       true  => 'present',
       false => 'absent'

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -2704,7 +2704,7 @@ define apache::vhost (
     }
   }
 
-  if ($h2_copy_files != undef or $h2_direct != undef or $h2_early_hints != undef or $h2_max_session_streams != undef or $h2_modern_tls_only != undef or $h2_push != undef or $h2_push_diary_size != undef or $h2_push_priority != [] or $h2_push_resource != [] or $h2_serialize_headers != undef or $h2_stream_max_mem_size != undef or $h2_tls_cool_down_secs != undef or $h2_tls_warm_up_size != undef or $h2_upgrade != undef or $h2_window_size != undef) and $ensure == 'present' {
+  if ('h2' in $protocols or 'h2c' in $protocols or $h2_copy_files != undef or $h2_direct != undef or $h2_early_hints != undef or $h2_max_session_streams != undef or $h2_modern_tls_only != undef or $h2_push != undef or $h2_push_diary_size != undef or $h2_push_priority != [] or $h2_push_resource != [] or $h2_serialize_headers != undef or $h2_stream_max_mem_size != undef or $h2_tls_cool_down_secs != undef or $h2_tls_warm_up_size != undef or $h2_upgrade != undef or $h2_window_size != undef) and $ensure == 'present' {
     include apache::mod::http2
 
     concat::fragment { "${name}-http2":


### PR DESCRIPTION
Following https://httpd.apache.org/docs/current/howto/http2.html the first step is to load the http2 module. By inspecting the protocols argument users can enable HTTP/2 via Hiera.