### PR TITLE
Make serveradmin an optional parameter and use it

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -489,7 +489,7 @@ class apache (
   Boolean $purge_configs                                                     = true,
   Optional[Boolean] $purge_vhost_dir                                         = undef,
   Boolean $purge_vdir                                                        = false,
-  String $serveradmin                                                        = 'root@localhost',
+  Optional[String[1]] $serveradmin                                           = undef,
   Enum['On', 'Off', 'on', 'off'] $sendfile                                   = 'On',
   Optional[Enum['On', 'Off', 'on', 'off']] $ldap_verify_server_cert          = undef,
   Optional[String] $ldap_trusted_mode                                        = undef,

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -39,6 +39,7 @@ describe 'apache', type: :class do
         'purge' => 'false'
       ).that_notifies('Class[Apache::Service]').that_requires('Package[httpd]')
     }
+    it { is_expected.to contain_file('/etc/apache2/apache2.conf').without_content(%r{ServerAdmin}) }
     it {
       is_expected.to contain_concat('/etc/apache2/ports.conf').with(
         'owner' => 'root', 'group' => 'root',
@@ -81,6 +82,16 @@ describe 'apache', type: :class do
       end
 
       it { is_expected.to contain_file('/etc/apache2/apache2.conf').with_content %r{^IncludeOptional "/etc/apache2/conf\.d/\*\.conf"$} }
+    end
+
+    context 'with serveradmin' do
+      let(:params) do
+        {
+          serveradmin: 'admin@example.com',
+        }
+      end
+
+      it { is_expected.to contain_file('/etc/apache2/apache2.conf').with_content %r{^ServerAdmin admin@example\.com$} }
     end
 
     context 'when specifying slash encoding behaviour' do

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -5,6 +5,9 @@ TraceEnable <%= scope.call_function('apache::bool2httpd', [@trace_enable]) %>
 
 ServerName "<%= @servername %>"
 ServerRoot "<%= @server_root %>"
+<%- if @serveradmin -%>
+ServerAdmin <%= @serveradmin %>
+<%- end -%>
 PidFile <%= @pidfile %>
 Timeout <%= @timeout %>
 KeepAlive <%= @keepalive %>


### PR DESCRIPTION
Since fc6cced03e60c5a78bceb006dd4267fc37f54959 the parameter no longer ends up in the main configuration. It was still used in apache::mod::shib until 049fd54b57e8a4f28ceeea4888456eafe1509fa1. Since then it's been unused.

This changes it to an optional non-empty string which means it doesn't change the default config, but still allows users to set the ServerAdmin in the main Apache config.