### PR TITLE
remove _module from apache::mod::unique_id name.

### DIFF
--- a/manifests/mod/security.pp
+++ b/manifests/mod/security.pp
@@ -200,7 +200,7 @@ class apache::mod::security (
     lib => 'mod_security2.so',
   }
 
-  ::apache::mod { 'unique_id_module':
+  ::apache::mod { 'unique_id':
     id  => 'unique_id_module',
     lib => 'mod_unique_id.so',
   }

--- a/spec/classes/mod/security_spec.rb
+++ b/spec/classes/mod/security_spec.rb
@@ -19,7 +19,7 @@ describe 'apache::mod::security', type: :class do
             )
           }
           it {
-            is_expected.to contain_apache__mod('unique_id_module').with(
+            is_expected.to contain_apache__mod('unique_id').with(
               id: 'unique_id_module',
               lib: 'mod_unique_id.so',
             )
@@ -189,7 +189,7 @@ describe 'apache::mod::security', type: :class do
             )
           }
           it {
-            is_expected.to contain_apache__mod('unique_id_module').with(
+            is_expected.to contain_apache__mod('unique_id').with(
               id: 'unique_id_module',
               lib: 'mod_unique_id.so',
             )


### PR DESCRIPTION
The unique_id module gets installed/loaded with its internal id 'unique_id_module' used as name; resulting in inconsistent naming and possible double entries if the module was already enabled outside of puppet (or security.pp). 