### PR TITLE
Extract acceptance node setup to a separate file

### DIFF
--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -1,0 +1,36 @@
+# needed by tests
+package { 'curl':
+  ensure => 'latest',
+}
+
+case $facts['os']['family'] {
+  'SLES', 'SUSE': {
+    # needed for netstat, for serverspec checks
+    package { 'net-tools-deprecated':
+      ensure => 'latest',
+    }
+  }
+  'RedHat': {
+    # Make sure selinux is disabled so the tests work.
+    if $facts['os']['selinux']['enabled'] {
+      exec { 'setenforce 0':
+        path => $facts['path'],
+      }
+    }
+
+    if versioncmp($facts['os']['release']['major'], '8') >= 0 {
+      package { 'iproute':
+        ensure => installed,
+      }
+    }
+    include epel
+  }
+  'Debian': {
+    if $facts['os']['name'] == 'Debian' and versioncmp($facts['os']['release']['major'], '11') >= 0 {
+      # Ensure ipv6 is enabled on our Debian 11 Docker boxes
+      exec { 'sysctl -w net.ipv6.conf.all.disable_ipv6=0':
+        path => $facts['path'],
+      }
+    }
+  }
+}


### PR DESCRIPTION
This makes it easier to maintain. You get proper syntax highlighting in your editor and can even lint it. This also converts some shell lines to pure Puppet. This reduces the need for large local spec_helper_acceptance modifications. The pattern is copied from voxpupuli-acceptance where the beaker setup automatically detects if the file is present and applies it.

It does drop EL6 EPEL support, following 4922544709313e0b7d176013e6f8118b85fdf96a.