### PR TITLE
Declare minimum Puppet version to be 6.24.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -83,7 +83,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 8.0.0"
+      "version_requirement": ">= 6.24.0 < 8.0.0"
     }
   ],
   "description": "Module for Apache configuration",


### PR DESCRIPTION
In a565ea97609979f7ccbc407534a553def0e865d8 the commands are passed as an array, but this feature was only [introduced in Puppet 6.24.0](https://puppet.com/docs/puppet/6/release_notes_puppet.html#enhancements_puppet_x-7-9-0-PUP-5704). This raises the minimum version to match, since it's no longer possible to use the module on anything older.

Fixes #2328