### PR TITLE
add LimitRequestLine parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -428,6 +428,9 @@
 #   The `limitreqfieldsize` parameter sets the maximum ammount of _bytes_ that will
 #   be allowed within a request header.
 #
+# @param limitreqline
+#   The 'limitreqline' parameter sets the limit on the allowed size of a client's HTTP request-line
+#
 # @param ip
 #   Specifies the ip address
 #
@@ -526,6 +529,7 @@ class apache (
   Integer $max_keepalive_requests                                            = $apache::params::max_keepalive_requests,
   Integer $limitreqfieldsize                                                 = 8190,
   Integer $limitreqfields                                                    = 100,
+  Optional[Integer] $limitreqline                                            = undef,
   Stdlib::Absolutepath $logroot                                              = $apache::params::logroot,
   Optional[Stdlib::Filemode] $logroot_mode                                   = $apache::params::logroot_mode,
   Apache::LogLevel $log_level                                                = $apache::params::log_level,

--- a/spec/acceptance/apache_parameters_spec.rb
+++ b/spec/acceptance/apache_parameters_spec.rb
@@ -566,6 +566,22 @@ describe 'apache parameters' do
     end
   end
 
+  describe 'limitreqline' do
+    pp = <<-MANIFEST
+        class { 'apache':
+          limitreqline => '8190',
+        }
+    MANIFEST
+    it 'applys cleanly' do
+      apply_manifest(pp, catch_failures: true)
+    end
+
+    describe file(apache_hash['conf_file']) do
+      it { is_expected.to be_file }
+      it { is_expected.to contain 'LimitRequestLine 8190' }
+    end
+  end
+
   describe 'file_e_tag' do
     pp = <<-MANIFEST
         class { 'apache':

--- a/spec/acceptance/apache_parameters_spec.rb
+++ b/spec/acceptance/apache_parameters_spec.rb
@@ -569,7 +569,7 @@ describe 'apache parameters' do
   describe 'limitreqline' do
     pp = <<-MANIFEST
         class { 'apache':
-          limitreqline => '8190',
+          limitreqline => 8190,
         }
     MANIFEST
     it 'applys cleanly' do

--- a/templates/httpd.conf.erb
+++ b/templates/httpd.conf.erb
@@ -15,6 +15,9 @@ MaxKeepAliveRequests <%= @max_keepalive_requests %>
 KeepAliveTimeout <%= @keepalive_timeout %>
 LimitRequestFieldSize <%= @limitreqfieldsize %>
 LimitRequestFields <%= @limitreqfields %>
+<% if @limitreqline -%>
+LimitRequestLine <%= @limitreqline %>
+<% end -%>
 <%# Actually >= 2.4.24, but the minor version is not provided -%>
 <%- if @http_protocol_options and scope.function_versioncmp([@apache_version, '2.4']) >= 0 -%>
 HttpProtocolOptions <%= @http_protocol_options %>


### PR DESCRIPTION
Adds optional parameter for setting the limit on the allowed size of a client's HTTP request-line
New PR reopened for closed PR https://github.com/puppetlabs/puppetlabs-apache/pull/2208
Added parameter definition and code for testing