### PR TITLE
disable::mpm_event: Fix module deactivation

### DIFF
--- a/manifests/mpm/disable_mpm_event.pp
+++ b/manifests/mpm/disable_mpm_event.pp
@@ -1,29 +1,11 @@
 # @summary disable Apache-Module event
 class apache::mpm::disable_mpm_event {
-  $event_command = ['/usr/sbin/a2dismod', 'event']
-  $event_onlyif = [['/usr/bin/test', '-e', join([$apache::mod_enable_dir, 'event.load'],'/')]]
-  exec { '/usr/sbin/a2dismod event':
+  $event_command = ['/usr/sbin/a2dismod', 'mpm_event']
+  $event_onlyif = [['/usr/bin/test', '-e', join([$apache::mod_enable_dir, 'mpm_event.load'],'/')]]
+  exec { '/usr/sbin/a2dismod mpm_event':
     command => $event_command,
     onlyif  => $event_onlyif,
     require => Package['httpd'],
-    before  => Class['apache::service'],
-  }
-
-  $event_load_command = ['/bin/rm', join([$apache::mod_enable_dir, 'event_event.load'],'/')]
-  $event_load_onlyif = [['/usr/bin/test', '-e', join([$apache::mod_enable_dir, 'event_event.load'],'/')]]
-  exec { 'remove distribution event load file':
-    command => $event_load_command,
-    onlyif  => $event_load_onlyif,
-    require => Package['httpd'],
-    before  => Class['apache::service'],
-  }
-
-  $event_conf_command = ['/bin/rm', join([$apache::mod_enable_dir, 'event_event.conf'],'/')]
-  $event_conf_onlyif = [['/usr/bin/test', '-e', join([$apache::mod_enable_dir, 'event_event.conf'],'/')]]
-  exec { 'remove distribution event conf file':
-    command => $event_conf_command,
-    onlyif  => $event_conf_onlyif,
-    require => Package['httpd'],
-    before  => Class['apache::service'],
+    notify  => Class['apache::service'],
   }
 }

--- a/spec/classes/apache_spec.rb
+++ b/spec/classes/apache_spec.rb
@@ -248,7 +248,7 @@ describe 'apache', type: :class do
         { mpm_module: 'worker' }
       end
 
-      it { is_expected.to contain_exec('/usr/sbin/a2dismod event') }
+      it { is_expected.to contain_exec('/usr/sbin/a2dismod mpm_event') }
       it { is_expected.to contain_exec('/usr/sbin/a2dismod prefork') }
     end
 


### PR DESCRIPTION
there were a few things broken:
* a2dismod was called with the wrong module name. at least on apache 2.4.54 on Debian 11 it is named mpm_event, not event
* the paths to the files were wrong
* a2dismod already purges the .load and .conf file, the exec resources
 are not required (even then a file resource would probably be cleaner
 to purge them)
* Apache needs to be reloaded, so just running this priot to
 apache2::service isn't enough, it needs to be a notify

This initially worked but was changed from mpm_event to event in https://github.com/puppetlabs/puppetlabs-apache/pull/1961. Then it was fixed in https://github.com/puppetlabs/puppetlabs-apache/pull/2034 by adding the exec resources, but the actual a2dismod was still broken.