### PR TITLE
fix mod_proxy_html on FreeBSD

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -519,7 +519,6 @@ class apache::params inherits apache::version {
       'passenger'   => 'www/rubygem-passenger',
       'perl'        => 'www/mod_perl2',
       'phpXXX'      => 'www/mod_phpXXX',
-      'proxy_html'  => 'www/mod_proxy_html',
       'python'      => 'www/mod_python3',
       'wsgi'        => 'www/mod_wsgi',
       'dav_svn'     => 'devel/subversion',

--- a/spec/classes/mod/proxy_html_spec.rb
+++ b/spec/classes/mod/proxy_html_spec.rb
@@ -46,7 +46,6 @@ describe 'apache::mod::proxy_html', type: :class do
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.to contain_apache__mod('proxy_html').with(loadfiles: nil) }
     it { is_expected.to contain_apache__mod('xml2enc').with(loadfiles: nil) }
-    it { is_expected.to contain_package('www/mod_proxy_html') }
   end
   context 'on a Gentoo OS', :compile do
     include_examples 'Gentoo'


### PR DESCRIPTION
Previously trying to activate mod_proxy_html on FreeBSD resulted in the following error:

```
Error: /Stage[main]/Apache::Mod::Proxy_html/Apache::Mod[proxy_html]/Package[www/mod_proxy_html]/ensure: change from 'absent' to 'present' failed:
  Execution of '/usr/local/sbin/pkg install -qy www/mod_proxy_html' returned 1:
  pkg: No packages available to install matching 'www/mod_proxy_html' have been found in the repositories
```

The module files are already included in the base Apache port/package, the separate port was EOLed in 2018:
https://www.freshports.org/www/mod_proxy_html