### PR TITLE
vhost: Make ProxyAddHeaders configureable

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -2448,7 +2448,7 @@ define apache::vhost (
   # - $proxy_preserve_host
   # - $proxy_add_headers
   # - $no_proxy_uris
-  if ($proxy_dest or $proxy_pass or $proxy_pass_match or $proxy_dest_match or $proxy_preserve_host) and $ensure == 'present' {
+  if ($proxy_dest or $proxy_pass or $proxy_pass_match or $proxy_dest_match or $proxy_preserve_host or ($proxy_add_headers =~ NotUndef)) and $ensure == 'present' {
     include apache::mod::proxy_http
 
     concat::fragment { "${name}-proxy":

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -2137,14 +2137,16 @@ define apache::vhost (
   if $directories {
     $_directories = $directories
   } elsif $docroot {
-    $_directories = [{
-      provider       => 'directory',
-      path           => $docroot,
-      options        => $options,
-      allow_override => $override,
-      directoryindex => $directoryindex,
-      require        => 'all granted',
-    }]
+    $_directories = [
+      {
+        provider       => 'directory',
+        path           => $docroot,
+        options        => $options,
+        allow_override => $override,
+        directoryindex => $directoryindex,
+        require        => 'all granted',
+      }
+    ]
   } else {
     $_directories = undef
   }

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -902,6 +902,113 @@ describe 'apache::vhost', type: :define do
             )
           }
         end
+        context 'vhost with proxy_add_headers true' do
+          let :params do
+            {
+              'docroot'                     => '/var/www/foo',
+              'manage_docroot'              => false,
+              'virtual_docroot'             => true,
+              'virtual_use_default_docroot' => false,
+              'port'                        => 8080,
+              'ip'                          => '127.0.0.1',
+              'ip_based'                    => true,
+              'add_listen'                  => false,
+              'serveradmin'                 => 'foo@localhost',
+              'priority'                    => 30,
+              'default_vhost'               => true,
+              'servername'                  => 'example.com',
+              'serveraliases'               => ['test-example.com'],
+              'options'                     => ['MultiView'],
+              'override'                    => ['All'],
+              'directoryindex'              => 'index.html',
+              'vhost_name'                  => 'test',
+              'proxy_add_headers'           => true,
+            }
+          end
+
+          it { is_expected.to compile }
+          it { is_expected.to contain_concat__fragment('rspec.example.com-proxy').with_content(%r{ProxyAddHeaders On}) }
+        end
+        context 'vhost with proxy_add_headers false' do
+          let :params do
+            {
+              'docroot'                     => '/var/www/foo',
+              'manage_docroot'              => false,
+              'virtual_docroot'             => true,
+              'virtual_use_default_docroot' => false,
+              'port'                        => 8080,
+              'ip'                          => '127.0.0.1',
+              'ip_based'                    => true,
+              'add_listen'                  => false,
+              'serveradmin'                 => 'foo@localhost',
+              'priority'                    => 30,
+              'default_vhost'               => true,
+              'servername'                  => 'example.com',
+              'serveraliases'               => ['test-example.com'],
+              'options'                     => ['MultiView'],
+              'override'                    => ['All'],
+              'directoryindex'              => 'index.html',
+              'vhost_name'                  => 'test',
+              'proxy_add_headers'           => false,
+            }
+          end
+
+          it { is_expected.to compile }
+          it { is_expected.to contain_concat__fragment('rspec.example.com-proxy').with_content(%r{ProxyAddHeaders Off}) }
+        end
+        context 'vhost without proxy' do
+          let :params do
+            {
+              'docroot'                     => '/var/www/foo',
+              'manage_docroot'              => false,
+              'virtual_docroot'             => true,
+              'virtual_use_default_docroot' => false,
+              'port'                        => 8080,
+              'ip'                          => '127.0.0.1',
+              'ip_based'                    => true,
+              'add_listen'                  => false,
+              'serveradmin'                 => 'foo@localhost',
+              'priority'                    => 30,
+              'default_vhost'               => true,
+              'servername'                  => 'example.com',
+              'serveraliases'               => ['test-example.com'],
+              'options'                     => ['MultiView'],
+              'override'                    => ['All'],
+              'directoryindex'              => 'index.html',
+              'vhost_name'                  => 'test',
+            }
+          end
+
+          it { is_expected.to compile }
+          it { is_expected.not_to contain_concat__fragment('rspec.example.com-proxy') }
+        end
+        context 'vhost without proxy_add_headers' do
+          let :params do
+            {
+              'docroot'                     => '/var/www/foo',
+              'manage_docroot'              => false,
+              'virtual_docroot'             => true,
+              'virtual_use_default_docroot' => false,
+              'port'                        => 8080,
+              'ip'                          => '127.0.0.1',
+              'ip_based'                    => true,
+              'add_listen'                  => false,
+              'serveradmin'                 => 'foo@localhost',
+              'priority'                    => 30,
+              'default_vhost'               => true,
+              'servername'                  => 'example.com',
+              'serveraliases'               => ['test-example.com'],
+              'options'                     => ['MultiView'],
+              'override'                    => ['All'],
+              'directoryindex'              => 'index.html',
+              'vhost_name'                  => 'test',
+              'proxy_preserve_host'         => true,
+            }
+          end
+
+          it { is_expected.to compile }
+          it { is_expected.not_to contain_concat__fragment('rspec.example.com-proxy').with_content(%r{ProxyAddHeaders}) }
+        end
         context 'vhost with scheme and port in servername and use_servername_for_filenames' do
           let :params do
             {

--- a/templates/vhost/_proxy.erb
+++ b/templates/vhost/_proxy.erb
@@ -1,4 +1,4 @@
-<% if @proxy_dest or @proxy_pass or @proxy_pass_match or @proxy_dest_match -%>
+<% if @proxy_dest or @proxy_pass or @proxy_pass_match or @proxy_dest_match or defined?(@proxy_add_headers) -%>
 
   ## Proxy rules
 <% if @proxy_requests -%>


### PR DESCRIPTION
It's a valid usecase to set ProxyAddHeaders to Off. That's currently only possible when other proxy settings are configured as well. It needs to be independant.