### PR TITLE
Suppress bad Directory comment when DocumentRoot is not set

### DIFF
--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -1,6 +1,10 @@
 
   <%- scope.setvar('_template_scope', {}) -%>
+  <%- if @docroot -%>
   ## Directories, there should at least be a declaration for <%= @docroot %>
+  <%- else -%>
+  ## Directories
+  <%- end -%>
   <%- @_directories.each do |directory| -%>
     <%- if directory['path'] and directory['path'] != '' -%>
       <%- if directory['provider'] and directory['provider'].match('(directory|location|files|proxy)') -%>


### PR DESCRIPTION
It's valid for a DocumentRoot to be missing (`docroot => false`).
However, in the directories section, this leads to a confusing message:

`## Directories, there should at least be a declaration for false`