### PR TITLE
 security{,_crs}.conf: switch to structured facts

### DIFF
--- a/spec/classes/mod/security_spec.rb
+++ b/spec/classes/mod/security_spec.rb
@@ -10,6 +10,13 @@ describe 'apache::mod::security', type: :class do
       end
 
       case facts[:os]['family']
+      when 'Suse'
+        context 'on Suse based systems' do
+          it {
+            is_expected.to contain_file('security.conf')
+              .with_content(%r{^\s+SecTmpDir /var/lib/mod_security$})
+          }
+        end
       when 'RedHat'
         context 'on RedHat based systems' do
           it {
@@ -42,6 +49,7 @@ describe 'apache::mod::security', type: :class do
               .with_content(%r{^\s+SecAuditLogType Serial$})
               .with_content(%r{^\s+SecDebugLog /var/log/httpd/modsec_debug.log$})
               .with_content(%r{^\s+SecAuditLog /var/log/httpd/modsec_audit.log$})
+              .with_content(%r{^\s+SecTmpDir /var/lib/mod_security$})
           }
           it {
             is_expected.to contain_file('/etc/httpd/modsecurity.d').with(
@@ -211,6 +219,7 @@ describe 'apache::mod::security', type: :class do
               .with_content(%r{^\s+SecAuditLogType Serial$})
               .with_content(%r{^\s+SecDebugLog /var/log/apache2/modsec_debug.log$})
               .with_content(%r{^\s+SecAuditLog /var/log/apache2/modsec_audit.log$})
+              .with_content(%r{^\s+SecTmpDir /var/cache/modsecurity$})
           }
           it {
             is_expected.to contain_file('/etc/modsecurity').with(

--- a/templates/mod/security.conf.erb
+++ b/templates/mod/security.conf.erb
@@ -54,13 +54,13 @@
     <%- end -%>
     SecArgumentSeparator &
     SecCookieFormat 0
-<%- if scope['os::family'] == 'Debian' -%>
+<%- if scope['facts']['os']['family'] == 'Debian' -%>
     SecDebugLog <%= @logroot %>/modsec_debug.log
     SecAuditLog <%= @logroot %>/modsec_audit.log
     SecTmpDir /var/cache/modsecurity
     SecDataDir /var/cache/modsecurity
     SecUploadDir /var/cache/modsecurity
-<%- elsif scope['os::family'] == 'Suse' -%>
+<%- elsif scope['facts']['os']['family'] == 'Suse' -%>
     SecDebugLog /var/log/apache2/modsec_debug.log
     SecAuditLog /var/log/apache2/modsec_audit.log
     SecTmpDir /var/lib/mod_security

--- a/templates/mod/security_crs.conf.erb
+++ b/templates/mod/security_crs.conf.erb
@@ -1,4 +1,4 @@
-<% if scope['os::family'] == 'Redhat' and scope['os::release::major'].to_i <= 7 -%>
+<% if scope['facts']['os']['family'] == 'Redhat' and scope['facts']['os']['release']['major'].to_i <= 7 -%>
 # ---------------------------------------------------------------
 # Core ModSecurity Rule Set ver.2.2.9
 # Copyright (C) 2006-2012 Trustwave All rights reserved.


### PR DESCRIPTION
https://github.com/puppetlabs/puppetlabs-apache/commit/175d6d4e513f632bce60b7a07b9ec199b5ee4fbd broke the template.

~~This commit switches back to the old syntax.~~

This commit switches to proper structured facts.

Contains the same changes as https://github.com/puppetlabs/puppetlabs-apache/pull/2372 to validate it works now properly.