### PR TITLE
(#2374) Suse: Switch modsec_default_rules to array 

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -651,7 +651,7 @@ class apache::params inherits apache::version {
     $modsec_version       = 1
     $modsec_crs_package   = undef
     $modsec_crs_path      = undef
-    $modsec_default_rules = undef
+    $modsec_default_rules = []
     $modsec_dir           = '/etc/apache2/modsecurity'
     $secpcrematchlimit = 1500
     $secpcrematchlimitrecursion = 1500

--- a/spec/classes/mod/security_spec.rb
+++ b/spec/classes/mod/security_spec.rb
@@ -10,6 +10,13 @@ describe 'apache::mod::security', type: :class do
       end
 
       case facts[:os]['family']
+      when 'Suse'
+        context 'on Suse based systems' do
+          it {
+            is_expected.to contain_file('security.conf')
+              .with_content(%r{^\s+SecTmpDir /var/lib/mod_security$})
+          }
+        end
       when 'RedHat'
         context 'on RedHat based systems' do
           it {
@@ -42,6 +49,7 @@ describe 'apache::mod::security', type: :class do
               .with_content(%r{^\s+SecAuditLogType Serial$})
               .with_content(%r{^\s+SecDebugLog /var/log/httpd/modsec_debug.log$})
               .with_content(%r{^\s+SecAuditLog /var/log/httpd/modsec_audit.log$})
+              .with_content(%r{^\s+SecTmpDir /var/lib/mod_security$})
           }
           it {
             is_expected.to contain_file('/etc/httpd/modsecurity.d').with(
@@ -211,6 +219,7 @@ describe 'apache::mod::security', type: :class do
               .with_content(%r{^\s+SecAuditLogType Serial$})
               .with_content(%r{^\s+SecDebugLog /var/log/apache2/modsec_debug.log$})
               .with_content(%r{^\s+SecAuditLog /var/log/apache2/modsec_audit.log$})
+              .with_content(%r{^\s+SecTmpDir /var/cache/modsecurity$})
           }
           it {
             is_expected.to contain_file('/etc/modsecurity').with(

--- a/templates/mod/security.conf.erb
+++ b/templates/mod/security.conf.erb
@@ -54,13 +54,13 @@
     <%- end -%>
     SecArgumentSeparator &
     SecCookieFormat 0
-<%- if scope['os::family'] == 'Debian' -%>
+<%- if scope['facts']['os']['family'] == 'Debian' -%>
     SecDebugLog <%= @logroot %>/modsec_debug.log
     SecAuditLog <%= @logroot %>/modsec_audit.log
     SecTmpDir /var/cache/modsecurity
     SecDataDir /var/cache/modsecurity
     SecUploadDir /var/cache/modsecurity
-<%- elsif scope['os::family'] == 'Suse' -%>
+<%- elsif scope['facts']['os']['family'] == 'Suse' -%>
     SecDebugLog /var/log/apache2/modsec_debug.log
     SecAuditLog /var/log/apache2/modsec_audit.log
     SecTmpDir /var/lib/mod_security

--- a/templates/mod/security_crs.conf.erb
+++ b/templates/mod/security_crs.conf.erb
@@ -1,4 +1,4 @@
-<% if scope['os::family'] == 'Redhat' and scope['os::release::major'].to_i <= 7 -%>
+<% if scope['facts']['os']['family'] == 'Redhat' and scope['facts']['os']['release']['major'].to_i <= 7 -%>
 # ---------------------------------------------------------------
 # Core ModSecurity Rule Set ver.2.2.9
 # Copyright (C) 2006-2012 Trustwave All rights reserved.


### PR DESCRIPTION
This fixes https://github.com/puppetlabs/puppetlabs-apache/issues/2374. The issue was discovered in https://github.com/puppetlabs/puppetlabs-apache/pull/2373 while fixing https://github.com/puppetlabs/puppetlabs-apache/issues/2371.