### PR TITLE
Adding mod_version module to be activated by default

### DIFF
--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -53,6 +53,7 @@ class apache::default_mods (
         include apache::mod::rewrite
         include apache::mod::speling
         include apache::mod::suexec
+        include apache::mod::version
         include apache::mod::vhost_alias
         ::apache::mod { 'auth_digest': }
         ::apache::mod { 'authn_anon': }
@@ -70,15 +71,16 @@ class apache::default_mods (
         include apache::mod::authn_core
         include apache::mod::cache
         include apache::mod::disk_cache
+        include apache::mod::filter
         include apache::mod::headers
         include apache::mod::info
         include apache::mod::mime_magic
         include apache::mod::reqtimeout
         include apache::mod::rewrite
-        include apache::mod::userdir
-        include apache::mod::vhost_alias
         include apache::mod::speling
-        include apache::mod::filter
+        include apache::mod::userdir
+        include apache::mod::version
+        include apache::mod::vhost_alias
 
         ::apache::mod { 'asis': }
         ::apache::mod { 'auth_digest': }

--- a/manifests/mod/version.pp
+++ b/manifests/mod/version.pp
@@ -1,0 +1,12 @@
+# @summary
+#   Installs `mod_version`.
+#
+# @see https://httpd.apache.org/docs/current/mod/mod_version.html for additional documentation.
+#
+class apache::mod::version {
+  if $facts['os']['family'] == 'debian' {
+    warning("${module_name}: module version_module is built-in and can't be loaded")
+  } else {
+    ::apache::mod { 'version': }
+  }
+}


### PR DESCRIPTION
re adding mod_version which was accidentally removed with the drop of "apache 2.2 Support" in #2329.