### PR TITLE
(BugFix) Update OS Family comparison to correctly match

### DIFF
--- a/spec/classes/mod/security_spec.rb
+++ b/spec/classes/mod/security_spec.rb
@@ -159,24 +159,42 @@ describe 'apache::mod::security', type: :class do
               }
             end
 
-            it {
-              is_expected.to contain_file('/etc/httpd/modsecurity.d/security_crs.conf').with_content \
-                %r{^SecAction \\\n\s+\"id:900000,\\\n\s+phase:1,\\\n\s+nolog,\\\n\s+pass,\\\n\s+t:none,\\\n\s+setvar:tx.paranoia_level=1"$}
-              is_expected.to contain_file('/etc/httpd/modsecurity.d/security_crs.conf').with_content \
-                %r{^SecAction \\\n\s+\"id:900001,\\\n\s+phase:1,\\\n\s+nolog,\\\n\s+pass,\\\n\s+t:none,\\\n\s+setvar:tx.executing_paranoia_level=2"$}
-              is_expected.to contain_file('/etc/httpd/modsecurity.d/security_crs.conf').with_content \
-                %r{
-                  ^SecAction\ \\\n
-                  \s+\"id:900700,\\\n
-                  \s+phase:1,\\\n
-                  \s+nolog,\\\n
-                  \s+pass,\\\n
-                  \s+t:none,\\\n
-                  \s+setvar:'tx.dos_burst_time_slice=30',\\\n
-                  \s+setvar:'tx.dos_counter_threshold=120',\\\n
-                  \s+setvar:'tx.dos_block_timeout=300'"$
-              }x
-            }
+            if facts[:os]['release']['major'].to_i < 8 && facts[:os]['family'] == 'RedHat'
+              it {
+                is_expected.to contain_file('/etc/httpd/modsecurity.d/security_crs.conf').with_content \
+                  %r{
+                    ^SecAction\ \\\n
+                    \ \ "id:'900001',\ \\\n
+                    \ \ phase:1,\ \\\n
+                    \ \ t:none,\ \\\n
+                    \ \ setvar:tx.critical_anomaly_score=5,\ \\\n
+                    \ \ setvar:tx.error_anomaly_score=4,\ \\\n
+                    \ \ setvar:tx.warning_anomaly_score=3,\ \\\n
+                    \ \ setvar:tx.notice_anomaly_score=2,\ \\\n
+                    \ \ nolog,\ \\\n
+                    \ \ pass"$
+                }x
+              }
+            else
+              it {
+                is_expected.to contain_file('/etc/httpd/modsecurity.d/security_crs.conf').with_content \
+                  %r{^SecAction \\\n\s+\"id:900000,\\\n\s+phase:1,\\\n\s+nolog,\\\n\s+pass,\\\n\s+t:none,\\\n\s+setvar:tx.paranoia_level=1"$}
+                is_expected.to contain_file('/etc/httpd/modsecurity.d/security_crs.conf').with_content \
+                  %r{^SecAction \\\n\s+\"id:900001,\\\n\s+phase:1,\\\n\s+nolog,\\\n\s+pass,\\\n\s+t:none,\\\n\s+setvar:tx.executing_paranoia_level=2"$}
+                is_expected.to contain_file('/etc/httpd/modsecurity.d/security_crs.conf').with_content \
+                  %r{
+                    ^SecAction\ \\\n
+                    \s+\"id:900700,\\\n
+                    \s+phase:1,\\\n
+                    \s+nolog,\\\n
+                    \s+pass,\\\n
+                    \s+t:none,\\\n
+                    \s+setvar:'tx.dos_burst_time_slice=30',\\\n
+                    \s+setvar:'tx.dos_counter_threshold=120',\\\n
+                    \s+setvar:'tx.dos_block_timeout=300'"$
+                }x
+              }
+            end
           end
 
           describe 'with invalid CRS parameters' do

--- a/templates/mod/security_crs.conf.erb
+++ b/templates/mod/security_crs.conf.erb
@@ -1,4 +1,4 @@
-<% if scope['facts']['os']['family'] == 'Redhat' and scope['facts']['os']['release']['major'].to_i <= 7 -%>
+<% if scope['facts']['os']['family'] == 'RedHat' and scope['facts']['os']['release']['major'].to_i <= 7 -%>
 # ---------------------------------------------------------------
 # Core ModSecurity Rule Set ver.2.2.9
 # Copyright (C) 2006-2012 Trustwave All rights reserved.


### PR DESCRIPTION
OS Family comparison should be against `RedHat` not `Redhat`