### PR TITLE
Fix example code for apache::vhost::php_values

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -9407,7 +9407,7 @@ Allows per-virtual host setting [`php_value`s](http://php.net/manual/en/configur
 These flags or values can be overwritten by a user or an application.
 Within a vhost declaration:
 ``` puppet
-  php_values    => [ 'include_path ".:/usr/local/example-app/include"' ],
+  php_values    => { 'include_path' => '.:/usr/local/example-app/include' },
 ```
 
 Default value: `{}`

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -818,7 +818,7 @@
 #   These flags or values can be overwritten by a user or an application.
 #   Within a vhost declaration:
 #   ``` puppet
-#     php_values    => [ 'include_path ".:/usr/local/example-app/include"' ],
+#     php_values    => { 'include_path' => '.:/usr/local/example-app/include' },
 #   ```
 #
 # @param php_flags


### PR DESCRIPTION
The `php_values` parameter requires a Hash, but gives examples from the ~v7 era when other values were allowed.