### PR TITLE
Fixes mod::proxy allow_from parameter inconsistency #2352

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -5611,9 +5611,9 @@ Default value: `'Off'`
 
 ##### <a name="-apache--mod--proxy--allow_from"></a>`allow_from`
 
-Data type: `Optional[Stdlib::IP::Address]`
+Data type: `Optional[Variant[Stdlib::IP::Address, Array[Stdlib::IP::Address]]]`
 
-List of IPs allowed to access proxy.
+IP address or list of IPs allowed to access proxy.
 
 Default value: `undef`
 

--- a/manifests/mod/proxy.pp
+++ b/manifests/mod/proxy.pp
@@ -5,7 +5,7 @@
 #   Enables forward (standard) proxy requests.
 #
 # @param allow_from
-#   List of IPs allowed to access proxy.
+#   IP address or list of IPs allowed to access proxy.
 #
 # @param package_name
 #   Name of the proxy package to install.
@@ -23,7 +23,7 @@
 #
 class apache::mod::proxy (
   String $proxy_requests                    = 'Off',
-  Optional[Stdlib::IP::Address] $allow_from = undef,
+  Optional[Variant[Stdlib::IP::Address, Array[Stdlib::IP::Address]]] $allow_from = undef,
   Optional[String] $package_name            = undef,
   String $proxy_via                         = 'On',
   Optional[Integer[0]] $proxy_timeout       = undef,

--- a/templates/mod/proxy.conf.erb
+++ b/templates/mod/proxy.conf.erb
@@ -10,7 +10,11 @@
 
   <% if @proxy_requests != 'Off' or ( @allow_from and ! @allow_from.empty? ) -%>
   <Proxy *>
+    <%- if @allow_from.is_a? Array -%>
     Require ip <%= @allow_from.join(" ") %>
+    <%- else -%>
+    Require ip <%= @allow_from %>
+    <%- end -%>
   </Proxy>
   <% end -%>
 


### PR DESCRIPTION
apache::mod::proxy allowed Stdlib::IP::Address as a class parameter, but proxy.conf.erb assumed it was an array.