### PR TITLE
(BUGFIX) Update to ensure correct facter comparisons

### DIFF
--- a/manifests/default_confd_files.pp
+++ b/manifests/default_confd_files.pp
@@ -8,7 +8,7 @@ class apache::default_confd_files (
   # The rest of the conf.d/* files only get loaded if we want them
   if $all {
     case $facts['os']['family'] {
-      'freebsd': {
+      'FreeBSD': {
         include apache::confd::no_accf
       }
       default: {

--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -11,7 +11,7 @@ class apache::default_mods (
   # They are not configurable at this time, so we just include
   # them to make sure it works.
   case $facts['os']['family'] {
-    'redhat': {
+    'RedHat': {
       ::apache::mod { 'log_config': }
       if $facts['os']['name'] != 'Amazon' and $use_systemd {
         ::apache::mod { 'systemd': }
@@ -21,7 +21,7 @@ class apache::default_mods (
       }
       ::apache::mod { 'unixd': }
     }
-    'freebsd': {
+    'FreeBSD': {
       ::apache::mod { 'log_config': }
       ::apache::mod { 'unixd': }
     }
@@ -31,7 +31,7 @@ class apache::default_mods (
     default: {}
   }
   case $facts['os']['family'] {
-    'gentoo': {}
+    'Gentoo': {}
     default: {
       ::apache::mod { 'authz_host': }
     }
@@ -39,11 +39,11 @@ class apache::default_mods (
   # The rest of the modules only get loaded if we want all modules enabled
   if $all {
     case $facts['os']['family'] {
-      'debian': {
+      'Debian': {
         include apache::mod::authn_core
         include apache::mod::reqtimeout
       }
-      'redhat': {
+      'RedHat': {
         include apache::mod::actions
         include apache::mod::authn_core
         include apache::mod::cache
@@ -66,7 +66,7 @@ class apache::default_mods (
         ::apache::mod { 'substitute': }
         ::apache::mod { 'usertrack': }
       }
-      'freebsd': {
+      'FreeBSD': {
         include apache::mod::actions
         include apache::mod::authn_core
         include apache::mod::cache

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -546,7 +546,7 @@ class apache (
   Optional[Boolean] $protocols_honor_order                                   = undef,
 ) inherits apache::params {
   if $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '7' {
-    # On redhat 7 the ssl.conf lives in /etc/httpd/conf.d (the confd_dir)
+    # On RedHat 7 the ssl.conf lives in /etc/httpd/conf.d (the confd_dir)
     # when all other module configs live in /etc/httpd/conf.modules.d (the
     # mod_dir). On all other platforms and versions, ssl.conf lives in the
     # mod_dir. This should maintain the expected location of ssl.conf
@@ -731,7 +731,7 @@ class apache (
   }
 
   if $apache::conf_dir and $apache::params::conf_file {
-    if $facts['os']['family'] == 'gentoo' {
+    if $facts['os']['family'] == 'Gentoo' {
       $error_documents_path = '/usr/share/apache2/error'
       if $default_mods =~ Array {
         if defined('apache::mod::ssl') {
@@ -755,7 +755,7 @@ class apache (
     }
 
     $apxs_workaround = $facts['os']['family'] ? {
-      'freebsd' => true,
+      'FreeBSD' => true,
       default   => false
     }
 
@@ -837,7 +837,7 @@ class apache (
       use_port_for_filenames       => true,
     }
     $ssl_access_log_file = $facts['os']['family'] ? {
-      'freebsd' => $access_log_file,
+      'FreeBSD' => $access_log_file,
       default   => "ssl_${access_log_file}",
     }
     ::apache::vhost { 'default-ssl':

--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -94,7 +94,7 @@ define apache::mod (
     # ordering, we ensure that our version of httpd.conf is reverted after
     # the module gets installed.
     $package_before = $facts['os']['family'] ? {
-      'freebsd' => [
+      'FreeBSD' => [
         File[$_loadfile_name],
         File["${apache::conf_dir}/${apache::params::conf_file}"]
       ],

--- a/manifests/mod/cgid.pp
+++ b/manifests/mod/cgid.pp
@@ -19,8 +19,8 @@ class apache::mod::cgid {
   # Debian specifies it's cgid sock path, but RedHat uses the default value
   # with no config file
   $cgisock_path = $facts['os']['family'] ? {
-    'debian'  => "\${APACHE_RUN_DIR}/cgisock",
-    'freebsd' => 'cgisock',
+    'Debian'  => "\${APACHE_RUN_DIR}/cgisock",
+    'FreeBSD' => 'cgisock',
     default   => undef,
   }
 

--- a/manifests/mod/dav_fs.pp
+++ b/manifests/mod/dav_fs.pp
@@ -6,8 +6,8 @@
 class apache::mod::dav_fs {
   include apache
   $dav_lock = $facts['os']['family'] ? {
-    'debian'  => "\${APACHE_LOCK_DIR}/DAVLock",
-    'freebsd' => '/usr/local/var/DavLock',
+    'Debian'  => "\${APACHE_LOCK_DIR}/DAVLock",
+    'FreeBSD' => '/usr/local/var/DavLock',
     default   => '/var/lib/dav/lockdb',
   }
 

--- a/manifests/mod/disk_cache.pp
+++ b/manifests/mod/disk_cache.pp
@@ -31,9 +31,9 @@ class apache::mod::disk_cache (
     $_cache_root = $cache_root
   } else {
     $_cache_root = $facts['os']['family'] ? {
-      'debian'  => '/var/cache/apache2/mod_cache_disk',
-      'redhat'  => '/var/cache/httpd/proxy',
-      'freebsd' => '/var/cache/mod_cache_disk',
+      'Debian'  => '/var/cache/apache2/mod_cache_disk',
+      'RedHat'  => '/var/cache/httpd/proxy',
+      'FreeBSD' => '/var/cache/mod_cache_disk',
     }
   }
 

--- a/manifests/mod/event.pp
+++ b/manifests/mod/event.pp
@@ -84,11 +84,11 @@ class apache::mod::event (
   }
 
   case $facts['os']['family'] {
-    'redhat', 'debian', 'freebsd' : {
+    'RedHat', 'Debian', 'FreeBSD' : {
       apache::mpm { 'event':
       }
     }
-    'gentoo': {
+    'Gentoo': {
       ::portage::makeconf { 'apache2_mpms':
         content => 'event',
       }

--- a/manifests/mod/itk.pp
+++ b/manifests/mod/itk.pp
@@ -79,18 +79,18 @@ class apache::mod::itk (
   }
 
   case $facts['os']['family'] {
-    'redhat': {
+    'RedHat': {
       package { 'httpd-itk':
         ensure => present,
       }
       ::apache::mpm { 'itk':
       }
     }
-    'debian', 'freebsd': {
+    'Debian', 'FreeBSD': {
       apache::mpm { 'itk':
       }
     }
-    'gentoo': {
+    'Gentoo': {
       ::portage::makeconf { 'apache2_mpms':
         content => 'itk',
       }

--- a/manifests/mod/peruser.pp
+++ b/manifests/mod/peruser.pp
@@ -33,11 +33,11 @@ class apache::mod::peruser (
 ) {
   include apache
   case $facts['os']['family'] {
-    'freebsd' : {
+    'FreeBSD' : {
       fail("Unsupported osfamily ${$facts['os']['family']}")
     }
     default: {
-      if $facts['os']['family'] == 'gentoo' {
+      if $facts['os']['family'] == 'Gentoo' {
         ::portage::makeconf { 'apache2_mpms':
           content => 'peruser',
         }

--- a/manifests/mod/prefork.pp
+++ b/manifests/mod/prefork.pp
@@ -76,7 +76,7 @@ class apache::mod::prefork (
   }
 
   case $facts['os']['family'] {
-    'redhat', 'debian', 'freebsd': {
+    'RedHat', 'Debian', 'FreeBSD': {
       ::apache::mpm { 'prefork':
       }
     }
@@ -85,7 +85,7 @@ class apache::mod::prefork (
         lib_path       => '/usr/lib64/apache2-prefork',
       }
     }
-    'gentoo': {
+    'Gentoo': {
       ::portage::makeconf { 'apache2_mpms':
         content => 'prefork',
       }

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -126,10 +126,10 @@ class apache::mod::ssl (
 
   if $stapling_cache =~ Undef {
     $_stapling_cache = $facts['os']['family'] ? {
-      'debian'  => "\${APACHE_RUN_DIR}/ocsp(32768)",
-      'redhat'  => '/run/httpd/ssl_stapling(32768)',
-      'freebsd' => '/var/run/ssl_stapling(32768)',
-      'gentoo'  => '/var/run/ssl_stapling(32768)',
+      'Debian'  => "\${APACHE_RUN_DIR}/ocsp(32768)",
+      'RedHat'  => '/run/httpd/ssl_stapling(32768)',
+      'FreeBSD' => '/var/run/ssl_stapling(32768)',
+      'Gentoo'  => '/var/run/ssl_stapling(32768)',
       'Suse'    => '/var/lib/apache2/ssl_stapling(32768)',
     }
   } else {

--- a/manifests/mod/version.pp
+++ b/manifests/mod/version.pp
@@ -4,7 +4,7 @@
 # @see https://httpd.apache.org/docs/current/mod/mod_version.html for additional documentation.
 #
 class apache::mod::version {
-  if $facts['os']['family'] == 'debian' {
+  if $facts['os']['family'] == 'Debian' {
     warning("${module_name}: module version_module is built-in and can't be loaded")
   } else {
     ::apache::mod { 'version': }

--- a/manifests/mod/worker.pp
+++ b/manifests/mod/worker.pp
@@ -87,7 +87,7 @@ class apache::mod::worker (
   }
 
   case $facts['os']['family'] {
-    'redhat', 'debian', 'freebsd': {
+    'RedHat', 'Debian', 'FreeBSD': {
       ::apache::mpm { 'worker':
       }
     }
@@ -97,7 +97,7 @@ class apache::mod::worker (
       }
     }
 
-    'gentoo': {
+    'Gentoo': {
       ::portage::makeconf { 'apache2_mpms':
         content => 'worker',
       }

--- a/manifests/mpm.pp
+++ b/manifests/mpm.pp
@@ -43,7 +43,7 @@ define apache::mpm (
   }
 
   case $facts['os']['family'] {
-    'debian': {
+    'Debian': {
       file { "${apache::mod_enable_dir}/${mpm}.conf":
         ensure  => link,
         target  => "${apache::mod_dir}/${mpm}.conf",
@@ -92,15 +92,15 @@ define apache::mpm (
       }
     }
 
-    'freebsd': {
+    'FreeBSD': {
       class { 'apache::package':
         mpm_module => $mpm,
       }
     }
-    'gentoo': {
+    'Gentoo': {
       # so we don't fail
     }
-    'redhat': {
+    'RedHat': {
       # so we don't fail
     }
     'Suse': {


### PR DESCRIPTION
Ensuring that the correct values are compared against facter, there seem to be many cases where lowercase has been used in place of uppercase.