### PR TITLE
#2391 Allow Sensitive type in addition to String type

### DIFF
--- a/manifests/custom_config.pp
+++ b/manifests/custom_config.pp
@@ -54,7 +54,7 @@
 define apache::custom_config (
   Enum['absent', 'present'] $ensure                                    = 'present',
   Stdlib::Absolutepath $confdir                                        = $apache::confd_dir,
-  Optional[String] $content                                            = undef,
+  Optional[Variant[Sensitive, String]] $content                        = undef,
   Apache::Vhost::Priority $priority                                    = 25,
   Optional[String] $source                                             = undef,
   Variant[String, Array[String], Array[Array[String]]] $verify_command = $apache::params::verify_command,


### PR DESCRIPTION
Allow Sensitive type in addition to String type for apache::custom_config::content