### PR TITLE
strickter loglevel syntax verification

### DIFF
--- a/spec/type_aliases/loglevel_spec.rb
+++ b/spec/type_aliases/loglevel_spec.rb
@@ -21,6 +21,7 @@ describe 'Apache::LogLevel' do
     [],
     ['info'],
     'thisiswarning',
+    'errorerror',
   ].each do |invalid_value|
     it { is_expected.not_to allow_value(invalid_value) }
   end

--- a/spec/type_aliases/loglevel_spec.rb
+++ b/spec/type_aliases/loglevel_spec.rb
@@ -10,6 +10,7 @@ describe 'Apache::LogLevel' do
     'warn mod_ssl.c:info',
     'warn ssl_module:info',
     'trace4',
+    'ssl:info',
   ].each do |allowed_value|
     it { is_expected.to allow_value(allowed_value) }
   end
@@ -19,6 +20,7 @@ describe 'Apache::LogLevel' do
     '',
     [],
     ['info'],
+    'thisiswarning',
   ].each do |invalid_value|
     it { is_expected.not_to allow_value(invalid_value) }
   end

--- a/types/loglevel.pp
+++ b/types/loglevel.pp
@@ -24,4 +24,4 @@
 # * `trace8`
 #
 # @see https://httpd.apache.org/docs/current/mod/core.html#loglevel
-type Apache::LogLevel = Pattern[/\A(([a-z_\.]+:)?(emerg|alert|crit|error|warn|notice|info|debug|trace[1-8])\W*)+\Z/]
+type Apache::LogLevel = Pattern[/\A([a-z_\.]+:)?(emerg|alert|crit|error|warn|notice|info|debug|trace[1-8])(\s+([a-z_\.]+:)?(emerg|alert|crit|error|warn|notice|info|debug|trace[1-8]))*\Z/]

--- a/types/loglevel.pp
+++ b/types/loglevel.pp
@@ -24,4 +24,4 @@
 # * `trace8`
 #
 # @see https://httpd.apache.org/docs/current/mod/core.html#loglevel
-type Apache::LogLevel = Pattern[/(emerg|alert|crit|error|warn|notice|info|debug|trace[1-8])/]
+type Apache::LogLevel = Pattern[/\A(([a-z_\.]+:)?(emerg|alert|crit|error|warn|notice|info|debug|trace[1-8])\W*)+\Z/]


### PR DESCRIPTION
Apache::LogLevel allows invalid strings like 'warning' which are not accepted by apache httpd