### PR TITLE
Remove has_key usage

### DIFF
--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -54,7 +54,7 @@ define apache::mod (
   $mod_libs = $apache::mod_libs
   if $lib {
     $_lib = $lib
-  } elsif has_key($mod_libs, $mod) { # 2.6 compatibility hack
+  } elsif $mod in $mod_libs { # 2.6 compatibility hack
     $_lib = $mod_libs[$mod]
   } else {
     $_lib = "mod_${mod}.so"
@@ -83,7 +83,7 @@ define apache::mod (
   $mod_packages = $apache::mod_packages
   if $package {
     $_package = $package
-  } elsif has_key($mod_packages, $mod) { # 2.6 compatibility hack
+  } elsif $mod in $mod_packages { # 2.6 compatibility hack
     $_package = $mod_packages[$mod]
   } else {
     $_package = undef

--- a/manifests/mod/jk.pp
+++ b/manifests/mod/jk.pp
@@ -329,7 +329,7 @@ class apache::mod::jk (
 
   # Ensure that we are not using variables with the typo fixed by MODULES-6225
   # anymore:
-  if !empty($workers_file_content) and has_key($workers_file_content, 'worker_mantain') {
+  if !empty($workers_file_content) and 'worker_mantain' in $workers_file_content {
     fail('Please replace $workers_file_content[\'worker_mantain\'] by $workers_file_content[\'worker_maintain\']. See MODULES-6225 for details.')
   }
 

--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -81,9 +81,9 @@ class apache::mod::php (
   $mod_packages = $apache::mod_packages
   if $package_name {
     $_package_name = $package_name
-  } elsif has_key($mod_packages, $mod) { # 2.6 compatibility hack
+  } elsif $mod in $mod_packages { # 2.6 compatibility hack
     $_package_name = $mod_packages[$mod]
-  } elsif has_key($mod_packages, 'phpXXX') { # 2.6 compatibility hack
+  } elsif 'phpXXX' in $mod_packages { # 2.6 compatibility hack
     $_package_name = regsubst($mod_packages['phpXXX'], 'XXX', $php_version)
   } else {
     $_package_name = undef


### PR DESCRIPTION
In the next puppetlabs-stdlib major version this function will be dropped. Native Puppet is used instead.

https://github.com/puppetlabs/puppetlabs-stdlib/pull/1319 broke this