### PR TITLE
(MAINT) Enable legacy SP3 repository for SUSE

### DIFF
--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -106,6 +106,16 @@ class apache::mod::php (
   }
 
   if $facts['os']['name'] == 'SLES' {
+    # Enable legacy repo to install apache2-mod_php7 package
+    # if SUSE OS major version is >= 15 and minor version is > 3
+    if ($_package_name == 'apache2-mod_php7' and versioncmp($facts['os']['release']['major'], '15') >= 0 and versioncmp($facts['os']['release']['minor'], '3') == 1) {
+      exec { 'enable legacy repos':
+        path    => '/bin:/usr/bin/:/sbin:/usr/sbin',
+        command => 'SUSEConnect --product sle-module-legacy/15.4/x86_64',
+        unless  => 'SUSEConnect --status-text | grep sle-module-legacy/15.4/x86_64',
+      }
+    }
+
     ::apache::mod { $mod:
       package        => $_package_name,
       package_ensure => $package_ensure,

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -5,6 +5,15 @@ package { 'curl':
 
 case $facts['os']['family'] {
   'SLES', 'SUSE': {
+    # Enable legacy repo to install net-tools-deprecated package
+    # If SUSE OS major version is >= 15 and minor version is > 3
+    if (versioncmp($facts['os']['release']['major'], '15') >= 0 and versioncmp($facts['os']['release']['minor'], '3') == 1) {
+      exec { 'enable legacy repos':
+        path    => '/bin:/usr/bin/:/sbin:/usr/sbin',
+        command => 'SUSEConnect --product sle-module-legacy/15.4/x86_64',
+        unless  => 'SUSEConnect --status-text | grep sle-module-legacy/15.4/x86_64',
+      }
+    }
     # needed for netstat, for serverspec checks
     package { 'net-tools-deprecated':
       ensure => 'latest',


### PR DESCRIPTION
## Summary


Enable legacy SP3 repo so that we can leverage the old packages without any issues.

## Additional Context

New release of SUSE 15 introduced new version SP4 which deprecated old packages where `apache2-mod_php7` is one of them. As the package is deprecated with SP4 repo so user will not able to install.

## Related Issues (if any)
Due to package got deprecated from new repo, respective package manager is not able to install.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)