### PR TITLE
(WIP) (maint) - re-add required legacy packages to sp4 repo

### DIFF
--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -106,6 +106,12 @@ class apache::mod::php (
   }
 
   if $facts['os']['name'] == 'SLES' {
+    if $_package_name == 'apache2-mod_php7' and versioncmp($facts['os']['release']['major'], '15') >= 0 {
+      exec { 'enable legacy repos':
+        command     => 'SUSEConnect --product sle-module-legacy/15.4/x86_64',
+        refreshonly => true
+      }
+    }
     ::apache::mod { $mod:
       package        => $_package_name,
       package_ensure => $package_ensure,


### PR DESCRIPTION
## Summary
This adds the required `apache2_mod_php7` and `netstat` back to the sles 15 sp4 repo so that they can be installed and used during testing.

## Additional Context
These packages were removed by sles in the sp4 repos.

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)

_this is a work in progress and will likely include some code changes._