### PR TITLE
(CAT-1261)-update_SUSE_repo_name

### DIFF
--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -111,8 +111,8 @@ class apache::mod::php (
     if ($_package_name == 'apache2-mod_php7' and versioncmp($facts['os']['release']['major'], '15') >= 0 and versioncmp($facts['os']['release']['minor'], '3') == 1) {
       exec { 'enable legacy repos':
         path    => '/bin:/usr/bin/:/sbin:/usr/sbin',
-        command => 'SUSEConnect --product sle-module-legacy/15.4/x86_64',
-        unless  => 'SUSEConnect --status-text | grep sle-module-legacy/15.4/x86_64',
+        command => 'SUSEConnect --product sle-module-legacy/15.5/x86_64',
+        unless  => 'SUSEConnect --status-text | grep sle-module-legacy/15.5/x86_64',
       }
     }
 

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -10,8 +10,8 @@ case $facts['os']['family'] {
     if (versioncmp($facts['os']['release']['major'], '15') >= 0 and versioncmp($facts['os']['release']['minor'], '3') == 1) {
       exec { 'enable legacy repos':
         path    => '/bin:/usr/bin/:/sbin:/usr/sbin',
-        command => 'SUSEConnect --product sle-module-legacy/15.4/x86_64',
-        unless  => 'SUSEConnect --status-text | grep sle-module-legacy/15.4/x86_64',
+        command => 'SUSEConnect --product sle-module-legacy/15.5/x86_64',
+        unless  => 'SUSEConnect --status-text | grep sle-module-legacy/15.5/x86_64',
       }
     }
     # needed for netstat, for serverspec checks


### PR DESCRIPTION
## Summary
Enable legacy SP5 repo so that we can leverage the old packages without any issues.

## Additional Context
Add any additional context about the problem here. 
New release of SUSE introduced new version SP5 which deprecated old apache2-mod_php7 package. As the package is deprecated with old SP4 repo so user will not able to install.

## Related Issues (if any)
Due to package got deprecated from new repo, respective package manager is not able to install. This also affects the modules that is using java internally as a dependency or to install packages.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)