### PR TITLE
(CAT-1281) - Support to add cipher with respective ssl protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@
 [`ssl`]: https://forge.puppet.com/modules/puppetlabs/apache/reference#ssl
 [`ssl_cert`]: https://forge.puppet.com/modules/puppetlabs/apache/reference#ssl_cert
 [`ssl_compression`]: https://forge.puppet.com/modules/puppetlabs/apache/reference#ssl_compression
+[`ssl_cipher`]: https://forge.puppet.com/modules/puppetlabs/apache/reference#ssl_compression
 [`ssl_key`]: https://forge.puppet.com/modules/puppetlabs/apache/reference#ssl_key
 [`StartServers`]: https://httpd.apache.org/docs/current/mod/mpm_common.html#startservers
 [supported operating system]: https://forge.puppet.com/supported#puppet-supported-modules-compatibility-matrix
@@ -654,6 +655,22 @@ class { 'apache::mod::ssl': }
 ``` puppet
 class { 'apache::mod::ssl':
   ssl_compression => true,
+}
+```
+
+You can pass the SSL Ciphers to override the default ciphers.
+```puppet
+class { 'apache::mod::ssl':
+  ssl_cipher => 'PROFILE=SYSTEM',
+}
+```
+
+You can also pass the different [`ssl_cipher`][] for different SSL protocols. This allows you to fine-tune the ciphers based on the specific SSL/TLS protocol version being used. 
+```puppet
+class { 'apache::mod::ssl':
+  ssl_cipher => {
+    'TLSv1.1' => 'RSA:!EXP:!NULL:+HIGH:+MEDIUM'
+  },
 }
 ```
 

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -95,7 +95,7 @@ class apache::mod::ssl (
   Optional[Stdlib::Absolutepath] $ssl_cert                  = undef,
   Optional[Stdlib::Absolutepath] $ssl_key                   = undef,
   Optional[Stdlib::Absolutepath] $ssl_ca                    = undef,
-  String $ssl_cipher                                        = $apache::params::ssl_cipher,
+  Variant[String, Hash[String[1], String[1]]] $ssl_cipher   = $apache::params::ssl_cipher,
   Variant[Boolean, Apache::OnOff] $ssl_honorcipherorder     = true,
   Array[String] $ssl_protocol                               = $apache::params::ssl_protocol,
   Array $ssl_proxy_protocol                                 = [],

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -95,7 +95,7 @@ class apache::mod::ssl (
   Optional[Stdlib::Absolutepath] $ssl_cert                  = undef,
   Optional[Stdlib::Absolutepath] $ssl_key                   = undef,
   Optional[Stdlib::Absolutepath] $ssl_ca                    = undef,
-  Variant[String, Hash[String[1], String[1]]] $ssl_cipher   = $apache::params::ssl_cipher,
+  Variant[String[1], Hash[String[1], String[1]]] $ssl_cipher   = $apache::params::ssl_cipher,
   Variant[Boolean, Apache::OnOff] $ssl_honorcipherorder     = true,
   Array[String] $ssl_protocol                               = $apache::params::ssl_protocol,
   Array $ssl_proxy_protocol                                 = [],

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1719,7 +1719,7 @@ define apache::vhost (
   Optional[Stdlib::Absolutepath] $ssl_certs_dir                                       = $apache::params::ssl_certs_dir,
   Boolean $ssl_reload_on_change                                                       = $apache::default_ssl_reload_on_change,
   Optional[Variant[Array[String], String]] $ssl_protocol                              = undef,
-  Optional[Variant[Array[String], String, Hash[String[1], String[1]]]] $ssl_cipher   = undef,
+  Optional[Variant[Array[String], String[1], Hash[String[1], String[1]]]] $ssl_cipher = undef,
   Variant[Boolean, Apache::OnOff, Undef] $ssl_honorcipherorder                        = undef,
   Optional[Enum['none', 'optional', 'require', 'optional_no_ca']] $ssl_verify_client  = undef,
   Optional[Integer] $ssl_verify_depth                                                 = undef,

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1719,7 +1719,7 @@ define apache::vhost (
   Optional[Stdlib::Absolutepath] $ssl_certs_dir                                       = $apache::params::ssl_certs_dir,
   Boolean $ssl_reload_on_change                                                       = $apache::default_ssl_reload_on_change,
   Optional[Variant[Array[String], String]] $ssl_protocol                              = undef,
-  Optional[Variant[Array[String], String]] $ssl_cipher                                = undef,
+  Optional[Variant[Array[String], String, Hash[String[1], String[1]]]] $ssl_cipher   = undef,
   Variant[Boolean, Apache::OnOff, Undef] $ssl_honorcipherorder                        = undef,
   Optional[Enum['none', 'optional', 'require', 'optional_no_ca']] $ssl_verify_client  = undef,
   Optional[Integer] $ssl_verify_depth                                                 = undef,

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1719,7 +1719,7 @@ define apache::vhost (
   Optional[Stdlib::Absolutepath] $ssl_certs_dir                                       = $apache::params::ssl_certs_dir,
   Boolean $ssl_reload_on_change                                                       = $apache::default_ssl_reload_on_change,
   Optional[Variant[Array[String], String]] $ssl_protocol                              = undef,
-  Optional[Variant[Array[String], String[1], Hash[String[1], String[1]]]] $ssl_cipher = undef,
+  Optional[Variant[Array[String[1]], String[1], Hash[String[1], String[1]]]] $ssl_cipher = undef,
   Variant[Boolean, Apache::OnOff, Undef] $ssl_honorcipherorder                        = undef,
   Optional[Enum['none', 'optional', 'require', 'optional_no_ca']] $ssl_verify_client  = undef,
   Optional[Integer] $ssl_verify_depth                                                 = undef,

--- a/spec/classes/mod/ssl_spec.rb
+++ b/spec/classes/mod/ssl_spec.rb
@@ -45,6 +45,20 @@ describe 'apache::mod::ssl', type: :class do
 
         it { is_expected.to contain_file('ssl.conf').without_content(%r{SSLProtocol}) }
       end
+
+      context 'ciphers with ssl_protocol' do
+        let(:params) do
+          {
+            ssl_cipher: {
+              'TLSv1.1' => 'RSA:!EXP:!NULL:+HIGH:+MEDIUM',
+              'TLSv1.2' => 'RSA:!EXP:!NULL:+HIGH:+MEDIUM:-LOW'
+            }
+          }
+        end
+
+        it { is_expected.to contain_file('ssl.conf').without_content(%r{  SSLCipherSuite TLSv1.1 RSA:!EXP:!NULL:+HIGH:+MEDIUM}) }
+        it { is_expected.to contain_file('ssl.conf').without_content(%r{  SSLCipherSuite TLSv1.2 RSA:!EXP:!NULL:+HIGH:+MEDIUM:-LOW}) }
+      end
     end
 
     context '7 OS with custom directories for PR#1635' do

--- a/templates/mod/ssl.conf.erb
+++ b/templates/mod/ssl.conf.erb
@@ -33,7 +33,13 @@
   SSLStaplingReturnResponderErrors <%= scope.call_function('apache::bool2httpd', [@ssl_stapling_return_errors]) %>
   <%- end -%>
   SSLStaplingCache "shmcb:<%= @_stapling_cache %>"
+  <%- if @ssl_cipher.kind_of?(Hash) -%>
+    <%- @ssl_cipher.map do |protocol, cipher| -%>
+  SSLCipherSuite <%= protocol %> <%= cipher %>
+    <%- end -%>
+  <%- else -%>
   SSLCipherSuite <%= @ssl_cipher %>
+  <%- end -%>
 <% if not @ssl_protocol.empty? -%>
   SSLProtocol <%= @ssl_protocol.compact.join(' ') %>
 <% end -%>

--- a/templates/vhost/_ssl.erb
+++ b/templates/vhost/_ssl.erb
@@ -15,6 +15,10 @@
   <%- if @ssl_cipher -%>
   <%- if @ssl_cipher.kind_of?(String) -%>
   SSLCipherSuite          <%= @ssl_cipher %>
+  <%- elsif @ssl_cipher.kind_of?(Hash) -%>
+    <%- @ssl_cipher.map do |protocol, cipher| -%>
+  SSLCipherSuite <%= protocol %> <%= cipher%>
+    <%- end -%>
   <%- else -%>
   SSLCipherSuite          <%= @ssl_cipher.flatten.compact.join(':') %>
   <%- end -%>


### PR DESCRIPTION
## Summary

Adding support for enable user to pass the different ciphers for different protocols.

## Additional Context
- https://github.com/puppetlabs/puppetlabs-apache/issues/2422

## Related Issues (if any)
- N/A

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)