### PR TITLE
(CAT-1283) - Enable forensic module

### DIFF
--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -125,6 +125,7 @@ class apache::default_mods (
     include apache::mod::negotiation
     include apache::mod::setenvif
     include apache::mod::auth_basic
+    include apache::mod::log_forensic
 
     # filter is needed by mod_deflate
     include apache::mod::filter

--- a/manifests/mod/log_forensic.pp
+++ b/manifests/mod/log_forensic.pp
@@ -1,0 +1,9 @@
+# @summary
+#   Installs `mod_log_forensic`
+# 
+# @see https://httpd.apache.org/docs/current/mod/mod_log_forensic.html for additional documentation.
+#
+class apache::mod::log_forensic {
+  include apache
+  apache::mod { 'log_forensic': }
+}

--- a/spec/classes/mod/log_forensic_spec.rb
+++ b/spec/classes/mod/log_forensic_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'apache::mod::log_forensic', type: :class do
+  ['Debian 11', 'RedHat 8'].each do |os|
+    context "on a #{os} OS" do
+      include_examples os
+
+      it { is_expected.to contain_class('apache::params') }
+      it { is_expected.to contain_class('apache::mod::log_forensic') }
+      it { is_expected.to contain_apache__mod('log_forensic') }
+      it { is_expected.to contain_file('log_forensic.load').with_content(%r{LoadModule log_forensic_module}) }
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Adding support for `log_forensic` module with apache.

## Additional Context
- https://github.com/puppetlabs/puppetlabs-apache/issues/2260

## Related Issues (if any)
- https://github.com/puppetlabs/puppetlabs-apache/issues/2260

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)