### PR TITLE
(CAT-1351) - Downgrading puppet-lint gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :development do
   gem "json", '= 2.6.1',                         require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.3',                         require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "racc", '~> 1.4.0',                        require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "voxpupuli-puppet-lint-plugins", '~> 5.0', require: false
+  gem "voxpupuli-puppet-lint-plugins", '~> 4.0', require: false
   gem "facterdb", '~> 1.18',                     require: false
   gem "metadata-json-lint", '~> 3.0',            require: false
   gem "puppetlabs_spec_helper", '~> 6.0',        require: false


### PR DESCRIPTION
## Summary
Recently rolled-out puppet-lint gem checking title as well for unsafe interpolation which seems to be a issue with feature so, downgrading the gem version to avoid the unsafe interpolation issue for title. 
Have reported the same to Team.

## Additional Context
Add any additional context about the problem here. 
- [x] Unsafe interpolation issue reported by puppet-lint (https://github.com/puppetlabs/puppet-lint/pull/142)

## Related Issues (if any)
- N/A

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)