### PR TITLE
CAT-1285 - RHEL-8 mode security CRS fix

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -116,33 +116,40 @@ class apache::params inherits apache::version {
     $mellon_post_directory = undef
     $modsec_version       = 1
     $modsec_crs_package   = 'mod_security_crs'
-    $modsec_crs_path      = '/usr/lib/modsecurity.d'
     $modsec_dir           = '/etc/httpd/modsecurity.d'
     $secpcrematchlimit = 1500
     $secpcrematchlimitrecursion = 1500
     $modsec_secruleengine = 'On'
-    $modsec_default_rules = [
-      'base_rules/modsecurity_35_bad_robots.data',
-      'base_rules/modsecurity_35_scanners.data',
-      'base_rules/modsecurity_40_generic_attacks.data',
-      'base_rules/modsecurity_50_outbound.data',
-      'base_rules/modsecurity_50_outbound_malware.data',
-      'base_rules/modsecurity_crs_20_protocol_violations.conf',
-      'base_rules/modsecurity_crs_21_protocol_anomalies.conf',
-      'base_rules/modsecurity_crs_23_request_limits.conf',
-      'base_rules/modsecurity_crs_30_http_policy.conf',
-      'base_rules/modsecurity_crs_35_bad_robots.conf',
-      'base_rules/modsecurity_crs_40_generic_attacks.conf',
-      'base_rules/modsecurity_crs_41_sql_injection_attacks.conf',
-      'base_rules/modsecurity_crs_41_xss_attacks.conf',
-      'base_rules/modsecurity_crs_42_tight_security.conf',
-      'base_rules/modsecurity_crs_45_trojans.conf',
-      'base_rules/modsecurity_crs_47_common_exceptions.conf',
-      'base_rules/modsecurity_crs_49_inbound_blocking.conf',
-      'base_rules/modsecurity_crs_50_outbound.conf',
-      'base_rules/modsecurity_crs_59_outbound_blocking.conf',
-      'base_rules/modsecurity_crs_60_correlation.conf',
-    ]
+    if $facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'], '7') <= 0 {
+      $modsec_crs_path      = '/usr/lib/modsecurity.d'
+      $modsec_default_rules = [
+        'base_rules/modsecurity_35_bad_robots.data',
+        'base_rules/modsecurity_35_scanners.data',
+        'base_rules/modsecurity_40_generic_attacks.data',
+        'base_rules/modsecurity_50_outbound.data',
+        'base_rules/modsecurity_50_outbound_malware.data',
+        'base_rules/modsecurity_crs_20_protocol_violations.conf',
+        'base_rules/modsecurity_crs_21_protocol_anomalies.conf',
+        'base_rules/modsecurity_crs_23_request_limits.conf',
+        'base_rules/modsecurity_crs_30_http_policy.conf',
+        'base_rules/modsecurity_crs_35_bad_robots.conf',
+        'base_rules/modsecurity_crs_40_generic_attacks.conf',
+        'base_rules/modsecurity_crs_41_sql_injection_attacks.conf',
+        'base_rules/modsecurity_crs_41_xss_attacks.conf',
+        'base_rules/modsecurity_crs_42_tight_security.conf',
+        'base_rules/modsecurity_crs_45_trojans.conf',
+        'base_rules/modsecurity_crs_47_common_exceptions.conf',
+        'base_rules/modsecurity_crs_49_inbound_blocking.conf',
+        'base_rules/modsecurity_crs_50_outbound.conf',
+        'base_rules/modsecurity_crs_59_outbound_blocking.conf',
+        'base_rules/modsecurity_crs_60_correlation.conf',
+      ]
+    } else {
+      $modsec_crs_path      = '/usr/share/mod_modsecurity_crs'
+      $modsec_default_rules = [
+        'rules/crawlers-user-agents.data',
+      ]
+    }
     $error_log           = 'error_log'
     $scriptalias         = "${httpd_root}/var/www/cgi-bin"
     $access_log_file     = 'access_log'
@@ -252,33 +259,91 @@ class apache::params inherits apache::version {
     $mellon_post_directory = undef
     $modsec_version       = 1
     $modsec_crs_package   = 'mod_security_crs'
-    $modsec_crs_path      = '/usr/lib/modsecurity.d'
     $modsec_dir           = '/etc/httpd/modsecurity.d'
     $secpcrematchlimit = 1500
     $secpcrematchlimitrecursion = 1500
     $modsec_secruleengine = 'On'
-    $modsec_default_rules = [
-      'base_rules/modsecurity_35_bad_robots.data',
-      'base_rules/modsecurity_35_scanners.data',
-      'base_rules/modsecurity_40_generic_attacks.data',
-      'base_rules/modsecurity_50_outbound.data',
-      'base_rules/modsecurity_50_outbound_malware.data',
-      'base_rules/modsecurity_crs_20_protocol_violations.conf',
-      'base_rules/modsecurity_crs_21_protocol_anomalies.conf',
-      'base_rules/modsecurity_crs_23_request_limits.conf',
-      'base_rules/modsecurity_crs_30_http_policy.conf',
-      'base_rules/modsecurity_crs_35_bad_robots.conf',
-      'base_rules/modsecurity_crs_40_generic_attacks.conf',
-      'base_rules/modsecurity_crs_41_sql_injection_attacks.conf',
-      'base_rules/modsecurity_crs_41_xss_attacks.conf',
-      'base_rules/modsecurity_crs_42_tight_security.conf',
-      'base_rules/modsecurity_crs_45_trojans.conf',
-      'base_rules/modsecurity_crs_47_common_exceptions.conf',
-      'base_rules/modsecurity_crs_49_inbound_blocking.conf',
-      'base_rules/modsecurity_crs_50_outbound.conf',
-      'base_rules/modsecurity_crs_59_outbound_blocking.conf',
-      'base_rules/modsecurity_crs_60_correlation.conf',
-    ]
+    if $facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'], '7') <= 0 {
+      $modsec_crs_path      = '/usr/lib/modsecurity.d'
+      $modsec_default_rules = [
+        'base_rules/modsecurity_35_bad_robots.data',
+        'base_rules/modsecurity_35_scanners.data',
+        'base_rules/modsecurity_40_generic_attacks.data',
+        'base_rules/modsecurity_50_outbound.data',
+        'base_rules/modsecurity_50_outbound_malware.data',
+        'base_rules/modsecurity_crs_20_protocol_violations.conf',
+        'base_rules/modsecurity_crs_21_protocol_anomalies.conf',
+        'base_rules/modsecurity_crs_23_request_limits.conf',
+        'base_rules/modsecurity_crs_30_http_policy.conf',
+        'base_rules/modsecurity_crs_35_bad_robots.conf',
+        'base_rules/modsecurity_crs_40_generic_attacks.conf',
+        'base_rules/modsecurity_crs_41_sql_injection_attacks.conf',
+        'base_rules/modsecurity_crs_41_xss_attacks.conf',
+        'base_rules/modsecurity_crs_42_tight_security.conf',
+        'base_rules/modsecurity_crs_45_trojans.conf',
+        'base_rules/modsecurity_crs_47_common_exceptions.conf',
+        'base_rules/modsecurity_crs_49_inbound_blocking.conf',
+        'base_rules/modsecurity_crs_50_outbound.conf',
+        'base_rules/modsecurity_crs_59_outbound_blocking.conf',
+        'base_rules/modsecurity_crs_60_correlation.conf',
+      ]
+    } else {
+      $modsec_crs_path      = '/usr/share/mod_modsecurity_crs'
+      $modsec_default_rules = [
+        'rules/crawlers-user-agents.data',
+        'rules/iis-errors.data',
+        'rules/java-classes.data',
+        'rules/java-code-leakages.data',
+        'rules/java-errors.data',
+        'rules/lfi-os-files.data',
+        'rules/php-config-directives.data',
+        'rules/php-errors.data',
+        'rules/php-function-names-933150.data',
+        'rules/php-function-names-933151.data',
+        'rules/php-variables.data',
+        'rules/REQUEST-901-INITIALIZATION.conf',
+        'rules/REQUEST-903.9001-DRUPAL-EXCLUSION-RULES.conf',
+        'rules/REQUEST-903.9002-WORDPRESS-EXCLUSION-RULES.conf',
+        'rules/REQUEST-903.9003-NEXTCLOUD-EXCLUSION-RULES.conf',
+        'rules/REQUEST-903.9004-DOKUWIKI-EXCLUSION-RULES.conf',
+        'rules/REQUEST-903.9005-CPANEL-EXCLUSION-RULES.conf',
+        'rules/REQUEST-903.9006-XENFORO-EXCLUSION-RULES.conf',
+        'rules/REQUEST-905-COMMON-EXCEPTIONS.conf',
+        'rules/REQUEST-910-IP-REPUTATION.conf',
+        'rules/REQUEST-911-METHOD-ENFORCEMENT.conf',
+        'rules/REQUEST-912-DOS-PROTECTION.conf',
+        'rules/REQUEST-913-SCANNER-DETECTION.conf',
+        'rules/REQUEST-920-PROTOCOL-ENFORCEMENT.conf',
+        'rules/REQUEST-921-PROTOCOL-ATTACK.conf',
+        'rules/REQUEST-922-MULTIPART-ATTACK.conf',
+        'rules/REQUEST-930-APPLICATION-ATTACK-LFI.conf',
+        'rules/REQUEST-931-APPLICATION-ATTACK-RFI.conf',
+        'rules/REQUEST-932-APPLICATION-ATTACK-RCE.conf',
+        'rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf',
+        'rules/REQUEST-934-APPLICATION-ATTACK-NODEJS.conf',
+        'rules/REQUEST-941-APPLICATION-ATTACK-XSS.conf',
+        'rules/REQUEST-942-APPLICATION-ATTACK-SQLI.conf',
+        'rules/REQUEST-943-APPLICATION-ATTACK-SESSION-FIXATION.conf',
+        'rules/REQUEST-944-APPLICATION-ATTACK-JAVA.conf',
+        'rules/REQUEST-949-BLOCKING-EVALUATION.conf',
+        'rules/RESPONSE-950-DATA-LEAKAGES.conf',
+        'rules/RESPONSE-951-DATA-LEAKAGES-SQL.conf',
+        'rules/RESPONSE-952-DATA-LEAKAGES-JAVA.conf',
+        'rules/RESPONSE-953-DATA-LEAKAGES-PHP.conf',
+        'rules/RESPONSE-954-DATA-LEAKAGES-IIS.conf',
+        'rules/RESPONSE-959-BLOCKING-EVALUATION.conf',
+        'rules/RESPONSE-980-CORRELATION.conf',
+        'rules/restricted-files.data',
+        'rules/restricted-upload.data',
+        'rules/scanners-headers.data',
+        'rules/scanners-urls.data',
+        'rules/scanners-user-agents.data',
+        'rules/scripting-user-agents.data',
+        'rules/sql-errors.data',
+        'rules/unix-shell.data',
+        'rules/windows-powershell-commands.data',
+      ]
+    }
     $error_log           = 'error_log'
     $scriptalias         = '/var/www/cgi-bin'
     $access_log_file     = 'access_log'

--- a/spec/acceptance/mod_security_spec.rb
+++ b/spec/acceptance/mod_security_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+apache_hash = apache_settings_hash
+
+describe 'apache::mod::security class', if: mod_supported_on_platform?('apache::mod::security') do
+  context 'default mod security config' do
+    pp = <<-MANIFEST
+        class { 'apache': }
+        class { 'apache::mod::security': }
+    MANIFEST
+    it 'succeeds in puppeting mod security' do
+      apply_manifest(pp, catch_failures: true)
+    end
+  end
+
+  context 'with vhost config' do
+    pp = <<-MANIFEST
+        class { 'apache': }
+        class { 'apache::mod::security': }
+        apache::vhost { 'modsecurity.example.com':
+          port    => 80,
+          docroot => '#{apache_hash['doc_root']}',
+        }
+        host { 'modsecurity.example.com': ip => '127.0.0.1', }
+    MANIFEST
+    it 'succeeds in puppeting mod security' do
+      apply_manifest(pp, catch_failures: true)
+    end
+  end
+end

--- a/spec/classes/mod/security_spec.rb
+++ b/spec/classes/mod/security_spec.rb
@@ -73,14 +73,25 @@ describe 'apache::mod::security', type: :class do
             )
           }
 
-          it { is_expected.to contain_apache__security__rule_link('base_rules/modsecurity_35_bad_robots.data') }
+          if facts[:os]['release']['major'].to_i <= 7
+            it { is_expected.to contain_apache__security__rule_link('base_rules/modsecurity_35_bad_robots.data') }
 
-          it {
-            expect(subject).to contain_file('modsecurity_35_bad_robots.data').with(
-              path: '/etc/httpd/modsecurity.d/activated_rules/modsecurity_35_bad_robots.data',
-              target: '/usr/lib/modsecurity.d/base_rules/modsecurity_35_bad_robots.data',
-            )
-          }
+            it {
+              expect(subject).to contain_file('modsecurity_35_bad_robots.data').with(
+                path: '/etc/httpd/modsecurity.d/activated_rules/modsecurity_35_bad_robots.data',
+                target: '/usr/lib/modsecurity.d/base_rules/modsecurity_35_bad_robots.data',
+              )
+            }
+          else
+            it { is_expected.to contain_apache__security__rule_link('rules/crawlers-user-agents.data') }
+
+            it {
+              expect(subject).to contain_file('crawlers-user-agents.data').with(
+                path: '/etc/httpd/modsecurity.d/activated_rules/crawlers-user-agents.data',
+                target: '/usr/share/mod_modsecurity_crs/rules/crawlers-user-agents.data',
+              )
+            }
+          end
 
           describe 'with parameters' do
             let :params do

--- a/spec/defines/modsec_link_spec.rb
+++ b/spec/defines/modsec_link_spec.rb
@@ -23,12 +23,21 @@ describe 'apache::security::rule_link', type: :define do
 
       case facts[:os]['family']
       when 'RedHat'
-        it {
-          expect(subject).to contain_file('modsecurity_35_bad_robots.data').with(
-            path: '/etc/httpd/modsecurity.d/activated_rules/modsecurity_35_bad_robots.data',
-            target: '/usr/lib/modsecurity.d/base_rules/modsecurity_35_bad_robots.data',
-          )
-        }
+        if facts[:os]['release']['major'].to_i <= 7
+          it {
+            expect(subject).to contain_file('modsecurity_35_bad_robots.data').with(
+              path: '/etc/httpd/modsecurity.d/activated_rules/modsecurity_35_bad_robots.data',
+              target: '/usr/lib/modsecurity.d/base_rules/modsecurity_35_bad_robots.data',
+            )
+          }
+        else
+          it {
+            expect(subject).to contain_file('modsecurity_35_bad_robots.data').with(
+              path: '/etc/httpd/modsecurity.d/activated_rules/modsecurity_35_bad_robots.data',
+              target: '/usr/share/mod_modsecurity_crs/base_rules/modsecurity_35_bad_robots.data',
+            )
+          }
+        end
       when 'Debian'
         it {
           expect(subject).to contain_file('modsecurity_35_bad_robots.data').with(


### PR DESCRIPTION
## Summary

Fixing the mod sec RHEL-8 compatibility issue.

## Additional Context
The fix was already introduced by community but [PR](https://github.com/puppetlabs/puppetlabs-apache/pull/2398) got closed due to capacity issue.

## Related Issues (if any)
https://github.com/puppetlabs/puppetlabs-apache/issues/2319

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)