### PR TITLE
(CAT-1308) Making mod list more restrictive and minor improvements in documentation for default mods override

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -346,7 +346,7 @@ Default value: `true`
 
 ##### <a name="-apache--default_mods"></a>`default_mods`
 
-Data type: `Variant[Array, Boolean]`
+Data type: `Variant[Array[String[1]], Boolean]`
 
 Determines whether to configure and enable a set of default Apache modules depending on
 your operating system.<br />
@@ -356,7 +356,14 @@ on your operating system, and you can declare any other modules separately using
 If `true`, Puppet installs additional modules, depending on the operating system and
 the value of the `mpm_module` parameter. Because these lists of
 modules can change frequently, consult the Puppet module's code for up-to-date lists.<br />
-If this parameter contains an array, Puppet instead enables all passed Apache modules.
+If this parameter contains an array, Puppet will enable all the Apache modules passed in it.
+Passing the values as an array of strings provides the flexibility to override the default mods and install modules defined in `$default_mods`.
+For example, with array of string:<br />
+```puppet
+class { 'apache':
+  default_mods => ['cache', 'info', 'mime_magic']
+}
+```
 
 Default value: `true`
 

--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -3,9 +3,9 @@
 #
 # @api private
 class apache::default_mods (
-  Boolean $all                                   = true,
-  Optional[Variant[Array[String], String]] $mods = undef,
-  Boolean $use_systemd                           = $apache::use_systemd,
+  Boolean $all                                         = true,
+  Optional[Variant[Array[String[1]], String[1]]] $mods = undef,
+  Boolean $use_systemd                                 = $apache::use_systemd,
 ) {
   # These are modules required to run the default configuration.
   # They are not configurable at this time, so we just include

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -459,7 +459,7 @@
 class apache (
   String $apache_name                                                        = $apache::params::apache_name,
   String $service_name                                                       = $apache::params::service_name,
-  Variant[Array, Boolean] $default_mods                                      = true,
+  Variant[Array[String[1]], Boolean] $default_mods                           = true,
   Boolean $default_vhost                                                     = true,
   Optional[String] $default_charset                                          = undef,
   Boolean $default_confd_files                                               = true,


### PR DESCRIPTION
## Summary
- Making mod list more restrictive.
- Improving the documentation for `default_mods` overriding with custom mods.

## Additional Context
N/A

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)