### PR TITLE
(CAT-1424)-Removal of redhat/scientific/oraclelinux 6 for apache module

### DIFF
--- a/spec/acceptance/itk_spec.rb
+++ b/spec/acceptance/itk_spec.rb
@@ -5,38 +5,22 @@ require 'spec_helper_acceptance'
 case os[:family]
 when 'debian', 'ubuntu'
   service_name = 'apache2'
-  variant = :prefork
 when 'redhat'
-  unless %r{^5}.match?(os[:release])
-    variant = (os[:release].to_i >= 7) ? :prefork : :itk_only
-    service_name = 'httpd'
-  end
+  service_name = 'httpd'
 when 'freebsd'
   service_name = 'apache24'
-  variant = :prefork
 end
 
 # IAC-787: The http-itk mod package is not available in any of the standard RHEL/CentOS 8.x repos. Disable this test
 # on those platforms until we can find a suitable source for this package.
 describe 'apache::mod::itk class', if: service_name && mod_supported_on_platform?('apache::mod::itk') do
   describe 'running puppet code' do
-    let(:pp) do
-      case variant
-      when :prefork
-        <<-MANIFEST
+    pp = <<-MANIFEST
             class { 'apache':
               mpm_module => 'prefork',
             }
             class { 'apache::mod::itk': }
-        MANIFEST
-      when :itk_only
-        <<-MANIFEST
-            class { 'apache':
-              mpm_module => 'itk',
-            }
-        MANIFEST
-      end
-    end
+    MANIFEST
 
     it 'behaves idempotently' do
       idempotent_apply(pp)

--- a/spec/classes/mod/lbmethod_bybusyness.rb
+++ b/spec/classes/mod/lbmethod_bybusyness.rb
@@ -17,23 +17,6 @@ describe 'apache::mod::lbmethod_byrequests', type: :class do
         # rubocop:disable Layout/LineLength
         expect(subject).to contain_file('/etc/apache2/mods-enabled/lbmethod_byrequests.load').with('ensure' => 'file',
                                                                                                    'content' => "LoadModule lbmethod_byrequests_module /usr/lib/apache2/modules/mod_lbmethod_byrequests.so\n")
-      }
-    end
-  end
-
-  context 'on a RedHat OS' do
-    include_examples 'RedHat 6'
-
-    context 'with Apache version >= 2.4' do
-      let :params do
-        {
-          apache_version: '2.4'
-        }
-      end
-
-      it {
-        expect(subject).to contain_file('/etc/httpd/conf.modules.d/lbmethod_byrequests.load').with('ensure' => 'file',
-                                                                                                   'content' => "LoadModule lbmethod_byrequests_module modules/mod_lbmethod_byrequests.so\n")
         # rubocop:enable Layout/LineLength
       }
     end

--- a/spec/classes/mod/lbmethod_byrequests.rb
+++ b/spec/classes/mod/lbmethod_byrequests.rb
@@ -17,23 +17,6 @@ describe 'apache::mod::lbmethod_byrequests', type: :class do
         # rubocop:disable Layout/LineLength
         expect(subject).to contain_file('/etc/apache2/mods-enabled/lbmethod_byrequests.load').with('ensure' => 'file',
                                                                                                    'content' => "LoadModule lbmethod_byrequests_module /usr/lib/apache2/modules/mod_lbmethod_byrequests.so\n")
-      }
-    end
-  end
-
-  context 'on a RedHat OS' do
-    include_examples 'RedHat 6'
-
-    context 'with Apache version >= 2.4' do
-      let :params do
-        {
-          apache_version: '2.4'
-        }
-      end
-
-      it {
-        expect(subject).to contain_file('/etc/httpd/conf.modules.d/lbmethod_byrequests.load').with('ensure' => 'file',
-                                                                                                   'content' => "LoadModule lbmethod_byrequests_module modules/mod_lbmethod_byrequests.so\n")
         # rubocop:enable Layout/LineLength
       }
     end

--- a/spec/classes/mod/lbmethod_bytraffic.rb
+++ b/spec/classes/mod/lbmethod_bytraffic.rb
@@ -17,23 +17,6 @@ describe 'apache::mod::lbmethod_byrequests', type: :class do
         # rubocop:disable Layout/LineLength
         expect(subject).to contain_file('/etc/apache2/mods-enabled/lbmethod_byrequests.load').with('ensure' => 'file',
                                                                                                    'content' => "LoadModule lbmethod_byrequests_module /usr/lib/apache2/modules/mod_lbmethod_byrequests.so\n")
-      }
-    end
-  end
-
-  context 'on a RedHat OS' do
-    include_examples 'RedHat 6'
-
-    context 'with Apache version >= 2.4' do
-      let :params do
-        {
-          apache_version: '2.4'
-        }
-      end
-
-      it {
-        expect(subject).to contain_file('/etc/httpd/conf.modules.d/lbmethod_byrequests.load').with('ensure' => 'file',
-                                                                                                   'content' => "LoadModule lbmethod_byrequests_module modules/mod_lbmethod_byrequests.so\n")
         # rubocop:enable Layout/LineLength
       }
     end

--- a/spec/classes/mod/lbmethod_heartbeat.rb
+++ b/spec/classes/mod/lbmethod_heartbeat.rb
@@ -17,23 +17,6 @@ describe 'apache::mod::lbmethod_byrequests', type: :class do
         # rubocop:disable Layout/LineLength
         expect(subject).to contain_file('/etc/apache2/mods-enabled/lbmethod_byrequests.load').with('ensure' => 'file',
                                                                                                    'content' => "LoadModule lbmethod_byrequests_module /usr/lib/apache2/modules/mod_lbmethod_byrequests.so\n")
-      }
-    end
-  end
-
-  context 'on a RedHat OS' do
-    include_examples 'RedHat 6'
-
-    context 'with Apache version >= 2.4' do
-      let :params do
-        {
-          apache_version: '2.4'
-        }
-      end
-
-      it {
-        expect(subject).to contain_file('/etc/httpd/conf.modules.d/lbmethod_byrequests.load').with('ensure' => 'file',
-                                                                                                   'content' => "LoadModule lbmethod_byrequests_module modules/mod_lbmethod_byrequests.so\n")
         # rubocop:enable Layout/LineLength
       }
     end

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -2020,8 +2020,7 @@ describe 'apache::vhost', type: :define do
             it { is_expected.to compile }
             it { is_expected.to contain_concat('25-rspec.example.com.conf') }
 
-            if (os_facts[:os]['family'] == 'RedHat' && os_facts[:os]['release']['major'].to_i > 6) ||
-               (os_facts[:os]['name'] == 'SLES' && os_facts[:os]['release']['major'].to_i > 11)
+            if os_facts[:os]['family'] == 'RedHat' || os_facts[:os]['name'] == 'SLES'
               it {
                 expect(subject).to contain_concat__fragment('rspec.example.com-directories').with(
                   content: %r{^\s+Require all granted$},

--- a/spec/util/apache_mod_platform_compatibility_spec.rb
+++ b/spec/util/apache_mod_platform_compatibility_spec.rb
@@ -12,10 +12,10 @@ describe ApacheModPlatformCompatibility do
   foobar_linux = 'foobar_linux'
 
   expected_compatible_platform_versions = {
-    'redhat' => [6, 7, 8],
-    'centos' => [6, 7, 8],
-    'oraclelinux' => [6, 7],
-    'scientific' => [6, 7],
+    'redhat' => [7, 8],
+    'centos' => [7, 8],
+    'oraclelinux' => [7],
+    'scientific' => [7],
     'debian' => [8, 9, 10],
     'sles' => [11, 12, 15],
     'ubuntu' => [14, 16, 18]


### PR DESCRIPTION
## Summary
With the removal of support for RHEL6 from our modules, work must be done to cleanup and remove any residual code.
This PR does the same for Apache repo module. More info can be found #2326 

## Additional Context

## Related Issues (if any)

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)