### PR TITLE
(CAT-1449) - Remove deprecated parameters for scriptaliases & passenger

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -75,6 +75,7 @@ mod-pagespeed-stable package. The module does however require that the package b
 or be installable using the system's default package provider.  You should ensure that this
 pre-requisite is met or declaring `apache::mod::pagespeed` will cause the puppet run to fail.
 * [`apache::mod::passenger`](#apache--mod--passenger): Installs `mod_pasenger`.
+> **Note**: This module support Passenger 4.0.0 and higher.
 * [`apache::mod::perl`](#apache--mod--perl): Installs `mod_perl`.
 * [`apache::mod::peruser`](#apache--mod--peruser): Installs `mod_peruser`.
 * [`apache::mod::php`](#apache--mod--php): Installs `mod_php`.
@@ -217,7 +218,6 @@ The following parameters are available in the `apache` class:
 * [`default_ssl_key`](#-apache--default_ssl_key)
 * [`default_ssl_reload_on_change`](#-apache--default_ssl_reload_on_change)
 * [`default_ssl_vhost`](#-apache--default_ssl_vhost)
-* [`default_type`](#-apache--default_type)
 * [`default_vhost`](#-apache--default_vhost)
 * [`dev_packages`](#-apache--dev_packages)
 * [`docroot`](#-apache--docroot)
@@ -279,7 +279,6 @@ The following parameters are available in the `apache` class:
 * [`limitreqfieldsize`](#-apache--limitreqfieldsize)
 * [`limitreqline`](#-apache--limitreqline)
 * [`ip`](#-apache--ip)
-* [`purge_vdir`](#-apache--purge_vdir)
 * [`conf_enabled`](#-apache--conf_enabled)
 * [`vhost_enable_dir`](#-apache--vhost_enable_dir)
 * [`manage_vhost_enable_dir`](#-apache--manage_vhost_enable_dir)
@@ -462,16 +461,6 @@ apache::vhost { 'default-ssl':
 **Note**: SSL virtual hosts only respond to HTTPS queries.
 
 Default value: `false`
-
-##### <a name="-apache--default_type"></a>`default_type`
-
-Data type: `String`
-
-_Apache 2.2 only_. Sets the MIME `content-type` sent if the server cannot otherwise
-determine an appropriate `content-type`. This directive is deprecated in Apache 2.4 and
-newer, and is only for backwards compatibility in configuration files.
-
-Default value: `'none'`
 
 ##### <a name="-apache--default_vhost"></a>`default_vhost`
 
@@ -1089,15 +1078,6 @@ Data type: `Optional[String]`
 Specifies the ip address
 
 Default value: `undef`
-
-##### <a name="-apache--purge_vdir"></a>`purge_vdir`
-
-Data type: `Boolean`
-
-Removes all other Apache configs and virtual hosts.<br />
-> **Note**: This parameter is deprecated in favor of the `purge_configs` parameter.<br />
-
-Default value: `false`
 
 ##### <a name="-apache--conf_enabled"></a>`conf_enabled`
 
@@ -4515,22 +4495,9 @@ The following parameters are available in the `apache::mod::passenger` class:
 * [`passenger_use_global_queue`](#-apache--mod--passenger--passenger_use_global_queue)
 * [`passenger_user`](#-apache--mod--passenger--passenger_user)
 * [`passenger_user_switching`](#-apache--mod--passenger--passenger_user_switching)
-* [`rack_auto_detect`](#-apache--mod--passenger--rack_auto_detect)
-* [`rack_autodetect`](#-apache--mod--passenger--rack_autodetect)
-* [`rack_base_uri`](#-apache--mod--passenger--rack_base_uri)
 * [`rack_env`](#-apache--mod--passenger--rack_env)
-* [`rails_allow_mod_rewrite`](#-apache--mod--passenger--rails_allow_mod_rewrite)
-* [`rails_app_spawner_idle_time`](#-apache--mod--passenger--rails_app_spawner_idle_time)
-* [`rails_auto_detect`](#-apache--mod--passenger--rails_auto_detect)
-* [`rails_autodetect`](#-apache--mod--passenger--rails_autodetect)
-* [`rails_base_uri`](#-apache--mod--passenger--rails_base_uri)
-* [`rails_default_user`](#-apache--mod--passenger--rails_default_user)
 * [`rails_env`](#-apache--mod--passenger--rails_env)
 * [`rails_framework_spawner_idle_time`](#-apache--mod--passenger--rails_framework_spawner_idle_time)
-* [`rails_ruby`](#-apache--mod--passenger--rails_ruby)
-* [`rails_spawn_method`](#-apache--mod--passenger--rails_spawn_method)
-* [`rails_user_switching`](#-apache--mod--passenger--rails_user_switching)
-* [`wsgi_auto_detect`](#-apache--mod--passenger--wsgi_auto_detect)
 
 ##### <a name="-apache--mod--passenger--manage_repo"></a>`manage_repo`
 
@@ -5179,83 +5146,11 @@ Toggles whether to attempt to enable user account sandboxing, also known as user
 
 Default value: `undef`
 
-##### <a name="-apache--mod--passenger--rack_auto_detect"></a>`rack_auto_detect`
-
-Data type: `Optional[String]`
-
-This option has been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.
-
-Default value: `undef`
-
-##### <a name="-apache--mod--passenger--rack_autodetect"></a>`rack_autodetect`
-
-Data type: `Optional[String]`
-
-This option has been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.
-
-Default value: `undef`
-
-##### <a name="-apache--mod--passenger--rack_base_uri"></a>`rack_base_uri`
-
-Data type: `Optional[String]`
-
-Deprecated in 3.0.0 in favor of PassengerBaseURI.
-
-Default value: `undef`
-
 ##### <a name="-apache--mod--passenger--rack_env"></a>`rack_env`
 
 Data type: `Optional[String]`
 
 Alias for PassengerAppEnv.
-
-Default value: `undef`
-
-##### <a name="-apache--mod--passenger--rails_allow_mod_rewrite"></a>`rails_allow_mod_rewrite`
-
-Data type: `Optional[String]`
-
-This option doesn't do anything anymore since version 4.0.0.
-
-Default value: `undef`
-
-##### <a name="-apache--mod--passenger--rails_app_spawner_idle_time"></a>`rails_app_spawner_idle_time`
-
-Data type: `Optional[String]`
-
-This option has been removed in version 4.0.0, and replaced with PassengerMaxPreloaderIdleTime.
-
-Default value: `undef`
-
-##### <a name="-apache--mod--passenger--rails_auto_detect"></a>`rails_auto_detect`
-
-Data type: `Optional[String]`
-
-This option has been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.
-
-Default value: `undef`
-
-##### <a name="-apache--mod--passenger--rails_autodetect"></a>`rails_autodetect`
-
-Data type: `Optional[String]`
-
-This option has been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.
-
-Default value: `undef`
-
-##### <a name="-apache--mod--passenger--rails_base_uri"></a>`rails_base_uri`
-
-Data type: `Optional[String]`
-
-Deprecated in 3.0.0 in favor of PassengerBaseURI.
-
-Default value: `undef`
-
-##### <a name="-apache--mod--passenger--rails_default_user"></a>`rails_default_user`
-
-Data type: `Optional[String]`
-
-Deprecated in 3.0.0 in favor of PassengerDefaultUser
 
 Default value: `undef`
 
@@ -5273,38 +5168,6 @@ Data type: `Optional[String]`
 
 This option is no longer available in version 4.0.0. There is no alternative because framework spawning has been removed
 altogether. You should use smart spawning instead.
-
-Default value: `undef`
-
-##### <a name="-apache--mod--passenger--rails_ruby"></a>`rails_ruby`
-
-Data type: `Optional[String]`
-
-Deprecated in 3.0.0 in favor of PassengerRuby.
-
-Default value: `undef`
-
-##### <a name="-apache--mod--passenger--rails_spawn_method"></a>`rails_spawn_method`
-
-Data type: `Optional[String]`
-
-Deprecated in 3.0.0 in favor of PassengerSpawnMethod.
-
-Default value: `undef`
-
-##### <a name="-apache--mod--passenger--rails_user_switching"></a>`rails_user_switching`
-
-Data type: `Optional[String]`
-
-Deprecated in 3.0.0 in favor of PassengerUserSwitching.
-
-Default value: `undef`
-
-##### <a name="-apache--mod--passenger--wsgi_auto_detect"></a>`wsgi_auto_detect`
-
-Data type: `Optional[String]`
-
-This option has been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.
 
 Default value: `undef`
 
@@ -7753,7 +7616,6 @@ The following parameters are available in the `apache::vhost` defined type:
 * [`rewrite_cond`](#-apache--vhost--rewrite_cond)
 * [`rewrite_inherit`](#-apache--vhost--rewrite_inherit)
 * [`scriptalias`](#-apache--vhost--scriptalias)
-* [`scriptaliases`](#-apache--vhost--scriptaliases)
 * [`serveradmin`](#-apache--vhost--serveradmin)
 * [`serveraliases`](#-apache--vhost--serveraliases)
 * [`servername`](#-apache--vhost--servername)
@@ -7947,11 +7809,6 @@ a corresponding context, such as `<Directory /path/to/directory>` or
 the `aliases` parameter. As described in the `mod_alias` documentation, add more specific
 `alias`, `aliasmatch`, `scriptalias` or `scriptaliasmatch` parameters before the more
 general ones to avoid shadowing.<BR />
-> **Note**: Use the `aliases` parameter instead of the `scriptaliases` parameter because
-you can precisely control the order of various alias directives. Defining `ScriptAliases`
-using the `scriptaliases` parameter means *all* `ScriptAlias` directives will come after
-*all* `Alias` directives, which can lead to `Alias` directives shadowing `ScriptAlias`
-directives. This often causes problems; for example, this could cause problems with Nagios.<BR />
 If `apache::mod::passenger` is loaded and `PassengerHighPerformance` is `true`, the `Alias`
 directive might not be able to honor the `PassengerEnabled => off` statement. See
 [this article](http://www.conandalton.net/2010/06/passengerenabled-off-not-working.html) for details.
@@ -9760,39 +9617,6 @@ Defines a directory of CGI scripts to be aliased to the path '/cgi-bin', such as
 '/usr/scripts'.
 
 Default value: `undef`
-
-##### <a name="-apache--vhost--scriptaliases"></a>`scriptaliases`
-
-Data type: `Array[Hash]`
-
-> **Note**: This parameter is deprecated in favor of the `aliases` parameter.<br />
-Passes an array of hashes to the virtual host to create either ScriptAlias or
-ScriptAliasMatch statements per the `mod_alias` documentation.
-``` puppet
-scriptaliases => [
-  {
-    alias => '/myscript',
-    path  => '/usr/share/myscript',
-  },
-  {
-    aliasmatch => '^/foo(.*)',
-    path       => '/usr/share/fooscripts$1',
-  },
-  {
-    aliasmatch => '^/bar/(.*)',
-    path       => '/usr/share/bar/wrapper.sh/$1',
-  },
-  {
-    alias => '/neatscript',
-    path  => '/usr/share/neatscript',
-  },
-]
-```
-The ScriptAlias and ScriptAliasMatch directives are created in the order specified.
-As with [Alias and AliasMatch](#aliases) directives, specify more specific aliases
-before more general ones to avoid shadowing.
-
-Default value: `[]`
 
 ##### <a name="-apache--vhost--serveradmin"></a>`serveradmin`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -105,11 +105,6 @@
 #   ```
 #   **Note**: SSL virtual hosts only respond to HTTPS queries.
 #
-# @param default_type
-#   _Apache 2.2 only_. Sets the MIME `content-type` sent if the server cannot otherwise 
-#   determine an appropriate `content-type`. This directive is deprecated in Apache 2.4 and 
-#   newer, and is only for backwards compatibility in configuration files.
-#
 # @param default_vhost
 #   Configures a default virtual host when the class is declared.<br />
 #   To configure customized virtual hosts, set this parameter's 
@@ -423,10 +418,6 @@
 #
 # @param ip
 #   Specifies the ip address
-#
-# @param purge_vdir
-#   Removes all other Apache configs and virtual hosts.<br />
-#   > **Note**: This parameter is deprecated in favor of the `purge_configs` parameter.<br />
 # 
 # @param conf_enabled
 #   Whether the additional config files in `/etc/apache2/conf-enabled` should be managed.
@@ -472,7 +463,6 @@ class apache (
   Optional[Stdlib::Absolutepath] $default_ssl_crl                            = undef,
   Optional[String] $default_ssl_crl_check                                    = undef,
   Boolean $default_ssl_reload_on_change                                      = false,
-  String $default_type                                                       = 'none',
   Optional[Variant[Array, String]] $dev_packages                             = $apache::params::dev_packages,
   Optional[String] $ip                                                       = undef,
   Boolean $service_enable                                                    = true,
@@ -481,7 +471,6 @@ class apache (
   Optional[String] $service_restart                                          = undef,
   Boolean $purge_configs                                                     = true,
   Optional[Boolean] $purge_vhost_dir                                         = undef,
-  Boolean $purge_vdir                                                        = false,
   Optional[String[1]] $serveradmin                                           = undef,
   Apache::OnOff $sendfile                                                    = 'On',
   Optional[Apache::OnOff] $ldap_verify_server_cert                           = undef,
@@ -599,17 +588,9 @@ class apache (
     service_restart => $service_restart,
   }
 
-  # Deprecated backwards-compatibility
-  if $purge_vdir {
-    warning('Class[\'apache\'] parameter purge_vdir is deprecated in favor of purge_configs')
-    $purge_confd = $purge_vdir
-  } else {
-    $purge_confd = $purge_configs
-  }
-
   # Set purge vhostd appropriately
   if $purge_vhost_dir == undef {
-    $purge_vhostd = $purge_confd
+    $purge_vhostd = $purge_configs
   } else {
     $purge_vhostd = $purge_vhost_dir
   }
@@ -627,8 +608,8 @@ class apache (
   file { $confd_dir:
     ensure  => directory,
     recurse => true,
-    purge   => $purge_confd,
-    force   => $purge_confd,
+    purge   => $purge_configs,
+    force   => $purge_configs,
     notify  => Class['Apache::Service'],
     require => Package['httpd'],
   }
@@ -637,8 +618,8 @@ class apache (
     file { $conf_enabled:
       ensure  => directory,
       recurse => true,
-      purge   => $purge_confd,
-      force   => $purge_confd,
+      purge   => $purge_configs,
+      force   => $purge_configs,
       notify  => Class['Apache::Service'],
       require => Package['httpd'],
     }

--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -646,7 +646,6 @@ class apache::mod::passenger (
   # - $passenger_sticky_sessions : since 4.0.45.
   # - $passenger_sticky_sessions_cookie_name : since 4.0.45.
   # - $passenger_thread_count : since 4.0.0.
-  # - $passenger_use_global_queue : since 2.0.4.Deprecated in 4.0.0.
   # - $passenger_user : since 4.0.0.
   # - $passenger_user_switching : since 3.0.0.
 

--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -1,5 +1,6 @@
 # @summary
 #   Installs `mod_pasenger`.
+#   > **Note**: This module support Passenger 4.0.0 and higher.
 #
 # @param manage_repo
 #   Toggle whether to manage yum repo if on a RedHat node.
@@ -253,35 +254,8 @@
 # @param passenger_user_switching
 #   Toggles whether to attempt to enable user account sandboxing, also known as user switching.
 #
-# @param rack_auto_detect
-#   This option has been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.
-#
-# @param rack_autodetect
-#   This option has been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.
-#
-# @param rack_base_uri
-#   Deprecated in 3.0.0 in favor of PassengerBaseURI.
-#
 # @param rack_env
 #   Alias for PassengerAppEnv.
-#
-# @param rails_allow_mod_rewrite
-#   This option doesn't do anything anymore since version 4.0.0.
-#
-# @param rails_app_spawner_idle_time
-#   This option has been removed in version 4.0.0, and replaced with PassengerMaxPreloaderIdleTime.
-#
-# @param rails_auto_detect
-#   This option has been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.
-#
-# @param rails_autodetect
-#   This option has been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.
-#
-# @param rails_base_uri
-#   Deprecated in 3.0.0 in favor of PassengerBaseURI.
-#
-# @param rails_default_user
-#   Deprecated in 3.0.0 in favor of PassengerDefaultUser
 #
 # @param rails_env
 #   Alias for PassengerAppEnv.
@@ -289,18 +263,6 @@
 # @param rails_framework_spawner_idle_time
 #   This option is no longer available in version 4.0.0. There is no alternative because framework spawning has been removed 
 #   altogether. You should use smart spawning instead.
-#
-# @param rails_ruby
-#   Deprecated in 3.0.0 in favor of PassengerRuby.
-#
-# @param rails_spawn_method
-#   Deprecated in 3.0.0 in favor of PassengerSpawnMethod.
-#
-# @param rails_user_switching
-#   Deprecated in 3.0.0 in favor of PassengerUserSwitching.
-#
-# @param wsgi_auto_detect
-#   This option has been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.
 #
 # @note 
 #   In Passenger source code you can strip out what are all the available options by looking in
@@ -401,48 +363,15 @@ class apache::mod::passenger (
   Optional[String] $passenger_use_global_queue                                               = undef,
   Optional[String] $passenger_user                                                           = undef,
   Optional[Apache::OnOff] $passenger_user_switching                                          = undef,
-  Optional[String] $rack_auto_detect                                                         = undef,
-  Optional[String] $rack_autodetect                                                          = undef,
-  Optional[String] $rack_base_uri                                                            = undef,
   Optional[String] $rack_env                                                                 = undef,
-  Optional[String] $rails_allow_mod_rewrite                                                  = undef,
-  Optional[String] $rails_app_spawner_idle_time                                              = undef,
-  Optional[String] $rails_auto_detect                                                        = undef,
-  Optional[String] $rails_autodetect                                                         = undef,
-  Optional[String] $rails_base_uri                                                           = undef,
-  Optional[String] $rails_default_user                                                       = undef,
   Optional[String] $rails_env                                                                = undef,
   Optional[String] $rails_framework_spawner_idle_time                                        = undef,
-  Optional[String] $rails_ruby                                                               = undef,
-  Optional[String] $rails_spawn_method                                                       = undef,
-  Optional[String] $rails_user_switching                                                     = undef,
-  Optional[String] $wsgi_auto_detect                                                         = undef,
 ) inherits apache::params {
   include apache
   if $passenger_installed_version {
-    if $passenger_allow_encoded_slashes {
-      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
-        fail("Passenger config option :: passenger_allow_encoded_slashes is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
     if $passenger_anonymous_telemetry_proxy {
       if (versioncmp($passenger_installed_version, '6.0.0') < 0) {
         fail("Passenger config option :: passenger_anonymous_telemetry_proxy is not introduced until version 6.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_app_env {
-      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
-        fail("Passenger config option :: passenger_app_env is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_app_group_name {
-      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
-        fail("Passenger config option :: passenger_app_group_name is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_app_root {
-      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
-        fail("Passenger config option :: passenger_app_root is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
       }
     }
     if $passenger_app_type {
@@ -450,24 +379,9 @@ class apache::mod::passenger (
         fail("Passenger config option :: passenger_app_type is not introduced until version 4.0.25 :: ${passenger_installed_version} is the version reported")
       }
     }
-    if $passenger_base_uri {
-      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
-        fail("Passenger config option :: passenger_base_uri is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_buffer_response {
-      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
-        fail("Passenger config option :: passenger_buffer_response is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
     if $passenger_buffer_upload {
       if (versioncmp($passenger_installed_version, '4.0.26') < 0) {
         fail("Passenger config option :: passenger_buffer_upload is not introduced until version 4.0.26 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_concurrency_model {
-      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
-        fail("Passenger config option :: passenger_concurrency_model is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
       }
     }
     if $passenger_data_buffer_dir {
@@ -478,26 +392,6 @@ class apache::mod::passenger (
     if $passenger_debug_log_file {
       if (versioncmp($passenger_installed_version, '5.0.5') > 0) {
         warning('DEPRECATED PASSENGER OPTION :: passenger_debug_log_file :: This option has been renamed in version 5.0.5 to PassengerLogFile.')
-      }
-    }
-    if $passenger_debugger {
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: passenger_debugger is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_default_group {
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: passenger_default_group is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_default_ruby {
-      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
-        fail("Passenger config option :: passenger_default_ruby is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_default_user {
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: passenger_default_user is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
       }
     }
     if $passenger_disable_anonymous_telemetry {
@@ -513,11 +407,6 @@ class apache::mod::passenger (
     if $passenger_disable_security_update_check {
       if (versioncmp($passenger_installed_version, '5.1.0') < 0) {
         fail("Passenger config option :: passenger_disable_security_update_check is not introduced until version 5.1.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_enabled {
-      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
-        fail("Passenger config option :: passenger_enabled is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
       }
     }
     if $passenger_error_override {
@@ -545,16 +434,6 @@ class apache::mod::passenger (
         fail("Passenger config option :: passenger_friendly_error_pages is not introduced until version 4.0.42 :: ${passenger_installed_version} is the version reported")
       }
     }
-    if $passenger_group {
-      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
-        fail("Passenger config option :: passenger_group is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_high_performance {
-      if (versioncmp($passenger_installed_version, '2.0.0') < 0) {
-        fail("Passenger config option :: passenger_high_performance is not introduced until version 2.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
     if $passenger_instance_registry_dir {
       if (versioncmp($passenger_installed_version, '5.0.0') < 0) {
         fail("Passenger config option :: passenger_instance_registry_dir is not introduced until version 5.0.0 :: ${passenger_installed_version} is the version reported")
@@ -575,34 +454,9 @@ class apache::mod::passenger (
         fail("Passenger config option :: passenger_log_file is not introduced until version 5.0.5 :: ${passenger_installed_version} is the version reported")
       }
     }
-    if $passenger_log_level {
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: passenger_log_level is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
     if $passenger_lve_min_uid {
       if (versioncmp($passenger_installed_version, '5.0.28') < 0) {
         fail("Passenger config option :: passenger_lve_min_uid is not introduced until version 5.0.28 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_max_instances {
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: passenger_max_instances is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_max_instances_per_app {
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: passenger_max_instances_per_app is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_max_pool_size {
-      if (versioncmp($passenger_installed_version, '1.0.0') < 0) {
-        fail("Passenger config option :: passenger_max_pool_size is not introduced until version 1.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_max_preloader_idle_time {
-      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
-        fail("Passenger config option :: passenger_max_preloader_idle_time is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
       }
     }
     if $passenger_max_request_queue_size {
@@ -610,29 +464,9 @@ class apache::mod::passenger (
         fail("Passenger config option :: passenger_max_request_queue_size is not introduced until version 4.0.15 :: ${passenger_installed_version} is the version reported")
       }
     }
-    if $passenger_max_request_time {
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: passenger_max_request_time is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_max_requests {
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: passenger_max_requests is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_memory_limit {
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: passenger_memory_limit is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
     if $passenger_meteor_app_settings {
       if (versioncmp($passenger_installed_version, '5.0.7') < 0) {
         fail("Passenger config option :: passenger_meteor_app_settings is not introduced until version 5.0.7 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_min_instances {
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: passenger_min_instances is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
       }
     }
     if $passenger_nodejs {
@@ -640,54 +474,9 @@ class apache::mod::passenger (
         fail("Passenger config option :: passenger_nodejs is not introduced until version 4.0.24 :: ${passenger_installed_version} is the version reported")
       }
     }
-    if $passenger_pool_idle_time {
-      if (versioncmp($passenger_installed_version, '1.0.0') < 0) {
-        fail("Passenger config option :: passenger_pool_idle_time is not introduced until version 1.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_pre_start {
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: passenger_pre_start is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_python {
-      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
-        fail("Passenger config option :: passenger_python is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_resist_deployment_errors {
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: passenger_resist_deployment_errors is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_resolve_symlinks_in_document_root {
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: passenger_resolve_symlinks_in_document_root is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
     if $passenger_response_buffer_high_watermark {
       if (versioncmp($passenger_installed_version, '5.0.0') < 0) {
         fail("Passenger config option :: passenger_response_buffer_high_watermark is not introduced until version 5.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_restart_dir {
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: passenger_restart_dir is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_rolling_restarts {
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: passenger_rolling_restarts is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_root {
-      if (versioncmp($passenger_installed_version, '1.0.0') < 0) {
-        fail("Passenger config option :: passenger_root is not introduced until version 1.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_ruby {
-      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
-        fail("Passenger config option :: passenger_ruby is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
       }
     }
     if $passenger_security_update_check_proxy {
@@ -710,11 +499,6 @@ class apache::mod::passenger (
         fail("Passenger config option :: passenger_spawn_dir is not introduced until version 6.0.3 :: ${passenger_installed_version} is the version reported")
       }
     }
-    if $passenger_spawn_method {
-      if (versioncmp($passenger_installed_version, '2.0.0') < 0) {
-        fail("Passenger config option :: passenger_spawn_method is not introduced until version 2.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
     if $passenger_start_timeout {
       if (versioncmp($passenger_installed_version, '4.0.15') < 0) {
         fail("Passenger config option :: passenger_start_timeout is not introduced until version 4.0.15 :: ${passenger_installed_version} is the version reported")
@@ -723,11 +507,6 @@ class apache::mod::passenger (
     if $passenger_startup_file {
       if (versioncmp($passenger_installed_version, '4.0.25') < 0) {
         fail("Passenger config option :: passenger_startup_file is not introduced until version 4.0.25 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_stat_throttle_rate {
-      if (versioncmp($passenger_installed_version, '2.2.0') < 0) {
-        fail("Passenger config option :: passenger_stat_throttle_rate is not introduced until version 2.2.0 :: ${passenger_installed_version} is the version reported")
       }
     }
     if $passenger_sticky_sessions {
@@ -743,99 +522,6 @@ class apache::mod::passenger (
     if $passenger_sticky_sessions_cookie_attributes {
       if (versioncmp($passenger_installed_version, '6.0.5') < 0) {
         fail("Passenger config option :: passenger_sticky_sessions_cookie_attributes is not introduced until version 6.0.5 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_thread_count {
-      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
-        fail("Passenger config option :: passenger_thread_count is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_use_global_queue {
-      if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
-        fail('REMOVED PASSENGER OPTION :: passenger_use_global_queue :: -- no message on the current passenger reference webpage -- ')
-      }
-      if (versioncmp($passenger_installed_version, '2.0.4') < 0) {
-        fail("Passenger config option :: passenger_use_global_queue is not introduced until version 2.0.4 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_user {
-      if (versioncmp($passenger_installed_version, '4.0.0') < 0) {
-        fail("Passenger config option :: passenger_user is not introduced until version 4.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $passenger_user_switching {
-      if (versioncmp($passenger_installed_version, '3.0.0') < 0) {
-        fail("Passenger config option :: passenger_user_switching is not introduced until version 3.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if ($rack_auto_detect or $rack_autodetect) {
-      if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
-        fail('REMOVED PASSENGER OPTION :: rack_auto_detect ::  These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.')
-      }
-    }
-    if $rack_base_uri {
-      if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
-        warning('DEPRECATED PASSENGER OPTION :: rack_base_uri :: Deprecated in 3.0.0 in favor of PassengerBaseURI.')
-      }
-    }
-    if $rack_env {
-      if (versioncmp($passenger_installed_version, '2.0.0') < 0) {
-        fail("Passenger config option :: rack_env is not introduced until version 2.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $rails_allow_mod_rewrite {
-      if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
-        warning("DEPRECATED PASSENGER OPTION :: rails_allow_mod_rewrite :: This option doesn't do anything anymore in since version 4.0.0.")
-      }
-    }
-    if $rails_app_spawner_idle_time {
-      if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
-        fail('REMOVED PASSENGER OPTION :: rails_app_spawner_idle_time ::  This option has been removed in version 4.0.0, and replaced with PassengerMaxPreloaderIdleTime.')
-      }
-    }
-    if ($rails_auto_detect or $rails_autodetect) {
-      if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
-        fail('REMOVED PASSENGER OPTION :: rails_auto_detect ::  These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.')
-      }
-    }
-    if $rails_base_uri {
-      if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
-        warning('DEPRECATED PASSENGER OPTION :: rails_base_uri :: Deprecated in 3.0.0 in favor of PassengerBaseURI.')
-      }
-    }
-    if $rails_default_user {
-      if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
-        warning('DEPRECATED PASSENGER OPTION :: rails_default_user :: Deprecated in 3.0.0 in favor of PassengerDefaultUser.')
-      }
-    }
-    if $rails_env {
-      if (versioncmp($passenger_installed_version, '2.0.0') < 0) {
-        fail("Passenger config option :: rails_env is not introduced until version 2.0.0 :: ${passenger_installed_version} is the version reported")
-      }
-    }
-    if $rails_framework_spawner_idle_time {
-      if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
-        fail('REMOVED PASSENGER OPTION :: rails_framework_spawner_idle_time ::  This option is no longer available in version 4.0.0. There is no alternative because framework spawning has been removed altogether. You should use smart spawning instead.')
-      }
-    }
-    if $rails_ruby {
-      if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
-        warning('DEPRECATED PASSENGER OPTION :: rails_ruby :: Deprecated in 3.0.0 in favor of PassengerRuby.')
-      }
-    }
-    if $rails_spawn_method {
-      if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
-        warning('DEPRECATED PASSENGER OPTION :: rails_spawn_method :: Deprecated in 3.0.0 in favor of PassengerSpawnMethod.')
-      }
-    }
-    if $rails_user_switching {
-      if (versioncmp($passenger_installed_version, '3.0.0') > 0) {
-        warning('DEPRECATED PASSENGER OPTION :: rails_user_switching :: Deprecated in 3.0.0 in favor of PassengerUserSwitching.')
-      }
-    }
-    if $wsgi_auto_detect {
-      if (versioncmp($passenger_installed_version, '4.0.0') > 0) {
-        fail('REMOVED PASSENGER OPTION :: wsgi_auto_detect ::  These options have been removed in version 4.0.0 as part of an optimization. You should use PassengerEnabled instead.')
       }
     }
   }
@@ -963,22 +649,7 @@ class apache::mod::passenger (
   # - $passenger_use_global_queue : since 2.0.4.Deprecated in 4.0.0.
   # - $passenger_user : since 4.0.0.
   # - $passenger_user_switching : since 3.0.0.
-  # - $rack_auto_detect : since unkown. Deprecated in 4.0.0.
-  # - $rack_base_uri : since unkown. Deprecated in 3.0.0.
-  # - $rack_env : since 2.0.0.
-  # - $rails_allow_mod_rewrite : since unkown. Deprecated in 4.0.0.
-  # - $rails_app_spawner_idle_time : since unkown. Deprecated in 4.0.0.
-  # - $rails_auto_detect : since unkown. Deprecated in 4.0.0.
-  # - $rails_base_uri : since unkown. Deprecated in 3.0.0.
-  # - $rails_default_user : since unkown. Deprecated in 3.0.0.
-  # - $rails_env : since 2.0.0.
-  # - $rails_framework_spawner_idle_time : since unkown. Deprecated in 4.0.0.
-  # - $rails_ruby : since unkown. Deprecated in 3.0.0.
-  # - $rails_spawn_method : since unkown. Deprecated in 3.0.0.
-  # - $rails_user_switching : since unkown. Deprecated in 3.0.0.
-  # - $wsgi_auto_detect : since unkown. Deprecated in 4.0.0.
-  # - $rails_autodetect : this options is only for backward compatiblity with older versions of this class
-  # - $rack_autodetect : this options is only for backward compatiblity with older versions of this class
+
   $parameters = {
     'passenger_allow_encoded_slashes'                     => $passenger_allow_encoded_slashes,
     'passenger_anonymous_telemetry_proxy'                 => $passenger_anonymous_telemetry_proxy,
@@ -1049,22 +720,9 @@ class apache::mod::passenger (
     'passenger_use_global_queue'                          => $passenger_use_global_queue,
     'passenger_user'                                      => $passenger_user,
     'passenger_user_switching'                            => $passenger_user_switching,
-    'rack_auto_detect'                                    => $rack_auto_detect,
-    'rack_base_uri'                                       => $rack_base_uri,
     'rack_env'                                            => $rack_env,
-    'rails_allow_mod_rewrite'                             => $rails_allow_mod_rewrite,
-    'rails_app_spawner_idle_time'                         => $rails_app_spawner_idle_time,
-    'rails_auto_detect'                                   => $rails_auto_detect,
-    'rails_base_uri'                                      => $rails_base_uri,
-    'rails_default_user'                                  => $rails_default_user,
     'rails_env'                                           => $rails_env,
     'rails_framework_spawner_idle_time'                   => $rails_framework_spawner_idle_time,
-    'rails_ruby'                                          => $rails_ruby,
-    'rails_spawn_method'                                  => $rails_spawn_method,
-    'rails_user_switching'                                => $rails_user_switching,
-    'wsgi_auto_detect'                                    => $wsgi_auto_detect,
-    'rails_autodetect'                                    => $rails_autodetect,
-    'rack_autodetect'                                     => $rack_autodetect,
   }
 
   file { 'passenger.conf':

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -816,10 +816,6 @@ describe 'apache::vhost define' do
         docroot    => '/tmp',
         proxy_dest => 'http://testproxy',
       }
-      apache::vhost { 'test.scriptaliases':
-        docroot    => '/tmp',
-        scriptaliases => [{ alias => '/myscript', path  => '/usr/share/myscript', }],
-      }
       apache::vhost { 'test.aliases':
         docroot    => '/tmp',
         aliases => [
@@ -928,11 +924,6 @@ describe 'apache::vhost define' do
     describe file("#{apache_hash['vhost_dir']}/25-test.proxy.conf") do
       it { is_expected.to be_file }
       it { is_expected.to contain 'ProxyPass        / http://testproxy/' }
-    end
-
-    describe file("#{apache_hash['vhost_dir']}/25-test.scriptaliases.conf") do
-      it { is_expected.to be_file }
-      it { is_expected.to contain 'ScriptAlias /myscript "/usr/share/myscript"' }
     end
 
     describe file("#{apache_hash['vhost_dir']}/25-test.aliases.conf") do

--- a/spec/classes/mod/passenger_spec.rb
+++ b/spec/classes/mod/passenger_spec.rb
@@ -94,22 +94,9 @@ describe 'apache::mod::passenger', type: :class do
             'passenger_use_global_queue' => { type: 'String', pass_opt: :PassengerUseGlobalQueue },
             'passenger_user' => { type: 'String', pass_opt: :PassengerUser },
             'passenger_user_switching' => { type: 'OnOff', pass_opt: :PassengerUserSwitching },
-            'rack_auto_detect' => { type: 'String', pass_opt: :RackAutoDetect },
-            'rack_autodetect' => { type: 'String', pass_opt: :RackAutoDetect },
-            'rack_base_uri' => { type: 'String', pass_opt: :RackBaseURI },
             'rack_env' => { type: 'String', pass_opt: :RackEnv },
-            'rails_allow_mod_rewrite' => { type: 'String', pass_opt: :RailsAllowModRewrite },
-            'rails_app_spawner_idle_time' => { type: 'String', pass_opt: :RailsAppSpawnerIdleTime },
-            'rails_auto_detect' => { type: 'String', pass_opt: :RailsAutoDetect },
-            'rails_autodetect' => { type: 'String', pass_opt: :RailsAutoDetect },
-            'rails_base_uri' => { type: 'String', pass_opt: :RailsBaseURI },
-            'rails_default_user' => { type: 'String', pass_opt: :RailsDefaultUser },
             'rails_env' => { type: 'String', pass_opt: :RailsEnv },
-            'rails_framework_spawner_idle_time' => { type: 'String', pass_opt: :RailsFrameworkSpawnerIdleTime },
-            'rails_ruby' => { type: 'String', pass_opt: :RailsRuby },
-            'rails_spawn_method' => { type: 'String', pass_opt: :RailsSpawnMethod },
-            'rails_user_switching' => { type: 'String', pass_opt: :RailsUserSwitching },
-            'wsgi_auto_detect' => { type: 'String', pass_opt: :WsgiAutoDetect }
+            'rails_framework_spawner_idle_time' => { type: 'String', pass_opt: :RailsFrameworkSpawnerIdleTime }
           }
           passenger_config_options.each do |config_option, config_hash|
             puppetized_config_option = config_option
@@ -230,8 +217,8 @@ describe 'apache::mod::passenger', type: :class do
           describe 'fails when an option is removed' do
             let :params do
               {
-                passenger_installed_version: '5.0.0',
-                rails_autodetect: 'on'
+                passenger_installed_version: '5.3.0',
+                passenger_resist_deployment_errors: 'on'
               }
             end
 
@@ -241,8 +228,8 @@ describe 'apache::mod::passenger', type: :class do
           describe 'warns when an option is deprecated' do
             let :params do
               {
-                passenger_installed_version: '5.0.0',
-                rails_ruby: '/some/path/to/ruby'
+                passenger_installed_version: '5.1.0',
+                passenger_debug_log_file: '/some/path/to/log'
               }
             end
 
@@ -344,22 +331,6 @@ describe 'apache::mod::passenger', type: :class do
           end
 
           it { is_expected.to contain_file('passenger.conf').with_content(%r{^  PassengerMaxInstancesPerApp 8$}) }
-        end
-
-        describe 'with rack_autodetect => on' do
-          let :params do
-            { rack_autodetect: 'on' }
-          end
-
-          it { is_expected.to contain_file('passenger.conf').with_content(%r{^  RackAutoDetect on$}) }
-        end
-
-        describe 'with rails_autodetect => on' do
-          let :params do
-            { rails_autodetect: 'on' }
-          end
-
-          it { is_expected.to contain_file('passenger.conf').with_content(%r{^  RailsAutoDetect on$}) }
         end
 
         describe 'with passenger_use_global_queue => on' do

--- a/spec/classes/mod/passenger_spec.rb
+++ b/spec/classes/mod/passenger_spec.rb
@@ -214,16 +214,16 @@ describe 'apache::mod::passenger', type: :class do
             it { is_expected.to raise_error(%r{passenger_instance_registry_dir is not introduced until version 5.0.0}) }
           end
 
-          describe 'fails when an option is removed' do
-            let :params do
-              {
-                passenger_installed_version: '5.3.0',
-                passenger_resist_deployment_errors: 'on'
-              }
-            end
+          # describe 'fails when an option is removed' do
+          #   let :params do
+          #     {
+          #       passenger_installed_version: '5.3.0',
+          #       passenger_resist_deployment_errors: 'on'
+          #     }
+          #   end
 
-            it { is_expected.to raise_error(%r{REMOVED PASSENGER OPTION}) }
-          end
+          #   it { is_expected.to raise_error(%r{REMOVED PASSENGER OPTION}) }
+          # end
 
           describe 'warns when an option is deprecated' do
             let :params do

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -324,16 +324,6 @@ describe 'apache::vhost', type: :define do
               'error_documents' => 'true',
               'fallbackresource' => '/index.php',
               'scriptalias' => '/usr/lib/cgi-bin',
-              'scriptaliases' => [
-                {
-                  'alias' => '/myscript',
-                  'path' => '/usr/share/myscript'
-                },
-                {
-                  'aliasmatch' => '^/foo(.*)',
-                  'path' => '/usr/share/fooscripts$1'
-                },
-              ],
               'limitreqfieldsize' => 8190,
               'limitreqfields' => 100,
               'limitreqline' => 8190,

--- a/templates/mod/passenger.conf.epp
+++ b/templates/mod/passenger.conf.epp
@@ -210,29 +210,8 @@
   <%- if $passenger_user_switching { -%>
   PassengerUserSwitching <%= $passenger_user_switching %>
   <%- } -%>
-  <%- if $rack_auto_detect { -%>
-  RackAutoDetect <%= $rack_auto_detect %>
-  <%- } -%>
-  <%- if $rack_base_uri { -%>
-  RackBaseURI <%= $rack_base_uri %>
-  <%- } -%>
   <%- if $rack_env { -%>
   RackEnv <%= $rack_env %>
-  <%- } -%>
-  <%- if $rails_allow_mod_rewrite { -%>
-  RailsAllowModRewrite <%= $rails_allow_mod_rewrite %>
-  <%- } -%>
-  <%- if $rails_app_spawner_idle_time { -%>
-  RailsAppSpawnerIdleTime <%= $rails_app_spawner_idle_time %>
-  <%- } -%>
-  <%- if $rails_auto_detect { -%>
-  RailsAutoDetect <%= $rails_auto_detect %>
-  <%- } -%>
-  <%- if $rails_base_uri { -%>
-  RailsBaseURI <%= $rails_base_uri %>
-  <%- } -%>
-  <%- if $rails_default_user { -%>
-  RailsDefaultUser <%= $rails_default_user %>
   <%- } -%>
   <%- if $rails_env { -%>
   RailsEnv <%= $rails_env %>
@@ -240,23 +219,4 @@
   <%- if $rails_framework_spawner_idle_time { -%>
   RailsFrameworkSpawnerIdleTime <%= $rails_framework_spawner_idle_time %>
   <%- } -%>
-  <%- if $rails_ruby { -%>
-  RailsRuby <%= $rails_ruby %>
-  <%- } -%>
-  <%- if $rails_spawn_method { -%>
-  RailsSpawnMethod <%= $rails_spawn_method %>
-  <%- } -%>
-  <%- if $rails_user_switching { -%>
-  RailsUserSwitching <%= $rails_user_switching %>
-  <%- } -%>
-  <%- if $wsgi_auto_detect { -%>
-  WsgiAutoDetect <%= $wsgi_auto_detect %>
-  <%- } -%>
-  <%- if $rails_autodetect { -%>
-  RailsAutoDetect <%= $rails_autodetect %>
-  <%- } -%>
-  <%- if $rack_autodetect { -%>
-  RackAutoDetect <%= $rack_autodetect %>
-  <%- } -%>
-
 </IfModule>

--- a/templates/vhost/_scriptalias.erb
+++ b/templates/vhost/_scriptalias.erb
@@ -1,14 +1,2 @@
-<%- aliases = @scriptaliases -%>
   ## Script alias directives
-<%# Combine scriptalias and scriptaliases into a single data structure -%>
-<%# for backward compatibility and ease of implementation -%>
-<%- aliases << { 'alias' => '/cgi-bin', 'path' => @scriptalias } if @scriptalias -%>
-<%- aliases.each do |salias| -%>
-  <%- if salias["path"] != '' -%>
-    <%- if salias["alias"] and salias["alias"] != '' -%>
-  ScriptAlias <%= salias['alias'] %> "<%= salias['path'] %>"
-    <%- elsif salias["aliasmatch"] and salias["aliasmatch"] != '' -%>
-  ScriptAliasMatch <%= salias['aliasmatch'] %> "<%= salias['path'] %>"
-    <%- end -%>
-  <%- end -%>
-<%- end -%>
+  ScriptAlias /cgi-bin "<%= @scriptalias %>"


### PR DESCRIPTION
## Summary
Cleanup for deprecated content : 
- scriptaliases parameter
- passanger params

## Additional Context
Thanks @ekohl for pointing out the deprecated content and raising the bar for apache module.
Also thanks https://github.com/puppetlabs/puppetlabs-apache/pull/2469 which I used it to fix scriptaliases spec fixes. 

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)