### PR TITLE
(CAT-1451) - Fixing nil check fix for SSL config

### DIFF
--- a/templates/mod/ssl.conf.epp
+++ b/templates/mod/ssl.conf.epp
@@ -29,7 +29,7 @@
   SSLCACertificateFile    "<%= $ssl_ca %>"
   <%- } -%>
   SSLUseStapling <%= apache::bool2httpd($ssl_stapling) %>
-  <%- if $ssl_stapling_return_errors { -%>
+  <%- if $ssl_stapling_return_errors != undef { -%>
   SSLStaplingReturnResponderErrors <%= apache::bool2httpd($ssl_stapling_return_errors) %>
   <%- } -%>
   SSLStaplingCache "shmcb:<%= $_stapling_cache %>"


### PR DESCRIPTION
## Summary

While converting ERB to EPP the nil check evaluation got missed, so fixing the same.
Have taken this opportunity to check other recently converted files and haven't seen discrepancy, seems the above was miss. 

## Additional Context
Issue - https://github.com/puppetlabs/puppetlabs-apache/issues/2472

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)