### PR TITLE
Drop EoL Debian 9 and older code

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1214,7 +1214,7 @@ Default value: `$apache::params::icons_prefix`
 
 Installs `mod_apreq2`.
 
-* **Note** Unsupported platforms: CentOS: all; Debian: 8; OracleLinux: all; RedHat: all; Scientific: all; SLES: all; Ubuntu: all
+* **Note** Unsupported platforms: CentOS: all; OracleLinux: all; RedHat: all; Scientific: all; SLES: all; Ubuntu: all
 
 * **See also**
   * http://httpd.apache.org/apreq/docs/libapreq2/group__mod__apreq2.html
@@ -3602,7 +3602,7 @@ Installs `mod_macro`.
 
 Installs and configures `mod_md`.
 
-* **Note** Unsupported platforms: CentOS: 6, 7; Debian: 8, 9; OracleLinux: all; RedHat: 6, 7; Scientific: all; SLES: all; Ubuntu: 14, 16, 18
+* **Note** Unsupported platforms: CentOS: 6, 7; OracleLinux: all; RedHat: 6, 7; Scientific: all; SLES: all; Ubuntu: 14, 16, 18
 
 * **See also**
   * https://httpd.apache.org/docs/current/mod/mod_md.html

--- a/manifests/mod/apreq2.pp
+++ b/manifests/mod/apreq2.pp
@@ -3,7 +3,7 @@
 #
 # @see http://httpd.apache.org/apreq/docs/libapreq2/group__mod__apreq2.html for additional documentation.
 #
-# @note Unsupported platforms: CentOS: all; Debian: 8; OracleLinux: all; RedHat: all; Scientific: all; SLES: all; Ubuntu: all
+# @note Unsupported platforms: CentOS: all; OracleLinux: all; RedHat: all; Scientific: all; SLES: all; Ubuntu: all
 class apache::mod::apreq2 {
   ::apache::mod { 'apreq2':
     id => 'apreq_module',

--- a/manifests/mod/md.pp
+++ b/manifests/mod/md.pp
@@ -31,7 +31,7 @@
 #
 # @param md_challenge_dns01
 #   Define a program to be called when the `dns-01` challenge needs to be
-#   setup/torn down. 
+#   setup/torn down.
 #
 # @param md_contact_email
 #   The ACME protocol requires you to give a contact url when you sign up.
@@ -91,7 +91,7 @@
 #
 # @see https://httpd.apache.org/docs/current/mod/mod_md.html for additional documentation.
 #
-# @note Unsupported platforms: CentOS: 6, 7; Debian: 8, 9; OracleLinux: all; RedHat: 6, 7; Scientific: all; SLES: all; Ubuntu: 14, 16, 18
+# @note Unsupported platforms: CentOS: 6, 7; OracleLinux: all; RedHat: 6, 7; Scientific: all; SLES: all; Ubuntu: 14, 16, 18
 class apache::mod::md (
   Optional[String]                                          $md_activation_delay       = undef,
   Optional[Apache::OnOff]                                   $md_base_server            = undef,

--- a/manifests/mod/shib.pp
+++ b/manifests/mod/shib.pp
@@ -1,28 +1,28 @@
 # @summary
 #   Installs and configures `mod_shib`.
-# 
+#
 # @param suppress_warning
 #   Toggles whether to trigger warning on RedHat nodes.
-# 
+#
 # @param mod_full_path
 #   Specifies a path to the module. Do not manually set this parameter without a special reason.
-# 
+#
 # @param package_name
 #   Name of the Shibboleth package to be installed.
-# 
+#
 # @param mod_lib
-#   Specifies a path to the module's libraries. Do not manually set this parameter without special reason. The `path` parameter 
-#   overrides this value. 
+#   Specifies a path to the module's libraries. Do not manually set this parameter without special reason. The `path` parameter
+#   overrides this value.
 #
 # This class installs and configures only the Apache components of a web application that consumes Shibboleth SSO identities. You
 # can manage the Shibboleth configuration manually, with Puppet, or using a [Shibboleth Puppet Module](https://github.com/aethylred/puppet-shibboleth).
-# 
+#
 # @note
-#   The Shibboleth module isn't available on RH/CentOS without providing dependency packages provided by Shibboleth's repositories. 
+#   The Shibboleth module isn't available on RH/CentOS without providing dependency packages provided by Shibboleth's repositories.
 #   See the [Shibboleth Service Provider Installation Guide](http://wiki.aaf.edu.au/tech-info/sp-install-guide).
 #
 # @see https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPApacheConfig for additional documentation.
-# @note Unsupported platforms: RedHat: all; CentOS: all; Scientific: all; SLES: all; Debian: 7, 8; Ubuntu: all; OracleLinux: all
+# @note Unsupported platforms: RedHat: all; CentOS: all; Scientific: all; SLES: all; Ubuntu: all; OracleLinux: all
 class apache::mod::shib (
   Boolean $suppress_warning                     = false,
   Optional[Stdlib::Absolutepath] $mod_full_path = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -375,7 +375,6 @@ class apache::params inherits apache::version {
     $default_ssl_key     = '/etc/ssl/private/ssl-cert-snakeoil.key'
     $ssl_sessioncache    = "\${APACHE_RUN_DIR}/ssl_scache(512000)"
     $php_version = $facts['os']['release']['major'] ? {
-      '9'     => '7.0', # Debian Stretch
       '10'    => '7.3', # Debian Buster
       '11'    => '7.4', # Debian Bullseye
       '12'    => '8.2', # Debian Bookworm
@@ -408,14 +407,6 @@ class apache::params inherits apache::version {
     $_os_mod_packages = case $facts['os']['name'] {
       'Debian': {
         case $facts['os']['release']['major'] {
-          '9': {
-            {
-              'auth_kerb' => 'libapache2-mod-auth-kerb',
-              'nss'       => 'libapache2-mod-nss',
-              'shib2'     => 'libapache2-mod-shib2',
-              'wsgi'      => 'libapache2-mod-wsgi',
-            }
-          }
           '10': {
             {
               'auth_kerb' => 'libapache2-mod-auth-kerb',
@@ -466,7 +457,7 @@ class apache::params inherits apache::version {
     $error_log           = 'error.log'
     $scriptalias         = '/usr/lib/cgi-bin'
     $access_log_file     = 'access.log'
-    if ($facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['major'], '19.04') < 0) or ($facts['os']['name'] == 'Debian' and versioncmp($facts['os']['release']['major'], '10') < 0) {
+    if ($facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['major'], '19.04') < 0) {
       $shib2_lib = 'mod_shib2.so'
     } else {
       $shib2_lib = 'mod_shib.so'

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -1221,8 +1221,7 @@ describe 'apache::vhost define' do
     end
   end
 
-  describe 'shibboleth parameters', if: (os[:family] == 'debian' && os[:release] != '7') do
-    # Debian 7 is too old for ShibCompatValidUser
+  describe 'shibboleth parameters', if: (os[:family] == 'debian') do
     pp = <<-MANIFEST
       class { 'apache': }
       class { 'apache::mod::shib': }

--- a/spec/classes/mod/php_spec.rb
+++ b/spec/classes/mod/php_spec.rb
@@ -292,7 +292,7 @@ describe 'apache::mod::php', type: :class do
       # all the following tests are for legacy php/apache versions. They don't work on modern ubuntu and redhat 8
       next if (facts[:os]['release']['major'].to_i > 15 && facts[:os]['name'] == 'Ubuntu') ||
               (facts[:os]['release']['major'].to_i >= 15 && facts[:os]['name'] == 'SLES')  ||
-              (facts[:os]['release']['major'].to_i >= 9 && facts[:os]['name'] == 'Debian') ||
+              (facts[:os]['name'] == 'Debian')                                             ||
               (facts[:os]['release']['major'].to_i >= 8 && (facts[:os]['name'] == 'RedHat' || facts[:os]['name'] == 'CentOS' ||
                                                             facts[:os]['name'] == 'Rocky'  || facts[:os]['name'] == 'AlmaLinux'))
 

--- a/spec/classes/mod/security_spec.rb
+++ b/spec/classes/mod/security_spec.rb
@@ -286,8 +286,7 @@ describe 'apache::mod::security', type: :class do
             )
           }
 
-          if (facts[:os]['release']['major'].to_i < 18 && facts[:os]['name'] == 'Ubuntu') ||
-             (facts[:os]['release']['major'].to_i < 9 && facts[:os]['name'] == 'Debian')
+          if facts[:os]['release']['major'].to_i < 18 && facts[:os]['name'] == 'Ubuntu'
             it { is_expected.to contain_apache__security__rule_link('base_rules/modsecurity_35_bad_robots.data') }
 
             it {
@@ -316,8 +315,7 @@ describe 'apache::mod::security', type: :class do
               }
             end
 
-            if (facts[:os]['release']['major'].to_i < 18 && facts[:os]['name'] == 'Ubuntu') ||
-               (facts[:os]['release']['major'].to_i < 9 && facts[:os]['name'] == 'Debian')
+            if facts[:os]['release']['major'].to_i < 18 && facts[:os]['name'] == 'Ubuntu'
               it { is_expected.to contain_file('security.conf').with_content %r{^\s+SecAuditLogRelevantStatus "\^\(\?:5\|4\(\?!01\|04\)\)"$} }
               it { is_expected.to contain_file('security.conf').with_content %r{^\s+SecAuditLogParts ABCDZ$} }
               it { is_expected.to contain_file('security.conf').with_content %r{^\s+SecAuditLogStorageDir /var/log/httpd/audit$} }


### PR DESCRIPTION
Debian 9 was already removed from metadata.json and isn't supported anymore. This PR drops some code leftovers.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)