### PR TITLE
Remove outdated parameter documentation for ssl_mutex

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6573,10 +6573,6 @@ Default value: `undef`
 Data type: `String`
 
 Configures mutex mechanism and lock file directory for all or specified mutexes.
-Default based on the OS and/or Apache version:
-- RedHat/FreeBSD/Suse/Gentoo: 'default'.
-- Debian/Ubuntu + Apache >= 2.4: 'default'.
-- Debian/Ubuntu + Apache < 2.4: 'file:${APACHE_RUN_DIR}/ssl_mutex'.
 
 Default value: `'default'`
 

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -67,10 +67,6 @@
 #
 # @param ssl_mutex
 #   Configures mutex mechanism and lock file directory for all or specified mutexes.
-#   Default based on the OS and/or Apache version:
-#   - RedHat/FreeBSD/Suse/Gentoo: 'default'.
-#   - Debian/Ubuntu + Apache >= 2.4: 'default'.
-#   - Debian/Ubuntu + Apache < 2.4: 'file:${APACHE_RUN_DIR}/ssl_mutex'.
 #
 # @param ssl_reload_on_change
 #   Enable reloading of apache if the content of ssl files have changed. It only affects ssl files configured here and not vhost ones.


### PR DESCRIPTION
Since Apache 2.2 was dropped, the value is always the same.

Fixes: cedd45b63be89ea54bd2a596e6cd3a3f60d4faf8 ("Drop Apache 2.2 support")