### PR TITLE
Drop EoL Ubuntu code

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -3602,7 +3602,7 @@ Installs `mod_macro`.
 
 Installs and configures `mod_md`.
 
-* **Note** Unsupported platforms: CentOS: 6, 7; OracleLinux: all; RedHat: 6, 7; Scientific: all; SLES: all; Ubuntu: 14, 16, 18
+* **Note** Unsupported platforms: CentOS: 6, 7; OracleLinux: all; RedHat: 6, 7; Scientific: all; SLES: all; Ubuntu: 18
 
 * **See also**
   * https://httpd.apache.org/docs/current/mod/mod_md.html

--- a/manifests/mod/md.pp
+++ b/manifests/mod/md.pp
@@ -91,7 +91,7 @@
 #
 # @see https://httpd.apache.org/docs/current/mod/mod_md.html for additional documentation.
 #
-# @note Unsupported platforms: CentOS: 6, 7; OracleLinux: all; RedHat: 6, 7; Scientific: all; SLES: all; Ubuntu: 14, 16, 18
+# @note Unsupported platforms: CentOS: 6, 7; OracleLinux: all; RedHat: 6, 7; Scientific: all; SLES: all; Ubuntu: 18
 class apache::mod::md (
   Optional[String]                                          $md_activation_delay       = undef,
   Optional[Apache::OnOff]                                   $md_base_server            = undef,

--- a/spec/classes/mod/php_spec.rb
+++ b/spec/classes/mod/php_spec.rb
@@ -290,9 +290,8 @@ describe 'apache::mod::php', type: :class do
       end
 
       # all the following tests are for legacy php/apache versions. They don't work on modern ubuntu and redhat 8
-      next if (facts[:os]['release']['major'].to_i > 15 && facts[:os]['name'] == 'Ubuntu') ||
-              (facts[:os]['release']['major'].to_i >= 15 && facts[:os]['name'] == 'SLES')  ||
-              (facts[:os]['name'] == 'Debian')                                             ||
+      next if (facts[:os]['release']['major'].to_i >= 15 && facts[:os]['name'] == 'SLES')  ||
+              (facts[:os]['family'] == 'Debian')                                           ||
               (facts[:os]['release']['major'].to_i >= 8 && (facts[:os]['name'] == 'RedHat' || facts[:os]['name'] == 'CentOS' ||
                                                             facts[:os]['name'] == 'Rocky'  || facts[:os]['name'] == 'AlmaLinux'))
 

--- a/spec/classes/mod/security_spec.rb
+++ b/spec/classes/mod/security_spec.rb
@@ -286,54 +286,6 @@ describe 'apache::mod::security', type: :class do
             )
           }
 
-          if facts[:os]['release']['major'].to_i < 18 && facts[:os]['name'] == 'Ubuntu'
-            it { is_expected.to contain_apache__security__rule_link('base_rules/modsecurity_35_bad_robots.data') }
-
-            it {
-              expect(subject).to contain_file('modsecurity_35_bad_robots.data').with(
-                path: '/etc/modsecurity/activated_rules/modsecurity_35_bad_robots.data',
-                target: '/usr/share/modsecurity-crs/base_rules/modsecurity_35_bad_robots.data',
-              )
-            }
-          end
-
-          describe 'with parameters' do
-            let :params do
-              {
-                activated_rules: [
-                  '/tmp/foo/bar.conf',
-                ],
-                audit_log_relevant_status: '^(?:5|4(?!01|04))',
-                audit_log_parts: 'ABCDZ',
-                audit_log_type: 'Concurrent',
-                audit_log_storage_dir: '/var/log/httpd/audit',
-                secdefaultaction: 'deny,status:406,nolog,auditlog',
-                secrequestbodyaccess: 'Off',
-                secresponsebodyaccess: 'On',
-                secrequestbodylimitaction: 'ProcessPartial',
-                secresponsebodylimitaction: 'Reject'
-              }
-            end
-
-            if facts[:os]['release']['major'].to_i < 18 && facts[:os]['name'] == 'Ubuntu'
-              it { is_expected.to contain_file('security.conf').with_content %r{^\s+SecAuditLogRelevantStatus "\^\(\?:5\|4\(\?!01\|04\)\)"$} }
-              it { is_expected.to contain_file('security.conf').with_content %r{^\s+SecAuditLogParts ABCDZ$} }
-              it { is_expected.to contain_file('security.conf').with_content %r{^\s+SecAuditLogStorageDir /var/log/httpd/audit$} }
-              it { is_expected.to contain_file('security.conf').with_content %r{^\s+SecRequestBodyAccess Off$} }
-              it { is_expected.to contain_file('security.conf').with_content %r{^\s+SecResponseBodyAccess On$} }
-              it { is_expected.to contain_file('security.conf').with_content %r{^\s+SecRequestBodyLimitAction ProcessPartial$} }
-              it { is_expected.to contain_file('security.conf').with_content %r{^\s+SecResponseBodyLimitAction Reject$} }
-              it { is_expected.to contain_file('/etc/modsecurity/security_crs.conf').with_content %r{^\s*SecDefaultAction "phase:2,deny,status:406,nolog,auditlog"$} }
-
-              it {
-                expect(subject).to contain_file('bar.conf').with(
-                  path: '/etc/modsecurity/activated_rules/bar.conf',
-                  target: '/tmp/foo/bar.conf',
-                )
-              }
-            end
-          end
-
           describe 'with custom parameters' do
             let :params do
               {

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -593,7 +593,7 @@ describe 'apache::vhost', type: :define do
                                                                                 'notify' => 'Class[Apache::Service]')
           }
 
-          if os_facts[:os]['release']['major'].to_i >= 18 && os_facts[:os]['name'] == 'Ubuntu'
+          if os_facts[:os]['name'] == 'Ubuntu'
             it {
               expect(subject).to contain_file('30-rspec.example.com.conf symlink').with('ensure' => 'link',
                                                                                         'path' => "/etc/#{apache_name}/sites-enabled/30-rspec.example.com.conf")


### PR DESCRIPTION
This deletes Ubuntu 16 and older code. Those versions are already gone from metadata.json.

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)