### PR TITLE
Update load.epp to avoid loading a module already loaded

### DIFF
--- a/templates/mod/load.epp
+++ b/templates/mod/load.epp
@@ -4,4 +4,6 @@ LoadFile <%= $loadfile %>
 <% } -%>
 
 <% } -%>
+<IfModule <%= $_id %> >
 LoadModule <%= $_id %> <%= $_path %>
+</IfModule>

--- a/templates/mod/load.epp
+++ b/templates/mod/load.epp
@@ -4,6 +4,6 @@ LoadFile <%= $loadfile %>
 <% } -%>
 
 <% } -%>
-<IfModule <%= $_id %> >
+<IfModule !<%= $_id %> >
 LoadModule <%= $_id %> <%= $_path %>
 </IfModule>


### PR DESCRIPTION
I encountered a problem during an Apache update. The scriplet executed during updates set up the default configuration of module loads. If the node with puppet agent no longer has the puppet configuration active then there is a duplicate problem in the loading of modules, example of warning returned: 
[so:warn] [pid 15619] AH01574: module dav_module is already loaded, skipping

The commit therefore makes it possible to load the module if it is not already loaded and thus avoid warnings on duplicates. 