### PR TITLE
Add AllowOverrideList support

### DIFF
--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -45,6 +45,9 @@
       <%- elsif provider == 'Directory' -%>
     AllowOverride None
       <%- end -%>
+      <%- if directory['allow_override_list'] -%>
+    AllowOverrideList <%= Array(directory['allow_override_list']).join(' ') %>
+      <%- end -%>
     <%- end -%>
     <%- scope.lookupvar('_template_scope')[:item] = directory -%>
 <%= scope.function_template(["apache/vhost/_require.erb"]) -%>


### PR DESCRIPTION
## Summary
`AllowOverrideList` allows more fine-grained control over which directives are allow in htaccess

## Additional Context
There aren't any existing tests for `AllowOverride` and I am not sure where I would put new tests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)