### PR TITLE
Remove useless notice

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -808,8 +808,6 @@ class apache (
       'error_documents_path'    => $error_documents_path,
     }
 
-    notice $conf_template
-
     file { "${apache::conf_dir}/${apache::params::conf_file}":
       ensure  => file,
       mode    => $apache::file_mode,


### PR DESCRIPTION
This was probably added while refactoring templates to help diagnose
issues and should have been removed before the relevant PR was merged
but slip through.

This serve no purpose and only log useless information in the
puppetserver log so get rid of it.
