### PR TITLE
Fix `mod_suexec` configuration

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -2713,7 +2713,7 @@ define apache::vhost (
     concat::fragment { "${name}-suexec":
       target  => "${priority_real}${filename}.conf",
       order   => 290,
-      content => "SuexecUserGroup ${suexec_user_group}",
+      content => "  SuexecUserGroup ${suexec_user_group}\n",
     }
   }
 

--- a/templates/vhost/_suexec.epp
+++ b/templates/vhost/_suexec.epp
@@ -1,4 +1,0 @@
-<% if $suexec_user_group { -%>
-
-SuexecUserGroup <%= $suexec_user_group %>
-<% } -%>


### PR DESCRIPTION
The missing newline break apache configuration:

```
apache2: Syntax error on line 50 of /etc/apache2/apache2.conf: Syntax error on line 6 of /etc/apache2/sites-enabled/25-example.com-443.conf:6: <VirtualHost> was not closed.
```

Add the missing new line.

While here, also remove the legacy (now unused) template and fix
indentation of the generated statement.

This regression was introduced in 31a137bcb490e6a9041959e8f7115dceac91d4c0 which appear in no release so far.  So maybe we should label this `maintenance` rather than `bugfix`?