### PR TITLE
Fix extra newline at end of headers

### DIFF
--- a/templates/vhost/_file_header.epp
+++ b/templates/vhost/_file_header.epp
@@ -40,4 +40,4 @@ MDomain <%= $servername %>
 <% } -%>
 <% if $limitreqbody { -%>
   LimitRequestBody <%= $limitreqbody %>
-<% } %>
+<% } -%>


### PR DESCRIPTION
This slept through while converting templates form erb to epp.  Remove
it so that it is easier to spot regressions if the catalog is not
supposed to change but applying it in noop mode wants to change the
actual files.
