### PR TITLE
Fix use_canonical_name directive

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -2946,7 +2946,7 @@ define apache::vhost (
     concat::fragment { "${name}-use_canonical_name":
       target  => "${priority_real}${filename}.conf",
       order   => 360,
-      content => "UseCanonicalName ${use_canonical_name}",
+      content => "  UseCanonicalName ${use_canonical_name}\n",
     }
   }
 


### PR DESCRIPTION
## Summary
This is missing a newline char and breaks on recent (12.0.0) puppetlabs-apache:
```
apache2: Syntax error on line 50 of /etc/apache2/apache2.conf: Syntax error on line 6 of /etc/apache2/sites-enabled/25-example.com-443.conf:6: <VirtualHost> was not closed.
```

This fix is inspired by fb9d1313, it's functionally the same. Adds the missing newline and also adds two spaces for indentation.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)