### PR TITLE
fix: adjust dead documentation link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing to Puppet modules
 
-Check out our [Contributing to Puppet modules document](https://www.puppet.com/docs/puppet/8/contributing) to find all the information that you will need.
+Check out our [Contributing to Puppet modules document](https://www.puppet.com/docs/puppet/latest/contributing) to find all the information that you will need.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing to Puppet modules
 
-Check out our [Contributing to Supported Modules Blog Post](https://puppetlabs.github.io/iac/docs/contributing_to_a_module.html) to find all the information that you will need.
+Check out our [Contributing to Puppet modules document](https://www.puppet.com/docs/puppet/8/contributing) to find all the information that you will need.


### PR DESCRIPTION
## Summary
Fix a dead documentation link, the puppetlabs.github.io pages seem to be gone.
