### PR TITLE
Stop managing mime support package on Debian

### DIFF
--- a/manifests/mod/mime.pp
+++ b/manifests/mod/mime.pp
@@ -13,9 +13,9 @@
 # @see https://httpd.apache.org/docs/current/mod/mod_mime.html for additional documentation.
 #
 class apache::mod::mime (
-  String $mime_support_package          = $apache::params::mime_support_package,
-  String $mime_types_config             = $apache::params::mime_types_config,
-  Optional[Hash] $mime_types_additional = undef,
+  Optional[String] $mime_support_package = $apache::params::mime_support_package,
+  String $mime_types_config              = $apache::params::mime_types_config,
+  Optional[Hash] $mime_types_additional  = undef,
 ) inherits apache::params {
   include apache
   $_mime_types_additional = pick($mime_types_additional, $apache::mime_types_additional)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -470,8 +470,8 @@ class apache::params inherits apache::version {
     $keepalive              = 'On'
     $keepalive_timeout      = 15
     $max_keepalive_requests = 100
-    $mime_support_package = 'mime-support'
     $mime_types_config    = '/etc/mime.types'
+    $mime_support_package = undef
     $docroot              = '/var/www/html'
     $cas_cookie_path      = '/var/cache/apache2/mod_auth_cas/'
     $mellon_lock_file     = undef


### PR DESCRIPTION
## Summary

All [apache2 packages](https://packages.debian.org/bullseye/apache2) on Debian 10 and later already have a hard dependency on the `mime-support` package. While `mime-support` still exists on Debian 12 as a transitonal package, upcoming Debian 13 has removed it entirely.

This sets the `$mime_support_package` to undefined so that the package isn't managed on Debian, since it doesn't need to be.

## Additional Context

Currently, the module fails completely on Debian testing (upcoming release 13 codenamed `trixie`):

```
Error: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install mime-support' returned 100: Reading package lists...                                                                          
Building dependency tree...                                                                                                                                                                                          
Reading state information...                                                                                                                                                                                         
Package mime-support is not available, but is referred to by another package.                                                                                                                                        
This may mean that the package is missing, has been obsoleted, or                                                                                                                                                    
is only available from another source                                                                                                                                                                                
However the following packages replace it:                                                                                                                                                                           
  media-types mailcap                                                                                                                                                                                                
                                                                                                                                                                                                                     
E: Package 'mime-support' has no installation candidate                                                                                                                                                              
Error: /Stage[main]/Apache::Mod::Mime/Package[mime-support]/ensure: change from 'purged' to 'present' failed: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install mime-support' returned 
100: Reading package lists...                                                                                                                                                                                        
Building dependency tree...                                                                                                                                                                                          
Reading state information...                                                                                                                                                                                         
Package mime-support is not available, but is referred to by another package.                                                                                                                                        
This may mean that the package is missing, has been obsoleted, or                                                                                                                                                    
is only available from another source                                                                                                                                                                                
However the following packages replace it:                                                                                                                                                                           
  media-types mailcap                                                                                                                                                                                                
                                                                                                                                                                                                                     
E: Package 'mime-support' has no installation candidate                                                                                                                                                              
Notice: /Stage[main]/Apache::Mod::Mime/File[mime.conf]: Dependency Package[mime-support] has failures: true
```

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)