### PR TITLE
bugfix: fix the vhost security configuration

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -2170,28 +2170,22 @@ define apache::vhost (
   }
 
   ## Create a global LocationMatch if locations aren't defined
-  if $modsec_disable_ids {
-    if $modsec_disable_ids =~ Array {
-      $_modsec_disable_ids = { '.*' => $modsec_disable_ids }
-    } else {
-      $_modsec_disable_ids = $modsec_disable_ids
-    }
+  if $modsec_disable_ids =~ Array {
+    $_modsec_disable_ids = { '.*' => $modsec_disable_ids }
+  } else {
+    $_modsec_disable_ids = $modsec_disable_ids
   }
 
-  if $modsec_disable_msgs {
-    if $modsec_disable_msgs =~ Array {
-      $_modsec_disable_msgs = { '.*' => $modsec_disable_msgs }
-    } else {
-      $_modsec_disable_msgs = $modsec_disable_msgs
-    }
+  if $modsec_disable_msgs =~ Array {
+    $_modsec_disable_msgs = { '.*' => $modsec_disable_msgs }
+  } else {
+    $_modsec_disable_msgs = $modsec_disable_msgs
   }
 
-  if $modsec_disable_tags {
-    if $modsec_disable_tags =~ Array {
-      $_modsec_disable_tags = { '.*' => $modsec_disable_tags }
-    } else {
-      $_modsec_disable_tags = $modsec_disable_tags
-    }
+  if $modsec_disable_tags =~ Array {
+    $_modsec_disable_tags = { '.*' => $modsec_disable_tags }
+  } else {
+    $_modsec_disable_tags = $modsec_disable_tags
   }
 
   concat { "${priority_real}${filename}.conf":
@@ -2828,14 +2822,14 @@ define apache::vhost (
     }
   }
 
-  if $modsec_disable_vhost or $modsec_disable_ids or !empty($modsec_disable_ips) or $modsec_disable_msgs or $modsec_disable_tags or $modsec_audit_log_destination or ($modsec_inbound_anomaly_threshold and $modsec_outbound_anomaly_threshold) or $modsec_allowed_methods {
+  if $modsec_disable_vhost or $_modsec_disable_ids or !empty($modsec_disable_ips) or $_modsec_disable_msgs or $_modsec_disable_tags or $modsec_audit_log_destination or ($modsec_inbound_anomaly_threshold and $modsec_outbound_anomaly_threshold) or $modsec_allowed_methods {
     $security_params = {
       'modsec_disable_vhost'              => $modsec_disable_vhost,
       'modsec_audit_log_destination'      => $modsec_audit_log_destination,
-      '_modsec_disable_ids'               => $modsec_disable_ids,
+      '_modsec_disable_ids'               => $_modsec_disable_ids,
       'modsec_disable_ips'                => $modsec_disable_ips,
-      '_modsec_disable_msgs'              => $modsec_disable_msgs,
-      '_modsec_disable_tags'              => $modsec_disable_tags,
+      '_modsec_disable_msgs'              => $_modsec_disable_msgs,
+      '_modsec_disable_tags'              => $_modsec_disable_tags,
       'modsec_body_limit'                 => $modsec_body_limit,
       'modsec_inbound_anomaly_threshold'  => $modsec_inbound_anomaly_threshold,
       'modsec_outbound_anomaly_threshold' => $modsec_outbound_anomaly_threshold,

--- a/templates/vhost/_security.epp
+++ b/templates/vhost/_security.epp
@@ -1,7 +1,5 @@
 <IfModule mod_security2.c>
-<% if $modsec_disable_vhost {-%>
-  SecRuleEngine Off
-<% } -%>
+  SecRuleEngine <%= apache::bool2httpd(!$modsec_disable_vhost) %>
 <% if $modsec_audit_log_destination {-%>
   SecAuditLog "<%= $modsec_audit_log_destination %>"
 <% } -%>


### PR DESCRIPTION
The modified variable was never passed to the template, resulting in a bad configuration of the vhost security if secrule were removed.
