### PR TITLE
Add EnableSendfile per directory

### DIFF
--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -139,7 +139,8 @@ describe 'apache::vhost', type: :define do
                   {
                     'enforce' => 'any',
                     'requires' => ['any-valid1', 'any-valid2']
-                  }
+                  },
+                  'enable_sendfile' => 'On',
                 },
                 {
                   'path' => '*',
@@ -641,6 +642,7 @@ describe 'apache::vhost', type: :define do
               .with_content(%r{^\s+</RequireAny>$})
               .with_content(%r{^\s+Require any-valid1$})
               .with_content(%r{^\s+Require any-valid2$})
+              .with_content(%r{^\s+EnableSendfile On$})
               .with_content(%r{^\s+LDAPReferrals off$})
               .with_content(%r{^\s+ProxyPass http://backend-b/ retry=0 timeout=5 noquery interpolate$})
               .with_content(%r{^\s+ProxyPassMatch http://backend-b/ retry=0 timeout=5 noquery interpolate$})

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -19,8 +19,11 @@
       <%- path = directory['path'] -%>
 
   <<%= provider %> "<%= path %>">
-      <%- if directory['headers'] -%>
-        <%- Array(directory['headers']).each do |header| -%>
+    <%- if directory['enable_sendfile'] -%>
+    EnableSendfile <%= directory['enable_sendfile'] %>
+    <%- end -%>
+    <%- if directory['headers'] -%>
+      <%- Array(directory['headers']).each do |header| -%>
     Header <%= header %>
       <%- end -%>
     <%- end -%>


### PR DESCRIPTION
## Summary
Support configuring the EnableSendfile option under Directory directives

## Additional Context
The EnableSendfile option can be configured in a Directory directive to disable/enable the snedfile feature for specific paths as is described in https://httpd.apache.org/docs/2.4/en/mod/core.html#enablesendfile .

## Related Issues (if any)
N/A

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)