### PR TITLE
vhost: Allow customizing show_diff

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -238,6 +238,9 @@
 # @param ensure
 #   Specifies if the virtual host is present or absent.<br />
 #
+# @param show_diff
+#   Specifies whether to set the show_diff parameter for the file resource.
+#
 # @param fallbackresource
 #   Sets the [FallbackResource](https://httpd.apache.org/docs/current/mod/mod_dir.html#fallbackresource) 
 #   directive, which specifies an action to take for any URL that doesn't map to anything in 
@@ -1836,6 +1839,7 @@ define apache::vhost (
   Variant[Array[String], String] $setenvifnocase                                      = [],
   Variant[Array[String], String] $block                                               = [],
   Enum['absent', 'present'] $ensure                                                   = 'present',
+  Boolean $show_diff                                                                  = true,
   Optional[String] $wsgi_application_group                                            = undef,
   Optional[Variant[String, Hash]] $wsgi_daemon_process                                = undef,
   Optional[Hash] $wsgi_daemon_process_options                                         = undef,
@@ -2195,14 +2199,15 @@ define apache::vhost (
   }
 
   concat { "${priority_real}${filename}.conf":
-    ensure  => $ensure,
-    path    => "${apache::vhost_dir}/${priority_real}${filename}.conf",
-    owner   => 'root',
-    group   => $apache::params::root_group,
-    mode    => $apache::file_mode,
-    order   => 'numeric',
-    require => Package['httpd'],
-    notify  => Class['apache::service'],
+    ensure    => $ensure,
+    path      => "${apache::vhost_dir}/${priority_real}${filename}.conf",
+    owner     => 'root',
+    group     => $apache::params::root_group,
+    mode      => $apache::file_mode,
+    show_diff => $show_diff,
+    order     => 'numeric',
+    require   => Package['httpd'],
+    notify    => Class['apache::service'],
   }
   # NOTE(pabelanger): This code is duplicated in ::apache::vhost::custom and
   # needs to be converted into something generic.

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -589,6 +589,7 @@ describe 'apache::vhost', type: :define do
           it {
             expect(subject).to contain_concat('30-rspec.example.com.conf').with('owner' => 'root',
                                                                                 'mode' => '0644',
+                                                                                'show_diff' => true,
                                                                                 'require' => 'Package[httpd]',
                                                                                 'notify' => 'Class[Apache::Service]')
           }
@@ -1527,6 +1528,7 @@ describe 'apache::vhost', type: :define do
               'error_log_pipe' => '/dev/null',
               'docroot' => '/var/www/foo',
               'ensure' => 'absent',
+              'show_diff' => false,
               'manage_docroot' => true,
               'logroot' => '/tmp/logroot',
               'logroot_ensure' => 'absent'
@@ -1556,7 +1558,8 @@ describe 'apache::vhost', type: :define do
           }
 
           it {
-            expect(subject).to contain_concat('25-rspec.example.com.conf').with('ensure' => 'absent')
+            expect(subject).to contain_concat('25-rspec.example.com.conf').with('ensure' => 'absent',
+                                                                                'show_diff' => false)
           }
 
           it { is_expected.to contain_concat__fragment('rspec.example.com-apache-header') }


### PR DESCRIPTION
## Summary
Allow customizing show_diff of vhost configuration file

## Additional Context
A vhost configuration file may contain sensitive information. For example when mod_auth_openidc is used then the file may contain OIDCCryptoPassphrase. This introduces the parameter to allow users to hide diff when applying manifests, to avoid leaking secrets to outputs.

## Related Issues (if any)
N/A

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)