### PR TITLE
Add missing brackets for function call

### DIFF
--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -316,6 +316,24 @@ describe 'apache::vhost', type: :define do
                   'mellon_cond' => ['isMemberOf "cn=example-access,ou=Groups,o=example,o=com" [MAP]'],
                   'mellon_session_length' => '300'
                 },
+                {
+                  'path' => '/secure',
+                  'provider' => 'location',
+                  'auth_type' => 'Basic',
+                  'authz_core' => {
+                    'require_all' => {
+                      'require_any' => {
+                        'require' => ['user superadmin'],
+                        'require_all' => {
+                          'require' => ['group admins', 'ldap-group "cn=Administrators,o=Airius"'],
+                        },
+                      },
+                      'require_none' => {
+                        'require' => ['group temps', 'ldap-group "cn=Temporary Employees,o=Airius"']
+                      }
+                    }
+                  }
+                }
               ],
               'error_log' => false,
               'error_log_file' => 'httpd_error_log',
@@ -630,6 +648,7 @@ describe 'apache::vhost', type: :define do
               .with_content(%r{^\s+Require valid-user$})
               .with_content(%r{^\s+Require all denied$})
               .with_content(%r{^\s+Require all granted$})
+              .with_content(%r{^\s+Require user superadmin$})
               .with_content(%r{^\s+<RequireAll>$})
               .with_content(%r{^\s+</RequireAll>$})
               .with_content(%r{^\s+Require all-valid1$})

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -333,7 +333,7 @@ describe 'apache::vhost', type: :define do
                       }
                     }
                   }
-                }
+                },
               ],
               'error_log' => false,
               'error_log_file' => 'httpd_error_log',

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -548,7 +548,7 @@
     <%= directory['custom_fragment'] %>
     <%- end -%>
     <%- if directory['authz_core'] -%>
-      <%= scope.call_function('epp',["apache/vhost/_authz_core.epp", 'authz_core_config' => scope.call_function('apache::authz_core_config', directory['authz_core'])]) -%>
+      <%= scope.call_function('epp',["apache/vhost/_authz_core.epp", 'authz_core_config' => scope.call_function('apache::authz_core_config', [ directory['authz_core'] ]) ]) -%>
     <%- end -%>
     <%- if directory['gssapi'] -%>
       <%= scope.call_function('epp',["apache/vhost/_gssapi.epp", directory['gssapi']]) -%>


### PR DESCRIPTION
## Summary
Two brackets have been added around the arguments of the second scope.call_function

## Additional Context
Add any additional context about the problem here. 
- [x] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

The problem here is or was that the argument was not passed correctly to the function "authz_core_config" and you then got an error message from it that an incorrect variable type was passed.
"parameter 'config' expects a Hash value, got Tuple"
thanks to @hufschmidt for helping to find the error and solve the problem

For error reproduction it is sufficient to use "authz_core" in some way within a directory in a vhost.
For example as described in the ReadMe: https://github.com/puppetlabs/puppetlabs-apache/blob/b9ac34ca8a17c1bd507de01fc109d8fe73bf110c/manifests/vhost.pp#L1369-L1392

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)