### PR TITLE
Unify Debian MPM management with "mpm_" prefix

### DIFF
--- a/manifests/mod/event.pp
+++ b/manifests/mod/event.pp
@@ -86,7 +86,12 @@ class apache::mod::event (
     'listenbacklog'           => $listenbacklog,
   }
 
-  file { "${apache::mod_dir}/event.conf":
+  $eventconffile = $facts['os']['family'] ? {
+    'Debian' => "${apache::mod_dir}/mpm_event.conf",
+    default  => "${apache::mod_dir}/event.conf",
+  }
+
+  file { $eventconffile:
     ensure  => file,
     mode    => $apache::file_mode,
     content => epp('apache/mod/event.conf.epp', $parameters),

--- a/manifests/mod/itk.pp
+++ b/manifests/mod/itk.pp
@@ -79,7 +79,12 @@ class apache::mod::itk (
     'enablecapabilities'  => $enablecapabilities,
   }
 
-  file { "${apache::mod_dir}/itk.conf":
+  $itkconffile = $facts['os']['family'] ? {
+    'Debian' => "${apache::mod_dir}/mpm_itk.conf",
+    default  => "${apache::mod_dir}/itk.conf",
+  }
+
+  file { $itkconffile:
     ensure  => file,
     mode    => $apache::file_mode,
     content => epp('apache/mod/itk.conf.epp', $parameters),

--- a/manifests/mod/prefork.pp
+++ b/manifests/mod/prefork.pp
@@ -79,7 +79,12 @@ class apache::mod::prefork (
     'listenbacklog'           => $listenbacklog,
   }
 
-  file { "${apache::mod_dir}/prefork.conf":
+  $preforkconffile = $facts['os']['family'] ? {
+    'Debian' => "${apache::mod_dir}/mpm_prefork.conf",
+    default  => "${apache::mod_dir}/prefork.conf",
+  }
+
+  file { $preforkconffile:
     ensure  => file,
     content => epp('apache/mod/prefork.conf.epp', $parameters),
     require => Exec["mkdir ${apache::mod_dir}"],

--- a/manifests/mod/worker.pp
+++ b/manifests/mod/worker.pp
@@ -90,7 +90,12 @@ class apache::mod::worker (
     'maxrequestworkers'   => $maxrequestworkers,
   }
 
-  file { "${apache::mod_dir}/worker.conf":
+  $workerconffile = $facts['os']['family'] ? {
+    'Debian' => "${apache::mod_dir}/mpm_worker.conf",
+    default  => "${apache::mod_dir}/worker.conf",
+  }
+
+  file { $workerconffile:
     ensure  => file,
     content => epp('apache/mod/worker.conf.epp', $parameters),
     require => Exec["mkdir ${apache::mod_dir}"],

--- a/manifests/mpm/disable_mpm_event.pp
+++ b/manifests/mpm/disable_mpm_event.pp
@@ -1,11 +1,14 @@
 # @summary disable Apache-Module event
 class apache::mpm::disable_mpm_event {
-  $event_command = ['/usr/sbin/a2dismod', 'mpm_event']
-  $event_onlyif = [['/usr/bin/test', '-e', join([$apache::mod_enable_dir, 'mpm_event.load'],'/')]]
-  exec { '/usr/sbin/a2dismod mpm_event':
-    command => $event_command,
-    onlyif  => $event_onlyif,
-    require => Package['httpd'],
-    notify  => Class['apache::service'],
+  $mod_names = ['event', 'mpm_event']
+  $mod_names.each | $mod_name| {
+    $event_command = ['/usr/sbin/a2dismod', $mod_name]
+    $event_onlyif = [['/usr/bin/test', '-e', join([$apache::mod_enable_dir, "${mod_name}.load"],'/')]]
+    exec { "/usr/sbin/a2dismod ${mod_name}":
+      command => $event_command,
+      onlyif  => $event_onlyif,
+      require => Package['httpd'],
+      notify  => Class['apache::service'],
+    }
   }
 }

--- a/manifests/mpm/disable_mpm_prefork.pp
+++ b/manifests/mpm/disable_mpm_prefork.pp
@@ -1,11 +1,14 @@
 # @summary disable Apache-Module prefork
 class apache::mpm::disable_mpm_prefork {
-  $prefork_command = ['/usr/sbin/a2dismod', 'prefork']
-  $prefork_onlyif = [['/usr/bin/test', '-e', join([$apache::mod_enable_dir, 'prefork.load'],'/')]]
-  exec { '/usr/sbin/a2dismod prefork':
-    command => $prefork_command,
-    onlyif  => $prefork_onlyif,
-    require => Package['httpd'],
-    before  => Class['apache::service'],
+  $mod_names = ['itk', 'mpm_itk', 'prefork', 'mpm_prefork']
+  $mod_names.each | $mod_name| {
+    $prefork_command = ['/usr/sbin/a2dismod', $mod_name]
+    $prefork_onlyif = [['/usr/bin/test', '-e', join([$apache::mod_enable_dir, "${mod_name}.load"],'/')]]
+    exec { "/usr/sbin/a2dismod ${mod_name}":
+      command => $prefork_command,
+      onlyif  => $prefork_onlyif,
+      require => Package['httpd'],
+      notify  => Class['apache::service'],
+    }
   }
 }

--- a/manifests/mpm/disable_mpm_worker.pp
+++ b/manifests/mpm/disable_mpm_worker.pp
@@ -1,11 +1,14 @@
 # @summary disable Apache-Module worker
 class apache::mpm::disable_mpm_worker {
-  $worker_command = ['/usr/sbin/a2dismod', 'worker']
-  $worker_onlyif = [['/usr/bin/test', '-e', join([$apache::mod_enable_dir, 'worker.load'],'/')]]
-  exec { '/usr/sbin/a2dismod worker':
-    command => $worker_command,
-    onlyif  => $worker_onlyif,
-    require => Package['httpd'],
-    before  => Class['apache::service'],
+  $mod_names = ['worker', 'mpm_worker']
+  $mod_names.each | $mod_name| {
+    $worker_command = ['/usr/sbin/a2dismod', $mod_name]
+    $worker_onlyif = [['/usr/bin/test', '-e', join([$apache::mod_enable_dir, "${mod_name}.load"],'/')]]
+    exec { "/usr/sbin/a2dismod ${mod_name}":
+      command => $worker_command,
+      onlyif  => $worker_onlyif,
+      require => Package['httpd'],
+      notify  => Class['apache::service'],
+    }
   }
 }

--- a/spec/classes/mod/event_spec.rb
+++ b/spec/classes/mod/event_spec.rb
@@ -25,6 +25,10 @@ describe 'apache::mod::event', type: :class do
 
   context 'on a Debian OS' do
     include_examples 'Debian 11'
+    let(:loadcontent) do
+      "# Conflicts: mpm_worker mpm_prefork\n"\
+      "LoadModule mpm_event_module /usr/lib/apache2/modules/mod_mpm_event.so\n"
+    end
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('event') }
@@ -111,7 +115,7 @@ describe 'apache::mod::event', type: :class do
 
     it {
       expect(subject).to contain_file('/etc/apache2/mods-available/mpm_event.load').with('ensure' => 'file',
-                                                                                     'content' => "# Conflicts: mpm_worker mpm_prefork\nLoadModule mpm_event_module /usr/lib/apache2/modules/mod_mpm_event.so\n")
+                                                                                     'content' => loadcontent)
     }
 
     it { is_expected.to contain_file('/etc/apache2/mods-enabled/mpm_event.load').with_ensure('link') }

--- a/spec/classes/mod/event_spec.rb
+++ b/spec/classes/mod/event_spec.rb
@@ -28,8 +28,8 @@ describe 'apache::mod::event', type: :class do
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('event') }
-    it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file') }
-    it { is_expected.to contain_file('/etc/apache2/mods-enabled/event.conf').with_ensure('link') }
+    it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file') }
+    it { is_expected.to contain_file('/etc/apache2/mods-enabled/mpm_event.conf').with_ensure('link') }
 
     context 'Test mpm_event new params' do
       let :params do
@@ -46,15 +46,15 @@ describe 'apache::mod::event', type: :class do
         }
       end
 
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').with_content(%r{^\s*ServerLimit\s*0}) }
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').with_content(%r{^\s*StartServers\s*1}) }
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').with_content(%r{^\s*MinSpareThreads\s*3}) }
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').with_content(%r{^\s*MaxSpareThreads\s*4}) }
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').with_content(%r{^\s*ThreadsPerChild\s*5}) }
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').with_content(%r{^\s*ThreadLimit\s*7}) }
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').with_content(%r{^\s*ListenBacklog\s*8}) }
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').with_content(%r{^\s*MaxRequestWorkers\s*9}) }
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').with_content(%r{^\s*MaxConnectionsPerChild\s*10}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').with_content(%r{^\s*ServerLimit\s*0}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').with_content(%r{^\s*StartServers\s*1}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').with_content(%r{^\s*MinSpareThreads\s*3}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').with_content(%r{^\s*MaxSpareThreads\s*4}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').with_content(%r{^\s*ThreadsPerChild\s*5}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').with_content(%r{^\s*ThreadLimit\s*7}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').with_content(%r{^\s*ListenBacklog\s*8}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').with_content(%r{^\s*MaxRequestWorkers\s*9}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').with_content(%r{^\s*MaxConnectionsPerChild\s*10}) }
     end
 
     context 'Test mpm_event old style params' do
@@ -72,15 +72,15 @@ describe 'apache::mod::event', type: :class do
         }
       end
 
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').with_content(%r{^\s*ServerLimit\s*0}) }
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').with_content(%r{^\s*StartServers\s*1}) }
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').with_content(%r{^\s*MinSpareThreads\s*3}) }
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').with_content(%r{^\s*MaxSpareThreads\s*4}) }
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').with_content(%r{^\s*ThreadsPerChild\s*5}) }
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').with_content(%r{^\s*ThreadLimit\s*7}) }
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').with_content(%r{^\s*ListenBacklog\s*8}) }
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').without_content(%r{^\s*MaxRequestWorkers}) }
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').without_content(%r{^\s*MaxConnectionsPerChild}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').with_content(%r{^\s*ServerLimit\s*0}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').with_content(%r{^\s*StartServers\s*1}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').with_content(%r{^\s*MinSpareThreads\s*3}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').with_content(%r{^\s*MaxSpareThreads\s*4}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').with_content(%r{^\s*ThreadsPerChild\s*5}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').with_content(%r{^\s*ThreadLimit\s*7}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').with_content(%r{^\s*ListenBacklog\s*8}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').without_content(%r{^\s*MaxRequestWorkers}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').without_content(%r{^\s*MaxConnectionsPerChild}) }
     end
 
     context 'Test mpm_event false params' do
@@ -98,23 +98,23 @@ describe 'apache::mod::event', type: :class do
         }
       end
 
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').without_content(%r{^\s*ServerLimit}) }
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').without_content(%r{^\s*StartServers}) }
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').without_content(%r{^\s*MinSpareThreads}) }
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').without_content(%r{^\s*MaxSpareThreads}) }
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').without_content(%r{^\s*ThreadsPerChild}) }
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').without_content(%r{^\s*ThreadLimit}) }
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').without_content(%r{^\s*ListenBacklog}) }
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').without_content(%r{^\s*MaxRequestWorkers}) }
-      it { is_expected.to contain_file('/etc/apache2/mods-available/event.conf').with_ensure('file').without_content(%r{^\s*MaxConnectionsPerChild}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').without_content(%r{^\s*ServerLimit}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').without_content(%r{^\s*StartServers}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').without_content(%r{^\s*MinSpareThreads}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').without_content(%r{^\s*MaxSpareThreads}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').without_content(%r{^\s*ThreadsPerChild}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').without_content(%r{^\s*ThreadLimit}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').without_content(%r{^\s*ListenBacklog}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').without_content(%r{^\s*MaxRequestWorkers}) }
+      it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_event.conf').with_ensure('file').without_content(%r{^\s*MaxConnectionsPerChild}) }
     end
 
     it {
-      expect(subject).to contain_file('/etc/apache2/mods-available/event.load').with('ensure' => 'file',
-                                                                                     'content' => "LoadModule mpm_event_module /usr/lib/apache2/modules/mod_mpm_event.so\n")
+      expect(subject).to contain_file('/etc/apache2/mods-available/mpm_event.load').with('ensure' => 'file',
+                                                                                     'content' => "# Conflicts: mpm_worker mpm_prefork\nLoadModule mpm_event_module /usr/lib/apache2/modules/mod_mpm_event.so\n")
     }
 
-    it { is_expected.to contain_file('/etc/apache2/mods-enabled/event.load').with_ensure('link') }
+    it { is_expected.to contain_file('/etc/apache2/mods-enabled/mpm_event.load').with_ensure('link') }
   end
 
   context 'on a RedHat OS' do

--- a/spec/classes/mod/itk_spec.rb
+++ b/spec/classes/mod/itk_spec.rb
@@ -12,8 +12,8 @@ describe 'apache::mod::itk', type: :class do
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('itk') }
-    it { is_expected.to contain_file('/etc/apache2/mods-available/itk.conf').with_ensure('file') }
-    it { is_expected.to contain_file('/etc/apache2/mods-enabled/itk.conf').with_ensure('link') }
+    it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_itk.conf').with_ensure('file') }
+    it { is_expected.to contain_file('/etc/apache2/mods-enabled/mpm_itk.conf').with_ensure('link') }
 
     context 'with prefork mpm' do
       let :pre_condition do
@@ -21,11 +21,11 @@ describe 'apache::mod::itk', type: :class do
       end
 
       it {
-        expect(subject).to contain_file('/etc/apache2/mods-available/itk.load').with('ensure' => 'file',
-                                                                                     'content' => "LoadModule mpm_itk_module /usr/lib/apache2/modules/mod_mpm_itk.so\n")
+        expect(subject).to contain_file('/etc/apache2/mods-available/mpm_itk.load').with('ensure' => 'file',
+                                                                                     'content' => "# Depends: mpm_prefork\nLoadModule mpm_itk_module /usr/lib/apache2/modules/mod_mpm_itk.so\n")
       }
 
-      it { is_expected.to contain_file('/etc/apache2/mods-enabled/itk.load').with_ensure('link') }
+      it { is_expected.to contain_file('/etc/apache2/mods-enabled/mpm_itk.load').with_ensure('link') }
     end
 
     context 'with enablecapabilities not set' do
@@ -33,7 +33,7 @@ describe 'apache::mod::itk', type: :class do
         'class { "apache": mpm_module => prefork, }'
       end
 
-      it { is_expected.not_to contain_file('/etc/apache2/mods-available/itk.conf').with_content(%r{EnableCapabilities}) }
+      it { is_expected.not_to contain_file('/etc/apache2/mods-available/mpm_itk.conf').with_content(%r{EnableCapabilities}) }
     end
   end
 

--- a/spec/classes/mod/itk_spec.rb
+++ b/spec/classes/mod/itk_spec.rb
@@ -9,6 +9,10 @@ describe 'apache::mod::itk', type: :class do
 
   context 'on a Debian OS' do
     include_examples 'Debian 11'
+    let(:loadcontent) do
+      "# Depends: mpm_prefork\n"\
+      "LoadModule mpm_itk_module /usr/lib/apache2/modules/mod_mpm_itk.so\n"
+    end
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('itk') }
@@ -22,7 +26,7 @@ describe 'apache::mod::itk', type: :class do
 
       it {
         expect(subject).to contain_file('/etc/apache2/mods-available/mpm_itk.load').with('ensure' => 'file',
-                                                                                     'content' => "# Depends: mpm_prefork\nLoadModule mpm_itk_module /usr/lib/apache2/modules/mod_mpm_itk.so\n")
+                                                                                     'content' => loadcontent)
       }
 
       it { is_expected.to contain_file('/etc/apache2/mods-enabled/mpm_itk.load').with_ensure('link') }

--- a/spec/classes/mod/prefork_spec.rb
+++ b/spec/classes/mod/prefork_spec.rb
@@ -9,6 +9,10 @@ describe 'apache::mod::prefork', type: :class do
 
   context 'on a Debian OS' do
     include_examples 'Debian 11'
+    let(:loadcontent) do
+      "# Conflicts: mpm_event mpm_worker\n"\
+      "LoadModule mpm_prefork_module /usr/lib/apache2/modules/mod_mpm_prefork.so\n"
+    end
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('prefork') }
@@ -17,7 +21,7 @@ describe 'apache::mod::prefork', type: :class do
 
     it {
       expect(subject).to contain_file('/etc/apache2/mods-available/mpm_prefork.load').with('ensure' => 'file',
-                                                                                       'content' => "# Conflicts: mpm_event mpm_worker\nLoadModule mpm_prefork_module /usr/lib/apache2/modules/mod_mpm_prefork.so\n")
+                                                                                       'content' => loadcontent)
     }
 
     it { is_expected.to contain_file('/etc/apache2/mods-enabled/mpm_prefork.load').with_ensure('link') }

--- a/spec/classes/mod/prefork_spec.rb
+++ b/spec/classes/mod/prefork_spec.rb
@@ -12,15 +12,15 @@ describe 'apache::mod::prefork', type: :class do
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('prefork') }
-    it { is_expected.to contain_file('/etc/apache2/mods-available/prefork.conf').with_ensure('file') }
-    it { is_expected.to contain_file('/etc/apache2/mods-enabled/prefork.conf').with_ensure('link') }
+    it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_prefork.conf').with_ensure('file') }
+    it { is_expected.to contain_file('/etc/apache2/mods-enabled/mpm_prefork.conf').with_ensure('link') }
 
     it {
-      expect(subject).to contain_file('/etc/apache2/mods-available/prefork.load').with('ensure' => 'file',
-                                                                                       'content' => "LoadModule mpm_prefork_module /usr/lib/apache2/modules/mod_mpm_prefork.so\n")
+      expect(subject).to contain_file('/etc/apache2/mods-available/mpm_prefork.load').with('ensure' => 'file',
+                                                                                       'content' => "# Conflicts: mpm_event mpm_worker\nLoadModule mpm_prefork_module /usr/lib/apache2/modules/mod_mpm_prefork.so\n")
     }
 
-    it { is_expected.to contain_file('/etc/apache2/mods-enabled/prefork.load').with_ensure('link') }
+    it { is_expected.to contain_file('/etc/apache2/mods-enabled/mpm_prefork.load').with_ensure('link') }
   end
 
   context 'on a RedHat OS' do

--- a/spec/classes/mod/worker_spec.rb
+++ b/spec/classes/mod/worker_spec.rb
@@ -9,6 +9,10 @@ describe 'apache::mod::worker', type: :class do
 
   context 'on a Debian OS' do
     include_examples 'Debian 11'
+    let(:loadcontent) do
+      "# Conflicts: mpm_event mpm_prefork\n"\
+      "LoadModule mpm_worker_module /usr/lib/apache2/modules/mod_mpm_worker.so\n"
+    end
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('worker') }
@@ -16,7 +20,7 @@ describe 'apache::mod::worker', type: :class do
 
     it {
       expect(subject).to contain_file('/etc/apache2/mods-available/mpm_worker.load').with('ensure' => 'file',
-                                                                                      'content' => "# Conflicts: mpm_event mpm_prefork\nLoadModule mpm_worker_module /usr/lib/apache2/modules/mod_mpm_worker.so\n")
+                                                                                      'content' => loadcontent)
     }
   end
 

--- a/spec/classes/mod/worker_spec.rb
+++ b/spec/classes/mod/worker_spec.rb
@@ -12,11 +12,11 @@ describe 'apache::mod::worker', type: :class do
 
     it { is_expected.to contain_class('apache::params') }
     it { is_expected.not_to contain_apache__mod('worker') }
-    it { is_expected.to contain_file('/etc/apache2/mods-available/worker.conf').with_ensure('file') }
+    it { is_expected.to contain_file('/etc/apache2/mods-available/mpm_worker.conf').with_ensure('file') }
 
     it {
-      expect(subject).to contain_file('/etc/apache2/mods-available/worker.load').with('ensure' => 'file',
-                                                                                      'content' => "LoadModule mpm_worker_module /usr/lib/apache2/modules/mod_mpm_worker.so\n")
+      expect(subject).to contain_file('/etc/apache2/mods-available/mpm_worker.load').with('ensure' => 'file',
+                                                                                      'content' => "# Conflicts: mpm_event mpm_prefork\nLoadModule mpm_worker_module /usr/lib/apache2/modules/mod_mpm_worker.so\n")
     }
   end
 


### PR DESCRIPTION
## Summary
This change unifies the management of MPM modules using the "mpm_" prefix on the Debian platform. Previously, there were inconsistencies in whether MPM modules were enabled or disabled with the title `$mpm` or `mpm_${mpm}`. The changes to `mpm.pp` and the related individual mod manifests make it so that on the Debian platform, MPM modules are always referred to with the "mpm_" prefix. This is consistent with how the modules are installed and addressed by the Apache package maintainers for the Debian platform.

With this change implemented, an administrator is able to enable or disable MPM modules without introducing conflicts to the Apache service. Prior to this change, if the "prefork" or "worker" modules were enabled under the package maintainer provided name "mpm_worker" or "mpm_prefork", the `disable_mpm_*.pp` would fail to disable the modules. Similarly, if the "mpm_event" module was enabled by this Puppet module, the associated `disable_mpm_event.pp` would fail to disable it, as it was looking for the module under the name "mpm_event," but the module was enabled as "event".

The changes to accomplish this are:

- Adding a switch to `event.pp`, `itk.pp`, `prefork.pp` and `worker.pp` that changes the conf file name to `mpm_*.conf` on Debian hosts.
- Changes `mpm.pp` to create load files that match the name and content as provided by the Debian Apache package maintainers.
- Modifies `mpm.pp` to refer to load and conf files on Debian by a relative symlink and with the "mpm_" prefix, to match behavior of the modules installed via APT and changes made by `a2enmod`.
- Adds mod names with and without "mpm_" prefixes to `disable_mpm_*.pp` to make sure that the module is disabled, regardless of name. Additionally, adds the `mpm_itk` to `disable_mpm_prefork.pp` as `mpm_itk` must be disabled for disabling `mpm_prefork` to succeed.
- All relevant spec tests are updated to pass with the modifications made, specifically, matching the new filenames and new content for the load files.

## Additional Context
The initial problem leading to this fix is that if you use the module to enable `mpm_event` and then later try to enable a different MPM module, applying the catalog will fail. This change fixes that issue, and makes sure behavior and naming is consistent and matches what the Debian Apache package maintainers provide for module load definitions.

## Related Issues (if any)
This resolves https://github.com/puppetlabs/puppetlabs-apache/issues/2555.
## Checklist
- [x] 🟢 Spec tests. All spec tests pass.
- [ ] 🟢 Acceptance tests. Debian 11 and 12 pass, errors about package availability encountered on SLES 15 from the litmusimage repo.
- [x] Manually verified. (For example `puppet apply`) Tested and verified on Debian 12 hosts in my Puppet environment.