### PR TITLE
Move expectation out of let block

### DIFF
--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -2182,6 +2182,8 @@ describe 'apache::vhost', type: :define do
             )
           end
 
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_class('apache::mod::userdir') }
           it do
             expect(subject).to contain_concat__fragment('rspec.example.com-userdir')
               .with(content: %r{^\s+UserDir disabled$})

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -2180,12 +2180,12 @@ describe 'apache::vhost', type: :define do
                 'enabled bob',
               ],
             )
+          end
 
-            it {
-              expect(subject).to contain_concat__fragment('rspec.example.com-apache-userdir')
-                .with(content: %r{^\s+UserDir disabled$})
-                .with(content: %r{^\s+UUserDir enabled bob$})
-            }
+          it do
+            expect(subject).to contain_concat__fragment('rspec.example.com-userdir')
+              .with(content: %r{^\s+UserDir disabled$})
+              .with(content: %r{^\s+UserDir enabled bob$})
           end
         end
       end


### PR DESCRIPTION
## Summary

Otherwise it isn't executed.

## Related Issues (if any)

Fixes: ec74a8e5f73130b0a0d5c0dd645e847a2787421f ("Add support for setting UserDir in Virtual Hosts")

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)