### PR TITLE
Include systemd module for Amazon Linux 2023

### DIFF
--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -16,7 +16,7 @@ class apache::default_mods (
       if $facts['os']['name'] != 'Amazon' and $use_systemd {
         ::apache::mod { 'systemd': }
       }
-      if ($facts['os']['name'] == 'Amazon' and $facts['os']['release']['full'] == '2') {
+      if ($facts['os']['name'] == 'Amazon' and $facts['os']['release']['major'] =~ /^(2|2023)$/) {
         ::apache::mod { 'systemd': }
       }
       ::apache::mod { 'unixd': }

--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -13,10 +13,7 @@ class apache::default_mods (
   case $facts['os']['family'] {
     'RedHat': {
       ::apache::mod { 'log_config': }
-      if $facts['os']['name'] != 'Amazon' and $use_systemd {
-        ::apache::mod { 'systemd': }
-      }
-      if ($facts['os']['name'] == 'Amazon' and $facts['os']['release']['major'] =~ /^(2|2023)$/) {
+      if $use_systemd {
         ::apache::mod { 'systemd': }
       }
       ::apache::mod { 'unixd': }


### PR DESCRIPTION
## Summary
Include the systemd module for both AL2 and AL2023.

## Additional Context
This resolves an issue where the service fails to start on AL2023.

## Related Issues (if any)
https://github.com/puppetlabs/puppetlabs-apache/issues/2561

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x ] Manually verified. (For example `puppet apply`)