### PR TITLE
Fix apache2-mod_php7 not found for SLES-15

### DIFF
--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -111,8 +111,8 @@ class apache::mod::php (
     if ($_package_name == 'apache2-mod_php7' and versioncmp($facts['os']['release']['major'], '15') >= 0 and versioncmp($facts['os']['release']['minor'], '3') == 1) {
       exec { 'enable legacy repos':
         path    => '/bin:/usr/bin/:/sbin:/usr/sbin',
-        command => 'SUSEConnect --product sle-module-legacy/15.5/x86_64',
-        unless  => 'SUSEConnect --status-text | grep sle-module-legacy/15.5/x86_64',
+        command => "SUSEConnect --product sle-module-legacy/${facts['os']['release']['major']}.${facts['os']['release']['minor']}/x86_64",
+        unless  => "SUSEConnect --status-text | grep sle-module-legacy/${facts['os']['release']['major']}.${facts['os']['release']['minor']}/x86_64",
       }
     }
 

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -10,8 +10,8 @@ case $facts['os']['family'] {
     if (versioncmp($facts['os']['release']['major'], '15') >= 0 and versioncmp($facts['os']['release']['minor'], '3') == 1) {
       exec { 'enable legacy repos':
         path    => '/bin:/usr/bin/:/sbin:/usr/sbin',
-        command => 'SUSEConnect --product sle-module-legacy/15.5/x86_64',
-        unless  => 'SUSEConnect --status-text | grep sle-module-legacy/15.5/x86_64',
+        command => "SUSEConnect --product sle-module-legacy/${facts['os']['release']['major']}.${facts['os']['release']['minor']}/x86_64",
+        unless  => "SUSEConnect --status-text | grep sle-module-legacy/${facts['os']['release']['major']}.${facts['os']['release']['minor']}/x86_64",
       }
     }
     # needed for netstat, for serverspec checks


### PR DESCRIPTION
## Summary
Updated code to use parameterised value for OS Major and Minor versions.

## Additional Context
Add any additional context about the problem here. 
- The acceptance tests were failing for SLES-15 server
- Package "apache2-mod_php7" was not found on the SLES-15 server
- 'enable legacy repos' exec block was updated to fix the issue. ([link](https://github.com/puppetlabs/puppetlabs-apache/blob/main/manifests/mod/php.pp#L108-L117))



## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)