### PR TITLE
apache::params: Use correct PHP version on Ubuntu 24.04

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -380,6 +380,7 @@ class apache::params inherits apache::version {
       '12'    => '8.2', # Debian Bookworm
       '20.04' => '7.4', # Ubuntu Foccal Fossal
       '22.04' => '8.1', # Ubuntu Jammy
+      '24.04' => '8.3', # Ubuntu Noble
       default => '7.2', # Ubuntu Bionic, Cosmic and Disco
     }
     $_base_mod_packages = {


### PR DESCRIPTION
## Summary

Update PHP version list for Ubuntu 24.04 (noble)

## Additional Context
Straightforward.

## Related Issues (if any)

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [X] Manually verified. (For example `puppet apply`)