### PR TITLE
Update types/oidcsettings UserInfoRefreshInterval to allow Integers again

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -11473,7 +11473,7 @@ Struct[{
     Optional['Scope']                                      => Pattern[/^\"?[A-Za-z0-9\-\._\s]+\"?$/],
     Optional['AuthRequestParams']                          => Pattern[/^[A-Za-z0-9\-\._%]+=[A-Za-z0-9\-\._%]+(&[A-Za-z0-9\-\._%]+=[A-Za-z0-9\-\._%]+)*$/],
     Optional['SSLValidateServer']                          => Apache::OnOff ,
-    Optional['UserInfoRefreshInterval']                    => Pattern[/^[0-9]+(\s+(logout_on_error|authenticate_on_error|502_on_error))?$/],
+    Optional['UserInfoRefreshInterval']                    => Variant[Integer[-1], Pattern[/^[0-9]+(\s+(logout_on_error|authenticate_on_error|502_on_error))?$/]],
     Optional['JWKSRefreshInterval']                        => Integer[-1],
     Optional['UserInfoTokenMethod']                        => Enum['authz_header', 'post_param'],
     Optional['ProviderAuthRequestMethod']                  => Enum['GET', 'POST', 'PAR'],

--- a/types/oidcsettings.pp
+++ b/types/oidcsettings.pp
@@ -20,7 +20,7 @@ type Apache::OIDCSettings = Struct[
     Optional['Scope']                                      => Pattern[/^\"?[A-Za-z0-9\-\._\s]+\"?$/],
     Optional['AuthRequestParams']                          => Pattern[/^[A-Za-z0-9\-\._%]+=[A-Za-z0-9\-\._%]+(&[A-Za-z0-9\-\._%]+=[A-Za-z0-9\-\._%]+)*$/],
     Optional['SSLValidateServer']                          => Apache::OnOff ,
-    Optional['UserInfoRefreshInterval']                    => Pattern[/^[0-9]+(\s+(logout_on_error|authenticate_on_error|502_on_error))?$/],
+    Optional['UserInfoRefreshInterval']                    => Variant[Integer[-1], Pattern[/^[0-9]+(\s+(logout_on_error|authenticate_on_error|502_on_error))?$/]],
     Optional['JWKSRefreshInterval']                        => Integer[-1],
     Optional['UserInfoTokenMethod']                        => Enum['authz_header', 'post_param'],
     Optional['ProviderAuthRequestMethod']                  => Enum['GET', 'POST', 'PAR'],


### PR DESCRIPTION
## Summary
#2569 / commit 90f7482290c4143d168f4d209e16518b5968c27f swapped `UserInfoRefreshInterval` from an `Integer` to a `Pattern` that was (string representations of numbers) || (some magic strings).  This breaks configs that had integers in play.

## Additional Context
Add any additional context about the problem here. 
- [X] Root cause and the steps to reproduce. (If applicable)
- [X] Thought process behind the implementation.

## Related Issues (if any)
#2569 

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [X] Manually verified. (For example `puppet apply`)