### PR TITLE
Allow configuring RemoteIPProxyProtocol at VHost level

### DIFF
--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -551,7 +551,9 @@ describe 'apache::vhost', type: :define do
                                    'ClientSecret' => 'aae053a9-4abf-4824-8956-e94b2af335c8',
                                    'CryptoPassphrase' => '4ad1bb46-9979-450e-ae58-c696967df3cd' },
               'mdomain' => 'example.com example.net auto',
-              'userdir' => 'disabled'
+              'userdir' => 'disabled',
+              'proxy_protocol' => true,
+              'proxy_protocol_exceptions' => ['127.0.0.1', '10.0.0.0/8'],
             }
           end
 
@@ -967,6 +969,13 @@ describe 'apache::vhost', type: :define do
             expect(subject).to contain_concat__fragment('rspec.example.com-apache-header').with(
               content: %r{^MDomain example\.com example\.net auto$},
             )
+          }
+
+          it {
+            expect(subject).to contain_concat__fragment('rspec.example.com-proxy_protocol')
+              .with_content(%r{^\s+RemoteIPProxyProtocol On$})
+              .with_content(%r{^\s+RemoteIPProxyProtocolExceptions 127\.0\.0\.1$})
+              .with_content(%r{^\s+RemoteIPProxyProtocolExceptions 10\.0\.0\.0/8$})
           }
         end
 

--- a/templates/vhost/_proxy_protocol.epp
+++ b/templates/vhost/_proxy_protocol.epp
@@ -1,0 +1,8 @@
+<%- |
+  Boolean $proxy_protocol,
+  Array[Stdlib::Host] $proxy_protocol_exceptions,
+| -%>
+  RemoteIPProxyProtocol <%= apache::bool2httpd($proxy_protocol) %>
+<% $proxy_protocol_exceptions.each |$exception| { -%>
+  RemoteIPProxyProtocolExceptions <%= $exception %>
+<% } -%>


### PR DESCRIPTION
The module currently support configuring RemoteIP PROXY Protocol at the
system level, but the settings can also be used for specific virtual
hosts.

Allow to set `RemoteIPProxyProtocol` and `RemoteIPProxyProtocolExceptions`
at the VHost level.  For cosistency, une the same parameter names and
types as the ones used for mod_remoteip configuration.
