### PR TITLE
Adding ModSecurity parameter for audit log format.

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6199,9 +6199,9 @@ Default value: `$apache::params::modsec_audit_log_type`
 
 Data type: `Enum['Native', 'JSON']`
 
-Defines what format the logs should be written in. Accepts `Native` and `JSON`.
+Defines what format the logs should be written in.
 
-Default value: `$apache::params::modsec_audit_log_format`
+Default value: `'Native'`
 
 ##### <a name="-apache--mod--security--audit_log_storage_dir"></a>`audit_log_storage_dir`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6075,6 +6075,7 @@ The following parameters are available in the `apache::mod::security` class:
 * [`audit_log_relevant_status`](#-apache--mod--security--audit_log_relevant_status)
 * [`audit_log_parts`](#-apache--mod--security--audit_log_parts)
 * [`audit_log_type`](#-apache--mod--security--audit_log_type)
+* [`audit_log_format`](#-apache--mod--security--audit_log_format)
 * [`audit_log_storage_dir`](#-apache--mod--security--audit_log_storage_dir)
 * [`secpcrematchlimit`](#-apache--mod--security--secpcrematchlimit)
 * [`secpcrematchlimitrecursion`](#-apache--mod--security--secpcrematchlimitrecursion)
@@ -6193,6 +6194,15 @@ Data type: `String`
 Defines the type of audit logging mechanism to be used.
 
 Default value: `$apache::params::modsec_audit_log_type`
+
+##### <a name="-apache--mod--security--audit_log_format"></a>`audit_log_format`
+
+Data type: `Enum['Native', 'JSON']`
+
+Defines what format the logs should be written in. Accepts `Native` and `JSON`.
+Default value: Native
+
+Default value: `$apache::params::modsec_audit_log_format`
 
 ##### <a name="-apache--mod--security--audit_log_storage_dir"></a>`audit_log_storage_dir`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6200,7 +6200,6 @@ Default value: `$apache::params::modsec_audit_log_type`
 Data type: `Enum['Native', 'JSON']`
 
 Defines what format the logs should be written in. Accepts `Native` and `JSON`.
-Default value: Native
 
 Default value: `$apache::params::modsec_audit_log_format`
 

--- a/manifests/mod/security.pp
+++ b/manifests/mod/security.pp
@@ -34,7 +34,7 @@
 #   Defines the type of audit logging mechanism to be used.
 #
 # @param audit_log_format
-#   Defines what format the logs should be written in. Accepts `Native` and `JSON`.
+#   Defines what format the logs should be written in.
 # 
 # @param audit_log_storage_dir
 #   Defines the directory where concurrent audit log entries are to be stored. This directive is only needed when concurrent audit logging is used.
@@ -146,7 +146,7 @@ class apache::mod::security (
   String $audit_log_relevant_status                            = '^(?:5|4(?!04))',
   String $audit_log_parts                                      = $apache::params::modsec_audit_log_parts,
   String $audit_log_type                                       = $apache::params::modsec_audit_log_type,
-  Enum['Native', 'JSON'] $audit_log_format                     = $apache::params::modsec_audit_log_format,
+  Enum['Native', 'JSON'] $audit_log_format                     = 'Native',
   Optional[Stdlib::Absolutepath] $audit_log_storage_dir        = undef,
   Integer $secpcrematchlimit                                   = $apache::params::secpcrematchlimit,
   Integer $secpcrematchlimitrecursion                          = $apache::params::secpcrematchlimitrecursion,

--- a/manifests/mod/security.pp
+++ b/manifests/mod/security.pp
@@ -35,7 +35,6 @@
 #
 # @param audit_log_format
 #   Defines what format the logs should be written in. Accepts `Native` and `JSON`.
-#   Default value: Native
 # 
 # @param audit_log_storage_dir
 #   Defines the directory where concurrent audit log entries are to be stored. This directive is only needed when concurrent audit logging is used.

--- a/manifests/mod/security.pp
+++ b/manifests/mod/security.pp
@@ -32,6 +32,10 @@
 # 
 # @param audit_log_type
 #   Defines the type of audit logging mechanism to be used.
+#
+# @param audit_log_format
+#   Defines what format the logs should be written in. Accepts `Native` and `JSON`.
+#   Default value: Native
 # 
 # @param audit_log_storage_dir
 #   Defines the directory where concurrent audit log entries are to be stored. This directive is only needed when concurrent audit logging is used.
@@ -143,6 +147,7 @@ class apache::mod::security (
   String $audit_log_relevant_status                            = '^(?:5|4(?!04))',
   String $audit_log_parts                                      = $apache::params::modsec_audit_log_parts,
   String $audit_log_type                                       = $apache::params::modsec_audit_log_type,
+  Enum['Native', 'JSON'] $audit_log_format                     = $apache::params::modsec_audit_log_format,
   Optional[Stdlib::Absolutepath] $audit_log_storage_dir        = undef,
   Integer $secpcrematchlimit                                   = $apache::params::secpcrematchlimit,
   Integer $secpcrematchlimitrecursion                          = $apache::params::secpcrematchlimitrecursion,
@@ -256,6 +261,7 @@ class apache::mod::security (
     'audit_log_relevant_status'   => $audit_log_relevant_status,
     'audit_log_parts'             => $audit_log_parts,
     'audit_log_type'              => $audit_log_type,
+    'audit_log_format'            => $audit_log_format,
     'audit_log_storage_dir'       => $audit_log_storage_dir,
     'logroot'                     => $logroot,
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,6 +36,7 @@ class apache::params inherits apache::version {
 
   $modsec_audit_log_parts = 'ABIJDEFHZ'
   $modsec_audit_log_type = 'Serial'
+  $modsec_audit_log_format = 'Native'
   $modsec_custom_rules = false
   $modsec_custom_rules_set = undef
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,7 +36,6 @@ class apache::params inherits apache::version {
 
   $modsec_audit_log_parts = 'ABIJDEFHZ'
   $modsec_audit_log_type = 'Serial'
-  $modsec_audit_log_format = 'Native'
   $modsec_custom_rules = false
   $modsec_custom_rules_set = undef
 

--- a/spec/classes/mod/security_spec.rb
+++ b/spec/classes/mod/security_spec.rb
@@ -102,6 +102,7 @@ describe 'apache::mod::security', type: :class do
                 audit_log_relevant_status: '^(?:5|4(?!01|04))',
                 audit_log_parts: 'ABCDZ',
                 audit_log_type: 'Concurrent',
+                audit_log_format: 'JSON',
                 audit_log_storage_dir: '/var/log/httpd/audit',
                 secdefaultaction: 'deny,status:406,nolog,auditlog',
                 secrequestbodyaccess: 'Off',
@@ -114,6 +115,7 @@ describe 'apache::mod::security', type: :class do
             it { is_expected.to contain_file('security.conf').with_content %r{^\s+SecAuditLogRelevantStatus "\^\(\?:5\|4\(\?!01\|04\)\)"$} }
             it { is_expected.to contain_file('security.conf').with_content %r{^\s+SecAuditLogParts ABCDZ$} }
             it { is_expected.to contain_file('security.conf').with_content %r{^\s+SecAuditLogType Concurrent$} }
+            it { is_expected.to contain_file('security.conf').with_content %r{^\s+SecAuditLogFormat JSON$} }
             it { is_expected.to contain_file('security.conf').with_content %r{^\s+SecAuditLogStorageDir /var/log/httpd/audit$} }
             it { is_expected.to contain_file('security.conf').with_content %r{^\s+SecRequestBodyAccess Off$} }
             it { is_expected.to contain_file('security.conf').with_content %r{^\s+SecResponseBodyAccess On$} }

--- a/templates/mod/security.conf.epp
+++ b/templates/mod/security.conf.epp
@@ -49,6 +49,9 @@
     SecAuditLogRelevantStatus "<%= $audit_log_relevant_status %>"
     SecAuditLogParts <%= $audit_log_parts %>
     SecAuditLogType <%= $audit_log_type %>
+    <%- if $audit_log_format == 'JSON' { -%>
+    SecAuditLogFormat JSON
+    <%- } -%>
     <%- if $audit_log_storage_dir { -%>
     SecAuditLogStorageDir <%= $audit_log_storage_dir %>
     <%- } -%>


### PR DESCRIPTION
## Summary
Adds a parameter to set the audit log format to `JSON`

https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-(v2.x)#user-content-SecAuditLogFormat

## Additional Context
Since as of the current version of ModSecurity, this can only have two values `Native` and `JSON`, and `Native` is default, I decided only add the line if someone specifically sets the value to `JSON`. This means it shouldn't touch any existing config, especially on versions where this parameter may not exist.

## Checklist
- [X] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [X] Manually verified. (For example `puppet apply`)