### PR TITLE
Allow to use the same domain multiple times with mod_md

### DIFF
--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -966,7 +966,7 @@ describe 'apache::vhost', type: :define do
           it { is_expected.to contain_class('apache::mod::md') }
 
           it {
-            expect(subject).to contain_concat__fragment('rspec.example.com-apache-header').with(
+            expect(subject).to contain_file('example.com-mod_md').with(
               content: %r{^MDomain example\.com example\.net auto$},
             )
           }
@@ -2166,7 +2166,7 @@ describe 'apache::vhost', type: :define do
           end
 
           it {
-            expect(subject).to contain_concat__fragment('rspec.example.com-apache-header').with(
+            expect(subject).to contain_file('rspec.example.com-mod_md').with(
               content: %r{^MDomain rspec.example.com$},
             )
           }

--- a/templates/mdomain.epp
+++ b/templates/mdomain.epp
@@ -1,0 +1,11 @@
+<%- |
+  Variant[Boolean, String[1]] $mdomain,
+  String[1]                   $servername,
+| -%>
+<%- if $mdomain { -%>
+  <%- if $mdomain =~ String { -%>
+MDomain <%= $mdomain %>
+  <%-} else {-%>
+MDomain <%= $servername %>
+  <%- } -%>
+<% } -%>

--- a/templates/vhost/_file_header.epp
+++ b/templates/vhost/_file_header.epp
@@ -3,15 +3,6 @@
 # Managed by Puppet
 # ************************************
 <%= [$comment].flatten.map |$c| { "# ${c}" }.join("\n") -%>
-<%- if $mdomain { -%>
-
-  <%- if $mdomain =~ String { -%>
-
-MDomain <%= $mdomain %>
-  <%-} else {-%>
-MDomain <%= $servername %>
-  <%- } -%>
-<% } -%>
 
 <VirtualHost <%= [$nvh_addr_port].flatten().filter |$value| { $value }.join(' ') %>>
 <% $define.each | $k, $v| { -%>


### PR DESCRIPTION
When using mod_md to manage TLS certificates, a domain can only appear
once as a parameter of a MDomain configuration.

When a single node configue multiple Virtual Hosts to serve the same
website on different IP Addresses or on different ports, and we want to
use mod_md to manage the TLS certificate, the current code produce a
MDomain entry in each virtual host, leading to configuration error and
preventing apache from starting.

This commit rework how the MDomain setting is emitted, and ensure it is
only output once even if multiple Virtual Hosts configure the same
domain.
