### PR TITLE
Install mod_http2 on EL if required

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -202,6 +202,7 @@ class apache::params inherits apache::version {
       'authnz_pam'            => 'mod_authnz_pam',
       'fcgid'                 => 'mod_fcgid',
       'geoip'                 => 'mod_geoip',
+      'http2'                 => 'mod_http2',
       'intercept_form_submit' => 'mod_intercept_form_submit',
       'ldap'                  => 'mod_ldap',
       'lookup_identity'       => 'mod_lookup_identity',

--- a/spec/classes/mod/http2_spec.rb
+++ b/spec/classes/mod/http2_spec.rb
@@ -85,4 +85,11 @@ describe 'apache::mod::http2', type: :class do
       it { is_expected.to contain_file('http2.conf').with(content: expected_content) }
     end
   end
+
+  context 'on Red Hat 8' do
+    include_examples 'RedHat 8' do
+      it { is_expected.to contain_class('apache::mod::http2') }
+      it { is_expected.to contain_package('mod_http2') }
+    end
+  end
 end


### PR DESCRIPTION
## Summary

In EL8 httpd had a hard requirement on mod_http2 but in EL9 it turned into a weak dependency. While most installs default to installing weak dependencies, it can be disabled by users (by setting `install_weak_deps=0` in `/etc/dnf/dnf.conf`). OracleLinux even defaults to disabled.

EL7 doesn't have http2 at all so the whole class can't be used with it.

## Additional Context
Add any additional context about the problem here.
- [x] Root cause and the steps to reproduce. (If applicable)
- [x] Thought process behind the implementation.

Still a draft, but having a PR makes it easy for me to test.

## Related Issues (if any)

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)