### PR TITLE
Correct whitespace in arrow alignment

### DIFF
--- a/manifests/mod/prefork.pp
+++ b/manifests/mod/prefork.pp
@@ -94,7 +94,7 @@ class apache::mod::prefork (
     }
     'Suse': {
       ::apache::mpm { 'prefork':
-        lib_path       => '/usr/lib64/apache2-prefork',
+        lib_path => '/usr/lib64/apache2-prefork',
       }
     }
     'Gentoo': {


### PR DESCRIPTION
## Summary

Fixes a warning:

    manifests/mod/prefork.pp - WARNING: there should be a single space before '=>' on line 97, column 17 on line 97 (check: space_before_arrow)

## Additional Context
Add any additional context about the problem here.
- [x] Root cause and the steps to reproduce. (If applicable)
- [x] Thought process behind the implementation.

## Related Issues (if any)

Caused in cedd45b63be8.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)