### PR TITLE
Update wsgi examples and documentation

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -10212,8 +10212,7 @@ Default value: `false`
 Data type: `Optional[Variant[String, Hash]]`
 
 Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
-wsgi_daemon_process_options, wsgi_process_group,
-wsgi_script_aliases and wsgi_pass_authorization.<br />
+wsgi_process_group, wsgi_script_aliases and wsgi_pass_authorization.<br />
 A hash that sets the name of the WSGI daemon, accepting
 [certain keys](http://modwsgi.readthedocs.org/en/latest/configuration-directives/WSGIDaemonProcess.html).<br />
 An example virtual host configuration with WSGI:
@@ -10221,11 +10220,12 @@ An example virtual host configuration with WSGI:
 apache::vhost { 'wsgi.example.com':
   port                        => 80,
   docroot                     => '/var/www/pythonapp',
-  wsgi_daemon_process         => 'wsgi',
-  wsgi_daemon_process_options =>
-    { processes    => 2,
-      threads      => 15,
-      display-name => '%{GROUP}',
+  wsgi_daemon_process         =>
+    { 'wsgi'  =>
+      { processes    => 2,
+        threads      => 15,
+        display-name => '%{GROUP}'
+      }
     },
   wsgi_process_group          => 'wsgi',
   wsgi_script_aliases         => { '/' => '/var/www/demo.wsgi' },
@@ -10239,10 +10239,7 @@ Default value: `undef`
 
 Data type: `Optional[Hash]`
 
-Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
-wsgi_daemon_process, wsgi_process_group,
-wsgi_script_aliases and wsgi_pass_authorization.<br />
-Sets the group ID that the virtual host runs under.
+DEPRECATED: Please add values inside Hash `wsgi_daemon_process`.
 
 Default value: `undef`
 
@@ -10251,7 +10248,7 @@ Default value: `undef`
 Data type: `Optional[String]`
 
 Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
-wsgi_daemon_process, wsgi_daemon_process_options, wsgi_process_group,
+wsgi_daemon_process, wsgi_process_group,
 and wsgi_pass_authorization.<br />
 This parameter defines the [`WSGIApplicationGroup directive`](https://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIApplicationGroup.html),
 thus allowing you to specify which application group the WSGI application belongs to,
@@ -10265,7 +10262,7 @@ Default value: `undef`
 Data type: `Optional[String]`
 
 Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
-wsgi_daemon_process, wsgi_daemon_process_options, wsgi_process_group,
+wsgi_daemon_process, wsgi_process_group,
 and wsgi_pass_authorization.<br />
 This parameter defines the [`WSGIImportScript directive`](https://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIImportScript.html),
 which can be used in order to specify a script file to be loaded upon a process starting.
@@ -10277,7 +10274,7 @@ Default value: `undef`
 Data type: `Optional[Hash]`
 
 Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
-wsgi_daemon_process, wsgi_daemon_process_options, wsgi_process_group,
+wsgi_daemon_process, wsgi_process_group,
 and wsgi_pass_authorization.<br />
 This parameter defines the [`WSGIImportScript directive`](https://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIImportScript.html),
 which can be used in order to specify a script file to be loaded upon a process starting.<br />
@@ -10290,7 +10287,7 @@ Default value: `undef`
 Data type: `Optional[Apache::OnOff]`
 
 Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
-wsgi_daemon_process, wsgi_daemon_process_options, wsgi_process_group,
+wsgi_daemon_process, wsgi_process_group,
 and wsgi_pass_authorization.<br />
 This parameter defines the [`WSGIChunkedRequest directive`](https://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIChunkedRequest.html),
 allowing you to enable support for chunked request content.<br />
@@ -10304,7 +10301,7 @@ Default value: `undef`
 Data type: `Optional[String]`
 
 Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
-wsgi_daemon_process, wsgi_daemon_process_options,
+wsgi_daemon_process,
 wsgi_script_aliases and wsgi_pass_authorization.<br />
 Requires a hash of web paths to filesystem `.wsgi paths/`.
 
@@ -10315,7 +10312,7 @@ Default value: `undef`
 Data type: `Optional[Hash]`
 
 Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
-wsgi_daemon_process, wsgi_daemon_process_options, wsgi_process_group,
+wsgi_daemon_process, wsgi_process_group,
 and wsgi_pass_authorization.<br />
 Uses the WSGI application to handle authorization instead of Apache when set to `On`.<br />
 For more information, see mod_wsgi's [WSGIPassAuthorization documentation](https://modwsgi.readthedocs.org/en/latest/configuration-directives/WSGIPassAuthorization.html).
@@ -10327,7 +10324,7 @@ Default value: `undef`
 Data type: `Optional[Hash]`
 
 Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
-wsgi_daemon_process, wsgi_daemon_process_options, wsgi_process_group,
+wsgi_daemon_process, wsgi_process_group,
 and wsgi_pass_authorization.<br />
 Uses the WSGI application to handle authorization instead of Apache when set to `On`.<br />
 This directive is similar to `wsgi_script_aliases`, but makes use of regular expressions
@@ -10341,7 +10338,7 @@ Default value: `undef`
 Data type: `Optional[Apache::OnOff]`
 
 Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
-wsgi_daemon_process, wsgi_daemon_process_options, wsgi_process_group and
+wsgi_daemon_process, wsgi_process_group and
 wsgi_script_aliases.<br />
 Enables support for chunked requests.
 

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1179,8 +1179,7 @@
 #
 # @param wsgi_daemon_process
 #   Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
-#   wsgi_daemon_process_options, wsgi_process_group, 
-#   wsgi_script_aliases and wsgi_pass_authorization.<br />
+#   wsgi_process_group, wsgi_script_aliases and wsgi_pass_authorization.<br />
 #   A hash that sets the name of the WSGI daemon, accepting 
 #   [certain keys](http://modwsgi.readthedocs.org/en/latest/configuration-directives/WSGIDaemonProcess.html).<br />
 #   An example virtual host configuration with WSGI:
@@ -1188,27 +1187,24 @@
 #   apache::vhost { 'wsgi.example.com':
 #     port                        => 80,
 #     docroot                     => '/var/www/pythonapp',
-#     wsgi_daemon_process         => 'wsgi',
-#     wsgi_daemon_process_options =>
-#       { processes    => 2,
-#         threads      => 15,
-#         display-name => '%{GROUP}',
+#     wsgi_daemon_process         =>
+#       { 'wsgi'  =>
+#         { processes    => 2,
+#           threads      => 15,
+#           display-name => '%{GROUP}'
+#         }
 #       },
 #     wsgi_process_group          => 'wsgi',
 #     wsgi_script_aliases         => { '/' => '/var/www/demo.wsgi' },
 #     wsgi_chunked_request        => 'On',
-#   }
 #   ```
 #
 # @param wsgi_daemon_process_options
-#   Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
-#   wsgi_daemon_process, wsgi_process_group, 
-#   wsgi_script_aliases and wsgi_pass_authorization.<br />
-#   Sets the group ID that the virtual host runs under.
+#   DEPRECATED: Please add values inside Hash `wsgi_daemon_process`.
 #
 # @param wsgi_application_group
 #   Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
-#   wsgi_daemon_process, wsgi_daemon_process_options, wsgi_process_group, 
+#   wsgi_daemon_process, wsgi_process_group, 
 #   and wsgi_pass_authorization.<br />
 #   This parameter defines the [`WSGIApplicationGroup directive`](https://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIApplicationGroup.html),
 #   thus allowing you to specify which application group the WSGI application belongs to,
@@ -1217,14 +1213,14 @@
 #
 # @param wsgi_import_script
 #   Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
-#   wsgi_daemon_process, wsgi_daemon_process_options, wsgi_process_group, 
+#   wsgi_daemon_process, wsgi_process_group, 
 #   and wsgi_pass_authorization.<br />
 #   This parameter defines the [`WSGIImportScript directive`](https://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIImportScript.html),
 #   which can be used in order to specify a script file to be loaded upon a process starting.
 #
 # @param wsgi_import_script_options
 #   Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
-#   wsgi_daemon_process, wsgi_daemon_process_options, wsgi_process_group, 
+#   wsgi_daemon_process, wsgi_process_group, 
 #   and wsgi_pass_authorization.<br />
 #   This parameter defines the [`WSGIImportScript directive`](https://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIImportScript.html),
 #   which can be used in order to specify a script file to be loaded upon a process starting.<br />
@@ -1232,7 +1228,7 @@
 #
 # @param wsgi_chunked_request
 #   Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
-#   wsgi_daemon_process, wsgi_daemon_process_options, wsgi_process_group, 
+#   wsgi_daemon_process, wsgi_process_group, 
 #   and wsgi_pass_authorization.<br />
 #   This parameter defines the [`WSGIChunkedRequest directive`](https://modwsgi.readthedocs.io/en/develop/configuration-directives/WSGIChunkedRequest.html),
 #   allowing you to enable support for chunked request content.<br />
@@ -1241,20 +1237,20 @@
 #
 # @param wsgi_process_group
 #   Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
-#   wsgi_daemon_process, wsgi_daemon_process_options,  
+#   wsgi_daemon_process,  
 #   wsgi_script_aliases and wsgi_pass_authorization.<br />
 #   Requires a hash of web paths to filesystem `.wsgi paths/`.
 #
 # @param wsgi_script_aliases
 #   Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
-#   wsgi_daemon_process, wsgi_daemon_process_options, wsgi_process_group, 
+#   wsgi_daemon_process, wsgi_process_group, 
 #   and wsgi_pass_authorization.<br />
 #   Uses the WSGI application to handle authorization instead of Apache when set to `On`.<br />
 #   For more information, see mod_wsgi's [WSGIPassAuthorization documentation](https://modwsgi.readthedocs.org/en/latest/configuration-directives/WSGIPassAuthorization.html).
 #
 # @param wsgi_script_aliases_match
 #   Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
-#   wsgi_daemon_process, wsgi_daemon_process_options, wsgi_process_group, 
+#   wsgi_daemon_process, wsgi_process_group, 
 #   and wsgi_pass_authorization.<br />
 #   Uses the WSGI application to handle authorization instead of Apache when set to `On`.<br />
 #   This directive is similar to `wsgi_script_aliases`, but makes use of regular expressions
@@ -1263,7 +1259,7 @@
 #
 # @param wsgi_pass_authorization
 #   Sets up a virtual host with [WSGI](https://github.com/GrahamDumpleton/mod_wsgi) alongside
-#   wsgi_daemon_process, wsgi_daemon_process_options, wsgi_process_group and
+#   wsgi_daemon_process, wsgi_process_group and
 #   wsgi_script_aliases.<br />
 #   Enables support for chunked requests.
 #

--- a/readmes/README_ja_JP.md
+++ b/readmes/README_ja_JP.md
@@ -558,12 +558,13 @@ apache::vhost { 'wsgi.example.com':
   port                        => '80',
   docroot                     => '/var/www/pythonapp',
   wsgi_application_group      => '%{GLOBAL}',
-  wsgi_daemon_process         => 'wsgi',
-  wsgi_daemon_process_options => {
-    processes    => '2',
-    threads      => '15',
-    display-name => '%{GROUP}',
-  },
+  wsgi_daemon_process         =>
+    { 'wsgi'  =>
+      { processes    => 2,
+        threads      => 15,
+        display-name => '%{GROUP}'
+      }
+    },
   wsgi_import_script          => '/var/www/demo.wsgi',
   wsgi_import_script_options  => {
     process-group     => 'wsgi',


### PR DESCRIPTION
Update example to avoid hitting `Error while evaluating a Function Call, deprecation. apache::vhost::wsgi_daemon_process_options. This parameter is deprecated. Please add values inside Hash wsgi_daemon_process`

## Summary
Examples for wsgi vhost use code that doesn't work, tested new code using `puppet apply`.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [X] Manually verified. (For example `puppet apply`)