### PR TITLE
Detect module dependencies when modules are not default-loaded

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -2340,6 +2340,10 @@ define apache::vhost (
         include apache::mod::dir
       }
 
+      if 'expires_active' in $directory {
+        include apache::mod::expires
+      }
+
       if 'gssapi' in $directory {
         include apache::mod::auth_gssapi
       }

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -2337,18 +2337,16 @@ define apache::vhost (
       }
 
       if 'options' in $directory {
-        if !('-ExecCGI' in $directory['options']) {
-          if 'ExecCGI' in $directory['options'] {
-            case $apache::mpm_module {
-              'prefork': {
-                include apache::mod::cgi
-              }
-              'worker': {
-                include apache::mod::cgid
-              }
-              default: {
-                # do nothing
-              }
+        if !('-ExecCGI' in $directory['options']) and 'ExecCGI' in $directory['options'] {
+          case $apache::mpm_module {
+            'prefork': {
+              include apache::mod::cgi
+            }
+            'worker': {
+              include apache::mod::cgid
+            }
+            default: {
+              # do nothing
             }
           }
         }

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -2336,6 +2336,24 @@ define apache::vhost (
         include apache::mod::authz_groupfile
       }
 
+      if 'options' in $directory {
+        if !('-ExecCGI' in $directory['options']) {
+          if 'ExecCGI' in $directory['options'] {
+            case $apache::mpm_module {
+              'prefork': {
+                include apache::mod::cgi
+              }
+              'worker': {
+                include apache::mod::cgid
+              }
+              default: {
+                # do nothing
+              }
+            }
+          }
+        }
+      }
+
       if 'dav' in $directory {
         include apache::mod::dav
         if $directory['dav'] == 'On' {

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -2357,6 +2357,10 @@ define apache::vhost (
         include apache::mod::auth_gssapi
       }
 
+      if 'index_options' in $directory or 'index_order_default' in $directory or 'index_style_sheet' in $directory {
+        include apache::mod::autoindex
+      }
+
       if $directory['provider'] and $directory['provider'] =~ 'location' and ('proxy_pass' in $directory or 'proxy_pass_match' in $directory) {
         include apache::mod::proxy_http
 

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -2356,10 +2356,10 @@ define apache::vhost (
 
       if 'dav' in $directory {
         include apache::mod::dav
-        if $directory['dav'] == 'On' {
-          include apache::mod::dav_fs
-        } elsif $directory['dav'] == 'svn' {
+        if $directory['dav'] == 'svn' {
           include apache::mod::dav_svn
+        } elsif apache::bool2httpd($directory['dav']) == 'On' {
+          include apache::mod::dav_fs
         }
       }
 

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -2336,6 +2336,15 @@ define apache::vhost (
         include apache::mod::authz_groupfile
       }
 
+      if 'dav' in $directory {
+        include apache::mod::dav
+        if $directory['dav'] == 'On' {
+          include apache::mod::dav_fs
+        } elsif $directory['dav'] == 'svn' {
+          include apache::mod::dav_svn
+        }
+      }
+
       if 'directoryindex' in $directory {
         include apache::mod::dir
       }

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -2300,6 +2300,7 @@ define apache::vhost (
   }
 
   if $fallbackresource {
+    include apache::mod::dir
     $fall_back_res_params = {
       'fallbackresource' => $fallbackresource,
     }
@@ -2333,6 +2334,10 @@ define apache::vhost (
 
       if 'auth_group_file' in $directory {
         include apache::mod::authz_groupfile
+      }
+
+      if 'directoryindex' in $directory {
+        include apache::mod::dir
       }
 
       if 'gssapi' in $directory {

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -2205,6 +2205,23 @@ describe 'apache::vhost', type: :define do
           it { is_expected.to compile }
           it { is_expected.to contain_class('apache::mod::dir') }
         end
+
+        context 'mod_expires is included when needed' do
+          let :params do
+            {
+              'docroot' => '/var/www/foo',
+              'directories' => [
+                {
+                  'expires_active' => 'On',
+                },
+              ]
+
+            }
+          end
+
+          it { is_expected.to compile }
+          it { is_expected.to contain_class('apache::mod::expires') }
+        end
       end
     end
   end

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -2275,6 +2275,70 @@ describe 'apache::vhost', type: :define do
           it { is_expected.to compile }
           it { is_expected.to contain_class('apache::mod::autoindex') }
         end
+
+        context 'mod_cgi is included when requested by array' do
+          let :params do
+            {
+              'docroot' => '/var/www/foo',
+              'directories' => [
+                {
+                  'options' => ['ExecCGI'],
+                },
+              ]
+
+            }
+          end
+
+          it { is_expected.to compile }
+          if os_facts[:os]['family'] == 'Debian'
+            it { is_expected.not_to contain_class('apache::mod::cgi') }
+            it { is_expected.to contain_class('apache::mod::cgid') }
+          else
+            it { is_expected.to contain_class('apache::mod::cgi') }
+            it { is_expected.not_to contain_class('apache::mod::cgid') }
+          end
+        end
+
+        context 'mod_cgi is included when requested by string' do
+          let :params do
+            {
+              'docroot' => '/var/www/foo',
+              'directories' => [
+                {
+                  'options' => 'Indexes ExecCGI',
+                },
+              ]
+
+            }
+          end
+
+          it { is_expected.to compile }
+          if os_facts[:os]['family'] == 'Debian'
+            it { is_expected.not_to contain_class('apache::mod::cgi') }
+            it { is_expected.to contain_class('apache::mod::cgid') }
+          else
+            it { is_expected.to contain_class('apache::mod::cgi') }
+            it { is_expected.not_to contain_class('apache::mod::cgid') }
+          end
+        end
+
+        context 'mod_cgi is not included when unrequested' do
+          let :params do
+            {
+              'docroot' => '/var/www/foo',
+              'directories' => [
+                {
+                  'options' => '+Indexes -ExecCGI',
+                },
+              ]
+
+            }
+          end
+
+          it { is_expected.to compile }
+          it { is_expected.not_to contain_class('apache::mod::cgi') }
+          it { is_expected.not_to contain_class('apache::mod::cgid') }
+        end
       end
     end
   end

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -2188,6 +2188,23 @@ describe 'apache::vhost', type: :define do
             }
           end
         end
+
+        context 'mod_dir is included when needed' do
+          let :params do
+            {
+              'docroot' => '/var/www/foo',
+              'directories' => [
+                {
+                  'directoryindex' => 'index.php',
+                },
+              ]
+
+            }
+          end
+
+          it { is_expected.to compile }
+          it { is_expected.to contain_class('apache::mod::dir') }
+        end
       end
     end
   end

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -2258,6 +2258,23 @@ describe 'apache::vhost', type: :define do
           it { is_expected.to contain_class('apache::mod::dav') }
           it { is_expected.to contain_class('apache::mod::dav_svn') }
         end
+
+        context 'mod_autoindex is included when needed' do
+          let :params do
+            {
+              'docroot' => '/var/www/foo',
+              'directories' => [
+                {
+                  'index_options' => ['FancyIndexing'],
+                },
+              ]
+
+            }
+          end
+
+          it { is_expected.to compile }
+          it { is_expected.to contain_class('apache::mod::autoindex') }
+        end
       end
     end
   end

--- a/spec/defines/vhost_spec.rb
+++ b/spec/defines/vhost_spec.rb
@@ -2222,6 +2222,42 @@ describe 'apache::vhost', type: :define do
           it { is_expected.to compile }
           it { is_expected.to contain_class('apache::mod::expires') }
         end
+
+        context 'mod_dav is included when on' do
+          let :params do
+            {
+              'docroot' => '/var/www/foo',
+              'directories' => [
+                {
+                  'dav' => 'On',
+                },
+              ]
+
+            }
+          end
+
+          it { is_expected.to compile }
+          it { is_expected.to contain_class('apache::mod::dav') }
+          it { is_expected.to contain_class('apache::mod::dav_fs') }
+        end
+
+        context 'mod_dav is included when set to svn' do
+          let :params do
+            {
+              'docroot' => '/var/www/foo',
+              'directories' => [
+                {
+                  'dav' => 'svn',
+                },
+              ]
+
+            }
+          end
+
+          it { is_expected.to compile }
+          it { is_expected.to contain_class('apache::mod::dav') }
+          it { is_expected.to contain_class('apache::mod::dav_svn') }
+        end
       end
     end
   end


### PR DESCRIPTION
## Additional Context
If you accept `default_mods => true` you get a -lot- of apache modules automatically.  In my experience it's too many, which has led to us doing `default_mods => []` to reduce the sprawl, and then adding back in what we need.  That leads to a bit of whack-a-mole upon new server buildout, as a lot of this module's code assumes that you have included the default modules and it doesn't need to check.  It also leads to "I'm not sure if I can remove this module" later, if you remove directives.

## Summary
This covers off the worst offenders I've hit in our environment: `mod_dir`, `mod_autoindex`, `mod_expires`, `mod_dav`, and `mod_cgi`.  If you use vhost directory parameters that will invoke these module directives, vhost will try to make sure the module is loaded.  If you're on `default_mods => true`, this is a 'wasted' extra load; if you don't have the module loaded (say, `default_mods => false`) then this brings the module in for you.

## Related Issues (if any)
N/A

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)