### PR TITLE
Remove mod_log_forensic from apache::default_mods (#2573)

### DIFF
--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -119,7 +119,6 @@ class apache::default_mods (
     include apache::mod::negotiation
     include apache::mod::setenvif
     include apache::mod::auth_basic
-    include apache::mod::log_forensic
 
     # filter is needed by mod_deflate
     include apache::mod::filter


### PR DESCRIPTION
## Summary
mod_log_forensic should not be included by default, as the module has security implications and might leak sensitive information from headers incl. passwords.

Upstream documentation also warns about this:
https://httpd.apache.org/docs/2.4/mod/mod_log_forensic.html#security

## Additional Context
The default installation through this module should be secure, `mod_log_forensics` weakens this.

## Related Issues (if any)
Fixes #2573

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)