### PR TITLE
FreeBSD loads apache::mod::info by default - there's no good reason for this

### DIFF
--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -68,7 +68,6 @@ class apache::default_mods (
         include apache::mod::authn_core
         include apache::mod::filter
         include apache::mod::headers
-        include apache::mod::info
         include apache::mod::mime_magic
         include apache::mod::reqtimeout
         include apache::mod::rewrite


### PR DESCRIPTION
## Summary
On FreeBSD (and only on FreeBSD) `apache::mod::info` is loaded by default.   I can discern no good reason for why this should be the case, and it's trivial to add if required.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [X] Manually verified. (For example `puppet apply`)