### PR TITLE
Add FileETag to vhost and directory

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -106,6 +106,10 @@
 #   default setting omits the declaration from the server configuration and selects the 
 #   Apache default setting of `Off`.
 #
+# @param file_e_tag
+#   Sets the server default for the `FileETag` declaration, which modifies the response header
+#   field for static files.
+#
 # @param block
 #   Specifies the list of things to which Apache blocks access. Valid options are: `scm` (which 
 #   blocks web access to `.svn`), `.git`, and `.bzr` directories.
@@ -1861,6 +1865,7 @@ define apache::vhost (
   Variant[Array[String], String] $additional_includes                                 = [],
   Boolean $use_optional_includes                                                      = $apache::use_optional_includes,
   Optional[Variant[Apache::OnOff, Enum['nodecode']]] $allow_encoded_slashes           = undef,
+  Optional[String] $file_e_tag                                                        = undef,
   Optional[Pattern[/^[\w-]+ [\w-]+$/]] $suexec_user_group                             = undef,
 
   Optional[Boolean] $h2_copy_files                                                    = undef,
@@ -2974,6 +2979,17 @@ define apache::vhost (
       target  => "${priority_real}${filename}.conf",
       order   => 400,
       content => epp('apache/vhost/_proxy_protocol.epp', $proxy_protocol_params),
+    }
+  }
+
+  if $file_e_tag {
+    $file_e_tag_params = {
+      'file_e_tag' => $file_e_tag,
+    }
+    concat::fragment { "${name}-file_e_tag":
+      target  => "${priority_real}${filename}.conf",
+      order   => 410,
+      content => epp('apache/vhost/_file_e_tag.epp', $file_e_tag_params),
     }
   }
 

--- a/spec/acceptance/vhost_spec.rb
+++ b/spec/acceptance/vhost_spec.rb
@@ -1306,4 +1306,23 @@ describe 'apache::vhost define' do
       it { is_expected.to contain 'OIDCCryptoPassphrase 4ad1bb46-9979-450e-ae58-c696967df3cd' }
     end
   end
+
+  describe 'file_e_tag' do
+    pp = <<-MANIFEST
+      class { 'apache': }
+      apache::vhost { 'test.server':
+        port       => 80,
+        docroot    => '/var/www/html',
+        file_e_tag => 'None',
+      }
+    MANIFEST
+    it 'applies cleanly' do
+      apply_manifest(pp, catch_failures: true)
+    end
+
+    describe file("#{apache_hash['vhost_dir']}/25-test.server.conf") do
+      it { is_expected.to be_file }
+      it { is_expected.to contain 'FileETag None' }
+    end
+  end
 end

--- a/templates/vhost/_directories.erb
+++ b/templates/vhost/_directories.erb
@@ -77,6 +77,9 @@
     </FilesMatch>
       <%- end -%>
     <%- end -%>
+    <%- unless directory['file_e_tag'].nil? -%>
+    FileETag <%= directory['file_e_tag'] %>
+    <%- end -%>
     <%- if directory['sethandler'] and directory['sethandler'] != '' -%>
     SetHandler <%= directory['sethandler'] %>
     <%- end -%>

--- a/templates/vhost/_file_e_tag.epp
+++ b/templates/vhost/_file_e_tag.epp
@@ -1,0 +1,4 @@
+<%- if $file_e_tag { -%>
+
+  FileETag <%= $file_e_tag %>
+<%- } -%>


### PR DESCRIPTION
## Summary
Add FileETag to vhost and directory

## Checklist
- [ ] 🟢 Spec tests.
- [X] 🟢 Acceptance tests.
- [X] Manually verified. (For example `puppet apply`)