### PR TITLE
(MAINT) Remove enforced Ubuntu runner from ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,5 @@ jobs:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     with:
-      flags: "--nightly --platform-exclude centos-7 --platform-exclude oraclelinux-7 --platform-exclude scientific-7"
+      flags: "--nightly --platform-exclude centos-7 --platform-exclude oraclelinux-7 --platform-exclude scientific-7 --platform-exclude almalinux-8"
     secrets: "inherit"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,6 +14,6 @@ jobs:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
     with:
-      flags: "--nightly --platform-exclude centos-7 --platform-exclude oraclelinux-7 --platform-exclude scientific-7"
+      flags: "--nightly --platform-exclude centos-7 --platform-exclude oraclelinux-7 --platform-exclude scientific-7 --platform-exclude almalinux-8"
     secrets: "inherit"
 


### PR DESCRIPTION
Recently, some updates have been implemented in litmusimage to ensure that Docker images are built correctly, however, the older images are often not compatible with latest ubuntu runners. We are allowing puppetlabs-provision to resolve what runner is expected for each machine.

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
