### PR TITLE
(MODULES-11606) Remove apache::mod::info as a default module for FreeBSD

### DIFF
--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -68,7 +68,6 @@ class apache::default_mods (
         include apache::mod::authn_core
         include apache::mod::filter
         include apache::mod::headers
-        include apache::mod::info
         include apache::mod::mime_magic
         include apache::mod::reqtimeout
         include apache::mod::rewrite


### PR DESCRIPTION
## Summary
Remove apache::mod::info as a default module for FreeBSD.

## Additional Context
This is because in some cases the /server-info url could be exposed.
Users who want to use mod_info module will have to manually add it.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)