### PR TITLE
Fix SELinux context for Apache configuration files

### DIFF
--- a/manifests/mod.pp
+++ b/manifests/mod.pp
@@ -126,6 +126,7 @@ define apache::mod (
     owner   => 'root',
     group   => $apache::params::root_group,
     mode    => $apache::file_mode,
+    seltype => 'httpd_config_t',
     content => epp('apache/mod/load.epp', $parameters),
     require => [
       Package['httpd'],
@@ -144,6 +145,7 @@ define apache::mod (
       owner   => 'root',
       group   => $apache::params::root_group,
       mode    => $apache::file_mode,
+      seltype => 'httpd_config_t',
       require => [
         File[$_loadfile_name],
         Exec["mkdir ${enable_dir}"],
@@ -162,6 +164,7 @@ define apache::mod (
         owner   => 'root',
         group   => $apache::params::root_group,
         mode    => $apache::file_mode,
+        seltype => 'httpd_config_t',
         require => [
           File["${mod}.conf"],
           Exec["mkdir ${enable_dir}"],
@@ -179,6 +182,7 @@ define apache::mod (
       owner   => 'root',
       group   => $apache::params::root_group,
       mode    => $apache::file_mode,
+      seltype => 'httpd_config_t',
       require => [
         File[$_loadfile_name],
         Exec["mkdir ${enable_dir}"],
@@ -197,6 +201,7 @@ define apache::mod (
         owner   => 'root',
         group   => $apache::params::root_group,
         mode    => $apache::file_mode,
+        seltype => 'httpd_config_t',
         require => [
           File["${mod}.conf"],
           Exec["mkdir ${enable_dir}"],

--- a/manifests/mod/alias.pp
+++ b/manifests/mod/alias.pp
@@ -39,6 +39,7 @@ class apache::mod::alias (
       ensure  => file,
       path    => "${apache::mod_dir}/alias.conf",
       mode    => $apache::file_mode,
+      seltype => 'httpd_config_t',
       content => epp('apache/mod/alias.conf.epp', $parameters),
       require => Exec["mkdir ${apache::mod_dir}"],
       before  => File[$apache::mod_dir],

--- a/manifests/mod/autoindex.pp
+++ b/manifests/mod/autoindex.pp
@@ -26,6 +26,7 @@ class apache::mod::autoindex (
     ensure  => file,
     path    => "${apache::mod_dir}/autoindex.conf",
     mode    => $apache::file_mode,
+    seltype => 'httpd_config_t',
     content => epp('apache/mod/autoindex.conf.epp', { 'icons_prefix' => $icons_prefix, 'icon_suffix' => $icon_suffix, }),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],

--- a/manifests/mod/dir.pp
+++ b/manifests/mod/dir.pp
@@ -32,6 +32,7 @@ class apache::mod::dir (
     ensure  => file,
     path    => "${apache::mod_dir}/dir.conf",
     mode    => $apache::file_mode,
+    seltype => 'httpd_config_t',
     content => epp('apache/mod/dir.conf.epp', { 'indexes' => $indexes }),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],

--- a/manifests/mod/event.pp
+++ b/manifests/mod/event.pp
@@ -89,6 +89,7 @@ class apache::mod::event (
   file { "${apache::mod_dir}/event.conf":
     ensure  => file,
     mode    => $apache::file_mode,
+    seltype => 'httpd_config_t',
     content => epp('apache/mod/event.conf.epp', $parameters),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],

--- a/manifests/mod/fcgid.pp
+++ b/manifests/mod/fcgid.pp
@@ -57,6 +57,7 @@ class apache::mod::fcgid (
     ensure  => file,
     path    => "${apache::mod_dir}/${conf_name}",
     mode    => $apache::file_mode,
+    seltype => 'httpd_config_t',
     content => epp('apache/mod/fcgid.conf.epp', { 'options'  => $options, }),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],

--- a/manifests/mod/geoip.pp
+++ b/manifests/mod/geoip.pp
@@ -64,6 +64,7 @@ class apache::mod::geoip (
     ensure  => file,
     path    => "${apache::mod_dir}/geoip.conf",
     mode    => $apache::file_mode,
+    seltype => 'httpd_config_t',
     content => epp('apache/mod/geoip.conf.epp', $parameters),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],

--- a/manifests/mod/http2.pp
+++ b/manifests/mod/http2.pp
@@ -110,6 +110,7 @@ class apache::mod::http2 (
     ensure  => file,
     content => epp('apache/mod/http2.conf.epp', $parameters),
     mode    => $apache::file_mode,
+    seltype => 'httpd_config_t',
     path    => "${apache::mod_dir}/http2.conf",
     owner   => $apache::params::user,
     group   => $apache::params::group,

--- a/manifests/mod/info.pp
+++ b/manifests/mod/info.pp
@@ -44,6 +44,7 @@ class apache::mod::info (
     ensure  => file,
     path    => "${apache::mod_dir}/info.conf",
     mode    => $apache::file_mode,
+    seltype => 'httpd_config_t',
     content => epp('apache/mod/info.conf.epp', $parameters),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],

--- a/manifests/mod/ldap.pp
+++ b/manifests/mod/ldap.pp
@@ -78,6 +78,7 @@ class apache::mod::ldap (
     ensure  => file,
     path    => "${apache::mod_dir}/ldap.conf",
     mode    => $apache::file_mode,
+    seltype => 'httpd_config_t',
     content => epp('apache/mod/ldap.conf.epp', $parameters),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],

--- a/manifests/mod/mime.pp
+++ b/manifests/mod/mime.pp
@@ -30,6 +30,7 @@ class apache::mod::mime (
     ensure  => file,
     path    => "${apache::mod_dir}/mime.conf",
     mode    => $apache::file_mode,
+    seltype => 'httpd_config_t',
     content => epp('apache/mod/mime.conf.epp', $parameters),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],

--- a/manifests/mod/negotiation.pp
+++ b/manifests/mod/negotiation.pp
@@ -28,6 +28,7 @@ class apache::mod::negotiation (
   file { 'negotiation.conf':
     ensure  => file,
     mode    => $apache::file_mode,
+    seltype => 'httpd_config_t',
     path    => "${apache::mod_dir}/negotiation.conf",
     content => epp('apache/mod/negotiation.conf.epp', $parameters),
     require => Exec["mkdir ${apache::mod_dir}"],

--- a/manifests/mod/nss.pp
+++ b/manifests/mod/nss.pp
@@ -45,6 +45,7 @@ class apache::mod::nss (
     ensure  => file,
     path    => "${apache::mod_dir}/nss.conf",
     mode    => $apache::file_mode,
+    seltype => 'httpd_config_t',
     content => epp('apache/mod/nss.conf.epp', $parameters),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],

--- a/manifests/mod/pagespeed.pp
+++ b/manifests/mod/pagespeed.pp
@@ -237,6 +237,7 @@ class apache::mod::pagespeed (
     ensure  => file,
     path    => "${apache::mod_dir}/pagespeed.conf",
     mode    => $apache::file_mode,
+    seltype => 'httpd_config_t',
     content => epp('apache/mod/pagespeed.conf.epp', $parameters),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],

--- a/manifests/mod/passenger.pp
+++ b/manifests/mod/passenger.pp
@@ -811,6 +811,7 @@ class apache::mod::passenger (
   file { 'passenger.conf':
     ensure  => file,
     path    => "${apache::mod_dir}/${passenger_conf_file}",
+    seltype => 'httpd_config_t',
     content => epp('apache/mod/passenger.conf.epp', $parameters),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],

--- a/manifests/mod/peruser.pp
+++ b/manifests/mod/peruser.pp
@@ -88,6 +88,7 @@ class apache::mod::peruser (
       file { "${apache::mod_dir}/peruser.conf":
         ensure  => file,
         mode    => $apache::file_mode,
+        seltype => 'httpd_config_t',
         content => epp('apache/mod/peruser.conf.epp', $parameters),
         require => Exec["mkdir ${apache::mod_dir}"],
         before  => File[$apache::mod_dir],

--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -152,6 +152,7 @@ class apache::mod::php (
     owner   => 'root',
     group   => $root_group,
     mode    => $apache::file_mode,
+    seltype => 'httpd_config_t',
     content => $manage_content,
     source  => $source,
     require => [

--- a/manifests/mod/prefork.pp
+++ b/manifests/mod/prefork.pp
@@ -82,6 +82,7 @@ class apache::mod::prefork (
   file { "${apache::mod_dir}/prefork.conf":
     ensure  => file,
     content => epp('apache/mod/prefork.conf.epp', $parameters),
+    seltype => 'httpd_config_t',
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],
     notify  => Class['apache::service'],

--- a/manifests/mod/proxy.pp
+++ b/manifests/mod/proxy.pp
@@ -48,6 +48,7 @@ class apache::mod::proxy (
     ensure  => file,
     path    => "${apache::mod_dir}/proxy.conf",
     mode    => $apache::file_mode,
+    seltype => 'httpd_config_t',
     content => epp('apache/mod/proxy.conf.epp', $parameters),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],

--- a/manifests/mod/proxy_balancer.pp
+++ b/manifests/mod/proxy_balancer.pp
@@ -27,6 +27,7 @@ class apache::mod::proxy_balancer (
       ensure  => file,
       path    => "${apache::mod_dir}/proxy_balancer.conf",
       mode    => $apache::file_mode,
+      seltype => 'httpd_config_t',
       content => epp('apache/mod/proxy_balancer.conf.epp', { 'manager_path' => $manager_path, 'allow_from'  => $allow_from, }),
       require => Exec["mkdir ${apache::mod_dir}"],
       before  => File[$apache::mod_dir],

--- a/manifests/mod/proxy_html.pp
+++ b/manifests/mod/proxy_html.pp
@@ -50,6 +50,7 @@ class apache::mod::proxy_html {
     ensure  => file,
     path    => "${apache::mod_dir}/proxy_html.conf",
     mode    => $apache::file_mode,
+    seltype => 'httpd_config_t',
     content => epp('apache/mod/proxy_html.conf.epp'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],

--- a/manifests/mod/remoteip.pp
+++ b/manifests/mod/remoteip.pp
@@ -96,6 +96,7 @@ class apache::mod::remoteip (
     ensure  => file,
     path    => "${apache::mod_dir}/remoteip.conf",
     mode    => $apache::file_mode,
+    seltype => 'httpd_config_t',
     content => epp('apache/mod/remoteip.conf.epp', $template_parameters),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],

--- a/manifests/mod/reqtimeout.pp
+++ b/manifests/mod/reqtimeout.pp
@@ -16,6 +16,7 @@ class apache::mod::reqtimeout (
     ensure  => file,
     path    => "${apache::mod_dir}/reqtimeout.conf",
     mode    => $apache::file_mode,
+    seltype => 'httpd_config_t',
     content => epp('apache/mod/reqtimeout.conf.epp', { 'timeouts'  => $timeouts, }),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],

--- a/manifests/mod/rpaf.pp
+++ b/manifests/mod/rpaf.pp
@@ -38,6 +38,7 @@ class apache::mod::rpaf (
     ensure  => file,
     path    => "${apache::mod_dir}/rpaf.conf",
     mode    => $apache::file_mode,
+    seltype => 'httpd_config_t',
     content => epp($template, $parameters),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],

--- a/manifests/mod/setenvif.pp
+++ b/manifests/mod/setenvif.pp
@@ -11,6 +11,7 @@ class apache::mod::setenvif {
     ensure  => file,
     path    => "${apache::mod_dir}/setenvif.conf",
     mode    => $apache::file_mode,
+    seltype => 'httpd_config_t',
     content => epp('apache/mod/setenvif.conf.epp'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],

--- a/manifests/mod/ssl.pp
+++ b/manifests/mod/ssl.pp
@@ -213,6 +213,7 @@ class apache::mod::ssl (
     ensure  => file,
     path    => $apache::_ssl_file,
     mode    => $apache::file_mode,
+    seltype => 'httpd_config_t',
     content => epp('apache/mod/ssl.conf.epp', $parameters),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],

--- a/manifests/mod/status.pp
+++ b/manifests/mod/status.pp
@@ -44,6 +44,7 @@ class apache::mod::status (
     ensure  => file,
     path    => "${apache::mod_dir}/status.conf",
     mode    => $apache::file_mode,
+    seltype => 'httpd_config_t',
     content => template('apache/mod/status.conf.erb'),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],

--- a/manifests/mod/userdir.pp
+++ b/manifests/mod/userdir.pp
@@ -51,6 +51,7 @@ class apache::mod::userdir (
     ensure  => file,
     path    => "${apache::mod_dir}/userdir.conf",
     mode    => $apache::file_mode,
+    seltype => 'httpd_config_t',
     content => epp('apache/mod/userdir.conf.epp', $parameters),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],

--- a/manifests/mod/watchdog.pp
+++ b/manifests/mod/watchdog.pp
@@ -22,6 +22,7 @@ class apache::mod::watchdog (
       ensure  => file,
       path    => "${apache::mod_dir}/watchdog.conf",
       mode    => $apache::file_mode,
+      seltype => 'httpd_config_t',
       content => "WatchdogInterval ${watchdog_interval}\n",
       require => Exec["mkdir ${apache::mod_dir}"],
       before  => File[$apache::mod_dir],

--- a/manifests/mod/worker.pp
+++ b/manifests/mod/worker.pp
@@ -93,6 +93,7 @@ class apache::mod::worker (
   file { "${apache::mod_dir}/worker.conf":
     ensure  => file,
     content => epp('apache/mod/worker.conf.epp', $parameters),
+    seltype => 'httpd_config_t',
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],
     notify  => Class['apache::service'],

--- a/manifests/mod/wsgi.pp
+++ b/manifests/mod/wsgi.pp
@@ -75,6 +75,7 @@ class apache::mod::wsgi (
     ensure  => file,
     path    => "${apache::mod_dir}/wsgi.conf",
     mode    => $apache::file_mode,
+    seltype => 'httpd_config_t',
     content => epp('apache/mod/wsgi.conf.epp', $parameters),
     require => Exec["mkdir ${apache::mod_dir}"],
     before  => File[$apache::mod_dir],

--- a/manifests/mpm.pp
+++ b/manifests/mpm.pp
@@ -20,6 +20,7 @@ define apache::mpm (
     file { "${mod_dir}/${mpm}.load":
       ensure  => file,
       path    => "${mod_dir}/${mpm}.load",
+      seltype => 'httpd_config_t',
       content => '',
       require => [
         Package['httpd'],
@@ -32,6 +33,7 @@ define apache::mpm (
     file { "${mod_dir}/${mpm}.load":
       ensure  => file,
       path    => "${mod_dir}/${mpm}.load",
+      seltype => 'httpd_config_t',
       content => "LoadModule ${_id} ${_path}\n",
       require => [
         Package['httpd'],


### PR DESCRIPTION

Add `seltype => 'httpd_config_t'` to all file resources that create Apache httpd configuration files. This ensures files are created with the correct SELinux context on RHEL-based systems.

Without this fix, files inherit `etc_t` context from parent directory instead of `httpd_config_t`, causing SELinux policy violations.
