### PR TITLE
(MODULES-11739) Add RHEL 10 support

### DIFF
--- a/manifests/mod/itk.pp
+++ b/manifests/mod/itk.pp
@@ -25,7 +25,7 @@
 #   capabilities, such as NFS.
 #
 # @see http://mpm-itk.sesse.net for additional documentation.
-# @note Unsupported platforms: CentOS: 8; RedHat: 8, 9; SLES: all
+# @note Unsupported platforms: CentOS: 8; RedHat: 8, 9, 10; SLES: all
 class apache::mod::itk (
   Integer $startservers                                  = 8,
   Integer $minspareservers                               = 5,

--- a/manifests/mod/php.pp
+++ b/manifests/mod/php.pp
@@ -25,7 +25,7 @@
 #
 # @param libphp_prefix
 #
-# @note Unsupported platforms: RedHat: 9
+# @note Unsupported platforms: RedHat: 9, 10
 class apache::mod::php (
   Optional[String] $package_name = undef,
   String $package_ensure         = 'present',

--- a/manifests/mod/security.pp
+++ b/manifests/mod/security.pp
@@ -137,6 +137,7 @@
 # @see https://github.com/SpiderLabs/ModSecurity/wiki for additional documentation.
 # @see https://coreruleset.org/docs/ for addional documentation
 #
+# @note Unsupported platforms: RedHat: 10
 class apache::mod::security (
   Stdlib::Absolutepath $logroot                                = $apache::params::logroot,
   Integer $version                                             = $apache::params::modsec_version,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -187,6 +187,7 @@ class apache::params inherits apache::version {
     $passenger_ruby       = undef
     $passenger_default_ruby = undef
     $php_version = $facts['os']['release']['major'] ? {
+      '10'    => undef, # RedHat 10 doesn't ship mod_php
       '9'     => undef, # RedHat 9 doesn't ship mod_php
       '8'     => '7', # RedHat8
       default => '5', # RedHat5, RedHat6, RedHat7

--- a/metadata.json
+++ b/metadata.json
@@ -23,7 +23,8 @@
       "operatingsystemrelease": [
         "7",
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -31,8 +31,13 @@ RSpec.configure do |c|
   # IPv6 is not enabled by default in the new travis-ci Trusty environment (see https://github.com/travis-ci/travis-ci/issues/8891 )
   c.filter_run_excluding ipv6: true if ENV['CI'] == 'true'
   c.before :suite do
-    # Pin to epel 5.x which is known to work - newer versions have file() function issues
-    LitmusHelper.instance.run_shell('puppet module install puppet/epel --version 5.0.0') if %r{redhat|oracle}.match?(os[:family])
+    if %r{redhat|oracle}.match?(os[:family])
+      # Pin to epel 5.x which is known to work - newer versions have file() function issues.
+      # RHEL 10 requires epel 6.x because the EPEL-10 GPG key (RPM-GPG-KEY-EPEL-10)
+      # is not shipped in 5.x. See https://github.com/voxpupuli/puppet-epel/pull/173.
+      epel_version = os[:release].to_i >= 10 ? '6.0.0' : '5.0.0'
+      LitmusHelper.instance.run_shell("puppet module install puppet/epel --version #{epel_version}")
+    end
 
     LitmusHelper.instance.apply_manifest(File.read(File.join(__dir__, 'setup_acceptance_node.pp')))
   end

--- a/spec/spec_helper_acceptance_local.rb
+++ b/spec/spec_helper_acceptance_local.rb
@@ -35,7 +35,7 @@ RSpec.configure do |c|
       # Pin to epel 5.x which is known to work - newer versions have file() function issues.
       # RHEL 10 requires epel 6.x because the EPEL-10 GPG key (RPM-GPG-KEY-EPEL-10)
       # is not shipped in 5.x. See https://github.com/voxpupuli/puppet-epel/pull/173.
-      epel_version = os[:release].to_i >= 10 ? '6.0.0' : '5.0.0'
+      epel_version = (os[:release].to_i >= 10) ? '6.0.0' : '5.0.0'
       LitmusHelper.instance.run_shell("puppet module install puppet/epel --version #{epel_version}")
     end
 


### PR DESCRIPTION
## Summary
- Adds `RedHat` `10` to `operatingsystem_support` in `metadata.json` so puppetlabs-apache declares RHEL 10 support.
- Uses `epel` 6.x on RHEL 10 acceptance nodes (`spec/spec_helper_acceptance_local.rb`) since earlier EPEL releases do not ship for RHEL 10.
- Marks `apache::mod::itk`, `apache::mod::php`, and `apache::mod::security` as unsupported on RHEL 10 — the underlying packages are not shipped by RHEL 10 base repos.

Notes on dependencies (now satisfied upstream, no Gemfile/metadata change needed in this PR):
- `puppetlabs/concat` widening to `< 11.0.0` landed on `main` via #2630; this branch was rebased on top of it.
- `puppet_litmus` RHEL 10 support landed via puppetlabs/puppet_litmus#621 and is available in the released gem, so the temporary git pin previously included in this PR has been dropped.

Jira: [MODULES-11739](https://perforce.atlassian.net/browse/MODULES-11739)

## Test plan
- [x] CI `Spec` job passes.
- [x] CI `Acceptance` job generates a matrix that includes `RedHat-10` (and `RedHat-10-arm`) and provisions the node via puppet_litmus's provision_service.
- [ ] Acceptance modules that depend on packages no longer shipped by RHEL 10 base repos (notably `mod_security` / `mod_security_crs` and `mod_php`) are expected to fail on RHEL 10 and will be addressed in follow-up tickets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)