### PR TITLE
(MODULES-11841) Remove mod_log_forensic from apache::default_mods (#2573)

### DIFF
--- a/manifests/default_mods.pp
+++ b/manifests/default_mods.pp
@@ -119,7 +119,6 @@ class apache::default_mods (
     include apache::mod::negotiation
     include apache::mod::setenvif
     include apache::mod::auth_basic
-    include apache::mod::log_forensic
 
     # filter is needed by mod_deflate
     include apache::mod::filter


### PR DESCRIPTION
This PR is created to execute tests for the original PR (https://github.com/puppetlabs/puppetlabs-apache/pull/2601)