### PR TITLE
(MODULES-11857) Scaffold OWASP CRS v4 support on EL10 via crs_source enum

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,7 @@
 ---
 fixtures:
   repositories:
-    archive: "https://github.com/puppetlabs/puppetlabs-archive.git"
+    archive: "https://github.com/voxpupuli/puppet-archive.git"
     concat: "https://github.com/puppetlabs/puppetlabs-concat.git"
     facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
     portage: "https://github.com/gentoo/puppet-portage.git"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,7 @@
 ---
 fixtures:
   repositories:
+    archive: "https://github.com/puppetlabs/puppetlabs-archive.git"
     concat: "https://github.com/puppetlabs/puppetlabs-concat.git"
     facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
     portage: "https://github.com/gentoo/puppet-portage.git"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 [Installing arbitrary modules]: #installing-arbitrary-modules
 [Installing specific modules]: #installing-specific-modules
 [Load balancing examples]: #load-balancing-examples
+[Configuring mod_security and the OWASP Core Rule Set]: #configuring-mod_security-and-the-owasp-core-rule-set
 [apache affects]: #what-the-apache-module-affects
 
 [Reference]: #reference
@@ -183,6 +184,7 @@
 [`mod_python`]: http://modpython.org/
 [`mod_rewrite`]: https://httpd.apache.org/docs/current/mod/mod_rewrite.html
 [`mod_security`]: https://www.modsecurity.org/
+[`puppet/archive`]: https://forge.puppet.com/modules/puppet/archive
 [`mod_ssl`]: https://httpd.apache.org/docs/current/mod/mod_ssl.html
 [`mod_status`]: https://httpd.apache.org/docs/current/mod/mod_status.html
 [`mod_version`]: https://httpd.apache.org/docs/current/mod/mod_version.html
@@ -274,6 +276,7 @@
 3. [Usage - The classes and defined types available for configuration][Usage]
     - [Configuring virtual hosts - Examples to help get started][Configuring virtual hosts]
     - [Load balancing with exported and non-exported resources][Load balancing examples]
+    - [Configuring mod_security and the OWASP Core Rule Set][Configuring mod_security and the OWASP Core Rule Set]
 4. [Reference - An under-the-hood peek at what the module is doing and how][Reference]
 5. [Limitations - OS compatibility, etc.][Limitations]
 6. [License][License]
@@ -740,6 +743,62 @@ apache::balancer { 'puppet01':
 ```
 
 Load balancing scheduler algorithms (`lbmethod`) are listed [in mod_proxy_balancer documentation](https://httpd.apache.org/docs/current/mod/mod_proxy_balancer.html).
+
+<a id="configuring-mod_security-and-the-owasp-core-rule-set"></a>
+### Configuring mod_security and the OWASP Core Rule Set
+
+The [`apache::mod::security`][] class configures [`mod_security`][] and, optionally, the OWASP Core Rule Set (CRS) rules that run on top of it. How CRS is obtained is controlled by the `crs_source` parameter:
+
+| `crs_source` | Behavior | Typical use |
+| --- | --- | --- |
+| `package` | Installs `crs_package` (CRS v2/v3) and activates rules via per-rule symlinks. Default on RHEL/CentOS 7, 8, and 9. | Distros where an EPEL/OS `mod_security_crs` package still exists. |
+| `archive` | Downloads a CRS v4 tarball with [`puppet/archive`][] from `crs_archive_source` and wires up the v4 `crs-setup.conf` + `rules/*.conf` includes. | RHEL/CentOS 10 and other platforms with no CRS package, when you can fetch the tarball from the internet or an internal mirror. |
+| `path` | Wires up an already-extracted CRS v4 directory at `crs_path`; nothing is downloaded. | Air-gapped hosts with no reachable download source, where CRS is pre-staged by other means. |
+| `none` | Manages the `mod_security`/`mod_security2` engine only; no CRS rules are installed or activated. Default on RHEL/CentOS 10. | You want the engine without CRS, or you're not yet ready to opt in to CRS on EL10. |
+
+> As of RHEL/CentOS 10, there is no `mod_security_crs` package available (from EPEL or otherwise), so `crs_source` defaults to `none` there. CRS is opt-in via `archive` or `path`. RHEL/CentOS 7/8/9 are unaffected and keep the `package` default.
+
+#### `package` (RHEL/CentOS 7, 8, 9 — default, unchanged)
+
+```puppet
+class { 'apache::mod::security': }
+```
+
+#### `archive` (download a CRS v4 tarball, e.g. from an internal mirror)
+
+`crs_archive_source` and `crs_version` are required. There is no module-shipped default URL or version — you pin both yourself, so upgrading CRS is always an explicit, deliberate action:
+
+```puppet
+class { 'apache::mod::security':
+  crs_source           => 'archive',
+  crs_archive_source   => 'https://mirror.example.com/coreruleset-4.27.0-minimal.tar.gz',
+  crs_version          => '4.27.0',
+  crs_archive_checksum => '<sha256 checksum of the tarball>',
+}
+```
+
+`crs_archive_source` accepts any source [`puppet/archive`][] supports (an `https://` URL, an internal Artifactory/Nexus mirror, or even a local `file://` path), which lets restricted environments point at an internal proxy instead of the public internet. `crs_archive_checksum` is optional — omit it only when the source is already trusted (for example, a controlled internal mirror).
+
+The tarball is expected to unpack to a versioned `coreruleset-<crs_version>/` directory containing `crs-setup.conf.example` and `rules/*.conf`, matching the layout of the [upstream CRS releases](https://github.com/coreruleset/coreruleset/releases). By default it's extracted under `/usr/share`; override the extraction base with `crs_path`.
+
+#### `path` (pre-staged directory, no download — for air-gapped hosts)
+
+```puppet
+class { 'apache::mod::security':
+  crs_source => 'path',
+  crs_path   => '/opt/crs',
+}
+```
+
+`crs_path` must point at a directory that already contains `crs-setup.conf` and `rules/*.conf` (for example, staged there by a separate content-delivery process). The module only wires up the `IncludeOptional` directives — it does not fetch or validate the rule content.
+
+#### `none` (engine only, no CRS — default on RHEL/CentOS 10)
+
+```puppet
+class { 'apache::mod::security':
+  crs_source => 'none',
+}
+```
 
 <a id="reference"></a>
 ## Reference

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6173,8 +6173,11 @@ Installs and configures `mod_security`.
 
 * **Note** On RHEL/EL 10 the ModSecurity engine is provided by EPEL (enable EPEL
 yourself; this module does not manage it). The OWASP CRS package
-(`mod_security_crs`) is not available on EL10, so the class manages the
-engine only there and does not install or activate CRS rules.
+(`mod_security_crs`) is not available on EL10, so `crs_source` defaults to
+`none` (engine only). CRS v4 can be opted into there via `crs_source =>
+'archive'` (downloaded from `crs_archive_source`, e.g. an internal mirror)
+or `crs_source => 'path'` (a pre-staged directory). EL7/8/9 keep the
+package-based default unchanged.
 
 * **See also**
   * https://github.com/SpiderLabs/ModSecurity/wiki
@@ -6189,6 +6192,12 @@ The following parameters are available in the `apache::mod::security` class:
 * [`version`](#-apache--mod--security--version)
 * [`logroot`](#-apache--mod--security--logroot)
 * [`crs_package`](#-apache--mod--security--crs_package)
+* [`crs_source`](#-apache--mod--security--crs_source)
+* [`crs_archive_source`](#-apache--mod--security--crs_archive_source)
+* [`crs_archive_checksum`](#-apache--mod--security--crs_archive_checksum)
+* [`crs_archive_checksum_type`](#-apache--mod--security--crs_archive_checksum_type)
+* [`crs_version`](#-apache--mod--security--crs_version)
+* [`crs_path`](#-apache--mod--security--crs_path)
 * [`activated_rules`](#-apache--mod--security--activated_rules)
 * [`custom_rules`](#-apache--mod--security--custom_rules)
 * [`custom_rules_set`](#-apache--mod--security--custom_rules_set)
@@ -6249,9 +6258,65 @@ Default value: `$apache::params::logroot`
 
 Data type: `Optional[String]`
 
-Name of package that installs CRS rules.
+Name of package that installs CRS rules. Only used when `crs_source` is `package`.
 
 Default value: `$apache::params::modsec_crs_package`
+
+##### <a name="-apache--mod--security--crs_source"></a>`crs_source`
+
+Data type: `Enum['package', 'archive', 'path', 'none']`
+
+How the OWASP Core Rule Set is obtained:
+* `package` - install `crs_package` and activate rules via per-rule symlinks (v2/v3 layout). Default on EL7/8/9.
+* `archive` - download the CRS v4 tarball via `puppet/archive` from `crs_archive_source` (e.g. an internal mirror) and wire the v4 includes.
+* `path`    - use a pre-staged CRS v4 directory given by `crs_path` (no download); only wires the v4 includes.
+* `none`    - engine only, no CRS managed. Default on EL10.
+
+Default value: `$apache::params::modsec_crs_source`
+
+##### <a name="-apache--mod--security--crs_archive_source"></a>`crs_archive_source`
+
+Data type: `Optional[String[1]]`
+
+Source URL or path for the CRS v4 tarball when `crs_source` is `archive`. No module default
+(user-pinned, e.g. an internal mirror) to avoid a version/CVE maintenance treadmill. Required for `archive`.
+
+Default value: `$apache::params::modsec_crs_archive_source`
+
+##### <a name="-apache--mod--security--crs_archive_checksum"></a>`crs_archive_checksum`
+
+Data type: `Optional[String[1]]`
+
+Checksum of the CRS v4 tarball for verification when `crs_source` is `archive`.
+
+Default value: `$apache::params::modsec_crs_archive_checksum`
+
+##### <a name="-apache--mod--security--crs_archive_checksum_type"></a>`crs_archive_checksum_type`
+
+Data type: `String[1]`
+
+Checksum algorithm for `crs_archive_checksum` (e.g. `sha256`).
+
+Default value: `$apache::params::modsec_crs_archive_checksum_type`
+
+##### <a name="-apache--mod--security--crs_version"></a>`crs_version`
+
+Data type: `Optional[String[1]]`
+
+The pinned CRS version (e.g. `4.27.0`), required for `crs_source => archive`. It fixes the
+extracted `coreruleset-<version>` directory name so the include paths are deterministic.
+
+Default value: `undef`
+
+##### <a name="-apache--mod--security--crs_path"></a>`crs_path`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+For `crs_source => path`: absolute path to the pre-staged CRS v4 directory (contains
+`crs-setup.conf` and `rules/`). For `crs_source => archive`: overrides the extraction base
+directory (default `/usr/share`); the ruleset then lives at `<crs_path>/coreruleset-<crs_version>`.
+
+Default value: `undef`
 
 ##### <a name="-apache--mod--security--activated_rules"></a>`activated_rules`
 

--- a/manifests/mod/security.pp
+++ b/manifests/mod/security.pp
@@ -8,8 +8,29 @@
 #   Configures the location of audit and debug logs.
 # 
 # @param crs_package
-#   Name of package that installs CRS rules.
-# 
+#   Name of package that installs CRS rules. Only used when `crs_source` is `package`.
+#
+# @param crs_source
+#   How the OWASP Core Rule Set is obtained:
+#   * `package` - install `crs_package` and activate rules via per-rule symlinks (v2/v3 layout). Default on EL7/8/9.
+#   * `archive` - download the CRS v4 tarball via `puppet/archive` from `crs_archive_source` (e.g. an internal mirror) and wire the v4 includes.
+#   * `path`    - use a pre-staged CRS v4 directory given by `crs_path` (no download); only wires the v4 includes.
+#   * `none`    - engine only, no CRS managed. Default on EL10.
+#
+# @param crs_archive_source
+#   Source URL or path for the CRS v4 tarball when `crs_source` is `archive`. No module default
+#   (user-pinned, e.g. an internal mirror) to avoid a version/CVE maintenance treadmill. Required for `archive`.
+#
+# @param crs_archive_checksum
+#   Checksum of the CRS v4 tarball for verification when `crs_source` is `archive`.
+#
+# @param crs_archive_checksum_type
+#   Checksum algorithm for `crs_archive_checksum` (e.g. `sha256`).
+#
+# @param crs_path
+#   Absolute path to the CRS v4 directory. Required for `crs_source => path` (pre-staged files);
+#   for `crs_source => archive` it overrides the extraction directory (default `${modsec_dir}/coreruleset`).
+#
 # @param activated_rules
 #   An array of rules from the modsec_crs_path or absolute to activate via symlinks.
 #
@@ -139,12 +160,20 @@
 #
 # @note On RHEL/EL 10 the ModSecurity engine is provided by EPEL (enable EPEL
 #   yourself; this module does not manage it). The OWASP CRS package
-#   (`mod_security_crs`) is not available on EL10, so the class manages the
-#   engine only there and does not install or activate CRS rules.
+#   (`mod_security_crs`) is not available on EL10, so `crs_source` defaults to
+#   `none` (engine only). CRS v4 can be opted into there via `crs_source =>
+#   'archive'` (downloaded from `crs_archive_source`, e.g. an internal mirror)
+#   or `crs_source => 'path'` (a pre-staged directory). EL7/8/9 keep the
+#   package-based default unchanged.
 class apache::mod::security (
   Stdlib::Absolutepath $logroot                                = $apache::params::logroot,
   Integer $version                                             = $apache::params::modsec_version,
   Optional[String] $crs_package                                = $apache::params::modsec_crs_package,
+  Enum['package', 'archive', 'path', 'none'] $crs_source       = $apache::params::modsec_crs_source,
+  Optional[String[1]] $crs_archive_source                      = $apache::params::modsec_crs_archive_source,
+  Optional[String[1]] $crs_archive_checksum                    = $apache::params::modsec_crs_archive_checksum,
+  String[1] $crs_archive_checksum_type                         = $apache::params::modsec_crs_archive_checksum_type,
+  Optional[Stdlib::Absolutepath] $crs_path                     = undef,
   Array[String] $activated_rules                               = $apache::params::modsec_default_rules,
   Boolean $custom_rules                                        = $apache::params::modsec_custom_rules,
   Optional[Array[String]] $custom_rules_set                    = $apache::params::modsec_custom_rules_set,
@@ -227,14 +256,63 @@ class apache::mod::security (
     lib => 'mod_unique_id.so',
   }
 
-  if $crs_package {
-    package { $crs_package:
-      ensure => 'installed',
-      before => [
-        File[$apache::confd_dir],
-        File[$modsec_dir],
-      ],
+  # Effective on-disk CRS v4 directory (used by archive/path modes). Kept
+  # outside $modsec_dir, which is managed with purge => true and would
+  # otherwise remove the extracted rule tree.
+  $_crs_dir = $crs_path ? {
+    undef   => '/usr/share/coreruleset',
+    default => $crs_path,
+  }
+
+  # CRS acquisition. The activation wiring is selected later by the same
+  # $crs_source: `package` keeps the legacy per-rule symlinks (v2/v3 layout),
+  # while `archive`/`path` use the v4 include layout.
+  case $crs_source {
+    'package': {
+      if $crs_package {
+        package { $crs_package:
+          ensure => 'installed',
+          before => [
+            File[$apache::confd_dir],
+            File[$modsec_dir],
+          ],
+        }
+      }
     }
+    'archive': {
+      if ! $crs_archive_source {
+        fail('apache::mod::security: crs_source => "archive" requires crs_archive_source (URL/path to the CRS v4 tarball, e.g. an internal mirror).')
+      }
+      # TODO: CRS tarballs extract to a versioned top-level dir
+      # (coreruleset-x.y.z/). Confirm whether to point $crs_path at that
+      # subdir or normalise the layout after extraction.
+      file { $_crs_dir:
+        ensure => directory,
+        owner  => 'root',
+        group  => 'root',
+        mode   => '0755',
+      }
+
+      archive { 'coreruleset.tar.gz':
+        ensure        => present,
+        path          => '/var/cache/coreruleset.tar.gz',
+        source        => $crs_archive_source,
+        checksum      => $crs_archive_checksum,
+        checksum_type => $crs_archive_checksum_type,
+        extract       => true,
+        extract_path  => $_crs_dir,
+        creates       => "${_crs_dir}/crs-setup.conf",
+        cleanup       => true,
+        require       => File[$_crs_dir],
+      }
+    }
+    'path': {
+      if ! $crs_path {
+        fail('apache::mod::security: crs_source => "path" requires crs_path (absolute path to a pre-staged CRS v4 directory).')
+      }
+    }
+    'none': {}
+    default: {}
   }
 
   # Template uses:
@@ -329,7 +407,9 @@ class apache::mod::security (
     }
   }
 
-  if $manage_security_crs {
+  if $manage_security_crs and $crs_source == 'package' {
+    # Legacy CRS v2/v3 layout: a tuning conf plus per-rule symlinks under
+    # activated_rules/. Unchanged behaviour for EL7/8/9 package installs.
     # Template uses:
     # - $_secdefaultaction
     # - $critical_anomaly_score
@@ -379,6 +459,18 @@ class apache::mod::security (
 
     unless $facts['os']['name'] == 'SLES' or $facts['os']['name'] == 'Debian' or $facts['os']['name'] == 'Ubuntu' {
       apache::security::rule_link { $activated_rules: }
+    }
+  }
+
+  if $manage_security_crs and $crs_source in ['archive', 'path'] {
+    # CRS v4 layout: load crs-setup.conf then rules/*.conf from the CRS
+    # directory. Dropped into $modsec_dir so the existing
+    # `IncludeOptional ${modsec_dir}/*.conf` in security.conf picks it up.
+    file { "${modsec_dir}/security_crs_v4.conf":
+      ensure  => file,
+      content => epp('apache/mod/security_crs_v4.conf.epp', { 'crs_dir' => $_crs_dir }),
+      require => File[$modsec_dir],
+      notify  => Class['apache::service'],
     }
   }
 }

--- a/manifests/mod/security.pp
+++ b/manifests/mod/security.pp
@@ -27,9 +27,14 @@
 # @param crs_archive_checksum_type
 #   Checksum algorithm for `crs_archive_checksum` (e.g. `sha256`).
 #
+# @param crs_version
+#   The pinned CRS version (e.g. `4.27.0`), required for `crs_source => archive`. It fixes the
+#   extracted `coreruleset-<version>` directory name so the include paths are deterministic.
+#
 # @param crs_path
-#   Absolute path to the CRS v4 directory. Required for `crs_source => path` (pre-staged files);
-#   for `crs_source => archive` it overrides the extraction directory (default `${modsec_dir}/coreruleset`).
+#   For `crs_source => path`: absolute path to the pre-staged CRS v4 directory (contains
+#   `crs-setup.conf` and `rules/`). For `crs_source => archive`: overrides the extraction base
+#   directory (default `/usr/share`); the ruleset then lives at `<crs_path>/coreruleset-<crs_version>`.
 #
 # @param activated_rules
 #   An array of rules from the modsec_crs_path or absolute to activate via symlinks.
@@ -173,6 +178,7 @@ class apache::mod::security (
   Optional[String[1]] $crs_archive_source                      = $apache::params::modsec_crs_archive_source,
   Optional[String[1]] $crs_archive_checksum                    = $apache::params::modsec_crs_archive_checksum,
   String[1] $crs_archive_checksum_type                         = $apache::params::modsec_crs_archive_checksum_type,
+  Optional[String[1]] $crs_version                             = undef,
   Optional[Stdlib::Absolutepath] $crs_path                     = undef,
   Array[String] $activated_rules                               = $apache::params::modsec_default_rules,
   Boolean $custom_rules                                        = $apache::params::modsec_custom_rules,
@@ -256,12 +262,19 @@ class apache::mod::security (
     lib => 'mod_unique_id.so',
   }
 
-  # Effective on-disk CRS v4 directory (used by archive/path modes). Kept
-  # outside $modsec_dir, which is managed with purge => true and would
-  # otherwise remove the extracted rule tree.
-  $_crs_dir = $crs_path ? {
-    undef   => '/usr/share/coreruleset',
+  # Effective on-disk CRS v4 directory used in the include wiring. Kept outside
+  # $modsec_dir, which is managed with purge => true and would otherwise remove
+  # the extracted rule tree.
+  # - path:    $crs_path is the ready CRS directory (contains crs-setup.conf + rules/).
+  # - archive: CRS tarballs unpack to a versioned dir, so the ruleset lives at
+  #            <base>/coreruleset-<crs_version> under the extraction base.
+  $_crs_extract_base = $crs_path ? {
+    undef   => '/usr/share',
     default => $crs_path,
+  }
+  $_crs_dir = $crs_source ? {
+    'archive' => "${_crs_extract_base}/coreruleset-${crs_version}",
+    default   => $crs_path,
   }
 
   # CRS acquisition. The activation wiring is selected later by the same
@@ -283,16 +296,16 @@ class apache::mod::security (
       if ! $crs_archive_source {
         fail('apache::mod::security: crs_source => "archive" requires crs_archive_source (URL/path to the CRS v4 tarball, e.g. an internal mirror).')
       }
-      # TODO: CRS tarballs extract to a versioned top-level dir
-      # (coreruleset-x.y.z/). Confirm whether to point $crs_path at that
-      # subdir or normalise the layout after extraction.
-      file { $_crs_dir:
-        ensure => directory,
-        owner  => 'root',
-        group  => 'root',
-        mode   => '0755',
+      if ! $crs_version {
+        fail('apache::mod::security: crs_source => "archive" requires crs_version (the pinned CRS version, e.g. "4.27.0"); it fixes the extracted coreruleset-<version> directory name.')
       }
 
+      file { $_crs_extract_base:
+        ensure => directory,
+      }
+
+      # Both the release "-minimal" asset and the source archive unpack to a
+      # versioned top-level dir, coreruleset-<crs_version>/.
       archive { 'coreruleset.tar.gz':
         ensure        => present,
         path          => '/var/cache/coreruleset.tar.gz',
@@ -300,10 +313,19 @@ class apache::mod::security (
         checksum      => $crs_archive_checksum,
         checksum_type => $crs_archive_checksum_type,
         extract       => true,
-        extract_path  => $_crs_dir,
-        creates       => "${_crs_dir}/crs-setup.conf",
+        extract_path  => $_crs_extract_base,
+        creates       => "${_crs_dir}/crs-setup.conf.example",
         cleanup       => true,
-        require       => File[$_crs_dir],
+        require       => File[$_crs_extract_base],
+      }
+
+      # CRS ships crs-setup.conf.example; create the active crs-setup.conf from
+      # it once. The creates guard prevents clobbering later user edits.
+      exec { 'apache-crs-setup-conf':
+        command => "/bin/cp ${_crs_dir}/crs-setup.conf.example ${_crs_dir}/crs-setup.conf",
+        creates => "${_crs_dir}/crs-setup.conf",
+        require => Archive['coreruleset.tar.gz'],
+        notify  => Class['apache::service'],
       }
     }
     'path': {

--- a/manifests/mod/security.pp
+++ b/manifests/mod/security.pp
@@ -325,7 +325,7 @@ class apache::mod::security (
       # CRS ships crs-setup.conf.example; create the active crs-setup.conf from
       # it once. The creates guard prevents clobbering later user edits.
       exec { 'apache-crs-setup-conf':
-        command => "/bin/cp ${_crs_dir}/crs-setup.conf.example ${_crs_dir}/crs-setup.conf",
+        command => ['/bin/cp', "${_crs_dir}/crs-setup.conf.example", "${_crs_dir}/crs-setup.conf"],
         creates => "${_crs_dir}/crs-setup.conf",
         require => Archive['coreruleset.tar.gz'],
         notify  => Class['apache::service'],

--- a/manifests/mod/security.pp
+++ b/manifests/mod/security.pp
@@ -305,18 +305,21 @@ class apache::mod::security (
       }
 
       # Both the release "-minimal" asset and the source archive unpack to a
-      # versioned top-level dir, coreruleset-<crs_version>/.
+      # versioned top-level dir, coreruleset-<crs_version>/. Checksum
+      # verification is only enabled when a checksum is supplied (a trusted
+      # internal mirror may legitimately be used without one).
       archive { 'coreruleset.tar.gz':
-        ensure        => present,
-        path          => '/var/cache/coreruleset.tar.gz',
-        source        => $crs_archive_source,
-        checksum      => $crs_archive_checksum,
-        checksum_type => $crs_archive_checksum_type,
-        extract       => true,
-        extract_path  => $_crs_extract_base,
-        creates       => "${_crs_dir}/crs-setup.conf.example",
-        cleanup       => true,
-        require       => File[$_crs_extract_base],
+        ensure          => present,
+        path            => '/var/cache/coreruleset.tar.gz',
+        source          => $crs_archive_source,
+        checksum        => $crs_archive_checksum,
+        checksum_type   => $crs_archive_checksum_type,
+        checksum_verify => $crs_archive_checksum =~ NotUndef,
+        extract         => true,
+        extract_path    => $_crs_extract_base,
+        creates         => "${_crs_dir}/crs-setup.conf.example",
+        cleanup         => true,
+        require         => File[$_crs_extract_base],
       }
 
       # CRS ships crs-setup.conf.example; create the active crs-setup.conf from

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -806,4 +806,19 @@ class apache::params inherits apache::version {
     $ssl_cipher = 'HIGH:MEDIUM:!aNULL:!MD5:!RC4:!3DES'
     $ssl_proxy_cipher_suite = undef
   }
+
+  # OWASP CRS acquisition mode (see apache::mod::security).
+  # EL10 has no mod_security_crs package, so default to engine-only there
+  # (CRS is opt-in via the archive/path modes). Every other platform keeps
+  # the existing package-based behaviour, so nothing changes for them.
+  if $facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'], '10') >= 0 {
+    $modsec_crs_source = 'none'
+  } else {
+    $modsec_crs_source = 'package'
+  }
+  # No module-shipped default version/URL: the archive source is user-pinned
+  # (e.g. an internal mirror) to keep us off the CRS version/CVE treadmill.
+  $modsec_crs_archive_source        = undef
+  $modsec_crs_archive_checksum      = undef
+  $modsec_crs_archive_checksum_type = 'sha256'
 }

--- a/metadata.json
+++ b/metadata.json
@@ -15,6 +15,10 @@
     {
       "name": "puppetlabs/concat",
       "version_requirement": ">= 2.2.1 < 11.0.0"
+    },
+    {
+      "name": "puppetlabs/archive",
+      "version_requirement": ">= 4.0.0 < 8.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 4.0.0 < 8.0.0"
+      "version_requirement": ">= 4.0.0 < 9.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,7 @@
       "version_requirement": ">= 2.2.1 < 11.0.0"
     },
     {
-      "name": "puppetlabs/archive",
+      "name": "puppet/archive",
       "version_requirement": ">= 4.0.0 < 8.0.0"
     }
   ],

--- a/spec/acceptance/mod_security_crs_v4_spec.rb
+++ b/spec/acceptance/mod_security_crs_v4_spec.rb
@@ -10,7 +10,7 @@ require 'spec_helper_acceptance'
 describe 'apache::mod::security CRS v4', if: (os[:family].include?('redhat') && os[:release].to_i >= 10) do
   before(:all) do
     # The module does not manage the ModSecurity engine on EL10; provide it from EPEL.
-    run_shell('dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm || true')
+    run_shell('rpm -q epel-release || dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm')
     run_shell('dnf install -y mod_security')
 
     # Minimal but valid CRS v4 layout for crs_source => path.

--- a/spec/acceptance/mod_security_crs_v4_spec.rb
+++ b/spec/acceptance/mod_security_crs_v4_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+# CRS v4 support (MODULES-11857). On modern Enterprise Linux (EL10) there is no
+# mod_security_crs package, so CRS is deployed via crs_source => path (pre-staged
+# directory) or archive (fetched from a configurable, e.g. internal-mirror, URL).
+# A minimal self-contained CRS fixture is built on the target so the test needs
+# no internet access for the rule content.
+describe 'apache::mod::security CRS v4', if: (os[:family].include?('redhat') && os[:release].to_i >= 10) do
+  before(:all) do
+    # The module does not manage the ModSecurity engine on EL10; provide it from EPEL.
+    run_shell('dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm || true')
+    run_shell('dnf install -y mod_security')
+
+    # Minimal but valid CRS v4 layout for crs_source => path.
+    run_shell('mkdir -p /opt/crs/rules')
+    run_shell(%q(printf 'SecDefaultAction "phase:1,pass,log"\n' > /opt/crs/crs-setup.conf))
+    run_shell(%q(printf 'SecRule ARGS "@rx evilpattern" "id:9001,phase:2,deny,status:403,log"\n' > /opt/crs/rules/REQUEST-901-TEST.conf))
+
+    # A tarball standing in for an internal mirror, unpacking to the versioned
+    # coreruleset-<version>/ dir with crs-setup.conf.example, as upstream ships.
+    run_shell('mkdir -p /tmp/crsbuild/coreruleset-9.9.9/rules /var/www/mirror')
+    run_shell('cp /opt/crs/crs-setup.conf /tmp/crsbuild/coreruleset-9.9.9/crs-setup.conf.example')
+    run_shell('cp /opt/crs/rules/REQUEST-901-TEST.conf /tmp/crsbuild/coreruleset-9.9.9/rules/')
+    run_shell('tar -C /tmp/crsbuild -czf /var/www/mirror/crs.tar.gz coreruleset-9.9.9')
+  end
+
+  context 'crs_source => path' do
+    pp = <<-MANIFEST
+      class { 'apache': }
+      class { 'apache::mod::security':
+        crs_source => 'path',
+        crs_path   => '/opt/crs',
+      }
+    MANIFEST
+
+    it 'applies idempotently' do
+      idempotent_apply(pp)
+    end
+
+    describe file('/etc/httpd/modsecurity.d/security_crs_v4.conf') do
+      it { is_expected.to be_file }
+      its(:content) { is_expected.to match(%r{IncludeOptional /opt/crs/crs-setup\.conf}) }
+      its(:content) { is_expected.to match(%r{IncludeOptional /opt/crs/rules/\*\.conf}) }
+    end
+
+    describe command('apachectl configtest') do
+      its(:exit_status) { is_expected.to eq 0 }
+    end
+  end
+
+  context 'crs_source => archive' do
+    pp = <<-MANIFEST
+      class { 'apache': }
+      class { 'apache::mod::security':
+        crs_source         => 'archive',
+        crs_archive_source => 'file:///var/www/mirror/crs.tar.gz',
+        crs_version        => '9.9.9',
+      }
+    MANIFEST
+
+    it 'applies idempotently' do
+      idempotent_apply(pp)
+    end
+
+    # Extracted to the versioned dir and crs-setup.conf created from the example.
+    describe file('/usr/share/coreruleset-9.9.9/crs-setup.conf') do
+      it { is_expected.to be_file }
+    end
+
+    describe file('/etc/httpd/modsecurity.d/security_crs_v4.conf') do
+      its(:content) { is_expected.to match(%r{IncludeOptional /usr/share/coreruleset-9\.9\.9/crs-setup\.conf}) }
+      its(:content) { is_expected.to match(%r{IncludeOptional /usr/share/coreruleset-9\.9\.9/rules/\*\.conf}) }
+    end
+
+    describe command('apachectl configtest') do
+      its(:exit_status) { is_expected.to eq 0 }
+    end
+  end
+end

--- a/spec/classes/mod/security_spec.rb
+++ b/spec/classes/mod/security_spec.rb
@@ -463,17 +463,26 @@ describe 'apache::mod::security', type: :class do
 
     context "crs_source => 'archive'" do
       context 'without crs_archive_source' do
-        let(:params) { { crs_source: 'archive' } }
+        let(:params) { { crs_source: 'archive', crs_version: '4.27.0' } }
 
         it { is_expected.to compile.and_raise_error(%r{crs_archive_source}) }
       end
 
-      context 'with crs_archive_source' do
+      context 'without crs_version' do
+        let(:params) do
+          { crs_source: 'archive', crs_archive_source: 'https://mirror.internal.example/crs.tar.gz' }
+        end
+
+        it { is_expected.to compile.and_raise_error(%r{crs_version}) }
+      end
+
+      context 'with crs_archive_source and crs_version' do
         let(:params) do
           {
             crs_source: 'archive',
-            crs_archive_source: 'https://mirror.internal.example/crs/coreruleset-4.10.0.tar.gz',
+            crs_archive_source: 'https://mirror.internal.example/crs/coreruleset-4.27.0-minimal.tar.gz',
             crs_archive_checksum: 'abc123',
+            crs_version: '4.27.0',
           }
         end
 
@@ -481,18 +490,21 @@ describe 'apache::mod::security', type: :class do
 
         it {
           expect(subject).to contain_archive('coreruleset.tar.gz').with(
-            source: 'https://mirror.internal.example/crs/coreruleset-4.10.0.tar.gz',
+            source: 'https://mirror.internal.example/crs/coreruleset-4.27.0-minimal.tar.gz',
             checksum: 'abc123',
             checksum_type: 'sha256',
             extract: true,
-            extract_path: '/usr/share/coreruleset',
+            extract_path: '/usr/share',
+            creates: '/usr/share/coreruleset-4.27.0/crs-setup.conf.example',
           )
         }
 
+        it { is_expected.to contain_exec('apache-crs-setup-conf').with_creates('/usr/share/coreruleset-4.27.0/crs-setup.conf') }
+
         it {
           expect(subject).to contain_file('/etc/httpd/modsecurity.d/security_crs_v4.conf')
-            .with_content(%r{IncludeOptional /usr/share/coreruleset/crs-setup\.conf})
-            .with_content(%r{IncludeOptional /usr/share/coreruleset/rules/\*\.conf})
+            .with_content(%r{IncludeOptional /usr/share/coreruleset-4\.27\.0/crs-setup\.conf})
+            .with_content(%r{IncludeOptional /usr/share/coreruleset-4\.27\.0/rules/\*\.conf})
         }
       end
     end

--- a/spec/classes/mod/security_spec.rb
+++ b/spec/classes/mod/security_spec.rb
@@ -438,4 +438,84 @@ describe 'apache::mod::security', type: :class do
       )
     }
   end
+
+  # CRS v4 acquisition modes (MODULES-11857). Exercised on EL10, where the
+  # default is engine-only and CRS is opt-in via archive/path.
+  context 'crs_source modes on RedHat 10' do
+    let :facts do
+      {
+        os: {
+          'architecture' => 'x86_64',
+          'family'       => 'RedHat',
+          'hardware'     => 'x86_64',
+          'name'         => 'RedHat',
+          'release'      => { 'full' => '10.0', 'major' => '10' },
+          'selinux'      => { 'enabled' => false },
+        },
+      }
+    end
+
+    context 'default (none)' do
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.not_to contain_archive('coreruleset.tar.gz') }
+      it { is_expected.not_to contain_file('/etc/httpd/modsecurity.d/security_crs_v4.conf') }
+    end
+
+    context "crs_source => 'archive'" do
+      context 'without crs_archive_source' do
+        let(:params) { { crs_source: 'archive' } }
+
+        it { is_expected.to compile.and_raise_error(%r{crs_archive_source}) }
+      end
+
+      context 'with crs_archive_source' do
+        let(:params) do
+          {
+            crs_source: 'archive',
+            crs_archive_source: 'https://mirror.internal.example/crs/coreruleset-4.10.0.tar.gz',
+            crs_archive_checksum: 'abc123',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        it {
+          expect(subject).to contain_archive('coreruleset.tar.gz').with(
+            source: 'https://mirror.internal.example/crs/coreruleset-4.10.0.tar.gz',
+            checksum: 'abc123',
+            checksum_type: 'sha256',
+            extract: true,
+            extract_path: '/usr/share/coreruleset',
+          )
+        }
+
+        it {
+          expect(subject).to contain_file('/etc/httpd/modsecurity.d/security_crs_v4.conf')
+            .with_content(%r{IncludeOptional /usr/share/coreruleset/crs-setup\.conf})
+            .with_content(%r{IncludeOptional /usr/share/coreruleset/rules/\*\.conf})
+        }
+      end
+    end
+
+    context "crs_source => 'path'" do
+      context 'without crs_path' do
+        let(:params) { { crs_source: 'path' } }
+
+        it { is_expected.to compile.and_raise_error(%r{crs_path}) }
+      end
+
+      context 'with crs_path' do
+        let(:params) { { crs_source: 'path', crs_path: '/opt/crs' } }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.not_to contain_archive('coreruleset.tar.gz') }
+
+        it {
+          expect(subject).to contain_file('/etc/httpd/modsecurity.d/security_crs_v4.conf')
+            .with_content(%r{IncludeOptional /opt/crs/crs-setup\.conf})
+            .with_content(%r{IncludeOptional /opt/crs/rules/\*\.conf})
+        }
+      end
+    end
+  end
 end

--- a/spec/classes/mod/security_spec.rb
+++ b/spec/classes/mod/security_spec.rb
@@ -493,11 +493,26 @@ describe 'apache::mod::security', type: :class do
             source: 'https://mirror.internal.example/crs/coreruleset-4.27.0-minimal.tar.gz',
             checksum: 'abc123',
             checksum_type: 'sha256',
+            checksum_verify: true,
             extract: true,
             extract_path: '/usr/share',
             creates: '/usr/share/coreruleset-4.27.0/crs-setup.conf.example',
           )
         }
+      end
+
+      context 'with crs_archive_source but no checksum (trusted mirror)' do
+        let(:params) do
+          {
+            crs_source: 'archive',
+            crs_archive_source: 'https://mirror.internal.example/crs/coreruleset-4.27.0-minimal.tar.gz',
+            crs_version: '4.27.0',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        # No checksum supplied -> verification is disabled (avoids empty-checksum mismatch).
+        it { is_expected.to contain_archive('coreruleset.tar.gz').with_checksum_verify(false) }
 
         it { is_expected.to contain_exec('apache-crs-setup-conf').with_creates('/usr/share/coreruleset-4.27.0/crs-setup.conf') }
 

--- a/templates/mod/security_crs_v4.conf.epp
+++ b/templates/mod/security_crs_v4.conf.epp
@@ -1,0 +1,9 @@
+<%- | Stdlib::Absolutepath $crs_dir | -%>
+# Managed by Puppet (apache::mod::security, crs_source => archive|path).
+#
+# OWASP Core Rule Set v4 on-disk layout. Unlike the v2/v3 package model
+# (per-rule symlinks under activated_rules/), v4 is loaded as a self-contained
+# directory: the setup file first, then every rule file in filename order
+# (CRS numbers its files so the wildcard include resolves the correct order).
+IncludeOptional <%= $crs_dir %>/crs-setup.conf
+IncludeOptional <%= $crs_dir %>/rules/*.conf


### PR DESCRIPTION
## Summary

Scaffolds OWASP Core Rule Set (CRS) v4 support on EL10, where there is no `mod_security_crs` package, while preserving the existing package-based behaviour on EL7/8/9. Implements the design locked in the SPIKE **MODULES-11852** (air-gapped customer with internal mirrors → mirror-first, no required internet call).

Introduces a `crs_source` enum on `apache::mod::security`:

| `crs_source` | Behaviour | Default for |
| --- | --- | --- |
| `package` | install `mod_security_crs` + per-rule symlinks (v2/v3 layout) — **unchanged** | EL7/8/9 |
| `archive` | fetch CRS v4 tarball via `puppet/archive` from a configurable `crs_archive_source` (e.g. an internal mirror) + checksum, extract, wire v4 includes | opt-in |
| `path` | use a pre-staged CRS v4 directory (`crs_path`), no download | opt-in |
| `none` | engine only, no CRS | EL10 |

## Changes

- **`manifests/params.pp`** — `crs_source` defaults (`none` on EL10, `package` elsewhere); archive source/checksum default to `undef` (user-pinned, no module-shipped version → avoids the CRS version/CVE treadmill).
- **`manifests/mod/security.pp`** — new params + `case $crs_source` for acquisition; rule activation branches between legacy per-rule symlinks (`package`) and the v4 include layout (`archive`/`path`); fail-fast validation when required inputs are missing. Extract dir is kept **outside** the purged `modsec_dir`.
- **`templates/mod/security_crs_v4.conf.epp`** — emits `IncludeOptional <dir>/crs-setup.conf` + `rules/*.conf`, auto-loaded via the existing `IncludeOptional ${modsec_dir}/*.conf`.
- **`metadata.json` / `.fixtures.yml`** — add `puppetlabs/archive` dependency.
- **`spec/classes/mod/security_spec.rb`** — cover none/archive/path modes + fail-fast cases.

## Validation

- `puppet parser validate`, `epp validate`, `puppet-lint`, `rubocop`, `metadata_lint`: clean
- Unit specs: **282 examples, 0 failures** (all `crs_source` values, with/without-checksum archive, fail-fast)
- **Acceptance (CI): passes on all EL platforms** incl. RedHat-10 / 10-arm (new `spec/acceptance/mod_security_crs_v4_spec.rb` exercises path + archive)
- Both modes also validated end-to-end on a **RHEL 10.1 VM** (apply, idempotency, `configtest`, SQLi/XSS/LFI → 403)

## Known limitation / follow-up

- **v4 tuning params** — the CRS tuning parameters (`paranoia_level`, `*_anomaly_threshold`, `allowed_methods`, DOS knobs, …) currently feed only the legacy `security_crs.conf` (package mode). In `archive`/`path` (v4) modes the CRS-shipped `crs-setup.conf` is used as-is, so those params are not applied. Operators can edit `crs-setup.conf` directly (preserved by the `creates` guard). Tracked as follow-up **MODULES-11895** — not a blocker for this PR.

## CI note

The only red checks are `Debian-13`, `SLES-12`, `SLES-15` acceptance — **pre-existing platform failures** (Debian-13 systemd start; SLES missing `apache2ctl`), unrelated to this change (same set is red on `main` nightly; this PR does not touch those code paths).

Relates to MODULES-11852 (design SPIKE), MODULES-11851 (engine restore), MODULES-11739 (parent), MODULES-11895 (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
