### PR TITLE
Fix: Ensure mod_md `tls-alpn-01` challenge is usable

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -774,7 +774,7 @@ Default value: `$apache::params::ports_file`
 
 ##### <a name="-apache--protocols"></a>`protocols`
 
-Data type: `Array[Enum['h2', 'h2c', 'http/1.1']]`
+Data type: `Array[Enum['h2', 'h2c', 'http/1.1', 'acme-tls/1']]`
 
 Sets the [Protocols](https://httpd.apache.org/docs/current/en/mod/core.html#protocols)
 directive, which lists available protocols for the server.
@@ -9747,7 +9747,7 @@ Default value: `undef`
 
 ##### <a name="-apache--vhost--protocols"></a>`protocols`
 
-Data type: `Array[Enum['h2', 'h2c', 'http/1.1']]`
+Data type: `Array[Enum['h2', 'h2c', 'http/1.1', 'acme-tls/1']]`
 
 Sets the [Protocols](https://httpd.apache.org/docs/current/en/mod/core.html#protocols)
 directive, which lists available protocols for the virutal host.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -531,7 +531,7 @@ class apache (
   String $error_log                                                          = $apache::params::error_log,
   String $scriptalias                                                        = $apache::params::scriptalias,
   String $access_log_file                                                    = $apache::params::access_log_file,
-  Array[Enum['h2', 'h2c', 'http/1.1']] $protocols                            = [],
+  Array[Enum['h2', 'h2c', 'http/1.1', 'acme-tls/1']] $protocols              = [],
   Optional[Boolean] $protocols_honor_order                                   = undef,
 ) inherits apache::params {
   if $facts['os']['family'] == 'RedHat' and $facts['os']['release']['major'] == '7' {
@@ -837,6 +837,9 @@ class apache (
 
     if 'h2' in $protocols or 'h2c' in $protocols {
       include apache::mod::http2
+    }
+    if 'acme-tls/1' in $protocols {
+      include apache::mod::md
     }
 
     $default_vhost_ensure = $default_vhost ? {

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1727,7 +1727,7 @@ define apache::vhost (
   String $docroot_owner                                                               = 'root',
   String $docroot_group                                                               = $apache::params::root_group,
   Optional[Stdlib::Filemode] $docroot_mode                                            = undef,
-  Array[Enum['h2', 'h2c', 'http/1.1']] $protocols                                     = [],
+  Array[Enum['h2', 'h2c', 'http/1.1', 'acme-tls/1']] $protocols                       = [],
   Optional[Boolean] $protocols_honor_order                                            = undef,
   Optional[String] $serveradmin                                                       = undef,
   Boolean $ssl                                                                        = false,
@@ -2749,6 +2749,9 @@ define apache::vhost (
       'h2_tls_warm_up_size'    => $h2_tls_warm_up_size,
       'h2_upgrade'             => $h2_upgrade,
       'h2_window_size'         => $h2_window_size,
+    }
+    if 'acme-tls/1' in $protocols {
+      include apache::mod::md
     }
 
     concat::fragment { "${name}-http2":


### PR DESCRIPTION
The challenge is already configurable in apache::mod::md, but it needs the `acme-tls/1` protocol to properly work (see "https: Challenges"): https://httpd.apache.org/docs/2.4/mod/mod_md.html